### PR TITLE
cxx-qt-lib: use generic templated method for converting returns

### DIFF
--- a/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/cxx-qt-gen/test_outputs/invokables.cpp
@@ -68,21 +68,24 @@ QColor
 MyObject::invokableReturnOpaque()
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return std::move(*m_rustObj->invokableReturnOpaqueWrapper());
+  return rust::cxxqtlib1::cxx_qt_convert<QColor, std::unique_ptr<QColor>>{}(
+    m_rustObj->invokableReturnOpaqueWrapper());
 }
 
 qint32
 MyObject::invokableReturnPrimitive()
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return m_rustObj->invokableReturnPrimitive();
+  return rust::cxxqtlib1::cxx_qt_convert<qint32, qint32>{}(
+    m_rustObj->invokableReturnPrimitive());
 }
 
 QString
 MyObject::invokableReturnStatic()
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return std::move(*m_rustObj->invokableReturnStaticWrapper());
+  return rust::cxxqtlib1::cxx_qt_convert<QString, std::unique_ptr<QString>>{}(
+    m_rustObj->invokableReturnStaticWrapper());
 }
 
 std::unique_ptr<CppObj>

--- a/cxx-qt-gen/test_outputs/signals.cpp
+++ b/cxx-qt-gen/test_outputs/signals.cpp
@@ -38,7 +38,13 @@ MyObject::emitDataChanged(qint32 first,
     [this,
      first = std::move(first),
      second = std::move(second),
-     third = std::move(third)]() { Q_EMIT dataChanged(first, *second, third); },
+     third = std::move(third)]() {
+      Q_EMIT dataChanged(
+        rust::cxxqtlib1::cxx_qt_convert<qint32, qint32>{}(first),
+        rust::cxxqtlib1::cxx_qt_convert<const QVariant&,
+                                        std::unique_ptr<QVariant>>{}(second),
+        rust::cxxqtlib1::cxx_qt_convert<const QPoint&, QPoint>{}(third));
+    },
     Qt::QueuedConnection);
   Q_ASSERT(signalSuccess);
 }

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
@@ -17,91 +17,105 @@ QColor
 MyObject::testColor(const QColor& color)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return std::move(*m_rustObj->testColorWrapper(*this, color));
+  return rust::cxxqtlib1::cxx_qt_convert<QColor, std::unique_ptr<QColor>>{}(
+    m_rustObj->testColorWrapper(*this, color));
 }
 
 QDate
 MyObject::testDate(const QDate& date)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return m_rustObj->testDateWrapper(*this, date);
+  return rust::cxxqtlib1::cxx_qt_convert<QDate, QDate>{}(
+    m_rustObj->testDateWrapper(*this, date));
 }
 
 QDateTime
 MyObject::testDateTime(const QDateTime& dateTime)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return std::move(*m_rustObj->testDateTimeWrapper(*this, dateTime));
+  return rust::cxxqtlib1::cxx_qt_convert<QDateTime,
+                                         std::unique_ptr<QDateTime>>{}(
+    m_rustObj->testDateTimeWrapper(*this, dateTime));
 }
 
 QPoint
 MyObject::testPoint(const QPoint& point)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return m_rustObj->testPointWrapper(*this, point);
+  return rust::cxxqtlib1::cxx_qt_convert<QPoint, QPoint>{}(
+    m_rustObj->testPointWrapper(*this, point));
 }
 
 QPointF
 MyObject::testPointf(const QPointF& pointf)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return m_rustObj->testPointfWrapper(*this, pointf);
+  return rust::cxxqtlib1::cxx_qt_convert<QPointF, QPointF>{}(
+    m_rustObj->testPointfWrapper(*this, pointf));
 }
 
 QRect
 MyObject::testRect(const QRect& rect)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return m_rustObj->testRectWrapper(*this, rect);
+  return rust::cxxqtlib1::cxx_qt_convert<QRect, QRect>{}(
+    m_rustObj->testRectWrapper(*this, rect));
 }
 
 QRectF
 MyObject::testRectf(const QRectF& rectf)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return m_rustObj->testRectfWrapper(*this, rectf);
+  return rust::cxxqtlib1::cxx_qt_convert<QRectF, QRectF>{}(
+    m_rustObj->testRectfWrapper(*this, rectf));
 }
 
 QSize
 MyObject::testSize(const QSize& size)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return m_rustObj->testSizeWrapper(*this, size);
+  return rust::cxxqtlib1::cxx_qt_convert<QSize, QSize>{}(
+    m_rustObj->testSizeWrapper(*this, size));
 }
 
 QSizeF
 MyObject::testSizef(const QSizeF& sizef)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return m_rustObj->testSizefWrapper(*this, sizef);
+  return rust::cxxqtlib1::cxx_qt_convert<QSizeF, QSizeF>{}(
+    m_rustObj->testSizefWrapper(*this, sizef));
 }
 
 QString
 MyObject::testString(const QString& string)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return std::move(*m_rustObj->testStringWrapper(*this, string));
+  return rust::cxxqtlib1::cxx_qt_convert<QString, std::unique_ptr<QString>>{}(
+    m_rustObj->testStringWrapper(*this, string));
 }
 
 QTime
 MyObject::testTime(const QTime& time)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return m_rustObj->testTimeWrapper(*this, time);
+  return rust::cxxqtlib1::cxx_qt_convert<QTime, QTime>{}(
+    m_rustObj->testTimeWrapper(*this, time));
 }
 
 QUrl
 MyObject::testUrl(const QUrl& url)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return std::move(*m_rustObj->testUrlWrapper(*this, url));
+  return rust::cxxqtlib1::cxx_qt_convert<QUrl, std::unique_ptr<QUrl>>{}(
+    m_rustObj->testUrlWrapper(*this, url));
 }
 
 QVariant
 MyObject::testVariant(const QVariant& variant)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  return std::move(*m_rustObj->testVariantWrapper(*this, variant));
+  return rust::cxxqtlib1::cxx_qt_convert<QVariant, std::unique_ptr<QVariant>>{}(
+    m_rustObj->testVariantWrapper(*this, variant));
 }
 
 std::unique_ptr<CppObj>

--- a/cxx-qt-lib/include/qt_types.h
+++ b/cxx-qt-lib/include/qt_types.h
@@ -27,6 +27,30 @@
 namespace rust {
 namespace cxxqtlib1 {
 
+template<typename R, typename T>
+struct cxx_qt_convert
+{
+  R operator()(T val) { return val; }
+};
+
+template<typename R, typename T>
+struct cxx_qt_convert<R&, T>
+{
+  R operator()(T val) { return val; }
+};
+
+template<typename R, typename T>
+struct cxx_qt_convert<R, std::unique_ptr<T>>
+{
+  R operator()(std::unique_ptr<T> ptr) { return std::move(*ptr); }
+};
+
+template<typename R, typename T>
+struct cxx_qt_convert<R&, std::unique_ptr<T>>
+{
+  R operator()(const std::unique_ptr<T>& ptr) { return *ptr; }
+};
+
 class UpdateRequester
 {
 public:


### PR DESCRIPTION
This simplifies generation later as we don't need to generate
code to convert between the types, we only need to write the
input and output types.