### PR TITLE
examples: fix qpointf test to ensure it uses y property

### DIFF
--- a/examples/basic_cxx_qt_qml/src/mock_qt_types.rs
+++ b/examples/basic_cxx_qt_qml/src/mock_qt_types.rs
@@ -18,7 +18,7 @@ mod mock_qt_types {
     impl Default for Data {
         fn default() -> Self {
             Data {
-                pointf: QPointF::new(1.0, 2.0),
+                pointf: QPointF::new(1.0, 3.0),
                 variant: Variant::from_int(1),
             }
         }
@@ -32,7 +32,7 @@ mod mock_qt_types {
         fn test_pointf_property(&self, cpp: &mut CppObj) {
             let mut point = *cpp.pointf();
             point.set_x(point.x() * 2.0);
-            point.set_y(point.y() * 2.0);
+            point.set_y(point.y() * 3.0);
             cpp.set_pointf(&point);
         }
 
@@ -40,7 +40,7 @@ mod mock_qt_types {
         fn test_pointf_invokable(&self, point: &QPointF) -> QPointF {
             let mut point = *point;
             point.set_x(point.x() * 2.0);
-            point.set_y(point.y() * 2.0);
+            point.set_y(point.y() * 3.0);
             point
         }
 

--- a/examples/basic_cxx_qt_qml/src/mock_qt_types.rs
+++ b/examples/basic_cxx_qt_qml/src/mock_qt_types.rs
@@ -40,7 +40,7 @@ mod mock_qt_types {
         fn test_pointf_invokable(&self, point: &QPointF) -> QPointF {
             let mut point = *point;
             point.set_x(point.x() * 2.0);
-            point.set_y(point.x() * 2.0);
+            point.set_y(point.y() * 2.0);
             point
         }
 

--- a/examples/basic_cxx_qt_qml/src/tests/qttypes/tst_qttypes.qml
+++ b/examples/basic_cxx_qt_qml/src/tests/qttypes/tst_qttypes.qml
@@ -36,20 +36,20 @@ TestCase {
             signalName: "pointfChanged",
             target: mock,
         });
-        compare(mock.pointf, Qt.point(1, 2));
+        compare(mock.pointf, Qt.point(1, 3));
 
         compare(spy.count, 0);
-        mock.pointf = Qt.point(10, 20);
+        mock.pointf = Qt.point(10, 30);
         tryCompare(spy, "count", 1);
-        compare(mock.pointf, Qt.point(10, 20));
+        compare(mock.pointf, Qt.point(10, 30));
     }
 
     // Check that we can pass the type as a parameter and return it back
     function test_qpointf_invokable() {
         const mock = createTemporaryObject(componentMockQtTypes, null, {});
 
-        const result = mock.testPointfInvokable(Qt.point(10, 20));
-        compare(result, Qt.point(20, 40));
+        const result = mock.testPointfInvokable(Qt.point(10, 30));
+        compare(result, Qt.point(20, 90));
     }
 
     // Check that an invokable can adjust (read and write) a property for the type
@@ -61,9 +61,9 @@ TestCase {
         });
 
         compare(spy.count, 0);
-        compare(mock.pointf, Qt.point(1, 2));
+        compare(mock.pointf, Qt.point(1, 3));
         mock.testPointfProperty();
-        compare(mock.pointf, Qt.point(2, 4));
+        compare(mock.pointf, Qt.point(2, 9));
         tryCompare(spy, "count", 1);
     }
 

--- a/examples/basic_cxx_qt_qml_plugin/src/mock_qt_types.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/mock_qt_types.rs
@@ -18,7 +18,7 @@ mod mock_qt_types {
     impl Default for Data {
         fn default() -> Self {
             Data {
-                pointf: QPointF::new(1.0, 2.0),
+                pointf: QPointF::new(1.0, 3.0),
                 variant: Variant::from_int(1),
             }
         }
@@ -32,7 +32,7 @@ mod mock_qt_types {
         fn test_pointf_property(&self, cpp: &mut CppObj) {
             let mut point = *cpp.pointf();
             point.set_x(point.x() * 2.0);
-            point.set_y(point.y() * 2.0);
+            point.set_y(point.y() * 3.0);
             cpp.set_pointf(&point);
         }
 
@@ -40,7 +40,7 @@ mod mock_qt_types {
         fn test_pointf_invokable(&self, point: &QPointF) -> QPointF {
             let mut point = *point;
             point.set_x(point.x() * 2.0);
-            point.set_y(point.y() * 2.0);
+            point.set_y(point.y() * 3.0);
             point
         }
 

--- a/examples/basic_cxx_qt_qml_plugin/src/mock_qt_types.rs
+++ b/examples/basic_cxx_qt_qml_plugin/src/mock_qt_types.rs
@@ -40,7 +40,7 @@ mod mock_qt_types {
         fn test_pointf_invokable(&self, point: &QPointF) -> QPointF {
             let mut point = *point;
             point.set_x(point.x() * 2.0);
-            point.set_y(point.x() * 2.0);
+            point.set_y(point.y() * 2.0);
             point
         }
 

--- a/examples/basic_cxx_qt_qml_plugin/src/tests/tst_qttypes.qml
+++ b/examples/basic_cxx_qt_qml_plugin/src/tests/tst_qttypes.qml
@@ -36,20 +36,20 @@ TestCase {
             signalName: "pointfChanged",
             target: mock,
         });
-        compare(mock.pointf, Qt.point(1, 2));
+        compare(mock.pointf, Qt.point(1, 3));
 
         compare(spy.count, 0);
-        mock.pointf = Qt.point(10, 20);
+        mock.pointf = Qt.point(10, 30);
         tryCompare(spy, "count", 1);
-        compare(mock.pointf, Qt.point(10, 20));
+        compare(mock.pointf, Qt.point(10, 30));
     }
 
     // Check that we can pass the type as a parameter and return it back
     function test_pointf_invokable() {
         const mock = createTemporaryObject(componentMockQtTypes, null, {});
 
-        const result = mock.testPointfInvokable(Qt.point(10, 20));
-        compare(result, Qt.point(20, 40));
+        const result = mock.testPointfInvokable(Qt.point(10, 30));
+        compare(result, Qt.point(20, 90));
     }
 
     // Check that an invokable can adjust (read and write) a property for the type
@@ -61,9 +61,9 @@ TestCase {
         });
 
         compare(spy.count, 0);
-        compare(mock.pointf, Qt.point(1, 2));
+        compare(mock.pointf, Qt.point(1, 3));
         mock.testPointfProperty();
-        compare(mock.pointf, Qt.point(2, 4));
+        compare(mock.pointf, Qt.point(2, 9));
         tryCompare(spy, "count", 1);
     }
 


### PR DESCRIPTION
Change-Id: Ie3d7048f35807ca790dfb6567e7d3e9d77910156