### PR TITLE
locking: add guards to rustObj inside C++ and postEvent property changes

### DIFF
--- a/cxx-qt-gen/src/cxx_qt.cpp
+++ b/cxx-qt-gen/src/cxx_qt.cpp
@@ -316,10 +316,17 @@ extern "C"
   void cxxqt1$qvariant$drop(QVariant* self) noexcept { self->~QVariant(); }
 }
 
-const QEvent::Type CxxQObject::UpdateStateEvent = []() {
-  auto eventId = QEvent::registerEventType(QEvent::User + 1);
+static const QEvent::Type
+createEventType(int hint)
+{
+  auto eventId = QEvent::registerEventType(hint);
   Q_ASSERT(eventId > -1);
   return static_cast<QEvent::Type>(eventId);
-}();
+}
+
+const QEvent::Type CxxQObject::UpdateStateEvent =
+  createEventType(QEvent::User + 1);
+const QEvent::Type CxxQObject::UpdatePropertyEvent =
+  createEventType(QEvent::User + 2);
 
 #endif // NO_QT

--- a/cxx-qt-gen/src/cxx_qt.h
+++ b/cxx-qt-gen/src/cxx_qt.h
@@ -9,6 +9,8 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
+#include <vector>
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -74,6 +76,7 @@ public:
   // want to create custom classes that derive from CxxQObject so that they
   // know to avoid clashes with it.
   static const QEvent::Type UpdateStateEvent;
+  static const QEvent::Type UpdatePropertyEvent;
 
 public:
   CxxQObject(QObject* parent = nullptr)
@@ -81,21 +84,45 @@ public:
   {}
   virtual ~CxxQObject() = default;
 
+  void requestPropertyChange(int propertyId)
+  {
+    const std::lock_guard<std::mutex> guard(m_propertyChangeQueueMutex);
+    m_propertyChangeQueue.push_back(propertyId);
+    QCoreApplication::postEvent(this, new QEvent(UpdatePropertyEvent));
+  }
+
   void requestUpdate()
   {
     if (!m_waitingForUpdate.exchange(true, std::memory_order_relaxed))
       QCoreApplication::postEvent(this, new QEvent(UpdateStateEvent));
   }
 
+  std::vector<int> takePropertyChangeQueue()
+  {
+    const std::lock_guard<std::mutex> guard(m_propertyChangeQueueMutex);
+    std::vector<int> queue;
+    std::swap(m_propertyChangeQueue, queue);
+    return queue;
+  }
+
   bool event(QEvent* event) override
   {
-    if (event->type() == UpdateStateEvent) {
+    // TODO: later if CxxQObject is a mixin or member and knows about m_rustObj
+    // can the locking for m_rustObj happen here so we only have one lock?
+    // also would this change the virtual methods we have now?
+
+    if (event->type() == UpdatePropertyEvent) {
+      for (auto propertyId : takePropertyChangeQueue()) {
+        updatePropertyChange(propertyId);
+      }
+      return true;
+    } else if (event->type() == UpdateStateEvent) {
       // New Rust-side events might come in while we are processing a request
       // and request a new update while we are processing the queue.
       //
-      // If we flip this flag before updateState then worst case we get an extra
-      // event with nothing to actually process whereas if we do it afterwards
-      // then we might miss an update request.
+      // If we flip this flag before updateState then worst case we get an
+      // extra event with nothing to actually process whereas if we do it
+      // afterwards then we might miss an update request.
       m_waitingForUpdate.store(false, std::memory_order_relaxed);
 
       updateState();
@@ -113,6 +140,13 @@ protected:
   // might want to consider making the function pure virtual. Objects that want
   // to opt out of the state mechanism should then instead derive from an
   // entirely different base class as to have less overhead overall.
+  virtual void updatePropertyChange(int propertyId)
+  {
+    qWarning()
+      << "An UpdatePropertyEvent event was posted to a CxxQObject that does "
+         "not override updatePropertyChange(int), this likely indicates a bug.";
+  }
+
   virtual void updateState()
   {
     qWarning()
@@ -122,4 +156,6 @@ protected:
 
 private:
   std::atomic_bool m_waitingForUpdate{ false };
+  std::vector<int> m_propertyChangeQueue;
+  std::mutex m_propertyChangeQueueMutex;
 };

--- a/cxx-qt-gen/test_outputs/basic_change_handler.cpp
+++ b/cxx-qt-gen/test_outputs/basic_change_handler.cpp
@@ -31,7 +31,7 @@ MyObject::setNumber(qint32 value)
     m_number = value;
 
     Q_EMIT numberChanged();
-    m_rustObj->handlePropertyChange(*this, Property::Number);
+    requestPropertyChange(static_cast<int>(Property::Number));
   }
 }
 
@@ -53,8 +53,15 @@ MyObject::setString(const QString& value)
     m_string = value;
 
     Q_EMIT stringChanged();
-    m_rustObj->handlePropertyChange(*this, Property::String);
+    requestPropertyChange(static_cast<int>(Property::String));
   }
