### PR TITLE
cxx-qt-build: remove the option to specify a custom namespace prefix

### DIFF
--- a/book/src/concepts/build_rs_and_cargo.md
+++ b/book/src/concepts/build_rs_and_cargo.md
@@ -13,20 +13,11 @@ The following options are available
 
   * Indicating which files should be parsed to look for macros
   * Deciding the clang-format style of the generated C++ code
-  * Specifiying a custom C++ namespace for the generated Rust types
 
 A build.rs script could look like the following
 
 ```rust,ignore,noplayground
 {{#include ../../../examples/qml_minimal/build.rs:book_build_rs}}
-```
-
-A non-default C++ namespace could be like the following
-
-Note that the namespace is a list, so `vec!["a", "b", "c"]` would become `a::b::c`
-
-```rust,ignore,noplayground
-{{#include ../../../examples/qml_features/build.rs:book_build_rs}}
 ```
 
 # Cargo.toml

--- a/cxx-qt/src/lib.rs
+++ b/cxx-qt/src/lib.rs
@@ -8,14 +8,6 @@ use syn::{parse_macro_input, ItemMod};
 
 use cxx_qt_gen::{extract_qobject, generate_qobject_rs};
 
-/// Read the C++ namespace prefix that cxx-qt-build has set for us
-fn read_cpp_namespace_prefix() -> Vec<String> {
-    let dir_target = std::env::var("CARGO_MANIFEST_DIR").expect("Could not get manifest dir");
-    let path = format!("{}/target/cxx-qt-gen/cpp_namespace_prefix.txt", dir_target);
-    let contents = std::fs::read_to_string(path).expect("Could not read cpp namespace prefix");
-    contents.split("::").map(|s| s.to_string()).collect()
-}
-
 /// A procedural macro which generates a QObject for a struct inside a module.
 ///
 /// # Example
@@ -41,8 +33,8 @@ pub fn bridge(_attr: TokenStream, input: TokenStream) -> TokenStream {
     // this triggers a compile failure if the tokens fail to parse.
     let module = parse_macro_input!(input as ItemMod);
 
-    // Read the C++ namespace prefix set by cxx-qt-build
-    let cpp_namespace_prefix = read_cpp_namespace_prefix();
+    // TODO: for now we use a fixed namespace, later this will come from the macro definition
+    let cpp_namespace_prefix: Vec<String> = vec!["cxx_qt".to_owned()];
 
     // Extract and generate the rust code
     extract_and_generate(module, &cpp_namespace_prefix)

--- a/examples/qml_features/build.rs
+++ b/examples/qml_features/build.rs
@@ -11,7 +11,6 @@ use cxx_qt_build::CxxQtBuilder;
 fn main() {
     CxxQtBuilder::new()
         .cpp_format(ClangFormatStyle::Mozilla)
-        .cpp_namespace_prefix(vec!["custom_namespace"])
         .file("src/data_struct_properties.rs")
         .file("src/empty.rs")
         .file("src/handler_property_change.rs")

--- a/examples/qml_features/src/main.cpp
+++ b/examples/qml_features/src/main.cpp
@@ -33,20 +33,17 @@ main(int argc, char* argv[])
     },
     Qt::QueuedConnection);
 
-  qmlRegisterType<
-    custom_namespace::data_struct_properties::DataStructProperties>(
+  qmlRegisterType<cxx_qt::data_struct_properties::DataStructProperties>(
     "com.kdab.cxx_qt.demo", 1, 0, "DataStructProperties");
-  qmlRegisterType<
-    custom_namespace::handler_property_change::HandlerPropertyChange>(
+  qmlRegisterType<cxx_qt::handler_property_change::HandlerPropertyChange>(
     "com.kdab.cxx_qt.demo", 1, 0, "HandlerPropertyChange");
-  qmlRegisterType<custom_namespace::my_object::MyObject>(
+  qmlRegisterType<cxx_qt::my_object::MyObject>(
     "com.kdab.cxx_qt.demo", 1, 0, "MyObject");
-  qmlRegisterType<custom_namespace::serialisation::Serialisation>(
+  qmlRegisterType<cxx_qt::serialisation::Serialisation>(
     "com.kdab.cxx_qt.demo", 1, 0, "Serialisation");
-  qmlRegisterType<custom_namespace::sub_object::SubObject>(
+  qmlRegisterType<cxx_qt::sub_object::SubObject>(
     "com.kdab.cxx_qt.demo", 1, 0, "SubObject");
-  qmlRegisterType<custom_namespace::types::Types>(
-    "com.kdab.cxx_qt.demo", 1, 0, "Types");
+  qmlRegisterType<cxx_qt::types::Types>("com.kdab.cxx_qt.demo", 1, 0, "Types");
 
   engine.load(url);
 

--- a/examples/qml_features/src/tests/myobject/tst_myobject.cpp
+++ b/examples/qml_features/src/tests/myobject/tst_myobject.cpp
@@ -19,9 +19,9 @@ class Setup : public QObject
 public:
   Setup()
   {
-    qmlRegisterType<custom_namespace::my_object::MyObject>(
+    qmlRegisterType<cxx_qt::my_object::MyObject>(
       "com.kdab.cxx_qt.demo", 1, 0, "MyObject");
-    qmlRegisterType<custom_namespace::sub_object::SubObject>(
+    qmlRegisterType<cxx_qt::sub_object::SubObject>(
       "com.kdab.cxx_qt.demo", 1, 0, "SubObject");
   }
 };

--- a/examples/qml_features/src/tests/qttypes/tst_qttypes.cpp
+++ b/examples/qml_features/src/tests/qttypes/tst_qttypes.cpp
@@ -18,7 +18,7 @@ class Setup : public QObject
 public:
   Setup()
   {
-    qmlRegisterType<custom_namespace::mock_qt_types::MockQtTypes>(
+    qmlRegisterType<cxx_qt::mock_qt_types::MockQtTypes>(
       "com.kdab.cxx_qt.demo", 1, 0, "MockQtTypes");
   }
 };

--- a/examples/qml_features/src/tests/serialisation/tst_serialisation.cpp
+++ b/examples/qml_features/src/tests/serialisation/tst_serialisation.cpp
@@ -18,7 +18,7 @@ class Setup : public QObject
 public:
   Setup()
   {
-    qmlRegisterType<custom_namespace::serialisation::Serialisation>(
+    qmlRegisterType<cxx_qt::serialisation::Serialisation>(
       "com.kdab.cxx_qt.demo", 1, 0, "Serialisation");
   }
 };


### PR DESCRIPTION
This will be removed from the build tool and instead later
this will be moved onto the macro.

For now just use cxx_qt as the default.