### PR TITLE
invokables: transparently use a CppObj wrapper

### DIFF
--- a/cxx-qt-gen/src/extract.rs
+++ b/cxx-qt-gen/src/extract.rs
@@ -302,10 +302,10 @@ fn extract_type_ident(
                         // For a given Pin<crate::A::T> we want to make it cxx_qt::A::T
                         ident_namespace_str: if let Some(ident) = type_idents.last() {
                             let ident_str = ident.to_string();
-                            // Ignore Pin<&mut CppObj> from our namespaces for now
+                            // Ignore Pin<&mut FFICppObj> from our namespaces for now
                             //
                             // TODO: does this need to be considered?
-                            if type_idents.len() == 1 && ident_str.as_str() == "CppObj" {
+                            if type_idents.len() == 1 && ident_str.as_str() == "FFICppObj" {
                                 ident_str
                             } else {
                                 // Extract the namespace of the type
@@ -325,9 +325,9 @@ fn extract_type_ident(
                             return Err(ExtractTypeIdentError::UnknownPinType(ty.span()));
                         },
                         is_mut,
-                        // If the T in Pin<T> is CppObj, then it is "this"
+                        // If the T in Pin<T> is FFICppObj, then it is "this"
                         is_this: if let Some(ident) = type_idents.first() {
-                            ident.to_string().as_str() == "CppObj"
+                            ident.to_string().as_str() == "FFICppObj"
                         } else {
                             false
                         },
@@ -1203,11 +1203,11 @@ mod tests {
             type_idents,
         } = &param_first.type_ident.qt_type
         {
-            assert_eq!(ident_namespace_str, "CppObj");
+            assert_eq!(ident_namespace_str, "FFICppObj");
             assert_eq!(is_mut, &true);
             assert_eq!(is_this, &true);
             assert_eq!(type_idents.len(), 1);
-            assert_eq!(type_idents[0].to_string(), "CppObj");
+            assert_eq!(type_idents[0].to_string(), "FFICppObj");
         } else {
             panic!();
         }
@@ -1245,11 +1245,11 @@ mod tests {
             type_idents,
         } = &param_first.type_ident.qt_type
         {
-            assert_eq!(ident_namespace_str, "CppObj");
+            assert_eq!(ident_namespace_str, "FFICppObj");
             assert_eq!(is_mut, &true);
             assert_eq!(is_this, &true);
             assert_eq!(type_idents.len(), 1);
-            assert_eq!(type_idents[0].to_string(), "CppObj");
+            assert_eq!(type_idents[0].to_string(), "FFICppObj");
         } else {
             panic!();
         }

--- a/cxx-qt-gen/src/extract.rs
+++ b/cxx-qt-gen/src/extract.rs
@@ -36,6 +36,15 @@ pub(crate) enum QtTypes {
         /// The ident of the type for Rust, eg the MyObject or CppObj from:
         /// Rust - MyObject or crate::sub_object::CppObj
         rust_type_idents: Vec<Ident>,
+        /// The combined name of the type, this is a single word which is used
+        /// as the type name of the C++ type in the Rust cxx bridge
+        /// eg MyObject or SubObject
+        /// This needs the match the name of the C++ class without namespace
+        /// as we add this in the macro attribute
+        //
+        // TODO: later can we use the fully qualified path
+        // eg crate::my_module::CppObj to Crate_MyModule_CppObj?
+        combined_name: Ident,
     },
     F32,
     F64,
@@ -175,6 +184,7 @@ fn extract_qt_type(
                 cpp_type_idents: vec![qt_ident.clone()],
                 cpp_type_idents_string: qt_ident.to_string(),
                 rust_type_idents: vec![qt_ident.clone()],
+                combined_name: qt_ident.clone(),
             }),
             "f32" => Ok(QtTypes::F32),
             "f64" => Ok(QtTypes::F64),
@@ -216,6 +226,12 @@ fn extract_qt_type(
                 .join("::"),
             cpp_type_idents,
             rust_type_idents: idents.to_vec(),
+            // TODO: later can we use the fully qualified path
+            // eg crate::my_module::CppObj to Crate_MyModule_CppObj?
+            combined_name: quote::format_ident!(
+                "{}",
+                idents[idents.len() - 2].to_string().to_case(Case::Pascal)
+            ),
         })
     // This is an unknown type that did not start with crate and has multiple parts
     } else {

--- a/cxx-qt-gen/src/gen_cpp.rs
+++ b/cxx-qt-gen/src/gen_cpp.rs
@@ -73,7 +73,6 @@ impl CppType for QtTypes {
             Self::F32 | Self::F64 => None,
             Self::I8 | Self::I16 | Self::I32 => None,
             Self::Pin { .. } => None,
-            Self::Ptr { .. } => None,
             Self::QPointF => None,
             Self::Str => Some("rustStrToQString"),
             Self::String => Some("rustStringToQString"),
@@ -110,10 +109,6 @@ impl CppType for QtTypes {
                 "#include \"cxx-qt-gen/include/{}.h\"",
                 type_idents.last().unwrap().to_string().to_case(Case::Snake)
             )],
-            Self::Ptr { ident_str, .. } => vec![format!(
-                "#include \"cxx-qt-gen/include/{}.h\"",
-                ident_str.to_case(Case::Snake)
-            )],
             Self::QPointF => vec!["#include <QtCore/QPointF>".to_owned()],
             // FIXME: do we need both variant and qvariant here?
             Self::QVariant | Self::Variant => vec!["#include <QtCore/QVariant>".to_owned()],
@@ -132,7 +127,6 @@ impl CppType for QtTypes {
             Self::F32 | Self::F64 => false,
             Self::I8 | Self::I16 | Self::I32 => false,
             Self::Pin { .. } => false,
-            Self::Ptr { .. } => false,
             Self::QPointF => true,
             Self::Str => true,
             Self::String => true,
@@ -158,7 +152,6 @@ impl CppType for QtTypes {
         match self {
             Self::CppObj { .. } => true,
             Self::Pin { .. } => true,
-            Self::Ptr { .. } => true,
             _other => false,
         }
     }
@@ -178,7 +171,6 @@ impl CppType for QtTypes {
             Self::F32 | Self::F64 => false,
             Self::I8 | Self::I16 | Self::I32 => false,
             Self::Pin { .. } => false,
-            Self::Ptr { .. } => false,
             Self::QPointF => true,
             Self::Str => true,
             Self::String => true,
@@ -220,10 +212,6 @@ impl CppType for QtTypes {
             } if is_this == &false => ident_namespace_str,
             // Pin<T> where T is_this should not be used as a CppType argument as it's internal
             Self::Pin { .. } => unreachable!(),
-            Self::Ptr {
-                ident_namespace_str,
-                ..
-            } => ident_namespace_str,
             Self::QPointF => "QPointF",
             Self::Str | Self::String | Self::QString => "QString",
             Self::QVariant | Self::Variant => "QVariant",

--- a/cxx-qt-gen/src/gen_cpp.rs
+++ b/cxx-qt-gen/src/gen_cpp.rs
@@ -838,7 +838,9 @@ pub fn generate_qobject_cpp(obj: &QObject) -> Result<CppObject, TokenStream> {
             {private_method_headers}
         }};
 
-        std::unique_ptr<{ident}> newCppObject();
+        typedef {ident} CppObj;
+
+        std::unique_ptr<CppObj> newCppObject();
 
         }} // namespace {namespace}
         "#,
@@ -885,9 +887,9 @@ pub fn generate_qobject_cpp(obj: &QObject) -> Result<CppObject, TokenStream> {
 
         {private_method_sources}
 
-        std::unique_ptr<{ident}> newCppObject()
+        std::unique_ptr<CppObj> newCppObject()
         {{
-            return std::make_unique<{ident}>();
+            return std::make_unique<CppObj>();
         }}
 
         }} // namespace {namespace}

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -67,7 +67,6 @@ impl RustType for QtTypes {
             Self::I32 => format_ident!("i32"),
             Self::Pin { .. } => unreachable!(),
             // Pointer types do not use this function (TODO: yet?)
-            Self::Ptr { .. } => unreachable!(),
             Self::QPointF => format_ident!("QPointF"),
             Self::Str | Self::String | Self::QString => format_ident!("QString"),
             Self::QVariant | Self::Variant => format_ident!("QVariant"),
@@ -105,10 +104,6 @@ impl RustType for QtTypes {
             Self::I16 => quote! {i16},
             Self::I32 => quote! {i32},
             Self::Pin { .. } => unreachable!(),
-            Self::Ptr { ident_str, .. } => {
-                let ident = format_ident!("{}", ident_str);
-                quote! {cxx::UniquePtr<ffi::#ident>}
-            }
             Self::QPointF => quote! {cxx_qt_lib::QPointF},
             Self::Str | Self::String | Self::QString => quote! {cxx_qt_lib::QString},
             Self::QVariant | Self::Variant => quote! {cxx_qt_lib::QVariant},

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -1075,7 +1075,7 @@ pub fn generate_qobject_rs(
 
     let wrapper_struct_impl = quote! {
         impl<'a> #rust_wrapper_name<'a> {
-            fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+            pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
                 Self { cpp }
             }
 

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -472,7 +472,7 @@ fn generate_cpp_object_initialiser(obj: &QObject) -> TokenStream {
     // We assume that all Data classes implement default
     let output = quote! {
         fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObjWrapper::new(cpp);
+            let mut wrapper = CppObj::new(cpp);
             wrapper.grab_values_from_data(&#data_class_name::default());
         }
     };
@@ -840,7 +840,7 @@ pub fn generate_qobject_rs(
 
     // Cache the rust class name
     let rust_class_name = format_ident!("RustObj");
-    let rust_wrapper_name = format_ident!("CppObjWrapper");
+    let rust_wrapper_name = format_ident!("CppObj");
 
     // Generate cxx block
     let cxx_block = generate_qobject_cxx(obj, cpp_namespace_prefix)?;
@@ -855,7 +855,7 @@ pub fn generate_qobject_rs(
     // TODO: we need to update this to only store fields defined as "private" once we have an API for that
     let data_struct = build_struct_with_fields(&obj.original_data_struct, &data_fields_no_ptr);
 
-    // Build a converter for Data -> CppObjWrapper
+    // Build a converter for Data -> CppObj
     let data_struct_impl = {
         let mut fields_into = vec![];
         // If there are no filtered fields then use _value

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -726,6 +726,12 @@ pub fn generate_qobject_rs(
                     }
                 }
             }
+
+            impl<'a> From<&mut #rust_wrapper_name<'a>> for #data_struct_name {
+                fn from(#value_ident: &mut #rust_wrapper_name<'a>) -> Self {
+                    Self::from(&*#value_ident)
+                }
+            }
         }
     };
 

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -1102,7 +1102,8 @@ pub fn generate_qobject_rs(
     let handle_update_request = if obj.handle_updates_impl.is_some() {
         quote! {
             fn call_handle_update_request(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
-                self.handle_update_request(cpp);
+                let mut cpp = CppObj::new(cpp);
+                self.handle_update_request(&mut cpp);
             }
         }
     } else {
@@ -1113,7 +1114,8 @@ pub fn generate_qobject_rs(
     let handle_property_change = if obj.handle_property_change_impl.is_some() {
         quote! {
             fn call_handle_property_change(&mut self, cpp: std::pin::Pin<&mut FFICppObj>, property: Property) {
-                self.handle_property_change(cpp, property);
+                let mut cpp = CppObj::new(cpp);
+                self.handle_property_change(&mut cpp, property);
             }
         }
     } else {

--- a/cxx-qt-gen/src/utils.rs
+++ b/cxx-qt-gen/src/utils.rs
@@ -4,22 +4,6 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-/// Return whether the given type ident segments suggest the type is a pointer
-pub fn is_type_ident_ptr(ident: &[syn::Ident]) -> bool {
-    // TODO: can we improve detection?
-    // currently we just assume if the first segment is crate then it must be a pointer
-    //
-    // A pointer must have at least three parts, as it must have at least crate, module, object.
-    if ident.len() < 3 {
-        false
-    } else {
-        // The type has at least three parts, so assume it is a pointer if first is crate
-        //
-        // We have checked if the ident has at least three parts so we can assume the first exists
-        ident[0].to_string().as_str() == "crate"
-    }
-}
-
 /// For a given type generate what will be the namespace
 ///
 /// We can have `crate::module::Object` (or more parent modules) as an input for idents
@@ -53,31 +37,6 @@ mod tests {
     use super::*;
 
     use quote::format_ident;
-
-    #[test]
-    fn is_type_ident_ptr_pointer() {
-        // Test that crate::module::Object is detected as a pointer
-        let pointer = vec![
-            format_ident!("crate"),
-            format_ident!("module"),
-            format_ident!("Object"),
-        ];
-        assert!(is_type_ident_ptr(&pointer));
-    }
-
-    #[test]
-    fn is_type_ident_ptr_primitive() {
-        // Test that i32 is not detected as a pointer
-        let primitive = vec![format_ident!("i32")];
-        assert!(!is_type_ident_ptr(&primitive));
-    }
-
-    #[test]
-    fn is_type_ident_ptr_two_parts() {
-        // Test that crate::Object is not detected as a pointer as we need three parts
-        let two_parts = vec![format_ident!("crate"), format_ident!("Object")];
-        assert!(!is_type_ident_ptr(&two_parts));
-    }
 
     #[test]
     fn type_to_namespace_err() {

--- a/cxx-qt-gen/test_inputs/basic_change_handler.rs
+++ b/cxx-qt-gen/test_inputs/basic_change_handler.rs
@@ -8,8 +8,8 @@ mod my_object {
     #[derive(Default)]
     struct RustObj;
 
-    impl PropertyChangeHandler<CppObj, Property> for RustObj {
-        fn handle_property_change(&mut self, _cpp: Pin<&mut CppObj>, _property: Property) {
+    impl PropertyChangeHandler<FFICppObj, Property> for RustObj {
+        fn handle_property_change(&mut self, _cpp: Pin<&mut FFICppObj>, _property: Property) {
             println!("change")
         }
     }

--- a/cxx-qt-gen/test_inputs/basic_change_handler.rs
+++ b/cxx-qt-gen/test_inputs/basic_change_handler.rs
@@ -8,8 +8,8 @@ mod my_object {
     #[derive(Default)]
     struct RustObj;
 
-    impl PropertyChangeHandler<FFICppObj, Property> for RustObj {
-        fn handle_property_change(&mut self, _cpp: Pin<&mut FFICppObj>, _property: Property) {
+    impl PropertyChangeHandler<CppObj, Property> for RustObj {
+        fn handle_property_change(&mut self, _cpp: &mut CppObj, _property: Property) {
             println!("change")
         }
     }

--- a/cxx-qt-gen/test_inputs/basic_invokable_and_properties.rs
+++ b/cxx-qt-gen/test_inputs/basic_invokable_and_properties.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     struct Data {
         number: i32,

--- a/cxx-qt-gen/test_inputs/basic_only_invokable.rs
+++ b/cxx-qt-gen/test_inputs/basic_only_invokable.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     struct RustObj;
 

--- a/cxx-qt-gen/test_inputs/basic_only_invokable_return.rs
+++ b/cxx-qt-gen/test_inputs/basic_only_invokable_return.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     struct RustObj;
 

--- a/cxx-qt-gen/test_inputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_inputs/basic_pin_invokable.rs
@@ -4,7 +4,7 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn say_hi(&self, _cpp: Pin<&mut CppObj>, string: &QString, number: i32) {
+        fn say_hi(&self, _cpp: Pin<&mut FFICppObj>, string: &QString, number: i32) {
             println!(
                 "Hi from Rust! String is {} and number is {}",
                 string, number
@@ -12,7 +12,7 @@ mod my_object {
         }
 
         #[invokable]
-        fn say_bye(&self, _cpp: Pin<&mut CppObj>) {
+        fn say_bye(&self, _cpp: Pin<&mut FFICppObj>) {
             println!("Bye from Rust!");
         }
     }

--- a/cxx-qt-gen/test_inputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_inputs/basic_pin_invokable.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     struct RustObj;
 

--- a/cxx-qt-gen/test_inputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_inputs/basic_pin_invokable.rs
@@ -4,7 +4,7 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn say_hi(&self, _cpp: Pin<&mut FFICppObj>, string: &QString, number: i32) {
+        fn say_hi(&self, _cpp: &mut CppObj, string: &QString, number: i32) {
             println!(
                 "Hi from Rust! String is {} and number is {}",
                 string, number
@@ -12,7 +12,7 @@ mod my_object {
         }
 
         #[invokable]
-        fn say_bye(&self, _cpp: Pin<&mut FFICppObj>) {
+        fn say_bye(&self, _cpp: &mut CppObj) {
             println!("Bye from Rust!");
         }
     }

--- a/cxx-qt-gen/test_inputs/basic_update_requester.rs
+++ b/cxx-qt-gen/test_inputs/basic_update_requester.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     struct RustObj;
 

--- a/cxx-qt-gen/test_inputs/basic_update_requester.rs
+++ b/cxx-qt-gen/test_inputs/basic_update_requester.rs
@@ -17,8 +17,8 @@ mod my_object {
         }
     }
 
-    impl UpdateRequestHandler<CppObj> for RustObj {
-        fn handle_update_request(&mut self, _cpp: Pin<&mut CppObj>) {
+    impl UpdateRequestHandler<FFICppObj> for RustObj {
+        fn handle_update_request(&mut self, _cpp: Pin<&mut FFICppObj>) {
             println!("update")
         }
     }

--- a/cxx-qt-gen/test_inputs/basic_update_requester.rs
+++ b/cxx-qt-gen/test_inputs/basic_update_requester.rs
@@ -17,8 +17,8 @@ mod my_object {
         }
     }
 
-    impl UpdateRequestHandler<FFICppObj> for RustObj {
-        fn handle_update_request(&mut self, _cpp: Pin<&mut FFICppObj>) {
+    impl UpdateRequestHandler<CppObj> for RustObj {
+        fn handle_update_request(&mut self, _cpp: &mut CppObj) {
             println!("update")
         }
     }

--- a/cxx-qt-gen/test_inputs/subobject_pin_invokable.rs
+++ b/cxx-qt-gen/test_inputs/subobject_pin_invokable.rs
@@ -4,7 +4,7 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn sub_test(&self, _cpp: Pin<&mut FFICppObj>, sub: Pin<&mut crate::sub_object::SubObject>) {
+        fn sub_test(&self, _cpp: &mut CppObj, sub: &mut crate::sub_object::CppObj) {
             println!("Bye from Rust!");
         }
     }

--- a/cxx-qt-gen/test_inputs/subobject_pin_invokable.rs
+++ b/cxx-qt-gen/test_inputs/subobject_pin_invokable.rs
@@ -4,7 +4,7 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn sub_test(&self, _cpp: Pin<&mut CppObj>, sub: Pin<&mut crate::sub_object::SubObject>) {
+        fn sub_test(&self, _cpp: Pin<&mut FFICppObj>, sub: Pin<&mut crate::sub_object::SubObject>) {
             println!("Bye from Rust!");
         }
     }

--- a/cxx-qt-gen/test_inputs/subobject_property.rs
+++ b/cxx-qt-gen/test_inputs/subobject_property.rs
@@ -1,7 +1,7 @@
 mod my_object {
     #[derive(Default)]
     struct Data {
-        obj: crate::sub_object::SubObject,
+        obj: crate::sub_object::CppObj,
     }
 
     #[derive(Default)]

--- a/cxx-qt-gen/test_inputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_invokable.rs
@@ -7,17 +7,17 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn test_pointf(&self, _cpp: Pin<&mut CppObj>, pointf: &QPointF) -> QPointF {
+        fn test_pointf(&self, _cpp: Pin<&mut FFICppObj>, pointf: &QPointF) -> QPointF {
             pointf
         }
 
         #[invokable]
-        fn test_string(&self, _cpp: Pin<&mut CppObj>, string: &QString) -> String {
+        fn test_string(&self, _cpp: Pin<&mut FFICppObj>, string: &QString) -> String {
             string.to_rust()
         }
 
         #[invokable]
-        fn test_variant(&self, _cpp: Pin<&mut CppObj>, variant: &QVariant) -> Variant {
+        fn test_variant(&self, _cpp: Pin<&mut FFICppObj>, variant: &QVariant) -> Variant {
             variant
         }
     }

--- a/cxx-qt-gen/test_inputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_invokable.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     struct Data;
 

--- a/cxx-qt-gen/test_inputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_invokable.rs
@@ -7,17 +7,17 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn test_pointf(&self, _cpp: Pin<&mut FFICppObj>, pointf: &QPointF) -> QPointF {
+        fn test_pointf(&self, _cpp: &mut CppObj, pointf: &QPointF) -> QPointF {
             pointf
         }
 
         #[invokable]
-        fn test_string(&self, _cpp: Pin<&mut FFICppObj>, string: &QString) -> String {
+        fn test_string(&self, _cpp: &mut CppObj, string: &QString) -> String {
             string.to_rust()
         }
 
         #[invokable]
-        fn test_variant(&self, _cpp: Pin<&mut FFICppObj>, variant: &QVariant) -> Variant {
+        fn test_variant(&self, _cpp: &mut CppObj, variant: &QVariant) -> Variant {
             variant
         }
     }

--- a/cxx-qt-gen/test_outputs/basic_change_handler.cpp
+++ b/cxx-qt-gen/test_outputs/basic_change_handler.cpp
@@ -65,10 +65,10 @@ MyObject::setString(const QString& value)
   }
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_change_handler.h
+++ b/cxx-qt-gen/test_outputs/basic_change_handler.h
@@ -38,7 +38,9 @@ private:
   QString m_string;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_change_handler.h
+++ b/cxx-qt-gen/test_outputs/basic_change_handler.h
@@ -44,3 +44,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/basic_change_handler.rs
+++ b/cxx-qt-gen/test_outputs/basic_change_handler.rs
@@ -66,7 +66,8 @@ mod my_object {
             cpp: std::pin::Pin<&mut FFICppObj>,
             property: Property,
         ) {
-            self.handle_property_change(cpp, property);
+            let mut cpp = CppObj::new(cpp);
+            self.handle_property_change(&mut cpp, property);
         }
     }
 
@@ -127,12 +128,8 @@ mod my_object {
         }
     }
 
-    impl PropertyChangeHandler<FFICppObj, Property> for RustObj {
-        fn handle_property_change(
-            &mut self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
-            _property: Property,
-        ) {
+    impl PropertyChangeHandler<CppObj, Property> for RustObj {
+        fn handle_property_change(&mut self, _cpp: &mut CppObj, _property: Property) {
             println!("change")
         }
     }

--- a/cxx-qt-gen/test_outputs/basic_change_handler.rs
+++ b/cxx-qt-gen/test_outputs/basic_change_handler.rs
@@ -75,7 +75,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_change_handler.rs
+++ b/cxx-qt-gen/test_outputs/basic_change_handler.rs
@@ -70,11 +70,11 @@ mod my_object {
         }
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -118,8 +118,8 @@ mod my_object {
         string: String,
     }
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(value: &CppObj<'a>) -> Self {
             Self {
                 number: value.number().into(),
                 string: value.string().into(),
@@ -142,7 +142,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_change_handler.rs
+++ b/cxx-qt-gen/test_outputs/basic_change_handler.rs
@@ -54,7 +54,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -63,7 +63,7 @@ mod my_object {
     impl RustObj {
         fn call_handle_property_change(
             &mut self,
-            cpp: std::pin::Pin<&mut CppObj>,
+            cpp: std::pin::Pin<&mut FFICppObj>,
             property: Property,
         ) {
             self.handle_property_change(cpp, property);
@@ -71,11 +71,11 @@ mod my_object {
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
@@ -98,7 +98,7 @@ mod my_object {
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -127,10 +127,10 @@ mod my_object {
         }
     }
 
-    impl PropertyChangeHandler<CppObj, Property> for RustObj {
+    impl PropertyChangeHandler<FFICppObj, Property> for RustObj {
         fn handle_property_change(
             &mut self,
-            _cpp: std::pin::Pin<&mut CppObj>,
+            _cpp: std::pin::Pin<&mut FFICppObj>,
             _property: Property,
         ) {
             println!("change")
@@ -141,7 +141,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_change_handler.rs
+++ b/cxx-qt-gen/test_outputs/basic_change_handler.rs
@@ -128,6 +128,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(value: &mut CppObj<'a>) -> Self {
+            Self::from(&*value)
+        }
+    }
+
     impl PropertyChangeHandler<CppObj, Property> for RustObj {
         fn handle_property_change(&mut self, _cpp: &mut CppObj, _property: Property) {
             println!("change")

--- a/cxx-qt-gen/test_outputs/basic_custom_default.rs
+++ b/cxx-qt-gen/test_outputs/basic_custom_default.rs
@@ -57,7 +57,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_custom_default.rs
+++ b/cxx-qt-gen/test_outputs/basic_custom_default.rs
@@ -52,11 +52,11 @@ mod my_object {
         fn invokable(&self) {}
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -88,8 +88,8 @@ mod my_object {
         number: i32,
     }
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(value: &CppObj<'a>) -> Self {
             Self {
                 number: value.number().into(),
             }
@@ -107,7 +107,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_custom_default.rs
+++ b/cxx-qt-gen/test_outputs/basic_custom_default.rs
@@ -96,6 +96,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(value: &mut CppObj<'a>) -> Self {
+            Self::from(&*value)
+        }
+    }
+
     impl Default for Data {
         fn default() -> Self {
             Self { number: 32 }

--- a/cxx-qt-gen/test_outputs/basic_custom_default.rs
+++ b/cxx-qt-gen/test_outputs/basic_custom_default.rs
@@ -42,7 +42,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -53,11 +53,11 @@ mod my_object {
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
@@ -72,7 +72,7 @@ mod my_object {
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -106,7 +106,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_ident_changes.cpp
+++ b/cxx-qt-gen/test_outputs/basic_ident_changes.cpp
@@ -41,10 +41,10 @@ MyObject::sayBye()
   m_rustObj->sayBye();
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_ident_changes.h
+++ b/cxx-qt-gen/test_outputs/basic_ident_changes.h
@@ -36,7 +36,9 @@ private:
   qint32 m_myNumber;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_ident_changes.h
+++ b/cxx-qt-gen/test_outputs/basic_ident_changes.h
@@ -42,3 +42,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/basic_ident_changes.rs
+++ b/cxx-qt-gen/test_outputs/basic_ident_changes.rs
@@ -99,6 +99,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(value: &mut CppObj<'a>) -> Self {
+            Self::from(&*value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/basic_ident_changes.rs
+++ b/cxx-qt-gen/test_outputs/basic_ident_changes.rs
@@ -42,7 +42,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -55,11 +55,11 @@ mod my_object {
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
@@ -74,7 +74,7 @@ mod my_object {
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -103,7 +103,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_ident_changes.rs
+++ b/cxx-qt-gen/test_outputs/basic_ident_changes.rs
@@ -54,11 +54,11 @@ mod my_object {
         }
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -91,8 +91,8 @@ mod my_object {
         my_number: i32,
     }
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(value: &CppObj<'a>) -> Self {
             Self {
                 my_number: value.my_number().into(),
             }
@@ -104,7 +104,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_ident_changes.rs
+++ b/cxx-qt-gen/test_outputs/basic_ident_changes.rs
@@ -59,7 +59,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_invokable_and_properties.cpp
+++ b/cxx-qt-gen/test_outputs/basic_invokable_and_properties.cpp
@@ -69,10 +69,10 @@ MyObject::sayBye()
   m_rustObj->sayBye();
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_invokable_and_properties.h
+++ b/cxx-qt-gen/test_outputs/basic_invokable_and_properties.h
@@ -41,7 +41,9 @@ private:
   QString m_string;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_invokable_and_properties.h
+++ b/cxx-qt-gen/test_outputs/basic_invokable_and_properties.h
@@ -47,3 +47,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/basic_invokable_and_properties.rs
+++ b/cxx-qt-gen/test_outputs/basic_invokable_and_properties.rs
@@ -69,11 +69,11 @@ mod my_object {
         }
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -117,8 +117,8 @@ mod my_object {
         string: String,
     }
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(value: &CppObj<'a>) -> Self {
             Self {
                 number: value.number().into(),
                 string: value.string().into(),
@@ -131,7 +131,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_invokable_and_properties.rs
+++ b/cxx-qt-gen/test_outputs/basic_invokable_and_properties.rs
@@ -74,7 +74,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_invokable_and_properties.rs
+++ b/cxx-qt-gen/test_outputs/basic_invokable_and_properties.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[cxx::bridge(namespace = "cxx_qt::my_object")]
     mod ffi {
         enum Property {
@@ -57,7 +59,7 @@ mod my_object {
     struct RustObj;
 
     impl RustObj {
-        fn say_hi(&self, string: &cxx_qt_lib::QString, number: i32) {
+        fn say_hi(&self, string: &QString, number: i32) {
             println!(
                 "Hi from Rust! String is {} and number is {}",
                 string, number

--- a/cxx-qt-gen/test_outputs/basic_invokable_and_properties.rs
+++ b/cxx-qt-gen/test_outputs/basic_invokable_and_properties.rs
@@ -128,6 +128,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(value: &mut CppObj<'a>) -> Self {
+            Self::from(&*value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/basic_invokable_and_properties.rs
+++ b/cxx-qt-gen/test_outputs/basic_invokable_and_properties.rs
@@ -50,7 +50,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -70,11 +70,11 @@ mod my_object {
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
@@ -97,7 +97,7 @@ mod my_object {
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -130,7 +130,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_mod_attrs_vis.rs
+++ b/cxx-qt-gen/test_outputs/basic_mod_attrs_vis.rs
@@ -46,7 +46,7 @@ pub mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_mod_attrs_vis.rs
+++ b/cxx-qt-gen/test_outputs/basic_mod_attrs_vis.rs
@@ -34,7 +34,7 @@ pub mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     struct RustObj;
@@ -42,18 +42,18 @@ pub mod my_object {
     impl RustObj {}
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -74,7 +74,7 @@ pub mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_mod_attrs_vis.rs
+++ b/cxx-qt-gen/test_outputs/basic_mod_attrs_vis.rs
@@ -70,6 +70,12 @@ pub mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(_value: &mut CppObj<'a>) -> Self {
+            Self::from(&*_value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/basic_mod_attrs_vis.rs
+++ b/cxx-qt-gen/test_outputs/basic_mod_attrs_vis.rs
@@ -41,11 +41,11 @@ pub mod my_object {
 
     impl RustObj {}
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -64,8 +64,8 @@ pub mod my_object {
 
     struct Data;
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(_value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(_value: &CppObj<'a>) -> Self {
             Self {}
         }
     }
@@ -75,7 +75,7 @@ pub mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_mod_passthrough.rs
+++ b/cxx-qt-gen/test_outputs/basic_mod_passthrough.rs
@@ -106,6 +106,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(value: &mut CppObj<'a>) -> Self {
+            Self::from(&*value)
+        }
+    }
+
     impl Default for Data {
         fn default() -> Self {
             Self { number: 32 }

--- a/cxx-qt-gen/test_outputs/basic_mod_passthrough.rs
+++ b/cxx-qt-gen/test_outputs/basic_mod_passthrough.rs
@@ -52,7 +52,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -63,11 +63,11 @@ mod my_object {
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
@@ -82,7 +82,7 @@ mod my_object {
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -122,7 +122,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_mod_passthrough.rs
+++ b/cxx-qt-gen/test_outputs/basic_mod_passthrough.rs
@@ -67,7 +67,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_mod_passthrough.rs
+++ b/cxx-qt-gen/test_outputs/basic_mod_passthrough.rs
@@ -62,11 +62,11 @@ mod my_object {
         fn invokable(&self) {}
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -98,8 +98,8 @@ mod my_object {
         number: i32,
     }
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(value: &CppObj<'a>) -> Self {
             Self {
                 number: value.number().into(),
             }
@@ -123,7 +123,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.cpp
@@ -27,10 +27,10 @@ MyObject::sayBye()
   m_rustObj->sayBye();
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.h
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.h
@@ -25,7 +25,9 @@ private:
   bool m_initialised = false;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.h
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.h
@@ -31,3 +31,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[cxx::bridge(namespace = "cxx_qt::my_object")]
     mod ffi {
         enum Property {}
@@ -44,7 +46,7 @@ mod my_object {
     struct RustObj;
 
     impl RustObj {
-        fn say_hi(&self, string: &cxx_qt_lib::QString, number: i32) {
+        fn say_hi(&self, string: &QString, number: i32) {
             println!(
                 "Hi from Rust! String is {} and number is {}",
                 string, number

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.rs
@@ -37,7 +37,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -61,18 +61,18 @@ mod my_object {
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -93,7 +93,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.rs
@@ -91,6 +91,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(_value: &mut CppObj<'a>) -> Self {
+            Self::from(&*_value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.rs
@@ -65,7 +65,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.rs
@@ -60,11 +60,11 @@ mod my_object {
         }
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -83,8 +83,8 @@ mod my_object {
 
     struct Data;
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(_value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(_value: &CppObj<'a>) -> Self {
             Self {}
         }
     }
@@ -94,7 +94,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_only_invokable_return.cpp
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable_return.cpp
@@ -34,10 +34,10 @@ MyObject::staticMessage()
   return rustStrToQString(m_rustObj->staticMessage());
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_only_invokable_return.h
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable_return.h
@@ -32,3 +32,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/basic_only_invokable_return.h
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable_return.h
@@ -26,7 +26,9 @@ private:
   bool m_initialised = false;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_only_invokable_return.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable_return.rs
@@ -90,6 +90,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(_value: &mut CppObj<'a>) -> Self {
+            Self::from(&*_value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/basic_only_invokable_return.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable_return.rs
@@ -59,11 +59,11 @@ mod my_object {
         }
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -82,8 +82,8 @@ mod my_object {
 
     struct Data;
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(_value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(_value: &CppObj<'a>) -> Self {
             Self {}
         }
     }
@@ -93,7 +93,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_only_invokable_return.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable_return.rs
@@ -64,7 +64,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_only_invokable_return.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable_return.rs
@@ -39,7 +39,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -60,18 +60,18 @@ mod my_object {
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -92,7 +92,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_only_invokable_return.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable_return.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[cxx::bridge(namespace = "cxx_qt::my_object")]
     mod ffi {
         enum Property {}
@@ -50,7 +52,7 @@ mod my_object {
             number * 2
         }
 
-        fn hello_message(&self, msg: &cxx_qt_lib::QString) -> String {
+        fn hello_message(&self, msg: &QString) -> String {
             format!("Hello {}", msg)
         }
 

--- a/cxx-qt-gen/test_outputs/basic_only_properties.cpp
+++ b/cxx-qt-gen/test_outputs/basic_only_properties.cpp
@@ -55,10 +55,10 @@ MyObject::setString(const QString& value)
   }
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_only_properties.h
+++ b/cxx-qt-gen/test_outputs/basic_only_properties.h
@@ -38,7 +38,9 @@ private:
   QString m_string;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_only_properties.h
+++ b/cxx-qt-gen/test_outputs/basic_only_properties.h
@@ -44,3 +44,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/basic_only_properties.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_properties.rs
@@ -58,7 +58,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_only_properties.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_properties.rs
@@ -45,7 +45,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -54,11 +54,11 @@ mod my_object {
     impl RustObj {}
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
@@ -81,7 +81,7 @@ mod my_object {
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -114,7 +114,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_only_properties.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_properties.rs
@@ -110,6 +110,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(value: &mut CppObj<'a>) -> Self {
+            Self::from(&*value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/basic_only_properties.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_properties.rs
@@ -53,11 +53,11 @@ mod my_object {
 
     impl RustObj {}
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -101,8 +101,8 @@ mod my_object {
         string: String,
     }
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(value: &CppObj<'a>) -> Self {
             Self {
                 number: value.number().into(),
                 string: value.string().into(),
@@ -115,7 +115,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.cpp
@@ -27,10 +27,10 @@ MyObject::sayBye()
   m_rustObj->sayByeWrapper(*this);
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.cpp
@@ -17,14 +17,14 @@ void
 MyObject::sayHi(const QString& string, qint32 number)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  m_rustObj->sayHi(*this, string, number);
+  m_rustObj->sayHiWrapper(*this, string, number);
 }
 
 void
 MyObject::sayBye()
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  m_rustObj->sayBye(*this);
+  m_rustObj->sayByeWrapper(*this);
 }
 
 std::unique_ptr<MyObject>

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.h
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.h
@@ -25,7 +25,9 @@ private:
   bool m_initialised = false;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.h
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.h
@@ -31,3 +31,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
@@ -61,11 +61,11 @@ mod my_object {
         }
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -84,8 +84,8 @@ mod my_object {
 
     struct Data;
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(_value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(_value: &CppObj<'a>) -> Self {
             Self {}
         }
     }
@@ -95,7 +95,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
@@ -24,10 +24,15 @@ mod my_object {
         extern "Rust" {
             type RustObj;
 
-            #[cxx_name = "sayHi"]
-            fn say_hi(self: &RustObj, _cpp: Pin<&mut MyObject>, string: &QString, number: i32);
-            #[cxx_name = "sayBye"]
-            fn say_bye(self: &RustObj, _cpp: Pin<&mut MyObject>);
+            #[cxx_name = "sayHiWrapper"]
+            fn say_hi_wrapper(
+                self: &RustObj,
+                _cpp: Pin<&mut MyObject>,
+                string: &QString,
+                number: i32,
+            );
+            #[cxx_name = "sayByeWrapper"]
+            fn say_bye_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>);
 
             #[cxx_name = "createRs"]
             fn create_rs() -> Box<RustObj>;
@@ -44,19 +49,29 @@ mod my_object {
     struct RustObj;
 
     impl RustObj {
-        fn say_hi(
+        fn say_hi_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             string: &cxx_qt_lib::QString,
             number: i32,
         ) {
+            let mut _cpp = CppObj::new(_cpp);
+            return self.say_hi(&mut _cpp, string, number);
+        }
+
+        fn say_bye_wrapper(&self, _cpp: std::pin::Pin<&mut FFICppObj>) {
+            let mut _cpp = CppObj::new(_cpp);
+            return self.say_bye(&mut _cpp);
+        }
+
+        fn say_hi(&self, _cpp: &mut CppObj, string: &cxx_qt_lib::QString, number: i32) {
             println!(
                 "Hi from Rust! String is {} and number is {}",
                 string, number
             );
         }
 
-        fn say_bye(&self, _cpp: std::pin::Pin<&mut FFICppObj>) {
+        fn say_bye(&self, _cpp: &mut CppObj) {
             println!("Bye from Rust!");
         }
     }

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
@@ -37,7 +37,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -46,7 +46,7 @@ mod my_object {
     impl RustObj {
         fn say_hi(
             &self,
-            _cpp: std::pin::Pin<&mut CppObj>,
+            _cpp: std::pin::Pin<&mut FFICppObj>,
             string: &cxx_qt_lib::QString,
             number: i32,
         ) {
@@ -56,24 +56,24 @@ mod my_object {
             );
         }
 
-        fn say_bye(&self, _cpp: std::pin::Pin<&mut CppObj>) {
+        fn say_bye(&self, _cpp: std::pin::Pin<&mut FFICppObj>) {
             println!("Bye from Rust!");
         }
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -94,7 +94,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[cxx::bridge(namespace = "cxx_qt::my_object")]
     mod ffi {
         enum Property {}
@@ -52,7 +54,7 @@ mod my_object {
         fn say_hi_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
-            string: &cxx_qt_lib::QString,
+            string: &QString,
             number: i32,
         ) {
             let mut _cpp = CppObj::new(_cpp);
@@ -64,7 +66,7 @@ mod my_object {
             return self.say_bye(&mut _cpp);
         }
 
-        fn say_hi(&self, _cpp: &mut CppObj, string: &cxx_qt_lib::QString, number: i32) {
+        fn say_hi(&self, _cpp: &mut CppObj, string: &QString, number: i32) {
             println!(
                 "Hi from Rust! String is {} and number is {}",
                 string, number

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
@@ -81,7 +81,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
@@ -107,6 +107,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(_value: &mut CppObj<'a>) -> Self {
+            Self::from(&*_value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.cpp
+++ b/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.cpp
@@ -13,10 +13,10 @@ MyObject::MyObject(QObject* parent)
 
 MyObject::~MyObject() = default;
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.h
+++ b/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.h
@@ -22,7 +22,9 @@ private:
   bool m_initialised = false;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.h
+++ b/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.h
@@ -28,3 +28,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.rs
+++ b/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.rs
@@ -48,11 +48,11 @@ mod my_object {
         }
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -71,8 +71,8 @@ mod my_object {
 
     struct Data;
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(_value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(_value: &CppObj<'a>) -> Self {
             Self {}
         }
     }
@@ -82,7 +82,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.rs
+++ b/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.rs
@@ -77,6 +77,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(_value: &mut CppObj<'a>) -> Self {
+            Self::from(&*_value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.rs
+++ b/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.rs
@@ -53,7 +53,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.rs
+++ b/cxx-qt-gen/test_outputs/basic_unknown_rust_obj_type.rs
@@ -32,7 +32,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -49,18 +49,18 @@ mod my_object {
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -81,7 +81,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_update_requester.cpp
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.cpp
@@ -40,10 +40,10 @@ MyObject::updateState()
   m_rustObj->handleUpdateRequest(*this);
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_update_requester.h
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.h
@@ -28,7 +28,9 @@ private:
   void updateState();
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/basic_update_requester.h
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.h
@@ -34,3 +34,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/basic_update_requester.rs
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.rs
@@ -42,7 +42,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -60,24 +60,24 @@ mod my_object {
             println!("Bye from Rust!");
         }
 
-        fn call_handle_update_request(&mut self, cpp: std::pin::Pin<&mut CppObj>) {
+        fn call_handle_update_request(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
             self.handle_update_request(cpp);
         }
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -94,8 +94,8 @@ mod my_object {
         }
     }
 
-    impl UpdateRequestHandler<CppObj> for RustObj {
-        fn handle_update_request(&mut self, _cpp: std::pin::Pin<&mut CppObj>) {
+    impl UpdateRequestHandler<FFICppObj> for RustObj {
+        fn handle_update_request(&mut self, _cpp: std::pin::Pin<&mut FFICppObj>) {
             println!("update")
         }
     }
@@ -104,7 +104,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/basic_update_requester.rs
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.rs
@@ -1,4 +1,5 @@
 mod my_object {
+    use cxx_qt_lib::QString;
     use cxx_qt_lib::UpdateRequestHandler;
 
     #[cxx::bridge(namespace = "cxx_qt::my_object")]
@@ -49,7 +50,7 @@ mod my_object {
     struct RustObj;
 
     impl RustObj {
-        fn say_hi(&self, string: &cxx_qt_lib::QString, number: i32) {
+        fn say_hi(&self, string: &QString, number: i32) {
             println!(
                 "Hi from Rust! String is {} and number is {}",
                 string, number

--- a/cxx-qt-gen/test_outputs/basic_update_requester.rs
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.rs
@@ -70,7 +70,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/basic_update_requester.rs
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.rs
@@ -65,11 +65,11 @@ mod my_object {
         }
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -88,8 +88,8 @@ mod my_object {
 
     struct Data;
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(_value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(_value: &CppObj<'a>) -> Self {
             Self {}
         }
     }
@@ -105,7 +105,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/basic_update_requester.rs
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.rs
@@ -96,6 +96,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(_value: &mut CppObj<'a>) -> Self {
+            Self::from(&*_value)
+        }
+    }
+
     impl UpdateRequestHandler<CppObj> for RustObj {
         fn handle_update_request(&mut self, _cpp: &mut CppObj) {
             println!("update")

--- a/cxx-qt-gen/test_outputs/basic_update_requester.rs
+++ b/cxx-qt-gen/test_outputs/basic_update_requester.rs
@@ -61,7 +61,8 @@ mod my_object {
         }
 
         fn call_handle_update_request(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
-            self.handle_update_request(cpp);
+            let mut cpp = CppObj::new(cpp);
+            self.handle_update_request(&mut cpp);
         }
     }
 
@@ -94,8 +95,8 @@ mod my_object {
         }
     }
 
-    impl UpdateRequestHandler<FFICppObj> for RustObj {
-        fn handle_update_request(&mut self, _cpp: std::pin::Pin<&mut FFICppObj>) {
+    impl UpdateRequestHandler<CppObj> for RustObj {
+        fn handle_update_request(&mut self, _cpp: &mut CppObj) {
             println!("update")
         }
     }

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.cpp
@@ -20,10 +20,10 @@ MyObject::subTest(cxx_qt::sub_object::SubObject* sub)
   m_rustObj->subTest(*this, *sub);
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.cpp
@@ -14,10 +14,10 @@ MyObject::MyObject(QObject* parent)
 MyObject::~MyObject() = default;
 
 void
-MyObject::subTest(cxx_qt::sub_object::SubObject* sub)
+MyObject::subTest(cxx_qt::sub_object::CppObj* sub)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  m_rustObj->subTest(*this, *sub);
+  m_rustObj->subTestWrapper(*this, *sub);
 }
 
 std::unique_ptr<CppObj>

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.h
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.h
@@ -26,7 +26,9 @@ private:
   bool m_initialised = false;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.h
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.h
@@ -18,7 +18,7 @@ public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
 
-  Q_INVOKABLE void subTest(cxx_qt::sub_object::SubObject* sub);
+  Q_INVOKABLE void subTest(cxx_qt::sub_object::CppObj* sub);
 
 private:
   rust::Box<RustObj> m_rustObj;
@@ -32,3 +32,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.rs
@@ -17,7 +17,7 @@ mod my_object {
             #[namespace = "CxxQt"]
             type Variant = cxx_qt_lib::Variant;
             #[namespace = "cxx_qt::sub_object"]
-            type SubObject = crate::sub_object::CppObj;
+            type SubObject = crate::sub_object::FFICppObj;
 
             #[rust_name = "new_cpp_object"]
             fn newCppObject() -> UniquePtr<MyObject>;
@@ -37,7 +37,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -46,26 +46,26 @@ mod my_object {
     impl RustObj {
         fn sub_test(
             &self,
-            _cpp: std::pin::Pin<&mut CppObj>,
-            sub: std::pin::Pin<&mut crate::sub_object::CppObj>,
+            _cpp: std::pin::Pin<&mut FFICppObj>,
+            sub: std::pin::Pin<&mut crate::sub_object::FFICppObj>,
         ) {
             println!("Bye from Rust!");
         }
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -86,7 +86,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.rs
@@ -58,7 +58,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.rs
@@ -88,6 +88,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(_value: &mut CppObj<'a>) -> Self {
+            Self::from(&*_value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.rs
@@ -26,8 +26,8 @@ mod my_object {
         extern "Rust" {
             type RustObj;
 
-            #[cxx_name = "subTest"]
-            fn sub_test(self: &RustObj, _cpp: Pin<&mut MyObject>, sub: Pin<&mut SubObject>);
+            #[cxx_name = "subTestWrapper"]
+            fn sub_test_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, sub: Pin<&mut SubObject>);
 
             #[cxx_name = "createRs"]
             fn create_rs() -> Box<RustObj>;
@@ -44,11 +44,17 @@ mod my_object {
     struct RustObj;
 
     impl RustObj {
-        fn sub_test(
+        fn sub_test_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             sub: std::pin::Pin<&mut crate::sub_object::FFICppObj>,
         ) {
+            let mut _cpp = CppObj::new(_cpp);
+            let mut sub = crate::sub_object::CppObj::new(sub);
+            return self.sub_test(&mut _cpp, &mut sub);
+        }
+
+        fn sub_test(&self, _cpp: &mut CppObj, sub: &mut crate::sub_object::CppObj) {
             println!("Bye from Rust!");
         }
     }

--- a/cxx-qt-gen/test_outputs/subobject_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/subobject_pin_invokable.rs
@@ -53,11 +53,11 @@ mod my_object {
         }
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -76,8 +76,8 @@ mod my_object {
 
     struct Data;
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(_value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(_value: &CppObj<'a>) -> Self {
             Self {}
         }
     }
@@ -87,7 +87,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/subobject_property.cpp
+++ b/cxx-qt-gen/test_outputs/subobject_property.cpp
@@ -13,14 +13,14 @@ MyObject::MyObject(QObject* parent)
 
 MyObject::~MyObject() = default;
 
-cxx_qt::sub_object::SubObject*
+cxx_qt::sub_object::CppObj*
 MyObject::getObj() const
 {
   return m_obj;
 }
 
 void
-MyObject::setObj(cxx_qt::sub_object::SubObject* value)
+MyObject::setObj(cxx_qt::sub_object::CppObj* value)
 {
   if (value != m_obj) {
     if (m_ownedObj) {
@@ -33,7 +33,7 @@ MyObject::setObj(cxx_qt::sub_object::SubObject* value)
   }
 }
 
-std::unique_ptr<cxx_qt::sub_object::SubObject>
+std::unique_ptr<cxx_qt::sub_object::CppObj>
 MyObject::takeObj()
 {
   auto value = std::move(m_ownedObj);
@@ -42,7 +42,7 @@ MyObject::takeObj()
 }
 
 void
-MyObject::giveObj(std::unique_ptr<cxx_qt::sub_object::SubObject> value)
+MyObject::giveObj(std::unique_ptr<cxx_qt::sub_object::CppObj> value)
 {
   Q_ASSERT(value.get() != m_obj);
 

--- a/cxx-qt-gen/test_outputs/subobject_property.cpp
+++ b/cxx-qt-gen/test_outputs/subobject_property.cpp
@@ -52,10 +52,10 @@ MyObject::giveObj(std::unique_ptr<cxx_qt::sub_object::SubObject> value)
   runOnGUIThread([&]() { Q_EMIT objChanged(); });
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/subobject_property.h
+++ b/cxx-qt-gen/test_outputs/subobject_property.h
@@ -39,7 +39,9 @@ private:
   std::unique_ptr<cxx_qt::sub_object::SubObject> m_ownedObj;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/subobject_property.h
+++ b/cxx-qt-gen/test_outputs/subobject_property.h
@@ -13,19 +13,19 @@ class RustObj;
 class MyObject : public CxxQObject
 {
   Q_OBJECT
-  Q_PROPERTY(cxx_qt::sub_object::SubObject* obj READ getObj WRITE setObj NOTIFY
-               objChanged)
+  Q_PROPERTY(
+    cxx_qt::sub_object::CppObj* obj READ getObj WRITE setObj NOTIFY objChanged)
 
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
 
-  cxx_qt::sub_object::SubObject* getObj() const;
-  std::unique_ptr<cxx_qt::sub_object::SubObject> takeObj();
-  void giveObj(std::unique_ptr<cxx_qt::sub_object::SubObject> value);
+  cxx_qt::sub_object::CppObj* getObj() const;
+  std::unique_ptr<cxx_qt::sub_object::CppObj> takeObj();
+  void giveObj(std::unique_ptr<cxx_qt::sub_object::CppObj> value);
 
 public Q_SLOTS:
-  void setObj(cxx_qt::sub_object::SubObject* value);
+  void setObj(cxx_qt::sub_object::CppObj* value);
 
 Q_SIGNALS:
   void objChanged();
@@ -35,8 +35,8 @@ private:
   std::mutex m_rustObjMutex;
   bool m_initialised = false;
 
-  cxx_qt::sub_object::SubObject* m_obj = nullptr;
-  std::unique_ptr<cxx_qt::sub_object::SubObject> m_ownedObj;
+  cxx_qt::sub_object::CppObj* m_obj = nullptr;
+  std::unique_ptr<cxx_qt::sub_object::CppObj> m_ownedObj;
 };
 
 typedef MyObject CppObj;

--- a/cxx-qt-gen/test_outputs/subobject_property.h
+++ b/cxx-qt-gen/test_outputs/subobject_property.h
@@ -45,3 +45,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/subobject_property.rs
+++ b/cxx-qt-gen/test_outputs/subobject_property.rs
@@ -49,11 +49,11 @@ mod my_object {
 
     impl RustObj {}
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -81,8 +81,8 @@ mod my_object {
     #[derive(Default)]
     struct Data;
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(_value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(_value: &CppObj<'a>) -> Self {
             Self {}
         }
     }
@@ -92,7 +92,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/subobject_property.rs
+++ b/cxx-qt-gen/test_outputs/subobject_property.rs
@@ -87,6 +87,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(_value: &mut CppObj<'a>) -> Self {
+            Self::from(&*_value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/subobject_property.rs
+++ b/cxx-qt-gen/test_outputs/subobject_property.rs
@@ -54,7 +54,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/subobject_property.rs
+++ b/cxx-qt-gen/test_outputs/subobject_property.rs
@@ -19,7 +19,7 @@ mod my_object {
             #[namespace = "CxxQt"]
             type Variant = cxx_qt_lib::Variant;
             #[namespace = "cxx_qt::sub_object"]
-            type SubObject = crate::sub_object::CppObj;
+            type SubObject = crate::sub_object::FFICppObj;
 
             #[rust_name = "take_obj"]
             fn takeObj(self: Pin<&mut MyObject>) -> UniquePtr<SubObject>;
@@ -41,7 +41,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -50,11 +50,11 @@ mod my_object {
     impl RustObj {}
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
@@ -69,7 +69,7 @@ mod my_object {
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -91,7 +91,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/types_primitive_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.cpp
@@ -202,10 +202,10 @@ MyObject::setUint32(quint32 value)
   }
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/types_primitive_property.h
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.h
@@ -76,7 +76,9 @@ private:
   quint32 m_uint32;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/types_primitive_property.h
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.h
@@ -82,3 +82,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -87,7 +87,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -96,11 +96,11 @@ mod my_object {
     impl RustObj {}
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
@@ -179,7 +179,7 @@ mod my_object {
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -240,7 +240,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -236,6 +236,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(value: &mut CppObj<'a>) -> Self {
+            Self::from(&*value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -95,11 +95,11 @@ mod my_object {
 
     impl RustObj {}
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -220,8 +220,8 @@ mod my_object {
         uint_32: u32,
     }
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(value: &CppObj<'a>) -> Self {
             Self {
                 boolean: value.boolean().into(),
                 float_32: value.float_32().into(),
@@ -241,7 +241,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -100,7 +100,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
@@ -17,21 +17,22 @@ QPointF
 MyObject::testPointf(const QPointF& pointf)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return m_rustObj->testPointf(*this, pointf);
+  return m_rustObj->testPointfWrapper(*this, pointf);
 }
 
 QString
 MyObject::testString(const QString& string)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return rustStringToQString(m_rustObj->testString(*this, string));
+  return rustStringToQString(m_rustObj->testStringWrapper(*this, string));
 }
 
 QVariant
 MyObject::testVariant(const QVariant& variant)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return ::CxxQt::rustVariantToQVariant(m_rustObj->testVariant(*this, variant));
+  return ::CxxQt::rustVariantToQVariant(
+    m_rustObj->testVariantWrapper(*this, variant));
 }
 
 std::unique_ptr<MyObject>

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
@@ -35,10 +35,10 @@ MyObject::testVariant(const QVariant& variant)
     m_rustObj->testVariantWrapper(*this, variant));
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.h
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.h
@@ -29,7 +29,9 @@ private:
   bool m_initialised = false;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.h
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.h
@@ -35,3 +35,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -132,6 +132,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(_value: &mut CppObj<'a>) -> Self {
+            Self::from(&*_value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -105,7 +105,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -41,43 +41,43 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
     struct RustObj;
 
     impl RustObj {
-        fn test_pointf(&self, _cpp: std::pin::Pin<&mut CppObj>, pointf: &QPointF) -> QPointF {
+        fn test_pointf(&self, _cpp: std::pin::Pin<&mut FFICppObj>, pointf: &QPointF) -> QPointF {
             pointf
         }
 
         fn test_string(
             &self,
-            _cpp: std::pin::Pin<&mut CppObj>,
+            _cpp: std::pin::Pin<&mut FFICppObj>,
             string: &cxx_qt_lib::QString,
         ) -> String {
             string.to_rust()
         }
 
-        fn test_variant(&self, _cpp: std::pin::Pin<&mut CppObj>, variant: &QVariant) -> Variant {
+        fn test_variant(&self, _cpp: std::pin::Pin<&mut FFICppObj>, variant: &QVariant) -> Variant {
             variant
         }
     }
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -99,7 +99,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -1,4 +1,6 @@
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[cxx::bridge(namespace = "cxx_qt::my_object")]
     mod ffi {
         enum Property {}
@@ -72,7 +74,7 @@ mod my_object {
         fn test_string_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
-            string: &cxx_qt_lib::QString,
+            string: &QString,
         ) -> String {
             let mut _cpp = CppObj::new(_cpp);
             return self.test_string(&mut _cpp, string);
@@ -91,7 +93,7 @@ mod my_object {
             pointf
         }
 
-        fn test_string(&self, _cpp: &mut CppObj, string: &cxx_qt_lib::QString) -> String {
+        fn test_string(&self, _cpp: &mut CppObj, string: &QString) -> String {
             string.to_rust()
         }
 

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -24,14 +24,26 @@ mod my_object {
         extern "Rust" {
             type RustObj;
 
-            #[cxx_name = "testPointf"]
-            fn test_pointf(self: &RustObj, _cpp: Pin<&mut MyObject>, pointf: &QPointF) -> QPointF;
+            #[cxx_name = "testPointfWrapper"]
+            fn test_pointf_wrapper(
+                self: &RustObj,
+                _cpp: Pin<&mut MyObject>,
+                pointf: &QPointF,
+            ) -> QPointF;
 
-            #[cxx_name = "testString"]
-            fn test_string(self: &RustObj, _cpp: Pin<&mut MyObject>, string: &QString) -> String;
+            #[cxx_name = "testStringWrapper"]
+            fn test_string_wrapper(
+                self: &RustObj,
+                _cpp: Pin<&mut MyObject>,
+                string: &QString,
+            ) -> String;
 
-            #[cxx_name = "testVariant"]
-            fn test_variant(self: &RustObj, _cpp: Pin<&mut MyObject>, variant: &QVariant) -> Variant;
+            #[cxx_name = "testVariantWrapper"]
+            fn test_variant_wrapper(
+                self: &RustObj,
+                _cpp: Pin<&mut MyObject>,
+                variant: &QVariant,
+            ) -> Variant;
 
             #[cxx_name = "createRs"]
             fn create_rs() -> Box<RustObj>;
@@ -48,19 +60,42 @@ mod my_object {
     struct RustObj;
 
     impl RustObj {
-        fn test_pointf(&self, _cpp: std::pin::Pin<&mut FFICppObj>, pointf: &QPointF) -> QPointF {
-            pointf
+        fn test_pointf_wrapper(
+            &self,
+            _cpp: std::pin::Pin<&mut FFICppObj>,
+            pointf: &QPointF,
+        ) -> QPointF {
+            let mut _cpp = CppObj::new(_cpp);
+            return self.test_pointf(&mut _cpp, pointf);
         }
 
-        fn test_string(
+        fn test_string_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             string: &cxx_qt_lib::QString,
         ) -> String {
+            let mut _cpp = CppObj::new(_cpp);
+            return self.test_string(&mut _cpp, string);
+        }
+
+        fn test_variant_wrapper(
+            &self,
+            _cpp: std::pin::Pin<&mut FFICppObj>,
+            variant: &QVariant,
+        ) -> Variant {
+            let mut _cpp = CppObj::new(_cpp);
+            return self.test_variant(&mut _cpp, variant);
+        }
+
+        fn test_pointf(&self, _cpp: &mut CppObj, pointf: &QPointF) -> QPointF {
+            pointf
+        }
+
+        fn test_string(&self, _cpp: &mut CppObj, string: &cxx_qt_lib::QString) -> String {
             string.to_rust()
         }
 
-        fn test_variant(&self, _cpp: std::pin::Pin<&mut FFICppObj>, variant: &QVariant) -> Variant {
+        fn test_variant(&self, _cpp: &mut CppObj, variant: &QVariant) -> Variant {
             variant
         }
     }

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -65,11 +65,11 @@ mod my_object {
         }
     }
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -89,8 +89,8 @@ mod my_object {
     #[derive(Default)]
     struct Data;
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(_value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(_value: &CppObj<'a>) -> Self {
             Self {}
         }
     }
@@ -100,7 +100,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/types_qt_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_property.cpp
@@ -76,10 +76,10 @@ MyObject::setVariant(const QVariant& value)
   }
 }
 
-std::unique_ptr<MyObject>
+std::unique_ptr<CppObj>
 newCppObject()
 {
-  return std::make_unique<MyObject>();
+  return std::make_unique<CppObj>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/types_qt_property.h
+++ b/cxx-qt-gen/test_outputs/types_qt_property.h
@@ -53,3 +53,5 @@ std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)

--- a/cxx-qt-gen/test_outputs/types_qt_property.h
+++ b/cxx-qt-gen/test_outputs/types_qt_property.h
@@ -47,7 +47,9 @@ private:
   QVariant m_variant;
 };
 
-std::unique_ptr<MyObject>
+typedef MyObject CppObj;
+
+std::unique_ptr<CppObj>
 newCppObject();
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -64,7 +64,7 @@ mod my_object {
     }
 
     impl<'a> CppObj<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
+        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -128,6 +128,12 @@ mod my_object {
         }
     }
 
+    impl<'a> From<&mut CppObj<'a>> for Data {
+        fn from(value: &mut CppObj<'a>) -> Self {
+            Self::from(&*value)
+        }
+    }
+
     fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -51,7 +51,7 @@ mod my_object {
         }
     }
 
-    pub type CppObj = ffi::MyObject;
+    pub type FFICppObj = ffi::MyObject;
     pub type Property = ffi::Property;
 
     #[derive(Default)]
@@ -60,11 +60,11 @@ mod my_object {
     impl RustObj {}
 
     pub struct CppObjWrapper<'a> {
-        cpp: std::pin::Pin<&'a mut CppObj>,
+        cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
     impl<'a> CppObjWrapper<'a> {
-        fn new(cpp: std::pin::Pin<&'a mut CppObj>) -> Self {
+        fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
 
@@ -95,7 +95,7 @@ mod my_object {
         pub fn update_requester(&self) -> cxx_qt_lib::update_requester::UpdateRequester {
             use cxx_qt_lib::update_requester::{CxxQObject, UpdateRequester};
 
-            let ptr: *const CppObj = unsafe { &*self.cpp.as_ref() };
+            let ptr: *const FFICppObj = unsafe { &*self.cpp.as_ref() };
             unsafe { UpdateRequester::new(ptr as *mut CxxQObject) }
         }
 
@@ -132,7 +132,7 @@ mod my_object {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut CppObj>) {
+    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObjWrapper::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -59,11 +59,11 @@ mod my_object {
 
     impl RustObj {}
 
-    pub struct CppObjWrapper<'a> {
+    pub struct CppObj<'a> {
         cpp: std::pin::Pin<&'a mut FFICppObj>,
     }
 
-    impl<'a> CppObjWrapper<'a> {
+    impl<'a> CppObj<'a> {
         fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
             Self { cpp }
         }
@@ -118,8 +118,8 @@ mod my_object {
         variant: Variant,
     }
 
-    impl<'a> From<&CppObjWrapper<'a>> for Data {
-        fn from(value: &CppObjWrapper<'a>) -> Self {
+    impl<'a> From<&CppObj<'a>> for Data {
+        fn from(value: &CppObj<'a>) -> Self {
             Self {
                 pointf: value.pointf().into(),
                 string: value.string().into(),
@@ -133,7 +133,7 @@ mod my_object {
     }
 
     fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObjWrapper::new(cpp);
+        let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(&Data::default());
     }
 }

--- a/cxx-qt-lib/src/lib.rs
+++ b/cxx-qt-lib/src/lib.rs
@@ -29,7 +29,7 @@ mod map_qt_value;
 pub use map_qt_value::*;
 
 pub trait PropertyChangeHandler<C, P> {
-    fn handle_property_change(&mut self, cpp: std::pin::Pin<&mut C>, property: P);
+    fn handle_property_change(&mut self, cpp: &mut C, property: P);
 }
 /// This mod contains private things that need to technically be pub so that
 /// they can be used inside macros. You should not use anything inside here

--- a/cxx-qt-lib/src/update_requester.rs
+++ b/cxx-qt-lib/src/update_requester.rs
@@ -93,5 +93,5 @@ unsafe impl Send for QPtr {}
 unsafe impl Sync for QPtr {}
 
 pub trait UpdateRequestHandler<C> {
-    fn handle_update_request(&mut self, cpp: std::pin::Pin<&mut C>);
+    fn handle_update_request(&mut self, cpp: &mut C);
 }

--- a/examples/basic_cxx_qt/src/data.rs
+++ b/examples/basic_cxx_qt/src/data.rs
@@ -27,9 +27,8 @@ mod my_data {
 
     impl RustObj {
         #[invokable]
-        fn as_json_str(&self, cpp: Pin<&mut FFICppObj>) -> String {
-            let wrapper = CppObj::new(cpp);
-            let data = Data::from(&wrapper);
+        fn as_json_str(&self, cpp: &mut CppObj) -> String {
+            let data = Data::from(&*cpp);
             serde_json::to_string(&data).unwrap()
         }
     }

--- a/examples/basic_cxx_qt/src/data.rs
+++ b/examples/basic_cxx_qt/src/data.rs
@@ -27,7 +27,7 @@ mod my_data {
 
     impl RustObj {
         #[invokable]
-        fn as_json_str(&self, cpp: Pin<&mut CppObj>) -> String {
+        fn as_json_str(&self, cpp: Pin<&mut FFICppObj>) -> String {
             let wrapper = CppObjWrapper::new(cpp);
             let data = Data::from(&wrapper);
             serde_json::to_string(&data).unwrap()

--- a/examples/basic_cxx_qt/src/data.rs
+++ b/examples/basic_cxx_qt/src/data.rs
@@ -28,7 +28,7 @@ mod my_data {
     impl RustObj {
         #[invokable]
         fn as_json_str(&self, cpp: Pin<&mut FFICppObj>) -> String {
-            let wrapper = CppObjWrapper::new(cpp);
+            let wrapper = CppObj::new(cpp);
             let data = Data::from(&wrapper);
             serde_json::to_string(&data).unwrap()
         }

--- a/examples/basic_cxx_qt/src/data.rs
+++ b/examples/basic_cxx_qt/src/data.rs
@@ -28,7 +28,7 @@ mod my_data {
     impl RustObj {
         #[invokable]
         fn as_json_str(&self, cpp: &mut CppObj) -> String {
-            let data = Data::from(&*cpp);
+            let data = Data::from(cpp);
             serde_json::to_string(&data).unwrap()
         }
     }

--- a/examples/basic_cxx_qt/src/lib.rs
+++ b/examples/basic_cxx_qt/src/lib.rs
@@ -49,7 +49,7 @@ mod my_object {
 
         #[invokable]
         fn request_update_test(&self, cpp: Pin<&mut FFICppObj>) {
-            let wrapper = CppObjWrapper::new(cpp);
+            let wrapper = CppObj::new(cpp);
             let update_requester = wrapper.update_requester();
             update_requester.request_update();
         }

--- a/examples/basic_cxx_qt/src/lib.rs
+++ b/examples/basic_cxx_qt/src/lib.rs
@@ -25,7 +25,7 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn double_number_self(&self, cpp: Pin<&mut CppObj>) {
+        fn double_number_self(&self, cpp: Pin<&mut FFICppObj>) {
             let value = cpp.number() * 2;
             cpp.set_number(value);
         }
@@ -48,7 +48,7 @@ mod my_object {
         }
 
         #[invokable]
-        fn request_update_test(&self, cpp: Pin<&mut CppObj>) {
+        fn request_update_test(&self, cpp: Pin<&mut FFICppObj>) {
             let wrapper = CppObjWrapper::new(cpp);
             let update_requester = wrapper.update_requester();
             update_requester.request_update();
@@ -60,8 +60,8 @@ mod my_object {
         }
     }
 
-    impl UpdateRequestHandler<CppObj> for RustObj {
-        fn handle_update_request(&mut self, _cpp: Pin<&mut CppObj>) {
+    impl UpdateRequestHandler<FFICppObj> for RustObj {
+        fn handle_update_request(&mut self, _cpp: Pin<&mut FFICppObj>) {
             self.update_call_count += 1;
         }
     }

--- a/examples/basic_cxx_qt/src/lib.rs
+++ b/examples/basic_cxx_qt/src/lib.rs
@@ -25,7 +25,7 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn double_number_self(&self, cpp: Pin<&mut FFICppObj>) {
+        fn double_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number() * 2;
             cpp.set_number(value);
         }
@@ -48,9 +48,8 @@ mod my_object {
         }
 
         #[invokable]
-        fn request_update_test(&self, cpp: Pin<&mut FFICppObj>) {
-            let wrapper = CppObj::new(cpp);
-            let update_requester = wrapper.update_requester();
+        fn request_update_test(&self, cpp: &mut CppObj) {
+            let update_requester = cpp.update_requester();
             update_requester.request_update();
         }
 

--- a/examples/basic_cxx_qt/src/lib.rs
+++ b/examples/basic_cxx_qt/src/lib.rs
@@ -31,7 +31,7 @@ mod my_object {
         }
 
         #[invokable]
-        fn double_number_sub(&self, sub: Pin<&mut crate::sub::sub_object::SubObject>) {
+        fn double_number_sub(&self, sub: &mut crate::sub::sub_object::CppObj) {
             let value = sub.number() * 2;
             sub.set_number(value);
         }

--- a/examples/basic_cxx_qt/src/lib.rs
+++ b/examples/basic_cxx_qt/src/lib.rs
@@ -11,6 +11,8 @@ mod types;
 
 #[make_qobject]
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     pub struct Data {
         number: i32,

--- a/examples/basic_cxx_qt/src/lib.rs
+++ b/examples/basic_cxx_qt/src/lib.rs
@@ -15,7 +15,7 @@ mod my_object {
     pub struct Data {
         number: i32,
         string: String,
-        sub: crate::sub::sub_object::SubObject,
+        sub: crate::sub::sub_object::CppObj,
     }
 
     #[derive(Default)]

--- a/examples/basic_cxx_qt/src/lib.rs
+++ b/examples/basic_cxx_qt/src/lib.rs
@@ -59,8 +59,8 @@ mod my_object {
         }
     }
 
-    impl UpdateRequestHandler<FFICppObj> for RustObj {
-        fn handle_update_request(&mut self, _cpp: Pin<&mut FFICppObj>) {
+    impl UpdateRequestHandler<CppObj<'_>> for RustObj {
+        fn handle_update_request(&mut self, _cpp: &mut CppObj) {
             self.update_call_count += 1;
         }
     }

--- a/examples/basic_cxx_qt/src/sub.rs
+++ b/examples/basic_cxx_qt/src/sub.rs
@@ -7,6 +7,8 @@ use cxx_qt::make_qobject;
 
 #[make_qobject]
 pub mod sub_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     pub struct Data {
         number: i32,

--- a/examples/basic_cxx_qt/src/sub.rs
+++ b/examples/basic_cxx_qt/src/sub.rs
@@ -18,7 +18,7 @@ pub mod sub_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: Pin<&mut CppObj>) {
+        fn increment_number_self(&self, cpp: Pin<&mut FFICppObj>) {
             let value = cpp.number();
             cpp.set_number(value + 1);
         }

--- a/examples/basic_cxx_qt/src/sub.rs
+++ b/examples/basic_cxx_qt/src/sub.rs
@@ -18,7 +18,7 @@ pub mod sub_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: Pin<&mut FFICppObj>) {
+        fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number();
             cpp.set_number(value + 1);
         }

--- a/examples/basic_cxx_qt_qml/src/data.rs
+++ b/examples/basic_cxx_qt_qml/src/data.rs
@@ -27,9 +27,8 @@ mod my_data {
 
     impl RustObj {
         #[invokable]
-        fn as_json_str(&self, cpp: Pin<&mut FFICppObj>) -> String {
-            let wrapper = CppObj::new(cpp);
-            let data = Data::from(&wrapper);
+        fn as_json_str(&self, cpp: &mut CppObj) -> String {
+            let data = Data::from(&*cpp);
             serde_json::to_string(&data).unwrap()
         }
     }

--- a/examples/basic_cxx_qt_qml/src/data.rs
+++ b/examples/basic_cxx_qt_qml/src/data.rs
@@ -27,7 +27,7 @@ mod my_data {
 
     impl RustObj {
         #[invokable]
-        fn as_json_str(&self, cpp: Pin<&mut CppObj>) -> String {
+        fn as_json_str(&self, cpp: Pin<&mut FFICppObj>) -> String {
             let wrapper = CppObjWrapper::new(cpp);
             let data = Data::from(&wrapper);
             serde_json::to_string(&data).unwrap()

--- a/examples/basic_cxx_qt_qml/src/data.rs
+++ b/examples/basic_cxx_qt_qml/src/data.rs
@@ -28,7 +28,7 @@ mod my_data {
     impl RustObj {
         #[invokable]
         fn as_json_str(&self, cpp: Pin<&mut FFICppObj>) -> String {
-            let wrapper = CppObjWrapper::new(cpp);
+            let wrapper = CppObj::new(cpp);
             let data = Data::from(&wrapper);
             serde_json::to_string(&data).unwrap()
         }

--- a/examples/basic_cxx_qt_qml/src/data.rs
+++ b/examples/basic_cxx_qt_qml/src/data.rs
@@ -28,7 +28,7 @@ mod my_data {
     impl RustObj {
         #[invokable]
         fn as_json_str(&self, cpp: &mut CppObj) -> String {
-            let data = Data::from(&*cpp);
+            let data = Data::from(cpp);
             serde_json::to_string(&data).unwrap()
         }
     }

--- a/examples/basic_cxx_qt_qml/src/lib.rs
+++ b/examples/basic_cxx_qt_qml/src/lib.rs
@@ -16,7 +16,7 @@ mod my_object {
     pub struct Data {
         number: i32,
         string: String,
-        sub: crate::sub::sub_object::SubObject,
+        sub: crate::sub::sub_object::CppObj,
     }
 
     #[derive(Default)]

--- a/examples/basic_cxx_qt_qml/src/lib.rs
+++ b/examples/basic_cxx_qt_qml/src/lib.rs
@@ -24,7 +24,7 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: Pin<&mut FFICppObj>) {
+        fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number() + 1;
             cpp.set_number(value);
         }

--- a/examples/basic_cxx_qt_qml/src/lib.rs
+++ b/examples/basic_cxx_qt_qml/src/lib.rs
@@ -24,7 +24,7 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: Pin<&mut CppObj>) {
+        fn increment_number_self(&self, cpp: Pin<&mut FFICppObj>) {
             let value = cpp.number() + 1;
             cpp.set_number(value);
         }

--- a/examples/basic_cxx_qt_qml/src/lib.rs
+++ b/examples/basic_cxx_qt_qml/src/lib.rs
@@ -12,6 +12,8 @@ pub mod sub;
 
 #[make_qobject]
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     pub struct Data {
         number: i32,

--- a/examples/basic_cxx_qt_qml/src/lib.rs
+++ b/examples/basic_cxx_qt_qml/src/lib.rs
@@ -30,7 +30,7 @@ mod my_object {
         }
 
         #[invokable]
-        fn increment_number_sub(&self, sub: Pin<&mut crate::sub::sub_object::SubObject>) {
+        fn increment_number_sub(&self, sub: &mut crate::sub::sub_object::CppObj) {
             let value = sub.number() + 1;
             sub.set_number(value);
         }

--- a/examples/basic_cxx_qt_qml/src/mock_qt_types.rs
+++ b/examples/basic_cxx_qt_qml/src/mock_qt_types.rs
@@ -30,7 +30,7 @@ mod mock_qt_types {
     impl RustObj {
         #[invokable]
         fn test_pointf_property(&self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObjWrapper::new(cpp);
+            let mut wrapper = CppObj::new(cpp);
             let mut point = *wrapper.pointf();
             point.set_x(point.x() * 2.0);
             point.set_y(point.y() * 2.0);
@@ -47,7 +47,7 @@ mod mock_qt_types {
 
         #[invokable]
         fn test_variant_property(&self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObjWrapper::new(cpp);
+            let mut wrapper = CppObj::new(cpp);
             match *wrapper.variant().to_rust() {
                 VariantImpl::Bool(b) => {
                     let new_variant = Variant::from_bool(!b);

--- a/examples/basic_cxx_qt_qml/src/mock_qt_types.rs
+++ b/examples/basic_cxx_qt_qml/src/mock_qt_types.rs
@@ -29,12 +29,11 @@ mod mock_qt_types {
 
     impl RustObj {
         #[invokable]
-        fn test_pointf_property(&self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObj::new(cpp);
-            let mut point = *wrapper.pointf();
+        fn test_pointf_property(&self, cpp: &mut CppObj) {
+            let mut point = *cpp.pointf();
             point.set_x(point.x() * 2.0);
             point.set_y(point.y() * 2.0);
-            wrapper.set_pointf(&point);
+            cpp.set_pointf(&point);
         }
 
         #[invokable]
@@ -46,18 +45,17 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_variant_property(&self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObj::new(cpp);
-            match *wrapper.variant().to_rust() {
+        fn test_variant_property(&self, cpp: &mut CppObj) {
+            match *cpp.variant().to_rust() {
                 VariantImpl::Bool(b) => {
                     let new_variant = Variant::from_bool(!b);
                     let_qvariant!(new_qvariant = &new_variant);
-                    wrapper.set_variant(&new_qvariant);
+                    cpp.set_variant(&new_qvariant);
                 }
                 VariantImpl::Int(i) => {
                     let new_variant = Variant::from_int(i * 2);
                     let_qvariant!(new_qvariant = &new_variant);
-                    wrapper.set_variant(&new_qvariant);
+                    cpp.set_variant(&new_qvariant);
                 }
                 _ => panic!("Incorrect variant type!"),
             }

--- a/examples/basic_cxx_qt_qml/src/mock_qt_types.rs
+++ b/examples/basic_cxx_qt_qml/src/mock_qt_types.rs
@@ -29,7 +29,7 @@ mod mock_qt_types {
 
     impl RustObj {
         #[invokable]
-        fn test_pointf_property(&self, cpp: Pin<&mut CppObj>) {
+        fn test_pointf_property(&self, cpp: Pin<&mut FFICppObj>) {
             let mut wrapper = CppObjWrapper::new(cpp);
             let mut point = *wrapper.pointf();
             point.set_x(point.x() * 2.0);
@@ -46,7 +46,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_variant_property(&self, cpp: Pin<&mut CppObj>) {
+        fn test_variant_property(&self, cpp: Pin<&mut FFICppObj>) {
             let mut wrapper = CppObjWrapper::new(cpp);
             match *wrapper.variant().to_rust() {
                 VariantImpl::Bool(b) => {

--- a/examples/basic_cxx_qt_qml/src/sub.rs
+++ b/examples/basic_cxx_qt_qml/src/sub.rs
@@ -7,6 +7,8 @@ use cxx_qt::make_qobject;
 
 #[make_qobject]
 pub mod sub_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     pub struct Data {
         number: i32,

--- a/examples/basic_cxx_qt_qml/src/sub.rs
+++ b/examples/basic_cxx_qt_qml/src/sub.rs
@@ -18,7 +18,7 @@ pub mod sub_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: Pin<&mut CppObj>) {
+        fn increment_number_self(&self, cpp: Pin<&mut FFICppObj>) {
             let value = cpp.number();
             cpp.set_number(value + 1);
         }

--- a/examples/basic_cxx_qt_qml/src/sub.rs
+++ b/examples/basic_cxx_qt_qml/src/sub.rs
@@ -18,7 +18,7 @@ pub mod sub_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: Pin<&mut FFICppObj>) {
+        fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number();
             cpp.set_number(value + 1);
         }

--- a/examples/basic_cxx_qt_qml_plugin/src/data.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/data.rs
@@ -27,9 +27,8 @@ mod my_data {
 
     impl RustObj {
         #[invokable]
-        fn as_json_str(&self, cpp: Pin<&mut FFICppObj>) -> String {
-            let wrapper = CppObj::new(cpp);
-            let data = Data::from(&wrapper);
+        fn as_json_str(&self, cpp: &mut CppObj) -> String {
+            let data = Data::from(&*cpp);
             serde_json::to_string(&data).unwrap()
         }
     }

--- a/examples/basic_cxx_qt_qml_plugin/src/data.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/data.rs
@@ -27,7 +27,7 @@ mod my_data {
 
     impl RustObj {
         #[invokable]
-        fn as_json_str(&self, cpp: Pin<&mut CppObj>) -> String {
+        fn as_json_str(&self, cpp: Pin<&mut FFICppObj>) -> String {
             let wrapper = CppObjWrapper::new(cpp);
             let data = Data::from(&wrapper);
             serde_json::to_string(&data).unwrap()

--- a/examples/basic_cxx_qt_qml_plugin/src/data.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/data.rs
@@ -28,7 +28,7 @@ mod my_data {
     impl RustObj {
         #[invokable]
         fn as_json_str(&self, cpp: Pin<&mut FFICppObj>) -> String {
-            let wrapper = CppObjWrapper::new(cpp);
+            let wrapper = CppObj::new(cpp);
             let data = Data::from(&wrapper);
             serde_json::to_string(&data).unwrap()
         }

--- a/examples/basic_cxx_qt_qml_plugin/src/data.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/data.rs
@@ -28,7 +28,7 @@ mod my_data {
     impl RustObj {
         #[invokable]
         fn as_json_str(&self, cpp: &mut CppObj) -> String {
-            let data = Data::from(&*cpp);
+            let data = Data::from(cpp);
             serde_json::to_string(&data).unwrap()
         }
     }

--- a/examples/basic_cxx_qt_qml_plugin/src/lib.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/lib.rs
@@ -16,7 +16,7 @@ mod my_object {
     pub struct Data {
         number: i32,
         string: String,
-        sub: crate::sub::sub_object::SubObject,
+        sub: crate::sub::sub_object::CppObj,
     }
 
     #[derive(Default)]

--- a/examples/basic_cxx_qt_qml_plugin/src/lib.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/lib.rs
@@ -24,7 +24,7 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: Pin<&mut FFICppObj>) {
+        fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number() + 1;
             cpp.set_number(value);
         }

--- a/examples/basic_cxx_qt_qml_plugin/src/lib.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/lib.rs
@@ -24,7 +24,7 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: Pin<&mut CppObj>) {
+        fn increment_number_self(&self, cpp: Pin<&mut FFICppObj>) {
             let value = cpp.number() + 1;
             cpp.set_number(value);
         }

--- a/examples/basic_cxx_qt_qml_plugin/src/lib.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/lib.rs
@@ -12,6 +12,8 @@ pub mod sub;
 
 #[make_qobject]
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     pub struct Data {
         number: i32,

--- a/examples/basic_cxx_qt_qml_plugin/src/lib.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/lib.rs
@@ -30,7 +30,7 @@ mod my_object {
         }
 
         #[invokable]
-        fn increment_number_sub(&self, sub: Pin<&mut crate::sub::sub_object::SubObject>) {
+        fn increment_number_sub(&self, sub: &mut crate::sub::sub_object::CppObj) {
             let value = sub.number() + 1;
             sub.set_number(value);
         }

--- a/examples/basic_cxx_qt_qml_plugin/src/mock_qt_types.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/mock_qt_types.rs
@@ -30,7 +30,7 @@ mod mock_qt_types {
     impl RustObj {
         #[invokable]
         fn test_pointf_property(&self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObjWrapper::new(cpp);
+            let mut wrapper = CppObj::new(cpp);
             let mut point = *wrapper.pointf();
             point.set_x(point.x() * 2.0);
             point.set_y(point.y() * 2.0);
@@ -47,7 +47,7 @@ mod mock_qt_types {
 
         #[invokable]
         fn test_variant_property(&self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObjWrapper::new(cpp);
+            let mut wrapper = CppObj::new(cpp);
             match *wrapper.variant().to_rust() {
                 VariantImpl::Bool(b) => {
                     let new_variant = Variant::from_bool(!b);

--- a/examples/basic_cxx_qt_qml_plugin/src/mock_qt_types.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/mock_qt_types.rs
@@ -29,12 +29,11 @@ mod mock_qt_types {
 
     impl RustObj {
         #[invokable]
-        fn test_pointf_property(&self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObj::new(cpp);
-            let mut point = *wrapper.pointf();
+        fn test_pointf_property(&self, cpp: &mut CppObj) {
+            let mut point = *cpp.pointf();
             point.set_x(point.x() * 2.0);
             point.set_y(point.y() * 2.0);
-            wrapper.set_pointf(&point);
+            cpp.set_pointf(&point);
         }
 
         #[invokable]
@@ -46,18 +45,17 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_variant_property(&self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObj::new(cpp);
-            match *wrapper.variant().to_rust() {
+        fn test_variant_property(&self, cpp: &mut CppObj) {
+            match *cpp.variant().to_rust() {
                 VariantImpl::Bool(b) => {
                     let new_variant = Variant::from_bool(!b);
                     let_qvariant!(new_qvariant = &new_variant);
-                    wrapper.set_variant(&new_qvariant);
+                    cpp.set_variant(&new_qvariant);
                 }
                 VariantImpl::Int(i) => {
                     let new_variant = Variant::from_int(i * 2);
                     let_qvariant!(new_qvariant = &new_variant);
-                    wrapper.set_variant(&new_qvariant);
+                    cpp.set_variant(&new_qvariant);
                 }
                 _ => panic!("Incorrect variant type!"),
             }

--- a/examples/basic_cxx_qt_qml_plugin/src/mock_qt_types.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/mock_qt_types.rs
@@ -29,7 +29,7 @@ mod mock_qt_types {
 
     impl RustObj {
         #[invokable]
-        fn test_pointf_property(&self, cpp: Pin<&mut CppObj>) {
+        fn test_pointf_property(&self, cpp: Pin<&mut FFICppObj>) {
             let mut wrapper = CppObjWrapper::new(cpp);
             let mut point = *wrapper.pointf();
             point.set_x(point.x() * 2.0);
@@ -46,7 +46,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_variant_property(&self, cpp: Pin<&mut CppObj>) {
+        fn test_variant_property(&self, cpp: Pin<&mut FFICppObj>) {
             let mut wrapper = CppObjWrapper::new(cpp);
             match *wrapper.variant().to_rust() {
                 VariantImpl::Bool(b) => {

--- a/examples/basic_cxx_qt_qml_plugin/src/sub.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/sub.rs
@@ -7,6 +7,8 @@ use cxx_qt::make_qobject;
 
 #[make_qobject]
 pub mod sub_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     pub struct Data {
         number: i32,

--- a/examples/basic_cxx_qt_qml_plugin/src/sub.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/sub.rs
@@ -18,7 +18,7 @@ pub mod sub_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: Pin<&mut CppObj>) {
+        fn increment_number_self(&self, cpp: Pin<&mut FFICppObj>) {
             let value = cpp.number();
             cpp.set_number(value + 1);
         }

--- a/examples/basic_cxx_qt_qml_plugin/src/sub.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/sub.rs
@@ -18,7 +18,7 @@ pub mod sub_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: Pin<&mut FFICppObj>) {
+        fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number();
             cpp.set_number(value + 1);
         }

--- a/examples/minimal_cxx_qt_qml/src/lib.rs
+++ b/examples/minimal_cxx_qt_qml/src/lib.rs
@@ -18,9 +18,8 @@ mod my_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number(&self, cpp: Pin<&mut CppObj>) {
-            let mut wrapper = CppObjWrapper::new(cpp);
-            wrapper.set_number(wrapper.number() + 1);
+        fn increment_number(&self, cpp: &mut CppObj) {
+            cpp.set_number(cpp.number() + 1);
         }
 
         #[invokable]

--- a/examples/minimal_cxx_qt_qml/src/lib.rs
+++ b/examples/minimal_cxx_qt_qml/src/lib.rs
@@ -7,6 +7,8 @@ use cxx_qt::make_qobject;
 
 #[make_qobject]
 mod my_object {
+    use cxx_qt_lib::QString;
+
     #[derive(Default)]
     pub struct Data {
         number: i32,

--- a/examples/qml_with_threaded_logic/src/lib.rs
+++ b/examples/qml_with_threaded_logic/src/lib.rs
@@ -113,24 +113,20 @@ mod website {
         }
     }
 
-    impl UpdateRequestHandler<FFICppObj> for RustObj {
-        fn handle_update_request(&mut self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObj::new(cpp);
-
+    impl UpdateRequestHandler<CppObj<'_>> for RustObj {
+        fn handle_update_request(&mut self, cpp: &mut CppObj) {
             while let Some(event) = self.event_queue.next().now_or_never() {
                 if let Some(event) = event {
-                    self.process_event(&event, &mut wrapper);
+                    self.process_event(&event, cpp);
                 }
             }
         }
     }
 
-    impl PropertyChangeHandler<FFICppObj, Property> for RustObj {
-        fn handle_property_change(&mut self, cpp: Pin<&mut FFICppObj>, property: Property) {
-            let mut wrapper = CppObj::new(cpp);
-
+    impl PropertyChangeHandler<CppObj<'_>, Property> for RustObj {
+        fn handle_property_change(&mut self, cpp: &mut CppObj, property: Property) {
             match property {
-                Property::Url => self.refresh_title(&mut wrapper),
+                Property::Url => self.refresh_title(cpp),
                 Property::Title => println!("title changed"),
                 _ => unreachable!(),
             }

--- a/examples/qml_with_threaded_logic/src/lib.rs
+++ b/examples/qml_with_threaded_logic/src/lib.rs
@@ -58,7 +58,7 @@ mod website {
 
     impl RustObj {
         #[invokable]
-        fn change_url(&self, cpp: Pin<&mut CppObj>) {
+        fn change_url(&self, cpp: Pin<&mut FFICppObj>) {
             let mut wrapper = CppObjWrapper::new(cpp);
 
             let url = wrapper.url().to_rust();
@@ -69,7 +69,7 @@ mod website {
         }
 
         #[invokable]
-        fn refresh_title(&self, cpp: Pin<&mut CppObj>) {
+        fn refresh_title(&self, cpp: Pin<&mut FFICppObj>) {
             let mut wrapper = CppObjWrapper::new(cpp);
 
             // TODO: SeqCst is probably not the most efficient solution
@@ -117,8 +117,8 @@ mod website {
         }
     }
 
-    impl UpdateRequestHandler<CppObj> for RustObj {
-        fn handle_update_request(&mut self, cpp: Pin<&mut CppObj>) {
+    impl UpdateRequestHandler<FFICppObj> for RustObj {
+        fn handle_update_request(&mut self, cpp: Pin<&mut FFICppObj>) {
             let mut wrapper = CppObjWrapper::new(cpp);
 
             while let Some(event) = self.event_queue.next().now_or_never() {
@@ -129,8 +129,8 @@ mod website {
         }
     }
 
-    impl PropertyChangeHandler<CppObj, Property> for RustObj {
-        fn handle_property_change(&mut self, cpp: Pin<&mut CppObj>, property: Property) {
+    impl PropertyChangeHandler<FFICppObj, Property> for RustObj {
+        fn handle_property_change(&mut self, cpp: Pin<&mut FFICppObj>, property: Property) {
             match property {
                 Property::Url => self.refresh_title(cpp),
                 Property::Title => println!("title changed"),

--- a/examples/qml_with_threaded_logic/src/lib.rs
+++ b/examples/qml_with_threaded_logic/src/lib.rs
@@ -59,7 +59,7 @@ mod website {
     impl RustObj {
         #[invokable]
         fn change_url(&self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObjWrapper::new(cpp);
+            let mut wrapper = CppObj::new(cpp);
 
             let url = wrapper.url().to_rust();
             let new_url = if url == "known" { "unknown" } else { "known" };
@@ -70,7 +70,7 @@ mod website {
 
         #[invokable]
         fn refresh_title(&self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObjWrapper::new(cpp);
+            let mut wrapper = CppObj::new(cpp);
 
             // TODO: SeqCst is probably not the most efficient solution
             let new_load =
@@ -106,7 +106,7 @@ mod website {
             thread::spawn(move || block_on(fetch_title));
         }
 
-        fn process_event(&mut self, event: &Event, cpp: &mut CppObjWrapper) {
+        fn process_event(&mut self, event: &Event, cpp: &mut CppObj) {
             match event {
                 Event::TitleArrived(title) => {
                     let_qstring!(s = title);
@@ -119,7 +119,7 @@ mod website {
 
     impl UpdateRequestHandler<FFICppObj> for RustObj {
         fn handle_update_request(&mut self, cpp: Pin<&mut FFICppObj>) {
-            let mut wrapper = CppObjWrapper::new(cpp);
+            let mut wrapper = CppObj::new(cpp);
 
             while let Some(event) = self.event_queue.next().now_or_never() {
                 if let Some(event) = event {


### PR DESCRIPTION
- [X] Add CppObj type
- [x] Use typedef on C++ so we have CppObj there as well (simplifies generation and allows custom Cpp class naming)
- [x] Support external modules for CppObj in inovkables
- [x] Support external modules for CppObj in properties ? (currently this is Ptr)
- [x] Support CppObj for traits (HandlePropertyChange and HandleUpdateRequest)
- [x] Remove unused types and code (Ptr and Pin ?)

Closes #8 