### PR TITLE
Use OUT_DIR to compute target dir, instead of  using MANIFEST_DIR

### DIFF
--- a/cxx-qt/src/lib.rs
+++ b/cxx-qt/src/lib.rs
@@ -10,8 +10,11 @@ use cxx_qt_gen::{extract_qobject, generate_qobject_rs};
 
 /// Read the C++ namespace prefix that cxx-qt-build has set for us
 fn read_cpp_namespace_prefix() -> Vec<String> {
-    let dir_target = std::env::var("CARGO_MANIFEST_DIR").expect("Could not get manifest dir");
-    let path = format!("{}/target/cxx-qt-gen/cpp_namespace_prefix.txt", dir_target);
+    let dir_target = std::env::var("OUT_DIR")
+        .and_then(|s| Ok(s + "/../../../.."))
+        .or(std::env::var("CARGO_MANIFEST_DIR").and_then(|s| Ok(s + "/target")))
+        .expect("Could not get target dir");
+    let path = format!("{}/cxx-qt-gen/cpp_namespace_prefix.txt", dir_target);
     let contents = std::fs::read_to_string(path).expect("Could not read cpp namespace prefix");
     contents.split("::").map(|s| s.to_string()).collect()
 }


### PR DESCRIPTION
fixed #139 
Then developers can specify target_dir in cmake, such as:
```cmake
    set(CARGO_TARGET_DIR "${CMAKE_BINARY_DIR}/target")
    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
        set(CARGO_CMD cargo build --target-dir ${CARGO_TARGET_DIR})
        set(TARGET_DIR "debug")
    else ()
        set(CARGO_CMD cargo build --release --target-dir ${CARGO_TARGET_DIR})
        set(TARGET_DIR "release")
    endif ()
```

Then the library that rust generated will be in `${CARGO_TARGET_DIR}/target/librust.a` or `${CARGO_TARGET_DIR}/target/rust.lib`. The `cxx-qt-gen` and `cxx-qt-lib` folders where generated cpp sources and headers are placed is in `${CARGO_TARGET_DIR}/target` folder. 
This will not generate Rust target directory outside of the Qt project build directory. This allows us to always have one build directory, rather than Rust having one and Qt having one.