+}
+
+void
+MyObject::updatePropertyChange(int propertyId)
+{
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
+  m_rustObj->handlePropertyChange(*this, static_cast<Property>(propertyId));
 }
 
 std::unique_ptr<MyObject>

--- a/cxx-qt-gen/test_outputs/basic_change_handler.h
+++ b/cxx-qt-gen/test_outputs/basic_change_handler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 namespace cxx_qt::my_object {
@@ -29,10 +31,13 @@ Q_SIGNALS:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 
   qint32 m_number;
   QString m_string;
+
+  void updatePropertyChange(int propertyId) override;
 };
 
 std::unique_ptr<MyObject>

--- a/cxx-qt-gen/test_outputs/basic_ident_changes.cpp
+++ b/cxx-qt-gen/test_outputs/basic_ident_changes.cpp
@@ -37,6 +37,7 @@ MyObject::setMyNumber(qint32 value)
 void
 MyObject::sayBye()
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->sayBye();
 }
 

--- a/cxx-qt-gen/test_outputs/basic_ident_changes.h
+++ b/cxx-qt-gen/test_outputs/basic_ident_changes.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 namespace cxx_qt::my_object {
@@ -28,6 +30,7 @@ Q_SIGNALS:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 
   qint32 m_myNumber;

--- a/cxx-qt-gen/test_outputs/basic_invokable_and_properties.cpp
+++ b/cxx-qt-gen/test_outputs/basic_invokable_and_properties.cpp
@@ -58,12 +58,14 @@ MyObject::setString(const QString& value)
 void
 MyObject::sayHi(const QString& string, qint32 number)
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->sayHi(string, number);
 }
 
 void
 MyObject::sayBye()
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->sayBye();
 }
 

--- a/cxx-qt-gen/test_outputs/basic_invokable_and_properties.h
+++ b/cxx-qt-gen/test_outputs/basic_invokable_and_properties.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 namespace cxx_qt::my_object {
@@ -32,6 +34,7 @@ Q_SIGNALS:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 
   qint32 m_number;

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.cpp
@@ -16,12 +16,14 @@ MyObject::~MyObject() = default;
 void
 MyObject::sayHi(const QString& string, qint32 number)
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->sayHi(string, number);
 }
 
 void
 MyObject::sayBye()
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->sayBye();
 }
 

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.h
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 namespace cxx_qt::my_object {
@@ -19,6 +21,7 @@ public:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 };
 

--- a/cxx-qt-gen/test_outputs/basic_only_invokable_return.cpp
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable_return.cpp
@@ -16,18 +16,21 @@ MyObject::~MyObject() = default;
 qint32
 MyObject::doubleNumber(qint32 number)
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   return m_rustObj->doubleNumber(number);
 }
 
 QString
 MyObject::helloMessage(const QString& msg)
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   return rustStringToQString(m_rustObj->helloMessage(msg));
 }
 
 QString
 MyObject::staticMessage()
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   return rustStrToQString(m_rustObj->staticMessage());
 }
 

