### PR TITLE
gen_cpp: fix new clippy 1.58 warnings

### DIFF
--- a/cxx-qt-gen/src/gen_cpp.rs
+++ b/cxx-qt-gen/src/gen_cpp.rs
@@ -385,7 +385,7 @@ fn generate_invokables_cpp(
             // we are passing *this across for cpp objects in rust.
             header: format!(
                 "Q_INVOKABLE {return_ident} {ident}({parameter_types});",
-                ident = invokable.ident.cpp_ident.to_string(),
+                ident = invokable.ident.cpp_ident,
                 parameter_types = parameter_arg_line,
                 return_ident = return_ident,
             ),


### PR DESCRIPTION
Change-Id: I17db117ad7a3344fa11d303011bde09cbdfd404d