### PR TITLE
invokable: support &mut self and self for invokables

### DIFF
--- a/cxx-qt-gen/test_inputs/basic_only_invokable.rs
+++ b/cxx-qt-gen/test_inputs/basic_only_invokable.rs
@@ -18,6 +18,11 @@ mod my_object {
             println!("Bye from Rust!");
         }
 
+        #[invokable]
+        fn mutable_invokable(&mut self) {
+            println!("This method is mutable!");
+        }
+
         fn plain_old_method(&self) {
             println!("QML can't call this :)");
         }

--- a/cxx-qt-gen/test_inputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_inputs/basic_pin_invokable.rs
@@ -14,7 +14,7 @@ mod my_object {
         }
 
         #[invokable]
-        fn say_bye(&self, _cpp: &mut CppObj) {
+        fn say_bye(&mut self, _cpp: &mut CppObj) {
             println!("Bye from Rust!");
         }
     }

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.cpp
@@ -27,6 +27,13 @@ MyObject::sayBye()
   m_rustObj->sayBye();
 }
 
+void
+MyObject::mutableInvokable()
+{
+  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
+  m_rustObj->mutableInvokable();
+}
+
 std::unique_ptr<CppObj>
 newCppObject()
 {

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.h
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.h
@@ -18,6 +18,7 @@ public:
 
   Q_INVOKABLE void sayHi(const QString& string, qint32 number);
   Q_INVOKABLE void sayBye();
+  Q_INVOKABLE void mutableInvokable();
 
 private:
   rust::Box<RustObj> m_rustObj;

--- a/cxx-qt-gen/test_outputs/basic_only_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_only_invokable.rs
@@ -47,6 +47,8 @@ mod my_object {
             fn say_hi(self: &RustObj, string: &QString, number: i32);
             #[cxx_name = "sayBye"]
             fn say_bye(self: &RustObj);
+            #[cxx_name = "mutableInvokable"]
+            fn mutable_invokable(self: &mut RustObj);
 
             #[cxx_name = "createRs"]
             fn create_rs() -> Box<RustObj>;
@@ -71,6 +73,10 @@ mod my_object {
 
         fn say_bye(&self) {
             println!("Bye from Rust!");
+        }
+
+        fn mutable_invokable(&mut self) {
+            println!("This method is mutable!");
         }
 
         fn plain_old_method(&self) {

--- a/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
+++ b/cxx-qt-gen/test_outputs/basic_pin_invokable.rs
@@ -51,7 +51,7 @@ mod my_object {
                 number: i32,
             );
             #[cxx_name = "sayByeWrapper"]
-            fn say_bye_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>);
+            fn say_bye_wrapper(self: &mut RustObj, _cpp: Pin<&mut MyObject>);
 
             #[cxx_name = "createRs"]
             fn create_rs() -> Box<RustObj>;
@@ -77,7 +77,7 @@ mod my_object {
             return self.say_hi(&mut _cpp, string, number);
         }
 
-        fn say_bye_wrapper(&self, _cpp: std::pin::Pin<&mut FFICppObj>) {
+        fn say_bye_wrapper(&mut self, _cpp: std::pin::Pin<&mut FFICppObj>) {
             let mut _cpp = CppObj::new(_cpp);
             return self.say_bye(&mut _cpp);
         }
@@ -89,7 +89,7 @@ mod my_object {
             );
         }
 
-        fn say_bye(&self, _cpp: &mut CppObj) {
+        fn say_bye(&mut self, _cpp: &mut CppObj) {
             println!("Bye from Rust!");
         }
     }

--- a/examples/qml_features/src/rust_obj_invokables.rs
+++ b/examples/qml_features/src/rust_obj_invokables.rs
@@ -35,18 +35,15 @@ pub mod rust_obj_invokables {
             self.rust_only_field
         }
 
-        // TODO: We need mutable invokable support for this
-        // https://github.com/KDAB/cxx-qt/pull/76
-        //
-        // #[invokable]
-        // fn invokable_multiply(&mut self, factor: i32) -> i32 {
-        //     self.rust_only_method(factor);
-        //     self.rust_only_field
-        // }
+        #[invokable]
+        fn invokable_multiply(&mut self, factor: i32) -> i32 {
+            self.rust_only_method(factor);
+            self.rust_only_field
+        }
 
-        // fn rust_only_method(&mut self, factor: i32) {
-        //     self.rust_only_field *= factor;
-        // }
+        fn rust_only_method(&mut self, factor: i32) {
+            self.rust_only_field *= factor;
+        }
     }
 }
 // ANCHOR_END: book_macro_code


### PR DESCRIPTION
This allows for invokables to mutate the RustObj

This came from #41, I thought i'd split it out so it can land earlier as it's useful.