--- a/cxx-qt-gen/test_outputs/basic_only_invokable_return.h
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable_return.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 namespace cxx_qt::my_object {
@@ -20,6 +22,7 @@ public:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 };
 

--- a/cxx-qt-gen/test_outputs/basic_only_properties.h
+++ b/cxx-qt-gen/test_outputs/basic_only_properties.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 namespace cxx_qt::my_object {
@@ -29,6 +31,7 @@ Q_SIGNALS:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 
   qint32 m_number;

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.cpp
@@ -16,12 +16,14 @@ MyObject::~MyObject() = default;
 void
 MyObject::sayHi(const QString& string, qint32 number)
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->sayHi(*this, string, number);
 }
 
 void
 MyObject::sayBye()
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->sayBye(*this);
 }
 

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.h
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 namespace cxx_qt::my_object {
@@ -19,6 +21,7 @@ public:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 };
 

--- a/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.h
+++ b/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 namespace cxx_qt::my_object {
@@ -16,6 +18,7 @@ public:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 };
 

--- a/cxx-qt-gen/test_outputs/basic_update_requester.cpp
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.cpp
@@ -16,18 +16,21 @@ MyObject::~MyObject() = default;
 void
 MyObject::sayHi(const QString& string, qint32 number)
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->sayHi(string, number);
 }
 
 void
 MyObject::sayBye()
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->sayBye();
 }
 
 void
 MyObject::updateState()
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->handleUpdateRequest(*this);
 }
 

--- a/cxx-qt-gen/test_outputs/basic_update_requester.h
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 namespace cxx_qt::my_object {
@@ -19,6 +21,7 @@ public:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 
   void updateState() override;

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.cpp
@@ -16,6 +16,7 @@ MyObject::~MyObject() = default;
 void
 MyObject::subTest(cxx_qt::sub_object::SubObject* sub)
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   m_rustObj->subTest(*this, *sub);
 }
 

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.h
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 #include "cxx-qt-gen/include/sub_object.h"
@@ -20,6 +22,7 @@ public:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 };
 

--- a/cxx-qt-gen/test_outputs/subobject_property.h
+++ b/cxx-qt-gen/test_outputs/subobject_property.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 #include "cxx-qt-gen/include/sub_object.h"
@@ -30,6 +32,7 @@ Q_SIGNALS:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 
   cxx_qt::sub_object::SubObject* m_obj = nullptr;

--- a/cxx-qt-gen/test_outputs/types_primitive_property.h
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 namespace cxx_qt::my_object {
@@ -60,6 +62,7 @@ Q_SIGNALS:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 
   bool m_boolean;

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
@@ -16,18 +16,21 @@ MyObject::~MyObject() = default;
 QPointF
 MyObject::testPointf(const QPointF& pointf)
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   return m_rustObj->testPointf(*this, pointf);
 }
 
 QString
 MyObject::testString(const QString& string)
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   return rustStringToQString(m_rustObj->testString(*this, string));
 }
 
 QVariant
 MyObject::testVariant(const QVariant& variant)
 {
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   return ::CxxQt::rustVariantToQVariant(m_rustObj->testVariant(*this, variant));
 }
 

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.h
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 #include <QtCore/QPointF>
@@ -23,6 +25,7 @@ public:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 };
 

--- a/cxx-qt-gen/test_outputs/types_qt_property.h
+++ b/cxx-qt-gen/test_outputs/types_qt_property.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "rust/cxx_qt.h"
 
 #include <QtCore/QPointF>
@@ -37,6 +39,7 @@ Q_SIGNALS:
 
 private:
   rust::Box<RustObj> m_rustObj;
+  std::mutex m_rustObjMutex;
   bool m_initialised = false;
 
   QPointF m_pointf;


### PR DESCRIPTION
Change-Id: Iff2de681e5ff8e553c1bf0e7a466af2f9926687d