### PR TITLE
qdate: fix tests failing in different timezones

### DIFF
--- a/examples/qml_features/src/tests/qttypes/tst_qttypes.qml
+++ b/examples/qml_features/src/tests/qttypes/tst_qttypes.qml
@@ -87,12 +87,16 @@ TestCase {
             signalName: "dateChanged",
             target: mock,
         });
-        compare(mock.date, new Date(2022, 0, 1));
+        compare(mock.date.getFullYear(), 2022);
+        compare(mock.date.getMonth(), 0);
+        compare(mock.date.getDate(), 1);
 
         compare(spy.count, 0);
         mock.date = new Date(2021, 11, 31);
         tryCompare(spy, "count", 1);
-        compare(mock.date, new Date(2021, 11, 31));
+        compare(mock.date.getFullYear(), 2021);
+        compare(mock.date.getMonth(), 11);
+        compare(mock.date.getDate(), 31);
     }
 
     // Check that we can pass the type as a parameter and return it back
@@ -100,7 +104,9 @@ TestCase {
         const mock = createTemporaryObject(componentMockQtTypes, null, {});
 
         const result = mock.testDateInvokable(new Date(2022, 0, 1));
-        compare(result, new Date(2021, 11, 31));
+        compare(result.getFullYear(), 2021);
+        compare(result.getMonth(), 11);
+        compare(result.getDate(), 31);
     }
 
     // Check that an invokable can adjust (read and write) a property for the type
@@ -112,9 +118,13 @@ TestCase {
         });
 
         compare(spy.count, 0);
-        compare(mock.date, new Date(2022, 0, 1));
+        compare(mock.date.getFullYear(), 2022);
+        compare(mock.date.getMonth(), 0);
+        compare(mock.date.getDate(), 1);
         mock.testDateProperty();
-        compare(mock.date, new Date(2021, 11, 31));
+        compare(mock.date.getFullYear(), 2021);
+        compare(mock.date.getMonth(), 11);
+        compare(mock.date.getDate(), 31);
         tryCompare(spy, "count", 1);
     }
 


### PR DESCRIPTION
Tests would fail when running in different timezones due to
QDate being converted to and from QDateTime.

Change-Id: I214c4d21125d33ae0a106447dc4c7d41ce5b6142