### PR TITLE
gen_cpp: ensure that Q_ASSERT in release mode won't break invokeMethods

### DIFF
--- a/cxx-qt-gen/src/gen_cpp.rs
+++ b/cxx-qt-gen/src/gen_cpp.rs
@@ -504,10 +504,11 @@ fn generate_properties_cpp(
         let call_property_change_handler = if has_property_change_handler {
             formatdoc! {
                 r#"
-                Q_ASSERT(QMetaObject::invokeMethod(this, [&]() {{
+                const auto handlePropertySuccess = QMetaObject::invokeMethod(this, [&]() {{
                     const std::lock_guard<std::mutex> guard(m_rustObjMutex);
                     m_rustObj->handlePropertyChange(*this, Property::{ident});
-                }}, Qt::QueuedConnection));
+                }}, Qt::QueuedConnection);
+                Q_ASSERT(handlePropertySuccess);
                 "#,
                 ident = parameter_ident_pascal
             }
@@ -545,7 +546,8 @@ fn generate_properties_cpp(
 
                         {member_ident} = value;
 
-                        Q_ASSERT(QMetaObject::invokeMethod(this, "{ident_changed}", Qt::QueuedConnection));
+                        const auto signalSuccess = QMetaObject::invokeMethod(this, "{ident_changed}", Qt::QueuedConnection);
+                        Q_ASSERT(signalSuccess);
 
                         {call_property_change_handler}
                     }}
@@ -610,7 +612,8 @@ fn generate_properties_cpp(
                   {member_owned_ident} = std::move(value);
                   {member_ident} = {member_owned_ident}.get();
 
-                  Q_ASSERT(QMetaObject::invokeMethod(this, "{ident_changed}", Qt::QueuedConnection));
+                  const auto signalSuccess = QMetaObject::invokeMethod(this, "{ident_changed}", Qt::QueuedConnection);
+                  Q_ASSERT(signalSuccess);
 
                   {call_change_handler}
                 }}
@@ -644,7 +647,8 @@ fn generate_properties_cpp(
                     if (value != {member_ident}) {{
                         {member_ident} = value;
 
-                        Q_ASSERT(QMetaObject::invokeMethod(this, "{ident_changed}", Qt::QueuedConnection));
+                        const auto signalSuccess = QMetaObject::invokeMethod(this, "{ident_changed}", Qt::QueuedConnection);
+                        Q_ASSERT(signalSuccess);
 
                         {call_change_handler}
                     }}

--- a/cxx-qt-gen/test_outputs/handlers.cpp
+++ b/cxx-qt-gen/test_outputs/handlers.cpp
@@ -30,16 +30,18 @@ MyObject::setNumber(qint32 value)
   if (value != m_number) {
     m_number = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "numberChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "numberChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
 
-    Q_ASSERT(QMetaObject::invokeMethod(
+    const auto handlePropertySuccess = QMetaObject::invokeMethod(
       this,
       [&]() {
         const std::lock_guard<std::mutex> guard(m_rustObjMutex);
         m_rustObj->handlePropertyChange(*this, Property::Number);
       },
-      Qt::QueuedConnection));
+      Qt::QueuedConnection);
+    Q_ASSERT(handlePropertySuccess);
   }
 }
 
@@ -60,16 +62,18 @@ MyObject::setString(const QString& value)
   if (value != m_string) {
     m_string = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "stringChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "stringChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
 
-    Q_ASSERT(QMetaObject::invokeMethod(
+    const auto handlePropertySuccess = QMetaObject::invokeMethod(
       this,
       [&]() {
         const std::lock_guard<std::mutex> guard(m_rustObjMutex);
         m_rustObj->handlePropertyChange(*this, Property::String);
       },
-      Qt::QueuedConnection));
+      Qt::QueuedConnection);
+    Q_ASSERT(handlePropertySuccess);
   }
 }
 

