### PR TITLE
ci: use release builds for tests

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -195,7 +195,7 @@ jobs:
       run: >-
         cmake
         -D QT_DEFAULT_MAJOR_VERSION=${{ matrix.qt_version }}
-        -D CMAKE_BUILD_TYPE=Debug
+        -D CMAKE_BUILD_TYPE=Release
         -G Ninja
         -S . -B build
       working-directory: ${{ matrix.workspace }}
@@ -204,12 +204,12 @@ jobs:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
     - name: "Build"
-      run: cmake --build build --config Debug --parallel 2
+      run: cmake --build build --config Release --parallel 2
       working-directory: ${{ matrix.workspace }}
       env:
         RUSTC_WRAPPER: sccache
     - name: "Test"
-      run: ctest ${{ matrix.ctest_args }} -C Debug -T test --output-on-failure --parallel 2
+      run: ctest ${{ matrix.ctest_args }} -C Release -T test --output-on-failure --parallel 2
       working-directory: ${{ matrix.workspace }}/build
       env:
         RUSTC_WRAPPER: sccache


### PR DESCRIPTION
This ensures that we pick up any failures from code being
optimised out inside Q_ASSERT etc.

Change-Id: Ie83484c98790c8db944b692650cdb9c6fb2d1d26