### PR TITLE
book: specify PRIVATE when using target_link_libaries

### DIFF
--- a/book/src/getting-started/2-our-first-cxx-qt-module.md
+++ b/book/src/getting-started/2-our-first-cxx-qt-module.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 As with all things Rust, we'll first want to create a cargo project.
 ```bash
-cargo new --lib cxx-qt-getting-started
+cargo new --lib qml-minimal
 ```
 Note the `--lib` option here.
 It is important that we create a static library in Rust, rather than an executable.

--- a/book/src/getting-started/3-exposing-to-qml.md
+++ b/book/src/getting-started/3-exposing-to-qml.md
@@ -37,11 +37,7 @@ Where `my_object` is the name of the Rust module we defined earlier.
 
 As we later want to include our QML GUI in a `main.qml` file inside the [Qt resource system](https://doc.qt.io/qt-5/resources.html), we'll have to add a `qml.qrc` file in the `src` folder as well:
 ```qrc,ignore
-<RCC version="1.0">
-    <qresource prefix="/">
-        <file>main.qml</file>
-    </qresource>
-</RCC>
+{{#include ../../../examples/qml_minimal/src/qml.qrc:book_rcc_block}}
 ```
 
 And that's it. We can now [use our cool new class from QML](./4-qml-gui.md).

--- a/book/src/getting-started/5-cmake-integration.md
+++ b/book/src/getting-started/5-cmake-integration.md
@@ -18,7 +18,7 @@ Before we can get started on building Qt with CMake, we first need to make our C
 If you've generated your project with the `cargo new --lib` command, your `Cargo.toml` likely looks something like this:
 ```toml,ignore
 [package]
-name = "cxx-qt-getting-started"
+name = "qml-minimal"
 version = "0.1.0"
 edition = "2021"
 
@@ -30,31 +30,9 @@ We'll have to do multiple things:
 - Add `cxx`, `cxx-qt`, as well as `cxx-qt-lib` as dependencies.
 - Add `clang-format` and `cxx-qt-build` as build-dependencies.
 
-In the end, your `Cargo.toml` should look like this:
+In the end, your `Cargo.toml` should look similar to this (note that `path` for the dependencies is not required):
 ```toml,ignore
-[package]
-name = "cxx-qt-getting-started"
-version = "0.1.0"
-edition = "2021"
-
-# This will instruct Cargo to create a static
-# lib named "rust" which CMake can link against
-[lib]
-name = "rust"
-crate-type = ["staticlib"]
-
-[dependencies]
-cxx = "1.0"
-cxx-qt = "0.2"
-cxx-qt-lib = "0.2"
-
-# cxx-qt needs to be able to generate C++ code at
-# compile time, which is what cxx-qt-build is needed for.
-# cxx-qt uses clang-format, if available, to format all
-# C++ code in a consistent manner.
-[build-dependencies]
-clang-format = "0.1"
-cxx-qt-build = "0.2"
+{{#include ../../../examples/qml_minimal/Cargo.toml:book_all}}
 ```
 
 We'll then also need to add a script named `build.rs` next to our `Cargo.toml`:
@@ -70,69 +48,15 @@ In our case, this is only the `src/lib.rs` file.
 Then we can write our `CMakeLists.txt` file:
 
 ```cmake,ignore
-cmake_minimum_required(VERSION 3.16)
-
-project(cxx_qt_getting_started)
-set(APP_NAME ${PROJECT_NAME})
-
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui Qml QuickControls2 QuickTest Test REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Qml QuickControls2 QuickTest Test REQUIRED)
-
-# Include the CXX-Qt CMake code, which provides some easy functions
-# to generate the CXX-Qt code.
-include(CxxQt)
-
-# Generate C++ code from Rust using Cargo in the current folder
-cxx_qt_generate_cpp(GEN_SOURCES)
-
-# Define our sources
-set(
-    CPP_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
-)
-
-set(
-    RESOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/qml.qrc
-)
-
-# Define our executable with our C++ source, generated sources, and QML resource files
-add_executable(${APP_NAME} "${CPP_SOURCES}" "${GEN_SOURCES}" "${RESOURCES}")
-
-# Include generated sources
-cxx_qt_include(${APP_NAME})
-
-# Link to generated rust library
-cxx_qt_link_rustlib(${APP_NAME})
-
-# Link to Qt in the normal way
-target_link_libraries(${APP_NAME} PRIVATE
-    Qt${QT_VERSION_MAJOR}::Core
-    Qt${QT_VERSION_MAJOR}::Gui
-    Qt${QT_VERSION_MAJOR}::Qml
-    Qt${QT_VERSION_MAJOR}::QuickControls2
-)
+{{#include ../../../examples/qml_minimal/CMakeLists.txt:book_tutorial_cmake_full}}
 ```
 
 This looks like a lot, but it is actually just a fairly standard CMake file for building a Qt application.
 
 The difference here are these lines:
 ```cmake,ignore
-include(CxxQt)
-
-# Generate C++ code from Rust using Cargo in the current folder
-cxx_qt_generate_cpp(GEN_SOURCES)
-
-# Include generated sources
-cxx_qt_include(${APP_NAME})
-
-# Link to generated rust library
-cxx_qt_link_rustlib(${APP_NAME})
+{{#include ../../../examples/qml_minimal/CMakeLists.txt:book_tutorial_cmake_diff_1}}
+{{#include ../../../examples/qml_minimal/CMakeLists.txt:book_tutorial_cmake_diff_2}}
 ```
 
 Which will do the code generation and include it into the C++ build.
@@ -153,7 +77,7 @@ If this fails for any reason, take a look at the [`examples/qml_minimal`](https:
 This should now configure and compile our project.
 If this was successful, you can now run our little project.
 ```shell
-$ ./cxx_qt_getting_started
+$ ./qml_minimal
 ```
 
 You should now see the two Labels that display the state of our `MyObject`, as well as the two buttons to call our two Rust functions.

--- a/book/src/getting-started/5-cmake-integration.md
+++ b/book/src/getting-started/5-cmake-integration.md
@@ -111,7 +111,7 @@ cxx_qt_include(${APP_NAME})
 cxx_qt_link_rustlib(${APP_NAME})
 
 # Link to Qt in the normal way
-target_link_libraries(${APP_NAME}
+target_link_libraries(${APP_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::Qml

--- a/examples/qml_minimal/CMakeLists.txt
+++ b/examples/qml_minimal/CMakeLists.txt
@@ -4,29 +4,34 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../cmake")
+
 # TODO: figure out what the actual hard minimum is
+
+# TODO: Add a helper function to our CMake module which automatically
+# handles some of this boilerplate for a "typical" Qt application
+
+# ANCHOR: book_tutorial_cmake_full
 cmake_minimum_required(VERSION 3.16)
 
 project(example_qml_minimal)
 set(APP_NAME ${PROJECT_NAME})
 
-# TODO: Add a helper function to our CMake module which automatically
-# handles some of this boilerplate for a "typical" Qt application
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui Qml QuickControls2 QmlImportScanner QuickTest Test REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Qml QuickControls2 QmlImportScanner QuickTest Test REQUIRED)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../cmake")
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui Qml QuickControls2 QmlImportScanner REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Qml QuickControls2 QmlImportScanner REQUIRED)
 
 # ANCHOR: book_cmake_generation
+# ANCHOR: book_tutorial_cmake_diff_1
 include(CxxQt)
 
 # Generate C++ code from Rust using Cargo in the current folder
 cxx_qt_generate_cpp(GEN_SOURCES)
+# ANCHOR_END: book_tutorial_cmake_diff_1
 
 # Define our sources
 set(
@@ -42,11 +47,13 @@ set(
 # Define our executable with our C++ source, generated sources, and QML resource files
 add_executable(${APP_NAME} "${CPP_SOURCES}" "${GEN_SOURCES}" "${RESOURCES}")
 
+# ANCHOR: book_tutorial_cmake_diff_2
 # Include generated sources
 cxx_qt_include(${APP_NAME})
 
 # Link to generated rust library
 cxx_qt_link_rustlib(${APP_NAME})
+# ANCHOR_END: book_tutorial_cmake_diff_2
 
 # Link to Qt in the normal way
 target_link_libraries(${APP_NAME} PRIVATE
@@ -54,15 +61,17 @@ target_link_libraries(${APP_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::Qml
     Qt${QT_VERSION_MAJOR}::QuickControls2
-    Qt${QT_VERSION_MAJOR}::Test
 )
 qt_import_qml_plugins(${APP_NAME})
-
 # ANCHOR_END: book_cmake_generation
+# ANCHOR_END: book_tutorial_cmake_full
 
 #
 # Unit test
 #
+
+find_package(QT NAMES Qt6 Qt5 COMPONENTS QuickTest Test REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS QuickTest Test REQUIRED)
 
 function(add_qml_test TEST_NAME)
     # Copy QML unit test to build folder

--- a/examples/qml_minimal/Cargo.toml
+++ b/examples/qml_minimal/Cargo.toml
@@ -3,6 +3,7 @@
 # SPDX-FileContributor: Gerhard de Clercq <gerhard.declercq@kdab.com>
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# ANCHOR: book_all
 [package]
 name = "qml-minimal"
 version = "0.1.0"
@@ -14,8 +15,8 @@ authors = [
 edition = "2018"
 license = "MIT OR Apache-2.0"
 
-# Don't touch this, the CMake file expects a static lib with a specific name
-#
+# This will instruct Cargo to create a static
+# lib named "rust" which CMake can link against
 # ANCHOR: book_static_lib
 [lib]
 name = "rust"
@@ -29,8 +30,14 @@ cxx-qt = { path = "../../cxx-qt", version = "0.2" }
 cxx-qt-lib = { path = "../../cxx-qt-lib", version = "0.2" }
 # ANCHOR_END: book_dependencies
 
+# cxx-qt needs to be able to generate C++ code at
+# compile time, which is what cxx-qt-build is needed for.
+# cxx-qt uses clang-format, if available, to format all
+# C++ code in a consistent manner.
 # ANCHOR: book_build_dependencies
 [build-dependencies]
 clang-format = "0.1"
 cxx-qt-build = { path = "../../cxx-qt-build", version = "0.2" }
 # ANCHOR_END: book_build_dependencies
+
+# ANCHOR_END: book_all

--- a/examples/qml_minimal/src/qml.qrc
+++ b/examples/qml_minimal/src/qml.qrc
@@ -6,8 +6,10 @@ SPDX-FileContributor: Gerhard de Clercq <gerhard.declercq@kdab.com>
 
 SPDX-License-Identifier: MIT OR Apache-2.0
 -->
+<!-- ANCHOR: book_rcc_block -->
 <RCC version="1.0">
     <qresource prefix="/">
         <file>main.qml</file>
     </qresource>
 </RCC>
+<!-- ANCHOR_END: book_rcc_block -->


### PR DESCRIPTION
As we specify PRIVATE in CxxQt.cmake further uses on the target
need to use PRIVATE or PUBLIC.

Closes #129

Change-Id: I0af585264a5859d77dd4a56b7178dfaf93852da5