--- a/cxx-qt-gen/test_outputs/naming.cpp
+++ b/cxx-qt-gen/test_outputs/naming.cpp
@@ -30,8 +30,9 @@ MyObject::setPropertyName(qint32 value)
   if (value != m_propertyName) {
     m_propertyName = value;
 
-    Q_ASSERT(QMetaObject::invokeMethod(
-      this, "propertyNameChanged", Qt::QueuedConnection));
+    const auto signalSuccess = QMetaObject::invokeMethod(
+      this, "propertyNameChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 

--- a/cxx-qt-gen/test_outputs/properties.cpp
+++ b/cxx-qt-gen/test_outputs/properties.cpp
@@ -30,8 +30,9 @@ MyObject::setPrimitive(qint32 value)
   if (value != m_primitive) {
     m_primitive = value;
 
-    Q_ASSERT(QMetaObject::invokeMethod(
-      this, "primitiveChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "primitiveChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -52,8 +53,9 @@ MyObject::setOpaque(const QColor& value)
   if (value != m_opaque) {
     m_opaque = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "opaqueChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "opaqueChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -73,8 +75,9 @@ MyObject::setNested(cxx_qt::nested_object::CppObj* value)
 
     m_nested = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "nestedChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "nestedChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -94,8 +97,9 @@ MyObject::giveNested(std::unique_ptr<cxx_qt::nested_object::CppObj> value)
   m_ownedNested = std::move(value);
   m_nested = m_ownedNested.get();
 
-  Q_ASSERT(
-    QMetaObject::invokeMethod(this, "nestedChanged", Qt::QueuedConnection));
+  const auto signalSuccess =
+    QMetaObject::invokeMethod(this, "nestedChanged", Qt::QueuedConnection);
+  Q_ASSERT(signalSuccess);
 }
 
 std::unique_ptr<CppObj>

--- a/cxx-qt-gen/test_outputs/types_primitive_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.cpp
@@ -30,8 +30,9 @@ MyObject::setBoolean(bool value)
   if (value != m_boolean) {
     m_boolean = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "booleanChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "booleanChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -52,8 +53,9 @@ MyObject::setFloat32(float value)
   if (value != m_float32) {
     m_float32 = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "float32Changed", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "float32Changed", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -74,8 +76,9 @@ MyObject::setFloat64(double value)
   if (value != m_float64) {
     m_float64 = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "float64Changed", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "float64Changed", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -96,8 +99,9 @@ MyObject::setInt8(qint8 value)
   if (value != m_int8) {
     m_int8 = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "int8Changed", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "int8Changed", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -118,8 +122,9 @@ MyObject::setInt16(qint16 value)
   if (value != m_int16) {
     m_int16 = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "int16Changed", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "int16Changed", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -140,8 +145,9 @@ MyObject::setInt32(qint32 value)
   if (value != m_int32) {
     m_int32 = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "int32Changed", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "int32Changed", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -162,8 +168,9 @@ MyObject::setUint8(quint8 value)
   if (value != m_uint8) {
     m_uint8 = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "uint8Changed", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "uint8Changed", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -184,8 +191,9 @@ MyObject::setUint16(quint16 value)
   if (value != m_uint16) {
     m_uint16 = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "uint16Changed", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "uint16Changed", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -206,8 +214,9 @@ MyObject::setUint32(quint32 value)
   if (value != m_uint32) {
     m_uint32 = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "uint32Changed", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "uint32Changed", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 

--- a/cxx-qt-gen/test_outputs/types_qt_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_property.cpp
@@ -30,8 +30,9 @@ MyObject::setColor(const QColor& value)
   if (value != m_color) {
     m_color = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "colorChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "colorChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -52,8 +53,9 @@ MyObject::setDate(const QDate& value)
   if (value != m_date) {
     m_date = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "dateChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "dateChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -74,8 +76,9 @@ MyObject::setDateTime(const QDateTime& value)
   if (value != m_dateTime) {
     m_dateTime = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "dateTimeChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "dateTimeChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -96,8 +99,9 @@ MyObject::setPoint(const QPoint& value)
   if (value != m_point) {
     m_point = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "pointChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "pointChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -118,8 +122,9 @@ MyObject::setPointf(const QPointF& value)
   if (value != m_pointf) {
     m_pointf = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "pointfChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "pointfChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -140,8 +145,9 @@ MyObject::setRect(const QRect& value)
   if (value != m_rect) {
     m_rect = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "rectChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "rectChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -162,8 +168,9 @@ MyObject::setRectf(const QRectF& value)
   if (value != m_rectf) {
     m_rectf = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "rectfChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "rectfChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -184,8 +191,9 @@ MyObject::setSize(const QSize& value)
   if (value != m_size) {
     m_size = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "sizeChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "sizeChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -206,8 +214,9 @@ MyObject::setSizef(const QSizeF& value)
   if (value != m_sizef) {
     m_sizef = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "sizefChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "sizefChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -228,8 +237,9 @@ MyObject::setString(const QString& value)
   if (value != m_string) {
     m_string = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "stringChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "stringChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -250,8 +260,9 @@ MyObject::setTime(const QTime& value)
   if (value != m_time) {
     m_time = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "timeChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "timeChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -272,8 +283,9 @@ MyObject::setUrl(const QUrl& value)
   if (value != m_url) {
     m_url = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "urlChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "urlChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 
@@ -294,8 +306,9 @@ MyObject::setVariant(const QVariant& value)
   if (value != m_variant) {
     m_variant = value;
 
-    Q_ASSERT(
-      QMetaObject::invokeMethod(this, "variantChanged", Qt::QueuedConnection));
+    const auto signalSuccess =
+      QMetaObject::invokeMethod(this, "variantChanged", Qt::QueuedConnection);
+    Q_ASSERT(signalSuccess);
   }
 }
 


### PR DESCRIPTION
In release mode signals and handlers were missed due to Q_ASSERT
being optimised out.

Change-Id: I3db834ee3851d4f9266115eeef06ed8534804c21