### PR TITLE
gen_rs: use CXX as module and move CXX-Qt to external module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,28 +53,28 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn increment(&self, cpp: &mut CppObj) {
+        pub fn increment(&self, cpp: &mut CppObj) {
             cpp.set_number(cpp.number() + 1);
         }
 
         #[invokable]
-        fn reset(&self, cpp: &mut CppObj) {
+        pub fn reset(&self, cpp: &mut CppObj) {
             let data: Data = serde_json::from_str(DEFAULT_STR).unwrap();
             cpp.grab_values_from_data(data);
         }
 
         #[invokable]
-        fn serialize(&self, cpp: &mut CppObj) -> String {
+        pub fn serialize(&self, cpp: &mut CppObj) -> String {
             let data = Data::from(cpp);
             serde_json::to_string(&data).unwrap()
         }
 
         #[invokable]
-        fn grab_values(&self, cpp: &mut CppObj) {
+        pub fn grab_values(&self, cpp: &mut CppObj) {
             let string = r#"{"number": 2, "string": "Goodbye!"}"#;
             let data: Data = serde_json::from_str(string).unwrap();
             cpp.grab_values_from_data(data);

--- a/book/src/concepts/nested_objects.md
+++ b/book/src/concepts/nested_objects.md
@@ -9,17 +9,19 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 Rust Qt objects can be nested as properties or parameters of each other.
 
-A nested object is referred to by it's path relative to `crate` and then `CppObj` as the last segment. Eg `crate::mymod::secondary_object::CppObj` refers a `mymod.rs` which contains a module `secondary_object` with [CXX-Qt macros](../qobject/macro.md).
+A nested object is referred to by it's path relative to `crate`, the second last segment needs `cxx_qt_` as the start of the module name, and then `CppObj` as the last segment. Eg `crate::mymod::cxx_qt_secondary_object::CppObj` refers a `mymod.rs` which contains a module `secondary_object` with [CXX-Qt macros](../qobject/macro.md).
 
-To use this as a property in another object write `secondary_object: crate::mymod::secondary_object::CppObj` as the property.
+To use this as a property in another object write `secondary_object: crate::mymod::cxx_qt_secondary_object::CppObj` as the property.
 
-For use as a parameter in an invokable write `secondary_object: &mut crate::mymod::secondary_object::CppObj` as the parameter. Then the `secondary_object` parameter can be used via the normal [`CppObj`](../qobject/cpp_object.md) methods.
+For use as a parameter in an invokable write `secondary_object: &mut crate::mymod::cxx_qt_secondary_object::CppObj` as the parameter. Then the `secondary_object` parameter can be used via the normal [`CppObj`](../qobject/cpp_object.md) methods.
 
 The following example shows a nested object as a property and parameter.
 
 ```rust,ignore,noplayground
 {{#include ../../../examples/qml_features/src/nested.rs:book_macro_code}}
 ```
+
+Note that until nested objects are `UniquePtr<T>` on the Rust side we need to use `cxx_qt_` as a prefix in the last module path to reach the correct `CppObj`.
 
 Note that nested objects cannot be used as return types yet ( [https://github.com/KDAB/cxx-qt/issues/66](https://github.com/KDAB/cxx-qt/issues/66) ).
 

--- a/cxx-qt-gen/src/extract.rs
+++ b/cxx-qt-gen/src/extract.rs
@@ -1009,10 +1009,10 @@ pub fn extract_qobject(
         namespace,
         original_mod,
         original_data_struct: original_data_struct
-            .unwrap_or_else(|| syn::parse_str("struct Data;").unwrap()),
+            .unwrap_or_else(|| syn::parse_str("pub struct Data;").unwrap()),
         original_signal_enum,
         original_rust_struct: original_rust_struct
-            .unwrap_or_else(|| syn::parse_str("struct RustObj;").unwrap()),
+            .unwrap_or_else(|| syn::parse_str("pub struct RustObj;").unwrap()),
         original_trait_impls,
         original_passthrough_decls,
         handle_updates_impl,

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -592,7 +592,7 @@ fn generate_cpp_object_initialiser(obj: &QObject) -> TokenStream {
 
     // We assume that all Data classes implement default
     let output = quote! {
-        fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+        pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
             let mut wrapper = CppObj::new(cpp);
             wrapper.grab_values_from_data(#data_class_name::default());
         }
@@ -874,14 +874,14 @@ fn invokable_generate_wrapper(
         };
 
         Ok(quote! {
-            fn #ident_wrapper(&#mutablility self, #(#input_parameters),*) -> #return_type_ident {
+            pub fn #ident_wrapper(&#mutablility self, #(#input_parameters),*) -> #return_type_ident {
                 #(#wrappers)*
                 return self.#ident(#(#output_parameters),*)#to_unique_ptr;
             }
         })
     } else {
         Ok(quote! {
-            fn #ident_wrapper(&#mutablility self, #(#input_parameters),*) {
+            pub fn #ident_wrapper(&#mutablility self, #(#input_parameters),*) {
                 #(#wrappers)*
                 self.#ident(#(#output_parameters),*);
             }
@@ -1036,7 +1036,7 @@ pub fn generate_qobject_rs(
     // Define a function to handle update requests if we have one
     let handle_update_request = if obj.handle_updates_impl.is_some() {
         quote! {
-            fn call_handle_update_request(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
+            pub fn call_handle_update_request(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
                 let mut cpp = CppObj::new(cpp);
                 self.handle_update_request(&mut cpp);
             }
@@ -1151,7 +1151,7 @@ pub fn generate_qobject_rs(
 
             #handle_updates_impl
 
-            fn create_rs() -> std::boxed::Box<RustObj> {
+            pub fn create_rs() -> std::boxed::Box<RustObj> {
                 std::default::Default::default()
             }
 

--- a/cxx-qt-gen/test_inputs/custom_default.rs
+++ b/cxx-qt-gen/test_inputs/custom_default.rs
@@ -1,5 +1,5 @@
 mod my_object {
-    struct Data {
+    pub struct Data {
         public: i32,
     }
 
@@ -9,7 +9,7 @@ mod my_object {
         }
     }
 
-    struct RustObj {
+    pub struct RustObj {
         private: i32,
     }
 

--- a/cxx-qt-gen/test_inputs/handlers.rs
+++ b/cxx-qt-gen/test_inputs/handlers.rs
@@ -1,12 +1,12 @@
 mod my_object {
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         number: i32,
         string: String,
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl UpdateRequestHandler<CppObj> for RustObj {
         fn handle_update_request(&mut self, _cpp: &mut CppObj) {

--- a/cxx-qt-gen/test_inputs/invokables.rs
+++ b/cxx-qt-gen/test_inputs/invokables.rs
@@ -2,36 +2,36 @@ mod my_object {
     use cxx_qt_lib::QColor;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn invokable(&self) {
+        pub fn invokable(&self) {
             println!("invokable");
         }
 
         #[invokable]
-        fn invokable_cpp_obj(&self, cpp: &mut CppObj) {
+        pub fn invokable_cpp_obj(&self, cpp: &mut CppObj) {
             println!("cppobj");
         }
 
         #[invokable]
-        fn invokable_mutable(&mut self) {
+        pub fn invokable_mutable(&mut self) {
             println!("This method is mutable!");
         }
 
         #[invokable]
-        fn invokable_mutable_cpp_obj(&mut self, cpp: &mut CppObj) {
+        pub fn invokable_mutable_cpp_obj(&mut self, cpp: &mut CppObj) {
             println!("This method is mutable!");
         }
 
         #[invokable]
-        fn invokable_nested_parameter(&self, nested: &mut crate::nested_object::CppObj) {
+        pub fn invokable_nested_parameter(&self, nested: &mut crate::nested_object::CppObj) {
             println!("nested!");
         }
 
         #[invokable]
-        fn invokable_parameters(&self, opaque: &QColor, trivial: &QPoint, primitive: i32) {
+        pub fn invokable_parameters(&self, opaque: &QColor, trivial: &QPoint, primitive: i32) {
             println!(
                 "Red: {}, Point X: {}, Number: {}",
                 opaque.red(),
@@ -41,26 +41,26 @@ mod my_object {
         }
 
         #[invokable]
-        fn invokable_parameters_cpp_obj(&self, primitive: i32, cpp: &mut CppObj) {
+        pub fn invokable_parameters_cpp_obj(&self, primitive: i32, cpp: &mut CppObj) {
             println!("{}", primitive);
         }
 
         #[invokable]
-        fn invokable_return_opaque(&mut self) -> QColor {
+        pub fn invokable_return_opaque(&mut self) -> QColor {
             cxx_qt_lib::QColor::from_rgba(255, 0, 0, 0)
         }
 
         #[invokable]
-        fn invokable_return_primitive(&mut self) -> i32 {
+        pub fn invokable_return_primitive(&mut self) -> i32 {
             2
         }
 
         #[invokable]
-        fn invokable_return_static(&mut self) -> &str {
+        pub fn invokable_return_static(&mut self) -> &str {
             "static"
         }
 
-        fn rust_only_method(&self) {
+        pub fn rust_only_method(&self) {
             println!("QML can't call this :)");
         }
     }

--- a/cxx-qt-gen/test_inputs/invokables.rs
+++ b/cxx-qt-gen/test_inputs/invokables.rs
@@ -26,7 +26,7 @@ mod my_object {
         }
 
         #[invokable]
-        pub fn invokable_nested_parameter(&self, nested: &mut crate::nested_object::CppObj) {
+        pub fn invokable_nested_parameter(&self, nested: &mut crate::cxx_qt_nested_object::CppObj) {
             println!("nested!");
         }
 

--- a/cxx-qt-gen/test_inputs/naming.rs
+++ b/cxx-qt-gen/test_inputs/naming.rs
@@ -1,15 +1,15 @@
 mod my_object {
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         property_name: i32,
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn invokable_name(&self) {
+        pub fn invokable_name(&self) {
             println!("Bye from Rust!");
         }
     }

--- a/cxx-qt-gen/test_inputs/passthrough.rs
+++ b/cxx-qt-gen/test_inputs/passthrough.rs
@@ -60,7 +60,7 @@ pub mod my_object {
     use super::MyTrait;
 
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         number: i32,
     }
 
@@ -71,7 +71,7 @@ pub mod my_object {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         fn test_angled(&self, optional: Option<bool>) -> Option<bool> {

--- a/cxx-qt-gen/test_inputs/properties.rs
+++ b/cxx-qt-gen/test_inputs/properties.rs
@@ -2,12 +2,12 @@ mod my_object {
     use cxx_qt_lib::QColor;
 
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         primitive: i32,
         opaque: QColor,
         nested: crate::nested_object::CppObj,
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 }

--- a/cxx-qt-gen/test_inputs/properties.rs
+++ b/cxx-qt-gen/test_inputs/properties.rs
@@ -5,7 +5,7 @@ mod my_object {
     pub struct Data {
         primitive: i32,
         opaque: QColor,
-        nested: crate::nested_object::CppObj,
+        nested: crate::cxx_qt_nested_object::CppObj,
     }
 
     #[derive(Default)]

--- a/cxx-qt-gen/test_inputs/signals.rs
+++ b/cxx-qt-gen/test_inputs/signals.rs
@@ -11,14 +11,14 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct Data;
+    pub struct Data;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn invokable(&self, cpp: &mut CppObj) {
+        pub fn invokable(&self, cpp: &mut CppObj) {
             unsafe {
                 cpp.emit_immediate(Signal::Ready);
             }

--- a/cxx-qt-gen/test_inputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_inputs/types_primitive_property.rs
@@ -1,6 +1,6 @@
 mod my_object {
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         boolean: bool,
         float_32: f32,
         float_64: f64,
@@ -13,5 +13,5 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 }

--- a/cxx-qt-gen/test_inputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_invokable.rs
@@ -1,73 +1,73 @@
 mod my_object {
     #[derive(Default)]
-    struct Data;
+    pub struct Data;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn test_color(&self, _cpp: &mut CppObj, color: &QColor) -> QColor {
+        pub fn test_color(&self, _cpp: &mut CppObj, color: &QColor) -> QColor {
             color
         }
 
         #[invokable]
-        fn test_date(&self, _cpp: &mut CppObj, date: &QDate) -> QDate {
+        pub fn test_date(&self, _cpp: &mut CppObj, date: &QDate) -> QDate {
             date
         }
 
         #[invokable]
-        fn test_date_time(&self, _cpp: &mut CppObj, dateTime: &QDateTime) -> QDateTime {
+        pub fn test_date_time(&self, _cpp: &mut CppObj, dateTime: &QDateTime) -> QDateTime {
             dateTime
         }
 
         #[invokable]
-        fn test_point(&self, _cpp: &mut CppObj, point: &QPoint) -> QPoint {
+        pub fn test_point(&self, _cpp: &mut CppObj, point: &QPoint) -> QPoint {
             point
         }
 
         #[invokable]
-        fn test_pointf(&self, _cpp: &mut CppObj, pointf: &QPointF) -> QPointF {
+        pub fn test_pointf(&self, _cpp: &mut CppObj, pointf: &QPointF) -> QPointF {
             pointf
         }
 
         #[invokable]
-        fn test_rect(&self, _cpp: &mut CppObj, rect: &QRect) -> QRect {
+        pub fn test_rect(&self, _cpp: &mut CppObj, rect: &QRect) -> QRect {
             rect
         }
 
         #[invokable]
-        fn test_rectf(&self, _cpp: &mut CppObj, rectf: &QRectF) -> QRectF {
+        pub fn test_rectf(&self, _cpp: &mut CppObj, rectf: &QRectF) -> QRectF {
             rectf
         }
 
         #[invokable]
-        fn test_size(&self, _cpp: &mut CppObj, size: &QSize) -> QSize {
+        pub fn test_size(&self, _cpp: &mut CppObj, size: &QSize) -> QSize {
             size
         }
 
         #[invokable]
-        fn test_sizef(&self, _cpp: &mut CppObj, sizef: &QSizeF) -> QSizeF {
+        pub fn test_sizef(&self, _cpp: &mut CppObj, sizef: &QSizeF) -> QSizeF {
             sizef
         }
 
         #[invokable]
-        fn test_string(&self, _cpp: &mut CppObj, string: &str) -> String {
+        pub fn test_string(&self, _cpp: &mut CppObj, string: &str) -> String {
             string.to_owned()
         }
 
         #[invokable]
-        fn test_time(&self, _cpp: &mut CppObj, time: &QTime) -> QTime {
+        pub fn test_time(&self, _cpp: &mut CppObj, time: &QTime) -> QTime {
             time
         }
 
         #[invokable]
-        fn test_url(&self, _cpp: &mut CppObj, url: &QUrl) -> QUrl {
+        pub fn test_url(&self, _cpp: &mut CppObj, url: &QUrl) -> QUrl {
             url
         }
 
         #[invokable]
-        fn test_variant(&self, _cpp: &mut CppObj, variant: &QVariant) -> QVariant {
+        pub fn test_variant(&self, _cpp: &mut CppObj, variant: &QVariant) -> QVariant {
             variant
         }
     }

--- a/cxx-qt-gen/test_inputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_property.rs
@@ -1,6 +1,6 @@
 mod my_object {
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         color: QColor,
         date: QDate,
         date_time: QDateTime,
@@ -17,5 +17,5 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 }

--- a/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/cxx-qt-gen/test_outputs/custom_default.rs
@@ -1,62 +1,65 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod my_object {
-    use cxx_qt_lib::ToUniquePtr;
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-    #[cxx::bridge(namespace = "cxx_qt::my_object")]
-    mod ffi {
-        unsafe extern "C++" {
-            include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        type MyObject;
 
-            type MyObject;
+        include!("cxx-qt-lib/include/qt_types.h");
+        #[namespace = ""]
+        type QColor = cxx_qt_lib::QColorCpp;
+        #[namespace = ""]
+        type QDate = cxx_qt_lib::QDate;
+        #[namespace = ""]
+        type QDateTime = cxx_qt_lib::QDateTimeCpp;
+        #[namespace = ""]
+        type QPoint = cxx_qt_lib::QPoint;
+        #[namespace = ""]
+        type QPointF = cxx_qt_lib::QPointF;
+        #[namespace = ""]
+        type QRect = cxx_qt_lib::QRect;
+        #[namespace = ""]
+        type QRectF = cxx_qt_lib::QRectF;
+        #[namespace = ""]
+        type QSize = cxx_qt_lib::QSize;
+        #[namespace = ""]
+        type QSizeF = cxx_qt_lib::QSizeF;
+        #[namespace = ""]
+        type QString = cxx_qt_lib::QStringCpp;
+        #[namespace = ""]
+        type QTime = cxx_qt_lib::QTime;
+        #[namespace = ""]
+        type QUrl = cxx_qt_lib::QUrlCpp;
+        #[namespace = ""]
+        type QVariant = cxx_qt_lib::QVariantCpp;
 
-            include!("cxx-qt-lib/include/qt_types.h");
-            #[namespace = ""]
-            type QColor = cxx_qt_lib::QColorCpp;
-            #[namespace = ""]
-            type QDate = cxx_qt_lib::QDate;
-            #[namespace = ""]
-            type QDateTime = cxx_qt_lib::QDateTimeCpp;
-            #[namespace = ""]
-            type QPoint = cxx_qt_lib::QPoint;
-            #[namespace = ""]
-            type QPointF = cxx_qt_lib::QPointF;
-            #[namespace = ""]
-            type QRect = cxx_qt_lib::QRect;
-            #[namespace = ""]
-            type QRectF = cxx_qt_lib::QRectF;
-            #[namespace = ""]
-            type QSize = cxx_qt_lib::QSize;
-            #[namespace = ""]
-            type QSizeF = cxx_qt_lib::QSizeF;
-            #[namespace = ""]
-            type QString = cxx_qt_lib::QStringCpp;
-            #[namespace = ""]
-            type QTime = cxx_qt_lib::QTime;
-            #[namespace = ""]
-            type QUrl = cxx_qt_lib::QUrlCpp;
-            #[namespace = ""]
-            type QVariant = cxx_qt_lib::QVariantCpp;
+        #[rust_name = "public"]
+        fn getPublic(self: &MyObject) -> i32;
+        #[rust_name = "set_public"]
+        fn setPublic(self: Pin<&mut MyObject>, value: i32);
 
-            #[rust_name = "public"]
-            fn getPublic(self: &MyObject) -> i32;
-            #[rust_name = "set_public"]
-            fn setPublic(self: Pin<&mut MyObject>, value: i32);
-
-            #[rust_name = "new_cpp_object"]
-            fn newCppObject() -> UniquePtr<MyObject>;
-        }
-
-        extern "Rust" {
-            type RustObj;
-
-            #[cxx_name = "createRs"]
-            fn create_rs() -> Box<RustObj>;
-
-            #[cxx_name = "initialiseCpp"]
-            fn initialise_cpp(cpp: Pin<&mut MyObject>);
-        }
+        #[rust_name = "new_cpp_object"]
+        fn newCppObject() -> UniquePtr<MyObject>;
     }
 
-    pub type FFICppObj = ffi::MyObject;
+    extern "Rust" {
+        type RustObj;
+
+        #[cxx_name = "createRs"]
+        fn create_rs() -> Box<RustObj>;
+
+        #[cxx_name = "initialiseCpp"]
+        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+    }
+}
+
+pub use self::cxx_qt_my_object::*;
+mod cxx_qt_my_object {
+    use super::my_object::*;
+
+    use cxx_qt_lib::ToUniquePtr;
+
+    pub type FFICppObj = super::my_object::MyObject;
 
     pub struct RustObj {
         private: i32,

--- a/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/cxx-qt-gen/test_outputs/custom_default.rs
@@ -58,7 +58,7 @@ mod my_object {
 
     pub type FFICppObj = ffi::MyObject;
 
-    struct RustObj {
+    pub struct RustObj {
         private: i32,
     }
 
@@ -86,7 +86,7 @@ mod my_object {
         }
     }
 
-    struct Data {
+    pub struct Data {
         public: i32,
     }
 
@@ -116,11 +116,11 @@ mod my_object {
         }
     }
 
-    fn create_rs() -> std::boxed::Box<RustObj> {
+    pub fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(Data::default());
     }

--- a/cxx-qt-gen/test_outputs/handlers.rs
+++ b/cxx-qt-gen/test_outputs/handlers.rs
@@ -1,77 +1,80 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod my_object {
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
+
+        type MyObject;
+
+        include!("cxx-qt-lib/include/qt_types.h");
+        #[namespace = ""]
+        type QColor = cxx_qt_lib::QColorCpp;
+        #[namespace = ""]
+        type QDate = cxx_qt_lib::QDate;
+        #[namespace = ""]
+        type QDateTime = cxx_qt_lib::QDateTimeCpp;
+        #[namespace = ""]
+        type QPoint = cxx_qt_lib::QPoint;
+        #[namespace = ""]
+        type QPointF = cxx_qt_lib::QPointF;
+        #[namespace = ""]
+        type QRect = cxx_qt_lib::QRect;
+        #[namespace = ""]
+        type QRectF = cxx_qt_lib::QRectF;
+        #[namespace = ""]
+        type QSize = cxx_qt_lib::QSize;
+        #[namespace = ""]
+        type QSizeF = cxx_qt_lib::QSizeF;
+        #[namespace = ""]
+        type QString = cxx_qt_lib::QStringCpp;
+        #[namespace = ""]
+        type QTime = cxx_qt_lib::QTime;
+        #[namespace = ""]
+        type QUrl = cxx_qt_lib::QUrlCpp;
+        #[namespace = ""]
+        type QVariant = cxx_qt_lib::QVariantCpp;
+
+        #[namespace = "rust::cxxqtlib1"]
+        type UpdateRequester = cxx_qt_lib::UpdateRequesterCpp;
+
+        #[rust_name = "number"]
+        fn getNumber(self: &MyObject) -> i32;
+        #[rust_name = "set_number"]
+        fn setNumber(self: Pin<&mut MyObject>, value: i32);
+
+        #[rust_name = "string"]
+        fn getString(self: &MyObject) -> &QString;
+        #[rust_name = "set_string"]
+        fn setString(self: Pin<&mut MyObject>, value: &QString);
+
+        #[rust_name = "new_cpp_object"]
+        fn newCppObject() -> UniquePtr<MyObject>;
+
+        #[rust_name = "update_requester"]
+        fn updateRequester(self: Pin<&mut MyObject>) -> UniquePtr<UpdateRequester>;
+    }
+
+    extern "Rust" {
+        type RustObj;
+
+        #[cxx_name = "createRs"]
+        fn create_rs() -> Box<RustObj>;
+
+        #[cxx_name = "initialiseCpp"]
+        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+
+        #[cxx_name = "handleUpdateRequest"]
+        fn call_handle_update_request(self: &mut RustObj, cpp: Pin<&mut MyObject>);
+    }
+}
+
+pub use self::cxx_qt_my_object::*;
+mod cxx_qt_my_object {
+    use super::my_object::*;
+
     use cxx_qt_lib::ToUniquePtr;
     use cxx_qt_lib::UpdateRequestHandler;
 
-    #[cxx::bridge(namespace = "cxx_qt::my_object")]
-    mod ffi {
-        unsafe extern "C++" {
-            include!("cxx-qt-gen/include/my_object.cxxqt.h");
-
-            type MyObject;
-
-            include!("cxx-qt-lib/include/qt_types.h");
-            #[namespace = ""]
-            type QColor = cxx_qt_lib::QColorCpp;
-            #[namespace = ""]
-            type QDate = cxx_qt_lib::QDate;
-            #[namespace = ""]
-            type QDateTime = cxx_qt_lib::QDateTimeCpp;
-            #[namespace = ""]
-            type QPoint = cxx_qt_lib::QPoint;
-            #[namespace = ""]
-            type QPointF = cxx_qt_lib::QPointF;
-            #[namespace = ""]
-            type QRect = cxx_qt_lib::QRect;
-            #[namespace = ""]
-            type QRectF = cxx_qt_lib::QRectF;
-            #[namespace = ""]
-            type QSize = cxx_qt_lib::QSize;
-            #[namespace = ""]
-            type QSizeF = cxx_qt_lib::QSizeF;
-            #[namespace = ""]
-            type QString = cxx_qt_lib::QStringCpp;
-            #[namespace = ""]
-            type QTime = cxx_qt_lib::QTime;
-            #[namespace = ""]
-            type QUrl = cxx_qt_lib::QUrlCpp;
-            #[namespace = ""]
-            type QVariant = cxx_qt_lib::QVariantCpp;
-
-            #[namespace = "rust::cxxqtlib1"]
-            type UpdateRequester = cxx_qt_lib::UpdateRequesterCpp;
-
-            #[rust_name = "number"]
-            fn getNumber(self: &MyObject) -> i32;
-            #[rust_name = "set_number"]
-            fn setNumber(self: Pin<&mut MyObject>, value: i32);
-
-            #[rust_name = "string"]
-            fn getString(self: &MyObject) -> &QString;
-            #[rust_name = "set_string"]
-            fn setString(self: Pin<&mut MyObject>, value: &QString);
-
-            #[rust_name = "new_cpp_object"]
-            fn newCppObject() -> UniquePtr<MyObject>;
-
-            #[rust_name = "update_requester"]
-            fn updateRequester(self: Pin<&mut MyObject>) -> UniquePtr<UpdateRequester>;
-        }
-
-        extern "Rust" {
-            type RustObj;
-
-            #[cxx_name = "createRs"]
-            fn create_rs() -> Box<RustObj>;
-
-            #[cxx_name = "initialiseCpp"]
-            fn initialise_cpp(cpp: Pin<&mut MyObject>);
-
-            #[cxx_name = "handleUpdateRequest"]
-            fn call_handle_update_request(self: &mut RustObj, cpp: Pin<&mut MyObject>);
-        }
-    }
-
-    pub type FFICppObj = ffi::MyObject;
+    pub type FFICppObj = super::my_object::MyObject;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/handlers.rs
+++ b/cxx-qt-gen/test_outputs/handlers.rs
@@ -74,10 +74,10 @@ mod my_object {
     pub type FFICppObj = ffi::MyObject;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
-        fn call_handle_update_request(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
+        pub fn call_handle_update_request(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
             let mut cpp = CppObj::new(cpp);
             self.handle_update_request(&mut cpp);
         }
@@ -119,7 +119,7 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         number: i32,
         string: String,
     }
@@ -145,11 +145,11 @@ mod my_object {
         }
     }
 
-    fn create_rs() -> std::boxed::Box<RustObj> {
+    pub fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(Data::default());
     }

--- a/cxx-qt-gen/test_outputs/invokables.rs
+++ b/cxx-qt-gen/test_outputs/invokables.rs
@@ -1,91 +1,95 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod my_object {
-    use cxx_qt_lib::QColor;
-    use cxx_qt_lib::ToUniquePtr;
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-    #[cxx::bridge(namespace = "cxx_qt::my_object")]
-    mod ffi {
-        unsafe extern "C++" {
-            include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        type MyObject;
 
-            type MyObject;
+        include!("cxx-qt-lib/include/qt_types.h");
+        #[namespace = ""]
+        type QColor = cxx_qt_lib::QColorCpp;
+        #[namespace = ""]
+        type QDate = cxx_qt_lib::QDate;
+        #[namespace = ""]
+        type QDateTime = cxx_qt_lib::QDateTimeCpp;
+        #[namespace = ""]
+        type QPoint = cxx_qt_lib::QPoint;
+        #[namespace = ""]
+        type QPointF = cxx_qt_lib::QPointF;
+        #[namespace = ""]
+        type QRect = cxx_qt_lib::QRect;
+        #[namespace = ""]
+        type QRectF = cxx_qt_lib::QRectF;
+        #[namespace = ""]
+        type QSize = cxx_qt_lib::QSize;
+        #[namespace = ""]
+        type QSizeF = cxx_qt_lib::QSizeF;
+        #[namespace = ""]
+        type QString = cxx_qt_lib::QStringCpp;
+        #[namespace = ""]
+        type QTime = cxx_qt_lib::QTime;
+        #[namespace = ""]
+        type QUrl = cxx_qt_lib::QUrlCpp;
+        #[namespace = ""]
+        type QVariant = cxx_qt_lib::QVariantCpp;
 
-            include!("cxx-qt-lib/include/qt_types.h");
-            #[namespace = ""]
-            type QColor = cxx_qt_lib::QColorCpp;
-            #[namespace = ""]
-            type QDate = cxx_qt_lib::QDate;
-            #[namespace = ""]
-            type QDateTime = cxx_qt_lib::QDateTimeCpp;
-            #[namespace = ""]
-            type QPoint = cxx_qt_lib::QPoint;
-            #[namespace = ""]
-            type QPointF = cxx_qt_lib::QPointF;
-            #[namespace = ""]
-            type QRect = cxx_qt_lib::QRect;
-            #[namespace = ""]
-            type QRectF = cxx_qt_lib::QRectF;
-            #[namespace = ""]
-            type QSize = cxx_qt_lib::QSize;
-            #[namespace = ""]
-            type QSizeF = cxx_qt_lib::QSizeF;
-            #[namespace = ""]
-            type QString = cxx_qt_lib::QStringCpp;
-            #[namespace = ""]
-            type QTime = cxx_qt_lib::QTime;
-            #[namespace = ""]
-            type QUrl = cxx_qt_lib::QUrlCpp;
-            #[namespace = ""]
-            type QVariant = cxx_qt_lib::QVariantCpp;
+        #[namespace = "cxx_qt::nested_object"]
+        type NestedObject = crate::cxx_qt_nested_object::FFICppObj;
 
-            #[namespace = "cxx_qt::nested_object"]
-            type NestedObject = crate::nested_object::FFICppObj;
-
-            #[rust_name = "new_cpp_object"]
-            fn newCppObject() -> UniquePtr<MyObject>;
-        }
-
-        extern "Rust" {
-            type RustObj;
-
-            #[cxx_name = "invokable"]
-            fn invokable(self: &RustObj);
-            #[cxx_name = "invokableCppObjWrapper"]
-            fn invokable_cpp_obj_wrapper(self: &RustObj, cpp: Pin<&mut MyObject>);
-            #[cxx_name = "invokableMutable"]
-            fn invokable_mutable(self: &mut RustObj);
-            #[cxx_name = "invokableMutableCppObjWrapper"]
-            fn invokable_mutable_cpp_obj_wrapper(self: &mut RustObj, cpp: Pin<&mut MyObject>);
-            #[cxx_name = "invokableNestedParameterWrapper"]
-            fn invokable_nested_parameter_wrapper(self: &RustObj, nested: Pin<&mut NestedObject>);
-            #[cxx_name = "invokableParametersWrapper"]
-            fn invokable_parameters_wrapper(
-                self: &RustObj,
-                opaque: &QColor,
-                trivial: &QPoint,
-                primitive: i32,
-            );
-            #[cxx_name = "invokableParametersCppObjWrapper"]
-            fn invokable_parameters_cpp_obj_wrapper(
-                self: &RustObj,
-                primitive: i32,
-                cpp: Pin<&mut MyObject>,
-            );
-            #[cxx_name = "invokableReturnOpaqueWrapper"]
-            fn invokable_return_opaque_wrapper(self: &mut RustObj) -> UniquePtr<QColor>;
-            #[cxx_name = "invokableReturnPrimitive"]
-            fn invokable_return_primitive(self: &mut RustObj) -> i32;
-            #[cxx_name = "invokableReturnStaticWrapper"]
-            fn invokable_return_static_wrapper(self: &mut RustObj) -> UniquePtr<QString>;
-
-            #[cxx_name = "createRs"]
-            fn create_rs() -> Box<RustObj>;
-
-            #[cxx_name = "initialiseCpp"]
-            fn initialise_cpp(cpp: Pin<&mut MyObject>);
-        }
+        #[rust_name = "new_cpp_object"]
+        fn newCppObject() -> UniquePtr<MyObject>;
     }
 
-    pub type FFICppObj = ffi::MyObject;
+    extern "Rust" {
+        type RustObj;
+
+        #[cxx_name = "invokable"]
+        fn invokable(self: &RustObj);
+        #[cxx_name = "invokableCppObjWrapper"]
+        fn invokable_cpp_obj_wrapper(self: &RustObj, cpp: Pin<&mut MyObject>);
+        #[cxx_name = "invokableMutable"]
+        fn invokable_mutable(self: &mut RustObj);
+        #[cxx_name = "invokableMutableCppObjWrapper"]
+        fn invokable_mutable_cpp_obj_wrapper(self: &mut RustObj, cpp: Pin<&mut MyObject>);
+        #[cxx_name = "invokableNestedParameterWrapper"]
+        fn invokable_nested_parameter_wrapper(self: &RustObj, nested: Pin<&mut NestedObject>);
+        #[cxx_name = "invokableParametersWrapper"]
+        fn invokable_parameters_wrapper(
+            self: &RustObj,
+            opaque: &QColor,
+            trivial: &QPoint,
+            primitive: i32,
+        );
+        #[cxx_name = "invokableParametersCppObjWrapper"]
+        fn invokable_parameters_cpp_obj_wrapper(
+            self: &RustObj,
+            primitive: i32,
+            cpp: Pin<&mut MyObject>,
+        );
+        #[cxx_name = "invokableReturnOpaqueWrapper"]
+        fn invokable_return_opaque_wrapper(self: &mut RustObj) -> UniquePtr<QColor>;
+        #[cxx_name = "invokableReturnPrimitive"]
+        fn invokable_return_primitive(self: &mut RustObj) -> i32;
+        #[cxx_name = "invokableReturnStaticWrapper"]
+        fn invokable_return_static_wrapper(self: &mut RustObj) -> UniquePtr<QString>;
+
+        #[cxx_name = "createRs"]
+        fn create_rs() -> Box<RustObj>;
+
+        #[cxx_name = "initialiseCpp"]
+        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+    }
+}
+
+pub use self::cxx_qt_my_object::*;
+mod cxx_qt_my_object {
+    use super::my_object::*;
+
+    use cxx_qt_lib::ToUniquePtr;
+
+    pub type FFICppObj = super::my_object::MyObject;
+
+    use cxx_qt_lib::QColor;
 
     #[derive(Default)]
     pub struct RustObj;
@@ -103,9 +107,9 @@ mod my_object {
 
         pub fn invokable_nested_parameter_wrapper(
             &self,
-            nested: std::pin::Pin<&mut crate::nested_object::FFICppObj>,
+            nested: std::pin::Pin<&mut crate::cxx_qt_nested_object::FFICppObj>,
         ) {
-            let mut nested = crate::nested_object::CppObj::new(nested);
+            let mut nested = crate::cxx_qt_nested_object::CppObj::new(nested);
             self.invokable_nested_parameter(&mut nested);
         }
 
@@ -154,7 +158,7 @@ mod my_object {
             println!("This method is mutable!");
         }
 
-        pub fn invokable_nested_parameter(&self, nested: &mut crate::nested_object::CppObj) {
+        pub fn invokable_nested_parameter(&self, nested: &mut crate::cxx_qt_nested_object::CppObj) {
             println!("nested!");
         }
 

--- a/cxx-qt-gen/test_outputs/invokables.rs
+++ b/cxx-qt-gen/test_outputs/invokables.rs
@@ -88,20 +88,20 @@ mod my_object {
     pub type FFICppObj = ffi::MyObject;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
-        fn invokable_cpp_obj_wrapper(&self, cpp: std::pin::Pin<&mut FFICppObj>) {
+        pub fn invokable_cpp_obj_wrapper(&self, cpp: std::pin::Pin<&mut FFICppObj>) {
             let mut cpp = CppObj::new(cpp);
             self.invokable_cpp_obj(&mut cpp);
         }
 
-        fn invokable_mutable_cpp_obj_wrapper(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
+        pub fn invokable_mutable_cpp_obj_wrapper(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
             let mut cpp = CppObj::new(cpp);
             self.invokable_mutable_cpp_obj(&mut cpp);
         }
 
-        fn invokable_nested_parameter_wrapper(
+        pub fn invokable_nested_parameter_wrapper(
             &self,
             nested: std::pin::Pin<&mut crate::nested_object::FFICppObj>,
         ) {
@@ -109,7 +109,7 @@ mod my_object {
             self.invokable_nested_parameter(&mut nested);
         }
 
-        fn invokable_parameters_wrapper(
+        pub fn invokable_parameters_wrapper(
             &self,
             opaque: &cxx_qt_lib::QColorCpp,
             trivial: &cxx_qt_lib::QPoint,
@@ -119,7 +119,7 @@ mod my_object {
             self.invokable_parameters(&opaque, trivial, primitive);
         }
 
-        fn invokable_parameters_cpp_obj_wrapper(
+        pub fn invokable_parameters_cpp_obj_wrapper(
             &self,
             primitive: i32,
             cpp: std::pin::Pin<&mut FFICppObj>,
@@ -128,35 +128,37 @@ mod my_object {
             self.invokable_parameters_cpp_obj(primitive, &mut cpp);
         }
 
-        fn invokable_return_opaque_wrapper(&mut self) -> cxx::UniquePtr<cxx_qt_lib::QColorCpp> {
+        pub fn invokable_return_opaque_wrapper(&mut self) -> cxx::UniquePtr<cxx_qt_lib::QColorCpp> {
             return self.invokable_return_opaque().to_unique_ptr();
         }
 
-        fn invokable_return_static_wrapper(&mut self) -> cxx::UniquePtr<cxx_qt_lib::QStringCpp> {
+        pub fn invokable_return_static_wrapper(
+            &mut self,
+        ) -> cxx::UniquePtr<cxx_qt_lib::QStringCpp> {
             return self.invokable_return_static().to_unique_ptr();
         }
 
-        fn invokable(&self) {
+        pub fn invokable(&self) {
             println!("invokable");
         }
 
-        fn invokable_cpp_obj(&self, cpp: &mut CppObj) {
+        pub fn invokable_cpp_obj(&self, cpp: &mut CppObj) {
             println!("cppobj");
         }
 
-        fn invokable_mutable(&mut self) {
+        pub fn invokable_mutable(&mut self) {
             println!("This method is mutable!");
         }
 
-        fn invokable_mutable_cpp_obj(&mut self, cpp: &mut CppObj) {
+        pub fn invokable_mutable_cpp_obj(&mut self, cpp: &mut CppObj) {
             println!("This method is mutable!");
         }
 
-        fn invokable_nested_parameter(&self, nested: &mut crate::nested_object::CppObj) {
+        pub fn invokable_nested_parameter(&self, nested: &mut crate::nested_object::CppObj) {
             println!("nested!");
         }
 
-        fn invokable_parameters(&self, opaque: &QColor, trivial: &QPoint, primitive: i32) {
+        pub fn invokable_parameters(&self, opaque: &QColor, trivial: &QPoint, primitive: i32) {
             println!(
                 "Red: {}, Point X: {}, Number: {}",
                 opaque.red(),
@@ -165,23 +167,23 @@ mod my_object {
             );
         }
 
-        fn invokable_parameters_cpp_obj(&self, primitive: i32, cpp: &mut CppObj) {
+        pub fn invokable_parameters_cpp_obj(&self, primitive: i32, cpp: &mut CppObj) {
             println!("{}", primitive);
         }
 
-        fn invokable_return_opaque(&mut self) -> QColor {
+        pub fn invokable_return_opaque(&mut self) -> QColor {
             cxx_qt_lib::QColor::from_rgba(255, 0, 0, 0)
         }
 
-        fn invokable_return_primitive(&mut self) -> i32 {
+        pub fn invokable_return_primitive(&mut self) -> i32 {
             2
         }
 
-        fn invokable_return_static(&mut self) -> &str {
+        pub fn invokable_return_static(&mut self) -> &str {
             "static"
         }
 
-        fn rust_only_method(&self) {
+        pub fn rust_only_method(&self) {
             println!("QML can't call this :)");
         }
     }
@@ -198,7 +200,7 @@ mod my_object {
         pub fn grab_values_from_data(&mut self, mut data: Data) {}
     }
 
-    struct Data;
+    pub struct Data;
 
     impl<'a> From<&CppObj<'a>> for Data {
         fn from(_value: &CppObj<'a>) -> Self {
@@ -212,11 +214,11 @@ mod my_object {
         }
     }
 
-    fn create_rs() -> std::boxed::Box<RustObj> {
+    pub fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(Data::default());
     }

--- a/cxx-qt-gen/test_outputs/naming.rs
+++ b/cxx-qt-gen/test_outputs/naming.rs
@@ -62,10 +62,10 @@ mod my_object {
     pub type FFICppObj = ffi::MyObject;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
-        fn invokable_name(&self) {
+        pub fn invokable_name(&self) {
             println!("Bye from Rust!");
         }
     }
@@ -93,7 +93,7 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         property_name: i32,
     }
 
@@ -111,11 +111,11 @@ mod my_object {
         }
     }
 
-    fn create_rs() -> std::boxed::Box<RustObj> {
+    pub fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(Data::default());
     }

--- a/cxx-qt-gen/test_outputs/naming.rs
+++ b/cxx-qt-gen/test_outputs/naming.rs
@@ -1,65 +1,68 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod my_object {
-    use cxx_qt_lib::ToUniquePtr;
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-    #[cxx::bridge(namespace = "cxx_qt::my_object")]
-    mod ffi {
-        unsafe extern "C++" {
-            include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        type MyObject;
 
-            type MyObject;
+        include!("cxx-qt-lib/include/qt_types.h");
+        #[namespace = ""]
+        type QColor = cxx_qt_lib::QColorCpp;
+        #[namespace = ""]
+        type QDate = cxx_qt_lib::QDate;
+        #[namespace = ""]
+        type QDateTime = cxx_qt_lib::QDateTimeCpp;
+        #[namespace = ""]
+        type QPoint = cxx_qt_lib::QPoint;
+        #[namespace = ""]
+        type QPointF = cxx_qt_lib::QPointF;
+        #[namespace = ""]
+        type QRect = cxx_qt_lib::QRect;
+        #[namespace = ""]
+        type QRectF = cxx_qt_lib::QRectF;
+        #[namespace = ""]
+        type QSize = cxx_qt_lib::QSize;
+        #[namespace = ""]
+        type QSizeF = cxx_qt_lib::QSizeF;
+        #[namespace = ""]
+        type QString = cxx_qt_lib::QStringCpp;
+        #[namespace = ""]
+        type QTime = cxx_qt_lib::QTime;
+        #[namespace = ""]
+        type QUrl = cxx_qt_lib::QUrlCpp;
+        #[namespace = ""]
+        type QVariant = cxx_qt_lib::QVariantCpp;
 
-            include!("cxx-qt-lib/include/qt_types.h");
-            #[namespace = ""]
-            type QColor = cxx_qt_lib::QColorCpp;
-            #[namespace = ""]
-            type QDate = cxx_qt_lib::QDate;
-            #[namespace = ""]
-            type QDateTime = cxx_qt_lib::QDateTimeCpp;
-            #[namespace = ""]
-            type QPoint = cxx_qt_lib::QPoint;
-            #[namespace = ""]
-            type QPointF = cxx_qt_lib::QPointF;
-            #[namespace = ""]
-            type QRect = cxx_qt_lib::QRect;
-            #[namespace = ""]
-            type QRectF = cxx_qt_lib::QRectF;
-            #[namespace = ""]
-            type QSize = cxx_qt_lib::QSize;
-            #[namespace = ""]
-            type QSizeF = cxx_qt_lib::QSizeF;
-            #[namespace = ""]
-            type QString = cxx_qt_lib::QStringCpp;
-            #[namespace = ""]
-            type QTime = cxx_qt_lib::QTime;
-            #[namespace = ""]
-            type QUrl = cxx_qt_lib::QUrlCpp;
-            #[namespace = ""]
-            type QVariant = cxx_qt_lib::QVariantCpp;
+        #[rust_name = "property_name"]
+        fn getPropertyName(self: &MyObject) -> i32;
+        #[rust_name = "set_property_name"]
+        fn setPropertyName(self: Pin<&mut MyObject>, value: i32);
 
-            #[rust_name = "property_name"]
-            fn getPropertyName(self: &MyObject) -> i32;
-            #[rust_name = "set_property_name"]
-            fn setPropertyName(self: Pin<&mut MyObject>, value: i32);
-
-            #[rust_name = "new_cpp_object"]
-            fn newCppObject() -> UniquePtr<MyObject>;
-        }
-
-        extern "Rust" {
-            type RustObj;
-
-            #[cxx_name = "invokableName"]
-            fn invokable_name(self: &RustObj);
-
-            #[cxx_name = "createRs"]
-            fn create_rs() -> Box<RustObj>;
-
-            #[cxx_name = "initialiseCpp"]
-            fn initialise_cpp(cpp: Pin<&mut MyObject>);
-        }
+        #[rust_name = "new_cpp_object"]
+        fn newCppObject() -> UniquePtr<MyObject>;
     }
 
-    pub type FFICppObj = ffi::MyObject;
+    extern "Rust" {
+        type RustObj;
+
+        #[cxx_name = "invokableName"]
+        fn invokable_name(self: &RustObj);
+
+        #[cxx_name = "createRs"]
+        fn create_rs() -> Box<RustObj>;
+
+        #[cxx_name = "initialiseCpp"]
+        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+    }
+}
+
+pub use self::cxx_qt_my_object::*;
+mod cxx_qt_my_object {
+    use super::my_object::*;
+
+    use cxx_qt_lib::ToUniquePtr;
+
+    pub type FFICppObj = super::my_object::MyObject;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/cxx-qt-gen/test_outputs/passthrough.rs
@@ -1,7 +1,67 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
+pub mod my_object {
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
+
+        type MyObject;
+
+        include!("cxx-qt-lib/include/qt_types.h");
+        #[namespace = ""]
+        type QColor = cxx_qt_lib::QColorCpp;
+        #[namespace = ""]
+        type QDate = cxx_qt_lib::QDate;
+        #[namespace = ""]
+        type QDateTime = cxx_qt_lib::QDateTimeCpp;
+        #[namespace = ""]
+        type QPoint = cxx_qt_lib::QPoint;
+        #[namespace = ""]
+        type QPointF = cxx_qt_lib::QPointF;
+        #[namespace = ""]
+        type QRect = cxx_qt_lib::QRect;
+        #[namespace = ""]
+        type QRectF = cxx_qt_lib::QRectF;
+        #[namespace = ""]
+        type QSize = cxx_qt_lib::QSize;
+        #[namespace = ""]
+        type QSizeF = cxx_qt_lib::QSizeF;
+        #[namespace = ""]
+        type QString = cxx_qt_lib::QStringCpp;
+        #[namespace = ""]
+        type QTime = cxx_qt_lib::QTime;
+        #[namespace = ""]
+        type QUrl = cxx_qt_lib::QUrlCpp;
+        #[namespace = ""]
+        type QVariant = cxx_qt_lib::QVariantCpp;
+
+        #[rust_name = "number"]
+        fn getNumber(self: &MyObject) -> i32;
+        #[rust_name = "set_number"]
+        fn setNumber(self: Pin<&mut MyObject>, value: i32);
+
+        #[rust_name = "new_cpp_object"]
+        fn newCppObject() -> UniquePtr<MyObject>;
+    }
+
+    extern "Rust" {
+        type RustObj;
+
+        #[cxx_name = "createRs"]
+        fn create_rs() -> Box<RustObj>;
+
+        #[cxx_name = "initialiseCpp"]
+        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+    }
+}
+
+pub use self::cxx_qt_my_object::*;
 #[attrA]
 #[attrB]
-pub mod my_object {
+pub mod cxx_qt_my_object {
+    use super::my_object::*;
+
     use cxx_qt_lib::ToUniquePtr;
+
+    pub type FFICppObj = super::my_object::MyObject;
 
     const MAX: u16 = 65535;
 
@@ -45,63 +105,6 @@ pub mod my_object {
     }
 
     use super::MyTrait;
-
-    #[cxx::bridge(namespace = "cxx_qt::my_object")]
-    mod ffi {
-        unsafe extern "C++" {
-            include!("cxx-qt-gen/include/my_object.cxxqt.h");
-
-            type MyObject;
-
-            include!("cxx-qt-lib/include/qt_types.h");
-            #[namespace = ""]
-            type QColor = cxx_qt_lib::QColorCpp;
-            #[namespace = ""]
-            type QDate = cxx_qt_lib::QDate;
-            #[namespace = ""]
-            type QDateTime = cxx_qt_lib::QDateTimeCpp;
-            #[namespace = ""]
-            type QPoint = cxx_qt_lib::QPoint;
-            #[namespace = ""]
-            type QPointF = cxx_qt_lib::QPointF;
-            #[namespace = ""]
-            type QRect = cxx_qt_lib::QRect;
-            #[namespace = ""]
-            type QRectF = cxx_qt_lib::QRectF;
-            #[namespace = ""]
-            type QSize = cxx_qt_lib::QSize;
-            #[namespace = ""]
-            type QSizeF = cxx_qt_lib::QSizeF;
-            #[namespace = ""]
-            type QString = cxx_qt_lib::QStringCpp;
-            #[namespace = ""]
-            type QTime = cxx_qt_lib::QTime;
-            #[namespace = ""]
-            type QUrl = cxx_qt_lib::QUrlCpp;
-            #[namespace = ""]
-            type QVariant = cxx_qt_lib::QVariantCpp;
-
-            #[rust_name = "number"]
-            fn getNumber(self: &MyObject) -> i32;
-            #[rust_name = "set_number"]
-            fn setNumber(self: Pin<&mut MyObject>, value: i32);
-
-            #[rust_name = "new_cpp_object"]
-            fn newCppObject() -> UniquePtr<MyObject>;
-        }
-
-        extern "Rust" {
-            type RustObj;
-
-            #[cxx_name = "createRs"]
-            fn create_rs() -> Box<RustObj>;
-
-            #[cxx_name = "initialiseCpp"]
-            fn initialise_cpp(cpp: Pin<&mut MyObject>);
-        }
-    }
-
-    pub type FFICppObj = ffi::MyObject;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/cxx-qt-gen/test_outputs/passthrough.rs
@@ -104,7 +104,7 @@ pub mod my_object {
     pub type FFICppObj = ffi::MyObject;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         fn test_angled(&self, optional: Option<bool>) -> Option<bool> {
@@ -139,7 +139,7 @@ pub mod my_object {
     }
 
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         number: i32,
     }
 
@@ -169,11 +169,11 @@ pub mod my_object {
         }
     }
 
-    fn create_rs() -> std::boxed::Box<RustObj> {
+    pub fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(Data::default());
     }

--- a/cxx-qt-gen/test_outputs/properties.rs
+++ b/cxx-qt-gen/test_outputs/properties.rs
@@ -73,7 +73,7 @@ mod my_object {
     pub type FFICppObj = ffi::MyObject;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {}
 
@@ -117,7 +117,7 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         primitive: i32,
         opaque: QColor,
     }
@@ -137,11 +137,11 @@ mod my_object {
         }
     }
 
-    fn create_rs() -> std::boxed::Box<RustObj> {
+    pub fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(Data::default());
     }

--- a/cxx-qt-gen/test_outputs/properties.rs
+++ b/cxx-qt-gen/test_outputs/properties.rs
@@ -1,76 +1,80 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod my_object {
-    use cxx_qt_lib::QColor;
-    use cxx_qt_lib::ToUniquePtr;
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-    #[cxx::bridge(namespace = "cxx_qt::my_object")]
-    mod ffi {
-        unsafe extern "C++" {
-            include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        type MyObject;
 
-            type MyObject;
+        include!("cxx-qt-lib/include/qt_types.h");
+        #[namespace = ""]
+        type QColor = cxx_qt_lib::QColorCpp;
+        #[namespace = ""]
+        type QDate = cxx_qt_lib::QDate;
+        #[namespace = ""]
+        type QDateTime = cxx_qt_lib::QDateTimeCpp;
+        #[namespace = ""]
+        type QPoint = cxx_qt_lib::QPoint;
+        #[namespace = ""]
+        type QPointF = cxx_qt_lib::QPointF;
+        #[namespace = ""]
+        type QRect = cxx_qt_lib::QRect;
+        #[namespace = ""]
+        type QRectF = cxx_qt_lib::QRectF;
+        #[namespace = ""]
+        type QSize = cxx_qt_lib::QSize;
+        #[namespace = ""]
+        type QSizeF = cxx_qt_lib::QSizeF;
+        #[namespace = ""]
+        type QString = cxx_qt_lib::QStringCpp;
+        #[namespace = ""]
+        type QTime = cxx_qt_lib::QTime;
+        #[namespace = ""]
+        type QUrl = cxx_qt_lib::QUrlCpp;
+        #[namespace = ""]
+        type QVariant = cxx_qt_lib::QVariantCpp;
 
-            include!("cxx-qt-lib/include/qt_types.h");
-            #[namespace = ""]
-            type QColor = cxx_qt_lib::QColorCpp;
-            #[namespace = ""]
-            type QDate = cxx_qt_lib::QDate;
-            #[namespace = ""]
-            type QDateTime = cxx_qt_lib::QDateTimeCpp;
-            #[namespace = ""]
-            type QPoint = cxx_qt_lib::QPoint;
-            #[namespace = ""]
-            type QPointF = cxx_qt_lib::QPointF;
-            #[namespace = ""]
-            type QRect = cxx_qt_lib::QRect;
-            #[namespace = ""]
-            type QRectF = cxx_qt_lib::QRectF;
-            #[namespace = ""]
-            type QSize = cxx_qt_lib::QSize;
-            #[namespace = ""]
-            type QSizeF = cxx_qt_lib::QSizeF;
-            #[namespace = ""]
-            type QString = cxx_qt_lib::QStringCpp;
-            #[namespace = ""]
-            type QTime = cxx_qt_lib::QTime;
-            #[namespace = ""]
-            type QUrl = cxx_qt_lib::QUrlCpp;
-            #[namespace = ""]
-            type QVariant = cxx_qt_lib::QVariantCpp;
+        #[rust_name = "primitive"]
+        fn getPrimitive(self: &MyObject) -> i32;
+        #[rust_name = "set_primitive"]
+        fn setPrimitive(self: Pin<&mut MyObject>, value: i32);
 
-            #[rust_name = "primitive"]
-            fn getPrimitive(self: &MyObject) -> i32;
-            #[rust_name = "set_primitive"]
-            fn setPrimitive(self: Pin<&mut MyObject>, value: i32);
+        #[rust_name = "opaque"]
+        fn getOpaque(self: &MyObject) -> &QColor;
+        #[rust_name = "set_opaque"]
+        fn setOpaque(self: Pin<&mut MyObject>, value: &QColor);
 
-            #[rust_name = "opaque"]
-            fn getOpaque(self: &MyObject) -> &QColor;
-            #[rust_name = "set_opaque"]
-            fn setOpaque(self: Pin<&mut MyObject>, value: &QColor);
+        #[namespace = "cxx_qt::nested_object"]
+        type NestedObject = crate::cxx_qt_nested_object::FFICppObj;
 
-            #[namespace = "cxx_qt::nested_object"]
-            type NestedObject = crate::nested_object::FFICppObj;
+        #[rust_name = "take_nested"]
+        fn takeNested(self: Pin<&mut MyObject>) -> UniquePtr<NestedObject>;
+        #[rust_name = "give_nested"]
+        fn giveNested(self: Pin<&mut MyObject>, value: UniquePtr<NestedObject>);
 
-            #[rust_name = "take_nested"]
-            fn takeNested(self: Pin<&mut MyObject>) -> UniquePtr<NestedObject>;
-            #[rust_name = "give_nested"]
-            fn giveNested(self: Pin<&mut MyObject>, value: UniquePtr<NestedObject>);
-
-            #[rust_name = "new_cpp_object"]
-            fn newCppObject() -> UniquePtr<MyObject>;
-        }
-
-        extern "Rust" {
-            type RustObj;
-
-            #[cxx_name = "createRs"]
-            fn create_rs() -> Box<RustObj>;
-
-            #[cxx_name = "initialiseCpp"]
-            fn initialise_cpp(cpp: Pin<&mut MyObject>);
-        }
+        #[rust_name = "new_cpp_object"]
+        fn newCppObject() -> UniquePtr<MyObject>;
     }
 
-    pub type FFICppObj = ffi::MyObject;
+    extern "Rust" {
+        type RustObj;
+
+        #[cxx_name = "createRs"]
+        fn create_rs() -> Box<RustObj>;
+
+        #[cxx_name = "initialiseCpp"]
+        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+    }
+}
+
+pub use self::cxx_qt_my_object::*;
+mod cxx_qt_my_object {
+    use super::my_object::*;
+
+    use cxx_qt_lib::ToUniquePtr;
+
+    pub type FFICppObj = super::my_object::MyObject;
+
+    use cxx_qt_lib::QColor;
 
     #[derive(Default)]
     pub struct RustObj;
@@ -102,11 +106,11 @@ mod my_object {
             self.cpp.as_mut().set_opaque(&value.to_unique_ptr());
         }
 
-        pub fn take_nested(&mut self) -> cxx::UniquePtr<ffi::NestedObject> {
+        pub fn take_nested(&mut self) -> cxx::UniquePtr<NestedObject> {
             self.cpp.as_mut().take_nested()
         }
 
-        pub fn give_nested(&mut self, value: cxx::UniquePtr<ffi::NestedObject>) {
+        pub fn give_nested(&mut self, value: cxx::UniquePtr<NestedObject>) {
             self.cpp.as_mut().give_nested(value);
         }
 

--- a/cxx-qt-gen/test_outputs/signals.rs
+++ b/cxx-qt-gen/test_outputs/signals.rs
@@ -81,15 +81,15 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
-        fn invokable_wrapper(&self, cpp: std::pin::Pin<&mut FFICppObj>) {
+        pub fn invokable_wrapper(&self, cpp: std::pin::Pin<&mut FFICppObj>) {
             let mut cpp = CppObj::new(cpp);
             self.invokable(&mut cpp);
         }
 
-        fn invokable(&self, cpp: &mut CppObj) {
+        pub fn invokable(&self, cpp: &mut CppObj) {
             unsafe {
                 cpp.emit_immediate(Signal::Ready);
             }
@@ -143,7 +143,7 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct Data;
+    pub struct Data;
 
     impl<'a> From<&CppObj<'a>> for Data {
         fn from(_value: &CppObj<'a>) -> Self {
@@ -157,11 +157,11 @@ mod my_object {
         }
     }
 
-    fn create_rs() -> std::boxed::Box<RustObj> {
+    pub fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(Data::default());
     }

--- a/cxx-qt-gen/test_outputs/signals.rs
+++ b/cxx-qt-gen/test_outputs/signals.rs
@@ -1,75 +1,79 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod my_object {
-    use cxx_qt_lib::QVariant;
-    use cxx_qt_lib::ToUniquePtr;
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-    #[cxx::bridge(namespace = "cxx_qt::my_object")]
-    mod ffi {
-        unsafe extern "C++" {
-            include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        type MyObject;
+        include!("cxx-qt-lib/include/qt_types.h");
+        #[namespace = ""]
+        type QColor = cxx_qt_lib::QColorCpp;
+        #[namespace = ""]
+        type QDate = cxx_qt_lib::QDate;
+        #[namespace = ""]
+        type QDateTime = cxx_qt_lib::QDateTimeCpp;
+        #[namespace = ""]
+        type QPoint = cxx_qt_lib::QPoint;
+        #[namespace = ""]
+        type QPointF = cxx_qt_lib::QPointF;
+        #[namespace = ""]
+        type QRect = cxx_qt_lib::QRect;
+        #[namespace = ""]
+        type QRectF = cxx_qt_lib::QRectF;
+        #[namespace = ""]
+        type QSize = cxx_qt_lib::QSize;
+        #[namespace = ""]
+        type QSizeF = cxx_qt_lib::QSizeF;
+        #[namespace = ""]
+        type QString = cxx_qt_lib::QStringCpp;
+        #[namespace = ""]
+        type QTime = cxx_qt_lib::QTime;
+        #[namespace = ""]
+        type QUrl = cxx_qt_lib::QUrlCpp;
+        #[namespace = ""]
+        type QVariant = cxx_qt_lib::QVariantCpp;
 
-            type MyObject;
-            include!("cxx-qt-lib/include/qt_types.h");
-            #[namespace = ""]
-            type QColor = cxx_qt_lib::QColorCpp;
-            #[namespace = ""]
-            type QDate = cxx_qt_lib::QDate;
-            #[namespace = ""]
-            type QDateTime = cxx_qt_lib::QDateTimeCpp;
-            #[namespace = ""]
-            type QPoint = cxx_qt_lib::QPoint;
-            #[namespace = ""]
-            type QPointF = cxx_qt_lib::QPointF;
-            #[namespace = ""]
-            type QRect = cxx_qt_lib::QRect;
-            #[namespace = ""]
-            type QRectF = cxx_qt_lib::QRectF;
-            #[namespace = ""]
-            type QSize = cxx_qt_lib::QSize;
-            #[namespace = ""]
-            type QSizeF = cxx_qt_lib::QSizeF;
-            #[namespace = ""]
-            type QString = cxx_qt_lib::QStringCpp;
-            #[namespace = ""]
-            type QTime = cxx_qt_lib::QTime;
-            #[namespace = ""]
-            type QUrl = cxx_qt_lib::QUrlCpp;
-            #[namespace = ""]
-            type QVariant = cxx_qt_lib::QVariantCpp;
+        #[rust_name = "ready"]
+        fn ready(self: Pin<&mut MyObject>);
+        #[rust_name = "emit_ready"]
+        fn emitReady(self: Pin<&mut MyObject>);
 
-            #[rust_name = "ready"]
-            fn ready(self: Pin<&mut MyObject>);
-            #[rust_name = "emit_ready"]
-            fn emitReady(self: Pin<&mut MyObject>);
+        #[rust_name = "data_changed"]
+        fn dataChanged(self: Pin<&mut MyObject>, first: i32, second: &QVariant, third: &QPoint);
+        #[rust_name = "emit_data_changed"]
+        fn emitDataChanged(
+            self: Pin<&mut MyObject>,
+            first: i32,
+            second: UniquePtr<QVariant>,
+            third: QPoint,
+        );
 
-            #[rust_name = "data_changed"]
-            fn dataChanged(self: Pin<&mut MyObject>, first: i32, second: &QVariant, third: &QPoint);
-            #[rust_name = "emit_data_changed"]
-            fn emitDataChanged(
-                self: Pin<&mut MyObject>,
-                first: i32,
-                second: UniquePtr<QVariant>,
-                third: QPoint,
-            );
-
-            #[rust_name = "new_cpp_object"]
-            fn newCppObject() -> UniquePtr<MyObject>;
-        }
-
-        extern "Rust" {
-            type RustObj;
-
-            #[cxx_name = "invokableWrapper"]
-            fn invokable_wrapper(self: &RustObj, cpp: Pin<&mut MyObject>);
-
-            #[cxx_name = "createRs"]
-            fn create_rs() -> Box<RustObj>;
-
-            #[cxx_name = "initialiseCpp"]
-            fn initialise_cpp(cpp: Pin<&mut MyObject>);
-        }
+        #[rust_name = "new_cpp_object"]
+        fn newCppObject() -> UniquePtr<MyObject>;
     }
 
-    pub type FFICppObj = ffi::MyObject;
+    extern "Rust" {
+        type RustObj;
+
+        #[cxx_name = "invokableWrapper"]
+        fn invokable_wrapper(self: &RustObj, cpp: Pin<&mut MyObject>);
+
+        #[cxx_name = "createRs"]
+        fn create_rs() -> Box<RustObj>;
+
+        #[cxx_name = "initialiseCpp"]
+        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+    }
+}
+
+pub use self::cxx_qt_my_object::*;
+mod cxx_qt_my_object {
+    use super::my_object::*;
+
+    use cxx_qt_lib::ToUniquePtr;
+
+    pub type FFICppObj = super::my_object::MyObject;
+
+    use cxx_qt_lib::QVariant;
 
     enum Signal {
         Ready,

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -99,7 +99,7 @@ mod my_object {
     pub type FFICppObj = ffi::MyObject;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {}
 
@@ -198,7 +198,7 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         boolean: bool,
         float_32: f32,
         float_64: f64,
@@ -232,11 +232,11 @@ mod my_object {
         }
     }
 
-    fn create_rs() -> std::boxed::Box<RustObj> {
+    pub fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(Data::default());
     }

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -1,102 +1,105 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod my_object {
-    use cxx_qt_lib::ToUniquePtr;
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-    #[cxx::bridge(namespace = "cxx_qt::my_object")]
-    mod ffi {
-        unsafe extern "C++" {
-            include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        type MyObject;
 
-            type MyObject;
+        include!("cxx-qt-lib/include/qt_types.h");
+        #[namespace = ""]
+        type QColor = cxx_qt_lib::QColorCpp;
+        #[namespace = ""]
+        type QDate = cxx_qt_lib::QDate;
+        #[namespace = ""]
+        type QDateTime = cxx_qt_lib::QDateTimeCpp;
+        #[namespace = ""]
+        type QPoint = cxx_qt_lib::QPoint;
+        #[namespace = ""]
+        type QPointF = cxx_qt_lib::QPointF;
+        #[namespace = ""]
+        type QRect = cxx_qt_lib::QRect;
+        #[namespace = ""]
+        type QRectF = cxx_qt_lib::QRectF;
+        #[namespace = ""]
+        type QSize = cxx_qt_lib::QSize;
+        #[namespace = ""]
+        type QSizeF = cxx_qt_lib::QSizeF;
+        #[namespace = ""]
+        type QString = cxx_qt_lib::QStringCpp;
+        #[namespace = ""]
+        type QTime = cxx_qt_lib::QTime;
+        #[namespace = ""]
+        type QUrl = cxx_qt_lib::QUrlCpp;
+        #[namespace = ""]
+        type QVariant = cxx_qt_lib::QVariantCpp;
 
-            include!("cxx-qt-lib/include/qt_types.h");
-            #[namespace = ""]
-            type QColor = cxx_qt_lib::QColorCpp;
-            #[namespace = ""]
-            type QDate = cxx_qt_lib::QDate;
-            #[namespace = ""]
-            type QDateTime = cxx_qt_lib::QDateTimeCpp;
-            #[namespace = ""]
-            type QPoint = cxx_qt_lib::QPoint;
-            #[namespace = ""]
-            type QPointF = cxx_qt_lib::QPointF;
-            #[namespace = ""]
-            type QRect = cxx_qt_lib::QRect;
-            #[namespace = ""]
-            type QRectF = cxx_qt_lib::QRectF;
-            #[namespace = ""]
-            type QSize = cxx_qt_lib::QSize;
-            #[namespace = ""]
-            type QSizeF = cxx_qt_lib::QSizeF;
-            #[namespace = ""]
-            type QString = cxx_qt_lib::QStringCpp;
-            #[namespace = ""]
-            type QTime = cxx_qt_lib::QTime;
-            #[namespace = ""]
-            type QUrl = cxx_qt_lib::QUrlCpp;
-            #[namespace = ""]
-            type QVariant = cxx_qt_lib::QVariantCpp;
+        #[rust_name = "boolean"]
+        fn getBoolean(self: &MyObject) -> bool;
+        #[rust_name = "set_boolean"]
+        fn setBoolean(self: Pin<&mut MyObject>, value: bool);
 
-            #[rust_name = "boolean"]
-            fn getBoolean(self: &MyObject) -> bool;
-            #[rust_name = "set_boolean"]
-            fn setBoolean(self: Pin<&mut MyObject>, value: bool);
+        #[rust_name = "float_32"]
+        fn getFloat32(self: &MyObject) -> f32;
+        #[rust_name = "set_float_32"]
+        fn setFloat32(self: Pin<&mut MyObject>, value: f32);
 
-            #[rust_name = "float_32"]
-            fn getFloat32(self: &MyObject) -> f32;
-            #[rust_name = "set_float_32"]
-            fn setFloat32(self: Pin<&mut MyObject>, value: f32);
+        #[rust_name = "float_64"]
+        fn getFloat64(self: &MyObject) -> f64;
+        #[rust_name = "set_float_64"]
+        fn setFloat64(self: Pin<&mut MyObject>, value: f64);
 
-            #[rust_name = "float_64"]
-            fn getFloat64(self: &MyObject) -> f64;
-            #[rust_name = "set_float_64"]
-            fn setFloat64(self: Pin<&mut MyObject>, value: f64);
+        #[rust_name = "int_8"]
+        fn getInt8(self: &MyObject) -> i8;
+        #[rust_name = "set_int_8"]
+        fn setInt8(self: Pin<&mut MyObject>, value: i8);
 
-            #[rust_name = "int_8"]
-            fn getInt8(self: &MyObject) -> i8;
-            #[rust_name = "set_int_8"]
-            fn setInt8(self: Pin<&mut MyObject>, value: i8);
+        #[rust_name = "int_16"]
+        fn getInt16(self: &MyObject) -> i16;
+        #[rust_name = "set_int_16"]
+        fn setInt16(self: Pin<&mut MyObject>, value: i16);
 
-            #[rust_name = "int_16"]
-            fn getInt16(self: &MyObject) -> i16;
-            #[rust_name = "set_int_16"]
-            fn setInt16(self: Pin<&mut MyObject>, value: i16);
+        #[rust_name = "int_32"]
+        fn getInt32(self: &MyObject) -> i32;
+        #[rust_name = "set_int_32"]
+        fn setInt32(self: Pin<&mut MyObject>, value: i32);
 
-            #[rust_name = "int_32"]
-            fn getInt32(self: &MyObject) -> i32;
-            #[rust_name = "set_int_32"]
-            fn setInt32(self: Pin<&mut MyObject>, value: i32);
+        #[rust_name = "uint_8"]
+        fn getUint8(self: &MyObject) -> u8;
+        #[rust_name = "set_uint_8"]
+        fn setUint8(self: Pin<&mut MyObject>, value: u8);
 
-            #[rust_name = "uint_8"]
-            fn getUint8(self: &MyObject) -> u8;
-            #[rust_name = "set_uint_8"]
-            fn setUint8(self: Pin<&mut MyObject>, value: u8);
+        #[rust_name = "uint_16"]
+        fn getUint16(self: &MyObject) -> u16;
+        #[rust_name = "set_uint_16"]
+        fn setUint16(self: Pin<&mut MyObject>, value: u16);
 
-            #[rust_name = "uint_16"]
-            fn getUint16(self: &MyObject) -> u16;
-            #[rust_name = "set_uint_16"]
-            fn setUint16(self: Pin<&mut MyObject>, value: u16);
+        #[rust_name = "uint_32"]
+        fn getUint32(self: &MyObject) -> u32;
+        #[rust_name = "set_uint_32"]
+        fn setUint32(self: Pin<&mut MyObject>, value: u32);
 
-            #[rust_name = "uint_32"]
-            fn getUint32(self: &MyObject) -> u32;
-            #[rust_name = "set_uint_32"]
-            fn setUint32(self: Pin<&mut MyObject>, value: u32);
-
-            #[rust_name = "new_cpp_object"]
-            fn newCppObject() -> UniquePtr<MyObject>;
-        }
-
-        extern "Rust" {
-            type RustObj;
-
-            #[cxx_name = "createRs"]
-            fn create_rs() -> Box<RustObj>;
-
-            #[cxx_name = "initialiseCpp"]
-            fn initialise_cpp(cpp: Pin<&mut MyObject>);
-        }
+        #[rust_name = "new_cpp_object"]
+        fn newCppObject() -> UniquePtr<MyObject>;
     }
 
-    pub type FFICppObj = ffi::MyObject;
+    extern "Rust" {
+        type RustObj;
+
+        #[cxx_name = "createRs"]
+        fn create_rs() -> Box<RustObj>;
+
+        #[cxx_name = "initialiseCpp"]
+        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+    }
+}
+
+pub use self::cxx_qt_my_object::*;
+mod cxx_qt_my_object {
+    use super::my_object::*;
+
+    use cxx_qt_lib::ToUniquePtr;
+
+    pub type FFICppObj = super::my_object::MyObject;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -1,132 +1,123 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod my_object {
-    use cxx_qt_lib::ToUniquePtr;
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-    #[cxx::bridge(namespace = "cxx_qt::my_object")]
-    mod ffi {
-        unsafe extern "C++" {
-            include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        type MyObject;
 
-            type MyObject;
+        include!("cxx-qt-lib/include/qt_types.h");
+        #[namespace = ""]
+        type QColor = cxx_qt_lib::QColorCpp;
+        #[namespace = ""]
+        type QDate = cxx_qt_lib::QDate;
+        #[namespace = ""]
+        type QDateTime = cxx_qt_lib::QDateTimeCpp;
+        #[namespace = ""]
+        type QPoint = cxx_qt_lib::QPoint;
+        #[namespace = ""]
+        type QPointF = cxx_qt_lib::QPointF;
+        #[namespace = ""]
+        type QRect = cxx_qt_lib::QRect;
+        #[namespace = ""]
+        type QRectF = cxx_qt_lib::QRectF;
+        #[namespace = ""]
+        type QSize = cxx_qt_lib::QSize;
+        #[namespace = ""]
+        type QSizeF = cxx_qt_lib::QSizeF;
+        #[namespace = ""]
+        type QString = cxx_qt_lib::QStringCpp;
+        #[namespace = ""]
+        type QTime = cxx_qt_lib::QTime;
+        #[namespace = ""]
+        type QUrl = cxx_qt_lib::QUrlCpp;
+        #[namespace = ""]
+        type QVariant = cxx_qt_lib::QVariantCpp;
 
-            include!("cxx-qt-lib/include/qt_types.h");
-            #[namespace = ""]
-            type QColor = cxx_qt_lib::QColorCpp;
-            #[namespace = ""]
-            type QDate = cxx_qt_lib::QDate;
-            #[namespace = ""]
-            type QDateTime = cxx_qt_lib::QDateTimeCpp;
-            #[namespace = ""]
-            type QPoint = cxx_qt_lib::QPoint;
-            #[namespace = ""]
-            type QPointF = cxx_qt_lib::QPointF;
-            #[namespace = ""]
-            type QRect = cxx_qt_lib::QRect;
-            #[namespace = ""]
-            type QRectF = cxx_qt_lib::QRectF;
-            #[namespace = ""]
-            type QSize = cxx_qt_lib::QSize;
-            #[namespace = ""]
-            type QSizeF = cxx_qt_lib::QSizeF;
-            #[namespace = ""]
-            type QString = cxx_qt_lib::QStringCpp;
-            #[namespace = ""]
-            type QTime = cxx_qt_lib::QTime;
-            #[namespace = ""]
-            type QUrl = cxx_qt_lib::QUrlCpp;
-            #[namespace = ""]
-            type QVariant = cxx_qt_lib::QVariantCpp;
-
-            #[rust_name = "new_cpp_object"]
-            fn newCppObject() -> UniquePtr<MyObject>;
-        }
-
-        extern "Rust" {
-            type RustObj;
-
-            #[cxx_name = "testColorWrapper"]
-            fn test_color_wrapper(
-                self: &RustObj,
-                _cpp: Pin<&mut MyObject>,
-                color: &QColor,
-            ) -> UniquePtr<QColor>;
-
-            #[cxx_name = "testDateWrapper"]
-            fn test_date_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, date: &QDate) -> QDate;
-
-            #[cxx_name = "testDateTimeWrapper"]
-            fn test_date_time_wrapper(
-                self: &RustObj,
-                _cpp: Pin<&mut MyObject>,
-                dateTime: &QDateTime,
-            ) -> UniquePtr<QDateTime>;
-
-            #[cxx_name = "testPointWrapper"]
-            fn test_point_wrapper(
-                self: &RustObj,
-                _cpp: Pin<&mut MyObject>,
-                point: &QPoint,
-            ) -> QPoint;
-
-            #[cxx_name = "testPointfWrapper"]
-            fn test_pointf_wrapper(
-                self: &RustObj,
-                _cpp: Pin<&mut MyObject>,
-                pointf: &QPointF,
-            ) -> QPointF;
-
-            #[cxx_name = "testRectWrapper"]
-            fn test_rect_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, rect: &QRect) -> QRect;
-
-            #[cxx_name = "testRectfWrapper"]
-            fn test_rectf_wrapper(
-                self: &RustObj,
-                _cpp: Pin<&mut MyObject>,
-                rectf: &QRectF,
-            ) -> QRectF;
-
-            #[cxx_name = "testSizeWrapper"]
-            fn test_size_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, size: &QSize) -> QSize;
-
-            #[cxx_name = "testSizefWrapper"]
-            fn test_sizef_wrapper(
-                self: &RustObj,
-                _cpp: Pin<&mut MyObject>,
-                sizef: &QSizeF,
-            ) -> QSizeF;
-
-            #[cxx_name = "testStringWrapper"]
-            fn test_string_wrapper(
-                self: &RustObj,
-                _cpp: Pin<&mut MyObject>,
-                string: &QString,
-            ) -> UniquePtr<QString>;
-
-            #[cxx_name = "testTimeWrapper"]
-            fn test_time_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, time: &QTime) -> QTime;
-
-            #[cxx_name = "testUrlWrapper"]
-            fn test_url_wrapper(
-                self: &RustObj,
-                _cpp: Pin<&mut MyObject>,
-                url: &QUrl,
-            ) -> UniquePtr<QUrl>;
-
-            #[cxx_name = "testVariantWrapper"]
-            fn test_variant_wrapper(
-                self: &RustObj,
-                _cpp: Pin<&mut MyObject>,
-                variant: &QVariant,
-            ) -> UniquePtr<QVariant>;
-
-            #[cxx_name = "createRs"]
-            fn create_rs() -> Box<RustObj>;
-
-            #[cxx_name = "initialiseCpp"]
-            fn initialise_cpp(cpp: Pin<&mut MyObject>);
-        }
+        #[rust_name = "new_cpp_object"]
+        fn newCppObject() -> UniquePtr<MyObject>;
     }
 
-    pub type FFICppObj = ffi::MyObject;
+    extern "Rust" {
+        type RustObj;
+
+        #[cxx_name = "testColorWrapper"]
+        fn test_color_wrapper(
+            self: &RustObj,
+            _cpp: Pin<&mut MyObject>,
+            color: &QColor,
+        ) -> UniquePtr<QColor>;
+
+        #[cxx_name = "testDateWrapper"]
+        fn test_date_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, date: &QDate) -> QDate;
+
+        #[cxx_name = "testDateTimeWrapper"]
+        fn test_date_time_wrapper(
+            self: &RustObj,
+            _cpp: Pin<&mut MyObject>,
+            dateTime: &QDateTime,
+        ) -> UniquePtr<QDateTime>;
+
+        #[cxx_name = "testPointWrapper"]
+        fn test_point_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, point: &QPoint) -> QPoint;
+
+        #[cxx_name = "testPointfWrapper"]
+        fn test_pointf_wrapper(
+            self: &RustObj,
+            _cpp: Pin<&mut MyObject>,
+            pointf: &QPointF,
+        ) -> QPointF;
+
+        #[cxx_name = "testRectWrapper"]
+        fn test_rect_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, rect: &QRect) -> QRect;
+
+        #[cxx_name = "testRectfWrapper"]
+        fn test_rectf_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, rectf: &QRectF) -> QRectF;
+
+        #[cxx_name = "testSizeWrapper"]
+        fn test_size_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, size: &QSize) -> QSize;
+
+        #[cxx_name = "testSizefWrapper"]
+        fn test_sizef_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, sizef: &QSizeF) -> QSizeF;
+
+        #[cxx_name = "testStringWrapper"]
+        fn test_string_wrapper(
+            self: &RustObj,
+            _cpp: Pin<&mut MyObject>,
+            string: &QString,
+        ) -> UniquePtr<QString>;
+
+        #[cxx_name = "testTimeWrapper"]
+        fn test_time_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, time: &QTime) -> QTime;
+
+        #[cxx_name = "testUrlWrapper"]
+        fn test_url_wrapper(
+            self: &RustObj,
+            _cpp: Pin<&mut MyObject>,
+            url: &QUrl,
+        ) -> UniquePtr<QUrl>;
+
+        #[cxx_name = "testVariantWrapper"]
+        fn test_variant_wrapper(
+            self: &RustObj,
+            _cpp: Pin<&mut MyObject>,
+            variant: &QVariant,
+        ) -> UniquePtr<QVariant>;
+
+        #[cxx_name = "createRs"]
+        fn create_rs() -> Box<RustObj>;
+
+        #[cxx_name = "initialiseCpp"]
+        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+    }
+}
+
+pub use self::cxx_qt_my_object::*;
+mod cxx_qt_my_object {
+    use super::my_object::*;
+
+    use cxx_qt_lib::ToUniquePtr;
+
+    pub type FFICppObj = super::my_object::MyObject;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -129,10 +129,10 @@ mod my_object {
     pub type FFICppObj = ffi::MyObject;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
-        fn test_color_wrapper(
+        pub fn test_color_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             color: &cxx_qt_lib::QColorCpp,
@@ -142,7 +142,7 @@ mod my_object {
             return self.test_color(&mut _cpp, &color).to_unique_ptr();
         }
 
-        fn test_date_wrapper(
+        pub fn test_date_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             date: &cxx_qt_lib::QDate,
@@ -151,7 +151,7 @@ mod my_object {
             return self.test_date(&mut _cpp, date);
         }
 
-        fn test_date_time_wrapper(
+        pub fn test_date_time_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             dateTime: &cxx_qt_lib::QDateTimeCpp,
@@ -161,7 +161,7 @@ mod my_object {
             return self.test_date_time(&mut _cpp, &dateTime).to_unique_ptr();
         }
 
-        fn test_point_wrapper(
+        pub fn test_point_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             point: &cxx_qt_lib::QPoint,
@@ -170,7 +170,7 @@ mod my_object {
             return self.test_point(&mut _cpp, point);
         }
 
-        fn test_pointf_wrapper(
+        pub fn test_pointf_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             pointf: &cxx_qt_lib::QPointF,
@@ -179,7 +179,7 @@ mod my_object {
             return self.test_pointf(&mut _cpp, pointf);
         }
 
-        fn test_rect_wrapper(
+        pub fn test_rect_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             rect: &cxx_qt_lib::QRect,
@@ -188,7 +188,7 @@ mod my_object {
             return self.test_rect(&mut _cpp, rect);
         }
 
-        fn test_rectf_wrapper(
+        pub fn test_rectf_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             rectf: &cxx_qt_lib::QRectF,
@@ -197,7 +197,7 @@ mod my_object {
             return self.test_rectf(&mut _cpp, rectf);
         }
 
-        fn test_size_wrapper(
+        pub fn test_size_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             size: &cxx_qt_lib::QSize,
@@ -206,7 +206,7 @@ mod my_object {
             return self.test_size(&mut _cpp, size);
         }
 
-        fn test_sizef_wrapper(
+        pub fn test_sizef_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             sizef: &cxx_qt_lib::QSizeF,
@@ -215,7 +215,7 @@ mod my_object {
             return self.test_sizef(&mut _cpp, sizef);
         }
 
-        fn test_string_wrapper(
+        pub fn test_string_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             string: &cxx_qt_lib::QStringCpp,
@@ -225,7 +225,7 @@ mod my_object {
             return self.test_string(&mut _cpp, &string).to_unique_ptr();
         }
 
-        fn test_time_wrapper(
+        pub fn test_time_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             time: &cxx_qt_lib::QTime,
@@ -234,7 +234,7 @@ mod my_object {
             return self.test_time(&mut _cpp, time);
         }
 
-        fn test_url_wrapper(
+        pub fn test_url_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             url: &cxx_qt_lib::QUrlCpp,
@@ -244,7 +244,7 @@ mod my_object {
             return self.test_url(&mut _cpp, &url).to_unique_ptr();
         }
 
-        fn test_variant_wrapper(
+        pub fn test_variant_wrapper(
             &self,
             _cpp: std::pin::Pin<&mut FFICppObj>,
             variant: &cxx_qt_lib::QVariantCpp,
@@ -254,55 +254,55 @@ mod my_object {
             return self.test_variant(&mut _cpp, &variant).to_unique_ptr();
         }
 
-        fn test_color(&self, _cpp: &mut CppObj, color: &QColor) -> QColor {
+        pub fn test_color(&self, _cpp: &mut CppObj, color: &QColor) -> QColor {
             color
         }
 
-        fn test_date(&self, _cpp: &mut CppObj, date: &QDate) -> QDate {
+        pub fn test_date(&self, _cpp: &mut CppObj, date: &QDate) -> QDate {
             date
         }
 
-        fn test_date_time(&self, _cpp: &mut CppObj, dateTime: &QDateTime) -> QDateTime {
+        pub fn test_date_time(&self, _cpp: &mut CppObj, dateTime: &QDateTime) -> QDateTime {
             dateTime
         }
 
-        fn test_point(&self, _cpp: &mut CppObj, point: &QPoint) -> QPoint {
+        pub fn test_point(&self, _cpp: &mut CppObj, point: &QPoint) -> QPoint {
             point
         }
 
-        fn test_pointf(&self, _cpp: &mut CppObj, pointf: &QPointF) -> QPointF {
+        pub fn test_pointf(&self, _cpp: &mut CppObj, pointf: &QPointF) -> QPointF {
             pointf
         }
 
-        fn test_rect(&self, _cpp: &mut CppObj, rect: &QRect) -> QRect {
+        pub fn test_rect(&self, _cpp: &mut CppObj, rect: &QRect) -> QRect {
             rect
         }
 
-        fn test_rectf(&self, _cpp: &mut CppObj, rectf: &QRectF) -> QRectF {
+        pub fn test_rectf(&self, _cpp: &mut CppObj, rectf: &QRectF) -> QRectF {
             rectf
         }
 
-        fn test_size(&self, _cpp: &mut CppObj, size: &QSize) -> QSize {
+        pub fn test_size(&self, _cpp: &mut CppObj, size: &QSize) -> QSize {
             size
         }
 
-        fn test_sizef(&self, _cpp: &mut CppObj, sizef: &QSizeF) -> QSizeF {
+        pub fn test_sizef(&self, _cpp: &mut CppObj, sizef: &QSizeF) -> QSizeF {
             sizef
         }
 
-        fn test_string(&self, _cpp: &mut CppObj, string: &str) -> String {
+        pub fn test_string(&self, _cpp: &mut CppObj, string: &str) -> String {
             string.to_owned()
         }
 
-        fn test_time(&self, _cpp: &mut CppObj, time: &QTime) -> QTime {
+        pub fn test_time(&self, _cpp: &mut CppObj, time: &QTime) -> QTime {
             time
         }
 
-        fn test_url(&self, _cpp: &mut CppObj, url: &QUrl) -> QUrl {
+        pub fn test_url(&self, _cpp: &mut CppObj, url: &QUrl) -> QUrl {
             url
         }
 
-        fn test_variant(&self, _cpp: &mut CppObj, variant: &QVariant) -> QVariant {
+        pub fn test_variant(&self, _cpp: &mut CppObj, variant: &QVariant) -> QVariant {
             variant
         }
     }
@@ -320,7 +320,7 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct Data;
+    pub struct Data;
 
     impl<'a> From<&CppObj<'a>> for Data {
         fn from(_value: &CppObj<'a>) -> Self {
@@ -334,11 +334,11 @@ mod my_object {
         }
     }
 
-    fn create_rs() -> std::boxed::Box<RustObj> {
+    pub fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(Data::default());
     }

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -1,122 +1,125 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod my_object {
-    use cxx_qt_lib::ToUniquePtr;
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-    #[cxx::bridge(namespace = "cxx_qt::my_object")]
-    mod ffi {
-        unsafe extern "C++" {
-            include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        type MyObject;
 
-            type MyObject;
+        include!("cxx-qt-lib/include/qt_types.h");
+        #[namespace = ""]
+        type QColor = cxx_qt_lib::QColorCpp;
+        #[namespace = ""]
+        type QDate = cxx_qt_lib::QDate;
+        #[namespace = ""]
+        type QDateTime = cxx_qt_lib::QDateTimeCpp;
+        #[namespace = ""]
+        type QPoint = cxx_qt_lib::QPoint;
+        #[namespace = ""]
+        type QPointF = cxx_qt_lib::QPointF;
+        #[namespace = ""]
+        type QRect = cxx_qt_lib::QRect;
+        #[namespace = ""]
+        type QRectF = cxx_qt_lib::QRectF;
+        #[namespace = ""]
+        type QSize = cxx_qt_lib::QSize;
+        #[namespace = ""]
+        type QSizeF = cxx_qt_lib::QSizeF;
+        #[namespace = ""]
+        type QString = cxx_qt_lib::QStringCpp;
+        #[namespace = ""]
+        type QTime = cxx_qt_lib::QTime;
+        #[namespace = ""]
+        type QUrl = cxx_qt_lib::QUrlCpp;
+        #[namespace = ""]
+        type QVariant = cxx_qt_lib::QVariantCpp;
 
-            include!("cxx-qt-lib/include/qt_types.h");
-            #[namespace = ""]
-            type QColor = cxx_qt_lib::QColorCpp;
-            #[namespace = ""]
-            type QDate = cxx_qt_lib::QDate;
-            #[namespace = ""]
-            type QDateTime = cxx_qt_lib::QDateTimeCpp;
-            #[namespace = ""]
-            type QPoint = cxx_qt_lib::QPoint;
-            #[namespace = ""]
-            type QPointF = cxx_qt_lib::QPointF;
-            #[namespace = ""]
-            type QRect = cxx_qt_lib::QRect;
-            #[namespace = ""]
-            type QRectF = cxx_qt_lib::QRectF;
-            #[namespace = ""]
-            type QSize = cxx_qt_lib::QSize;
-            #[namespace = ""]
-            type QSizeF = cxx_qt_lib::QSizeF;
-            #[namespace = ""]
-            type QString = cxx_qt_lib::QStringCpp;
-            #[namespace = ""]
-            type QTime = cxx_qt_lib::QTime;
-            #[namespace = ""]
-            type QUrl = cxx_qt_lib::QUrlCpp;
-            #[namespace = ""]
-            type QVariant = cxx_qt_lib::QVariantCpp;
+        #[rust_name = "color"]
+        fn getColor(self: &MyObject) -> &QColor;
+        #[rust_name = "set_color"]
+        fn setColor(self: Pin<&mut MyObject>, value: &QColor);
 
-            #[rust_name = "color"]
-            fn getColor(self: &MyObject) -> &QColor;
-            #[rust_name = "set_color"]
-            fn setColor(self: Pin<&mut MyObject>, value: &QColor);
+        #[rust_name = "date"]
+        fn getDate(self: &MyObject) -> &QDate;
+        #[rust_name = "set_date"]
+        fn setDate(self: Pin<&mut MyObject>, value: &QDate);
 
-            #[rust_name = "date"]
-            fn getDate(self: &MyObject) -> &QDate;
-            #[rust_name = "set_date"]
-            fn setDate(self: Pin<&mut MyObject>, value: &QDate);
+        #[rust_name = "date_time"]
+        fn getDateTime(self: &MyObject) -> &QDateTime;
+        #[rust_name = "set_date_time"]
+        fn setDateTime(self: Pin<&mut MyObject>, value: &QDateTime);
 
-            #[rust_name = "date_time"]
-            fn getDateTime(self: &MyObject) -> &QDateTime;
-            #[rust_name = "set_date_time"]
-            fn setDateTime(self: Pin<&mut MyObject>, value: &QDateTime);
+        #[rust_name = "point"]
+        fn getPoint(self: &MyObject) -> &QPoint;
+        #[rust_name = "set_point"]
+        fn setPoint(self: Pin<&mut MyObject>, value: &QPoint);
 
-            #[rust_name = "point"]
-            fn getPoint(self: &MyObject) -> &QPoint;
-            #[rust_name = "set_point"]
-            fn setPoint(self: Pin<&mut MyObject>, value: &QPoint);
+        #[rust_name = "pointf"]
+        fn getPointf(self: &MyObject) -> &QPointF;
+        #[rust_name = "set_pointf"]
+        fn setPointf(self: Pin<&mut MyObject>, value: &QPointF);
 
-            #[rust_name = "pointf"]
-            fn getPointf(self: &MyObject) -> &QPointF;
-            #[rust_name = "set_pointf"]
-            fn setPointf(self: Pin<&mut MyObject>, value: &QPointF);
+        #[rust_name = "rect"]
+        fn getRect(self: &MyObject) -> &QRect;
+        #[rust_name = "set_rect"]
+        fn setRect(self: Pin<&mut MyObject>, value: &QRect);
 
-            #[rust_name = "rect"]
-            fn getRect(self: &MyObject) -> &QRect;
-            #[rust_name = "set_rect"]
-            fn setRect(self: Pin<&mut MyObject>, value: &QRect);
+        #[rust_name = "rectf"]
+        fn getRectf(self: &MyObject) -> &QRectF;
+        #[rust_name = "set_rectf"]
+        fn setRectf(self: Pin<&mut MyObject>, value: &QRectF);
 
-            #[rust_name = "rectf"]
-            fn getRectf(self: &MyObject) -> &QRectF;
-            #[rust_name = "set_rectf"]
-            fn setRectf(self: Pin<&mut MyObject>, value: &QRectF);
+        #[rust_name = "size"]
+        fn getSize(self: &MyObject) -> &QSize;
+        #[rust_name = "set_size"]
+        fn setSize(self: Pin<&mut MyObject>, value: &QSize);
 
-            #[rust_name = "size"]
-            fn getSize(self: &MyObject) -> &QSize;
-            #[rust_name = "set_size"]
-            fn setSize(self: Pin<&mut MyObject>, value: &QSize);
+        #[rust_name = "sizef"]
+        fn getSizef(self: &MyObject) -> &QSizeF;
+        #[rust_name = "set_sizef"]
+        fn setSizef(self: Pin<&mut MyObject>, value: &QSizeF);
 
-            #[rust_name = "sizef"]
-            fn getSizef(self: &MyObject) -> &QSizeF;
-            #[rust_name = "set_sizef"]
-            fn setSizef(self: Pin<&mut MyObject>, value: &QSizeF);
+        #[rust_name = "string"]
+        fn getString(self: &MyObject) -> &QString;
+        #[rust_name = "set_string"]
+        fn setString(self: Pin<&mut MyObject>, value: &QString);
 
-            #[rust_name = "string"]
-            fn getString(self: &MyObject) -> &QString;
-            #[rust_name = "set_string"]
-            fn setString(self: Pin<&mut MyObject>, value: &QString);
+        #[rust_name = "time"]
+        fn getTime(self: &MyObject) -> &QTime;
+        #[rust_name = "set_time"]
+        fn setTime(self: Pin<&mut MyObject>, value: &QTime);
 
-            #[rust_name = "time"]
-            fn getTime(self: &MyObject) -> &QTime;
-            #[rust_name = "set_time"]
-            fn setTime(self: Pin<&mut MyObject>, value: &QTime);
+        #[rust_name = "url"]
+        fn getUrl(self: &MyObject) -> &QUrl;
+        #[rust_name = "set_url"]
+        fn setUrl(self: Pin<&mut MyObject>, value: &QUrl);
 
-            #[rust_name = "url"]
-            fn getUrl(self: &MyObject) -> &QUrl;
-            #[rust_name = "set_url"]
-            fn setUrl(self: Pin<&mut MyObject>, value: &QUrl);
+        #[rust_name = "variant"]
+        fn getVariant(self: &MyObject) -> &QVariant;
+        #[rust_name = "set_variant"]
+        fn setVariant(self: Pin<&mut MyObject>, value: &QVariant);
 
-            #[rust_name = "variant"]
-            fn getVariant(self: &MyObject) -> &QVariant;
-            #[rust_name = "set_variant"]
-            fn setVariant(self: Pin<&mut MyObject>, value: &QVariant);
-
-            #[rust_name = "new_cpp_object"]
-            fn newCppObject() -> UniquePtr<MyObject>;
-        }
-
-        extern "Rust" {
-            type RustObj;
-
-            #[cxx_name = "createRs"]
-            fn create_rs() -> Box<RustObj>;
-
-            #[cxx_name = "initialiseCpp"]
-            fn initialise_cpp(cpp: Pin<&mut MyObject>);
-        }
+        #[rust_name = "new_cpp_object"]
+        fn newCppObject() -> UniquePtr<MyObject>;
     }
 
-    pub type FFICppObj = ffi::MyObject;
+    extern "Rust" {
+        type RustObj;
+
+        #[cxx_name = "createRs"]
+        fn create_rs() -> Box<RustObj>;
+
+        #[cxx_name = "initialiseCpp"]
+        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+    }
+}
+
+pub use self::cxx_qt_my_object::*;
+mod cxx_qt_my_object {
+    use super::my_object::*;
+
+    use cxx_qt_lib::ToUniquePtr;
+
+    pub type FFICppObj = super::my_object::MyObject;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -119,7 +119,7 @@ mod my_object {
     pub type FFICppObj = ffi::MyObject;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {}
 
@@ -254,7 +254,7 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct Data {
+    pub struct Data {
         color: QColor,
         date: QDate,
         date_time: QDateTime,
@@ -296,11 +296,11 @@ mod my_object {
         }
     }
 
-    fn create_rs() -> std::boxed::Box<RustObj> {
+    pub fn create_rs() -> std::boxed::Box<RustObj> {
         std::default::Default::default()
     }
 
-    fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
         let mut wrapper = CppObj::new(cpp);
         wrapper.grab_values_from_data(Data::default());
     }

--- a/examples/demo_threading/src/lib.rs
+++ b/examples/demo_threading/src/lib.rs
@@ -149,7 +149,7 @@ mod energy_usage {
         }
     }
 
-    struct RustObj {
+    pub struct RustObj {
         qt_rx: Receiver<Data>,
         qt_tx: SyncSender<Data>,
         join_handles: Option<[JoinHandle<()>; 4]>,
@@ -216,7 +216,7 @@ mod energy_usage {
         }
 
         #[invokable]
-        fn start_server(&mut self, cpp: &mut CppObj) {
+        pub fn start_server(&mut self, cpp: &mut CppObj) {
             if self.join_handles.is_some() {
                 println!("Already running a server!");
                 return;

--- a/examples/qml_extension_plugin/core/src/lib.rs
+++ b/examples/qml_extension_plugin/core/src/lib.rs
@@ -25,28 +25,28 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn increment(&self, cpp: &mut CppObj) {
+        pub fn increment(&self, cpp: &mut CppObj) {
             cpp.set_number(cpp.number() + 1);
         }
 
         #[invokable]
-        fn reset(&self, cpp: &mut CppObj) {
+        pub fn reset(&self, cpp: &mut CppObj) {
             let data: Data = serde_json::from_str(DEFAULT_STR).unwrap();
             cpp.grab_values_from_data(data);
         }
 
         #[invokable]
-        fn serialize(&self, cpp: &mut CppObj) -> String {
+        pub fn serialize(&self, cpp: &mut CppObj) -> String {
             let data = Data::from(cpp);
             serde_json::to_string(&data).unwrap()
         }
 
         #[invokable]
-        fn grab_values(&self, cpp: &mut CppObj) {
+        pub fn grab_values(&self, cpp: &mut CppObj) {
             let string = r#"{"number": 2, "string": "Goodbye!"}"#;
             let data: Data = serde_json::from_str(string).unwrap();
             cpp.grab_values_from_data(data);

--- a/examples/qml_features/src/data_struct_properties.rs
+++ b/examples/qml_features/src/data_struct_properties.rs
@@ -12,6 +12,6 @@ mod data_struct_properties {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 }
 // ANCHOR_END: book_macro_code

--- a/examples/qml_features/src/empty.rs
+++ b/examples/qml_features/src/empty.rs
@@ -9,5 +9,5 @@ mod empty {
     pub struct Data;
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 }

--- a/examples/qml_features/src/lib.rs
+++ b/examples/qml_features/src/lib.rs
@@ -24,28 +24,28 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: &mut CppObj) {
+        pub fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number() + 1;
             cpp.set_number(value);
         }
 
         #[invokable]
-        fn increment_number_sub(&self, sub: &mut crate::sub::sub_object::CppObj) {
+        pub fn increment_number_sub(&self, sub: &mut crate::sub::sub_object::CppObj) {
             let value = sub.number() + 1;
             sub.set_number(value);
         }
 
         #[invokable]
-        fn increment_number(&self, number: i32) -> i32 {
+        pub fn increment_number(&self, number: i32) -> i32 {
             number + 1
         }
 
         #[invokable]
-        fn say_hi(&self, string: &str, number: i32) {
+        pub fn say_hi(&self, string: &str, number: i32) {
             println!(
                 "Hi from Rust! String is {} and number is {}",
                 string, number

--- a/examples/qml_features/src/lib.rs
+++ b/examples/qml_features/src/lib.rs
@@ -20,7 +20,7 @@ mod my_object {
     pub struct Data {
         number: i32,
         string: String,
-        sub: crate::sub::sub_object::CppObj,
+        sub: crate::sub::cxx_qt_sub_object::CppObj,
     }
 
     #[derive(Default)]
@@ -34,7 +34,7 @@ mod my_object {
         }
 
         #[invokable]
-        pub fn increment_number_sub(&self, sub: &mut crate::sub::sub_object::CppObj) {
+        pub fn increment_number_sub(&self, sub: &mut crate::sub::cxx_qt_sub_object::CppObj) {
             let value = sub.number() + 1;
             sub.set_number(value);
         }

--- a/examples/qml_features/src/mock_qt_types.rs
+++ b/examples/qml_features/src/mock_qt_types.rs
@@ -55,11 +55,11 @@ mod mock_qt_types {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn test_signal(&self, cpp: &mut CppObj) {
+        pub fn test_signal(&self, cpp: &mut CppObj) {
             cpp.emit_queued(Signal::Ready);
             cpp.emit_queued(Signal::DataChanged {
                 variant: QVariant::from(true),
@@ -67,7 +67,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_unsafe_signal(&self, cpp: &mut CppObj) {
+        pub fn test_unsafe_signal(&self, cpp: &mut CppObj) {
             unsafe {
                 cpp.emit_immediate(Signal::Ready);
                 cpp.emit_immediate(Signal::DataChanged {
@@ -77,31 +77,31 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_color_property(&self, cpp: &mut CppObj) {
+        pub fn test_color_property(&self, cpp: &mut CppObj) {
             cpp.set_color(QColor::from_rgba(0, 0, 255, 255));
         }
 
         #[invokable]
-        fn test_color_invokable(&self, _color: &QColor) -> QColor {
+        pub fn test_color_invokable(&self, _color: &QColor) -> QColor {
             QColor::from_rgba(0, 255, 0, 255)
         }
 
         #[invokable]
-        fn test_date_property(&self, cpp: &mut CppObj) {
+        pub fn test_date_property(&self, cpp: &mut CppObj) {
             let mut date = *cpp.date();
             date.set_date(2021, 12, 31);
             cpp.set_date(&date);
         }
 
         #[invokable]
-        fn test_date_invokable(&self, date: &QDate) -> QDate {
+        pub fn test_date_invokable(&self, date: &QDate) -> QDate {
             let mut date = *date;
             date.set_date(2021, 12, 31);
             date
         }
 
         #[invokable]
-        fn test_date_time_property(&self, cpp: &mut CppObj) {
+        pub fn test_date_time_property(&self, cpp: &mut CppObj) {
             let date_time = cpp.date_time();
             let new_date_time = QDateTime::from_date_and_time(
                 &QDate::new(2021, 12, 31),
@@ -116,7 +116,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_date_time_invokable(&self, date_time: &QDateTime) -> QDateTime {
+        pub fn test_date_time_invokable(&self, date_time: &QDateTime) -> QDateTime {
             QDateTime::from_date_and_time(
                 &QDate::new(2021, 12, 31),
                 &QTime::new(
@@ -129,7 +129,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_point_property(&self, cpp: &mut CppObj) {
+        pub fn test_point_property(&self, cpp: &mut CppObj) {
             let mut point = *cpp.point();
             point.set_x(point.x() * 2);
             point.set_y(point.y() * 3);
@@ -137,7 +137,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_point_invokable(&self, point: &QPoint) -> QPoint {
+        pub fn test_point_invokable(&self, point: &QPoint) -> QPoint {
             let mut point = *point;
             point.set_x(point.x() * 2);
             point.set_y(point.y() * 3);
@@ -145,7 +145,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_pointf_property(&self, cpp: &mut CppObj) {
+        pub fn test_pointf_property(&self, cpp: &mut CppObj) {
             let mut point = *cpp.pointf();
             point.set_x(point.x() * 2.0);
             point.set_y(point.y() * 3.0);
@@ -153,7 +153,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_pointf_invokable(&self, point: &QPointF) -> QPointF {
+        pub fn test_pointf_invokable(&self, point: &QPointF) -> QPointF {
             let mut point = *point;
             point.set_x(point.x() * 2.0);
             point.set_y(point.y() * 3.0);
@@ -161,7 +161,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_rect_property(&self, cpp: &mut CppObj) {
+        pub fn test_rect_property(&self, cpp: &mut CppObj) {
             let mut rect = *cpp.rect();
             // Copy width and height, otherwise when we adjust the x and y it affects the width and height
             let (width, height) = (rect.width(), rect.height());
@@ -173,7 +173,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_rect_invokable(&self, rect: &QRect) -> QRect {
+        pub fn test_rect_invokable(&self, rect: &QRect) -> QRect {
             let mut rect = *rect;
             // Copy width and height, otherwise when we adjust the x and y it affects the width and height
             let (width, height) = (rect.width(), rect.height());
@@ -185,7 +185,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_rectf_property(&self, cpp: &mut CppObj) {
+        pub fn test_rectf_property(&self, cpp: &mut CppObj) {
             let mut rect = *cpp.rectf();
             // Copy width and height, otherwise when we adjust the x and y it affects the width and height
             let (width, height) = (rect.width(), rect.height());
@@ -197,7 +197,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_rectf_invokable(&self, rect: &QRectF) -> QRectF {
+        pub fn test_rectf_invokable(&self, rect: &QRectF) -> QRectF {
             let mut rect = *rect;
             // Copy width and height, otherwise when we adjust the x and y it affects the width and height
             let (width, height) = (rect.width(), rect.height());
@@ -209,7 +209,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_size_property(&self, cpp: &mut CppObj) {
+        pub fn test_size_property(&self, cpp: &mut CppObj) {
             let mut size = *cpp.size();
             size.set_width(size.width() * 2);
             size.set_height(size.height() * 3);
@@ -217,7 +217,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_size_invokable(&self, size: &QSize) -> QSize {
+        pub fn test_size_invokable(&self, size: &QSize) -> QSize {
             let mut size = *size;
             size.set_width(size.width() * 2);
             size.set_height(size.height() * 3);
@@ -225,7 +225,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_sizef_property(&self, cpp: &mut CppObj) {
+        pub fn test_sizef_property(&self, cpp: &mut CppObj) {
             let mut size = *cpp.sizef();
             size.set_width(size.width() * 2.0);
             size.set_height(size.height() * 3.0);
@@ -233,7 +233,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_sizef_invokable(&self, size: &QSizeF) -> QSizeF {
+        pub fn test_sizef_invokable(&self, size: &QSizeF) -> QSizeF {
             let mut size = *size;
             size.set_width(size.width() * 2.0);
             size.set_height(size.height() * 3.0);
@@ -241,7 +241,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_time_property(&self, cpp: &mut CppObj) {
+        pub fn test_time_property(&self, cpp: &mut CppObj) {
             let mut time = *cpp.time();
             time.set_hms(
                 time.hour() * 2,
@@ -253,7 +253,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_time_invokable(&self, time: &QTime) -> QTime {
+        pub fn test_time_invokable(&self, time: &QTime) -> QTime {
             let mut time = *time;
             time.set_hms(
                 time.hour() * 2,
@@ -265,18 +265,18 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_url_property(&self, cpp: &mut CppObj) {
+        pub fn test_url_property(&self, cpp: &mut CppObj) {
             let url = QUrl::from_str(&(cpp.url().string() + "/cxx-qt")).unwrap();
             cpp.set_url(url);
         }
 
         #[invokable]
-        fn test_url_invokable(&self, url: &QUrl) -> QUrl {
+        pub fn test_url_invokable(&self, url: &QUrl) -> QUrl {
             QUrl::from_str(&(url.string() + "/cxx-qt")).unwrap()
         }
 
         #[invokable]
-        fn test_variant_property(&self, cpp: &mut CppObj) {
+        pub fn test_variant_property(&self, cpp: &mut CppObj) {
             match cpp.variant().value() {
                 QVariantValue::Bool(b) => cpp.set_variant(QVariant::from(!b)),
                 QVariantValue::F32(f) => cpp.set_variant(QVariant::from(f * 2.0)),
@@ -363,7 +363,7 @@ mod mock_qt_types {
         }
 
         #[invokable]
-        fn test_variant_invokable(&self, variant: &QVariant) -> QVariant {
+        pub fn test_variant_invokable(&self, variant: &QVariant) -> QVariant {
             match variant.value() {
                 QVariantValue::Bool(b) => QVariant::from(!b),
                 QVariantValue::F32(f) => QVariant::from(f * 2.0),

--- a/examples/qml_features/src/nested.rs
+++ b/examples/qml_features/src/nested.rs
@@ -8,7 +8,7 @@
 mod nested {
     #[derive(Default)]
     pub struct Data {
-        nested: crate::rust_obj_invokables::rust_obj_invokables::CppObj,
+        nested: crate::rust_obj_invokables::cxx_qt_rust_obj_invokables::CppObj,
     }
 
     #[derive(Default)]
@@ -18,7 +18,7 @@ mod nested {
         #[invokable]
         pub fn nested_parameter(
             &self,
-            nested: &mut crate::rust_obj_invokables::rust_obj_invokables::CppObj,
+            nested: &mut crate::rust_obj_invokables::cxx_qt_rust_obj_invokables::CppObj,
         ) {
             println!("Number: {}", nested.number());
             // TODO: we can't reach the nested object's RustObj yet
@@ -36,7 +36,7 @@ mod nested {
             // https://github.com/KDAB/cxx-qt/issues/30
             let mut nested = cpp.take_nested();
 
-            crate::rust_obj_invokables::rust_obj_invokables::CppObj::new(nested.pin_mut())
+            crate::rust_obj_invokables::cxx_qt_rust_obj_invokables::CppObj::new(nested.pin_mut())
                 .set_number(10);
 
             // The nested object is now back in QML

--- a/examples/qml_features/src/nested.rs
+++ b/examples/qml_features/src/nested.rs
@@ -12,11 +12,11 @@ mod nested {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn nested_parameter(
+        pub fn nested_parameter(
             &self,
             nested: &mut crate::rust_obj_invokables::rust_obj_invokables::CppObj,
         ) {
@@ -27,7 +27,7 @@ mod nested {
         }
 
         #[invokable]
-        fn nested_take_give(&self, cpp: &mut CppObj) {
+        pub fn nested_take_give(&self, cpp: &mut CppObj) {
             // We now own the nested object and QML would be null
             //
             // TODO: should this return a OwnedCppObj which derefs to the CppObj ?

--- a/examples/qml_features/src/rust_obj_invokables.rs
+++ b/examples/qml_features/src/rust_obj_invokables.rs
@@ -11,7 +11,7 @@ pub mod rust_obj_invokables {
         number: i32,
     }
 
-    struct RustObj {
+    pub struct RustObj {
         rust_only_field: i32,
     }
 
@@ -24,18 +24,18 @@ pub mod rust_obj_invokables {
     impl RustObj {
         // ANCHOR: book_cpp_obj
         #[invokable]
-        fn invokable_mutate_cpp(&self, cpp: &mut CppObj) {
+        pub fn invokable_mutate_cpp(&self, cpp: &mut CppObj) {
             cpp.set_number(cpp.number() * 2);
         }
         // ANCHOR_END: book_cpp_obj
 
         #[invokable]
-        fn invokable_return(&self) -> i32 {
+        pub fn invokable_return(&self) -> i32 {
             self.rust_only_field
         }
 
         #[invokable]
-        fn invokable_multiply(&mut self, factor: i32) -> i32 {
+        pub fn invokable_multiply(&mut self, factor: i32) -> i32 {
             self.rust_only_method(factor);
             self.rust_only_field
         }

--- a/examples/qml_features/src/serialisation.rs
+++ b/examples/qml_features/src/serialisation.rs
@@ -23,18 +23,18 @@ mod serialisation {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn as_json_str(&self, cpp: &mut CppObj) -> String {
+        pub fn as_json_str(&self, cpp: &mut CppObj) -> String {
             let data = Data::from(cpp);
             serde_json::to_string(&data).unwrap()
         }
 
         // ANCHOR: book_grab_values
         #[invokable]
-        fn grab_values(&self, cpp: &mut CppObj) {
+        pub fn grab_values(&self, cpp: &mut CppObj) {
             let string = r#"{"number": 2, "string": "Goodbye!"}"#;
             let data: Data = serde_json::from_str(string).unwrap();
             cpp.grab_values_from_data(data);

--- a/examples/qml_features/src/signals.rs
+++ b/examples/qml_features/src/signals.rs
@@ -25,12 +25,12 @@ pub mod signals {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     // ANCHOR: book_rust_obj_impl
     impl RustObj {
         #[invokable]
-        fn invokable(&self, cpp: &mut CppObj) {
+        pub fn invokable(&self, cpp: &mut CppObj) {
             unsafe {
                 cpp.emit_immediate(Signal::Ready);
             }

--- a/examples/qml_features/src/sub.rs
+++ b/examples/qml_features/src/sub.rs
@@ -17,18 +17,18 @@ pub mod sub_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: &mut CppObj) {
+        pub fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number();
             cpp.set_number(value + 1);
         }
 
         #[invokable]
-        fn increment_number(&self, number: i32) -> i32 {
+        pub fn increment_number(&self, number: i32) -> i32 {
             number + 1
         }
 
         #[invokable]
-        fn say_hi(&self, string: &str, number: i32) {
+        pub fn say_hi(&self, string: &str, number: i32) {
             let s: String = string.into();
             println!("Hi from Rust! String is {} and number is {}", s, number);
         }

--- a/examples/qml_features/src/types.rs
+++ b/examples/qml_features/src/types.rs
@@ -21,11 +21,11 @@ mod types {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn test_variant_property(&self, cpp: &mut CppObj) {
+        pub fn test_variant_property(&self, cpp: &mut CppObj) {
             match cpp.variant().value() {
                 QVariantValue::Bool(b) => {
                     cpp.set_variant(QVariant::from(!b));
@@ -38,7 +38,7 @@ mod types {
         }
 
         #[invokable]
-        fn test_variant_invokable(&self, variant: &QVariant) -> QVariant {
+        pub fn test_variant_invokable(&self, variant: &QVariant) -> QVariant {
             match variant.value() {
                 QVariantValue::Bool(b) => QVariant::from(!b),
                 QVariantValue::I32(i) => QVariant::from(i * 2),

--- a/examples/qml_minimal/src/lib.rs
+++ b/examples/qml_minimal/src/lib.rs
@@ -21,18 +21,18 @@ mod my_object {
 
     // ANCHOR: book_rustobj_struct
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
     // ANCHOR_END: book_rustobj_struct
 
     // ANCHOR: book_rustobj_impl
     impl RustObj {
         #[invokable]
-        fn increment_number(&self, cpp: &mut CppObj) {
+        pub fn increment_number(&self, cpp: &mut CppObj) {
             cpp.set_number(cpp.number() + 1);
         }
 
         #[invokable]
-        fn say_hi(&self, string: &str, number: i32) {
+        pub fn say_hi(&self, string: &str, number: i32) {
             println!(
                 "Hi from Rust! String is '{}' and number is {}",
                 string, number

--- a/examples/qml_with_threaded_logic/src/lib.rs
+++ b/examples/qml_with_threaded_logic/src/lib.rs
@@ -37,7 +37,7 @@ mod website {
         }
     }
 
-    struct RustObj {
+    pub struct RustObj {
         event_sender: UnboundedSender<Event>,
         event_queue: UnboundedReceiver<Event>,
         loading: AtomicBool,
@@ -57,14 +57,14 @@ mod website {
 
     impl RustObj {
         #[invokable]
-        fn change_url(&self, cpp: &mut CppObj) {
+        pub fn change_url(&self, cpp: &mut CppObj) {
             let url = cpp.url();
             let new_url = if url == "known" { "unknown" } else { "known" };
             cpp.set_url(new_url);
         }
 
         #[invokable]
-        fn refresh_title(&self, cpp: &mut CppObj) {
+        pub fn refresh_title(&self, cpp: &mut CppObj) {
             // TODO: SeqCst is probably not the most efficient solution
             let new_load =
                 self.loading
@@ -114,12 +114,12 @@ mod website {
         }
 
         #[invokable]
-        fn new_title_value(&mut self) {
+        pub fn new_title_value(&mut self) {
             println!("title changed");
         }
 
         #[invokable]
-        fn new_url_value(&mut self, cpp: &mut CppObj) {
+        pub fn new_url_value(&mut self, cpp: &mut CppObj) {
             self.refresh_title(cpp);
         }
     }

--- a/tests/basic_cxx_qt/src/data.rs
+++ b/tests/basic_cxx_qt/src/data.rs
@@ -23,17 +23,17 @@ mod my_data {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 
     impl RustObj {
         #[invokable]
-        fn as_json_str(&self, cpp: &mut CppObj) -> String {
+        pub fn as_json_str(&self, cpp: &mut CppObj) -> String {
             let data = Data::from(cpp);
             serde_json::to_string(&data).unwrap()
         }
 
         #[invokable]
-        fn grab_values(&self, cpp: &mut CppObj) {
+        pub fn grab_values(&self, cpp: &mut CppObj) {
             let string = r#"{"number": 2, "string": "Goodbye!"}"#;
             let data: Data = serde_json::from_str(string).unwrap();
             cpp.grab_values_from_data(data);

--- a/tests/basic_cxx_qt/src/lib.rs
+++ b/tests/basic_cxx_qt/src/lib.rs
@@ -14,7 +14,7 @@ mod my_object {
     pub struct Data {
         number: i32,
         string: String,
-        sub: crate::sub::sub_object::CppObj,
+        sub: crate::sub::cxx_qt_sub_object::CppObj,
     }
 
     #[derive(Default)]
@@ -30,7 +30,7 @@ mod my_object {
         }
 
         #[invokable]
-        pub fn double_number_sub(&self, sub: &mut crate::sub::sub_object::CppObj) {
+        pub fn double_number_sub(&self, sub: &mut crate::sub::cxx_qt_sub_object::CppObj) {
             let value = sub.number() * 2;
             sub.set_number(value);
         }

--- a/tests/basic_cxx_qt/src/lib.rs
+++ b/tests/basic_cxx_qt/src/lib.rs
@@ -18,30 +18,30 @@ mod my_object {
     }
 
     #[derive(Default)]
-    struct RustObj {
+    pub struct RustObj {
         update_call_count: i32,
     }
 
     impl RustObj {
         #[invokable]
-        fn double_number_self(&self, cpp: &mut CppObj) {
+        pub fn double_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number() * 2;
             cpp.set_number(value);
         }
 
         #[invokable]
-        fn double_number_sub(&self, sub: &mut crate::sub::sub_object::CppObj) {
+        pub fn double_number_sub(&self, sub: &mut crate::sub::sub_object::CppObj) {
             let value = sub.number() * 2;
             sub.set_number(value);
         }
 
         #[invokable]
-        fn double_number(&self, number: i32) -> i32 {
+        pub fn double_number(&self, number: i32) -> i32 {
             number * 2
         }
 
         #[invokable]
-        fn say_hi(&self, string: &str, number: i32) {
+        pub fn say_hi(&self, string: &str, number: i32) {
             println!(
                 "Hi from Rust! String is {} and number is {}",
                 string, number
@@ -49,13 +49,13 @@ mod my_object {
         }
 
         #[invokable]
-        fn request_update_test(&self, cpp: &mut CppObj) {
+        pub fn request_update_test(&self, cpp: &mut CppObj) {
             let update_requester = cpp.update_requester();
             update_requester.request_update();
         }
 
         #[invokable]
-        fn request_update_test_multi_thread(&self, cpp: &mut CppObj) {
+        pub fn request_update_test_multi_thread(&self, cpp: &mut CppObj) {
             static N_THREADS: usize = 100;
             static N_REQUESTS: std::sync::atomic::AtomicUsize =
                 std::sync::atomic::AtomicUsize::new(0);
@@ -81,7 +81,7 @@ mod my_object {
         }
 
         #[invokable]
-        fn update_call_count(&self) -> i32 {
+        pub fn update_call_count(&self) -> i32 {
             self.update_call_count
         }
     }

--- a/tests/basic_cxx_qt/src/sub.rs
+++ b/tests/basic_cxx_qt/src/sub.rs
@@ -17,18 +17,18 @@ pub mod sub_object {
 
     impl RustObj {
         #[invokable]
-        fn increment_number_self(&self, cpp: &mut CppObj) {
+        pub fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number();
             cpp.set_number(value + 1);
         }
 
         #[invokable]
-        fn increment_number(&self, number: i32) -> i32 {
+        pub fn increment_number(&self, number: i32) -> i32 {
             number + 1
         }
 
         #[invokable]
-        fn say_hi(&self, string: &str, number: i32) {
+        pub fn say_hi(&self, string: &str, number: i32) {
             println!(
                 "Hi from Rust! String is {} and number is {}",
                 string, number

--- a/tests/basic_cxx_qt/src/types.rs
+++ b/tests/basic_cxx_qt/src/types.rs
@@ -20,5 +20,5 @@ mod my_types {
     }
 
     #[derive(Default)]
-    struct RustObj;
+    pub struct RustObj;
 }


### PR DESCRIPTION
Note that nested objects now need to be referred to by cxx_qt_
in the last module name to reach the correct CppObj.

This will be improved in the future when we move to the new API
which will store nested objects as a pointer directly.