### PR TITLE
Add Qt6 support

### DIFF
--- a/cxx-qt-gen/src/cxx_qt.cpp
+++ b/cxx-qt-gen/src/cxx_qt.cpp
@@ -74,11 +74,19 @@ namespace {
 // We assume that std::size_t is the same size as Rust's usize.
 // cxx.cc has some asserts to ensure that is true.
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+static_assert(alignof(QString) <= alignof(std::size_t[3]),
+              "unexpectedly large QString alignment");
+
+static_assert(sizeof(QString) <= sizeof(std::size_t[3]),
+              "unexpectedly large QString size");
+#else
 static_assert(alignof(QString) <= alignof(std::size_t),
               "unexpectedly large QString alignment");
 
 static_assert(sizeof(QString) <= sizeof(std::size_t),
               "unexpectedly large QString size");
+#endif
 
 // We also assume that C++ char and Rust u8 are the same
 

--- a/cxx-qt-lib/Cargo.toml
+++ b/cxx-qt-lib/Cargo.toml
@@ -15,3 +15,6 @@ repository = "https://github.com/KDAB/cxx-qt/"
 [dependencies]
 cxx = "1.0"
 static_assertions = "1.1.0"
+
+[features]
+Qt6 = []

--- a/cxx-qt-lib/src/qstring.rs
+++ b/cxx-qt-lib/src/qstring.rs
@@ -117,6 +117,9 @@ impl QString {
 pub struct StackQString {
     // Static assertions in cxx_qt.cpp validate that this
     // is large enough and aligned enough.
+    #[cfg(feature = "Qt6")]
+    space: MaybeUninit<[usize; 3]>,
+    #[cfg(not(feature = "Qt6"))]
     space: MaybeUninit<usize>,
 }
 

--- a/examples/qt_types_standalone/Cargo.toml
+++ b/examples/qt_types_standalone/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib"]
 [dependencies]
 cxx = "1.0"
 cxx-qt = { path = "../../cxx-qt" }
-cxx-qt-lib = { path = "../../cxx-qt-lib" }
+cxx-qt-lib = { path = "../../cxx-qt-lib", features=["Qt6"] }
 
 [build-dependencies]
 clang-format = { path = "../../clang-format" }


### PR DESCRIPTION
This patch adds "Qt6" as a feature to cxx-qt-lib as to support the
change in QString binary size in Qt6.

Change-Id: I68c214eee48ec24b78ee3121892ed2689786dc21