### PR TITLE
cxx-qt-gen: use extern "C++" block to define Qt lib types

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ mod my_object {
 
     const DEFAULT_STR: &str = r#"{"number": 1, "string": "Hello World!"}"#;
 
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     pub struct Data {
         pub number: i32,
         pub string: UniquePtr<QString>,

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -533,33 +533,6 @@ pub fn generate_qobject_cxx(
                 #[cxx_name = #class_name_str]
                 type #rust_class_name_cpp;
 
-                include!("cxx-qt-lib/include/qt_types.h");
-                #[namespace = ""]
-                type QColor = cxx_qt_lib::QColor;
-                #[namespace = ""]
-                type QDate = cxx_qt_lib::QDate;
-                #[namespace = ""]
-                type QDateTime = cxx_qt_lib::QDateTime;
-                #[namespace = ""]
-                type QPoint = cxx_qt_lib::QPoint;
-                #[namespace = ""]
-                type QPointF = cxx_qt_lib::QPointF;
-                #[namespace = ""]
-                type QRect = cxx_qt_lib::QRect;
-                #[namespace = ""]
-                type QRectF = cxx_qt_lib::QRectF;
-                #[namespace = ""]
-                type QSize = cxx_qt_lib::QSize;
-                #[namespace = ""]
-                type QSizeF = cxx_qt_lib::QSizeF;
-                #[namespace = ""]
-                type QString = cxx_qt_lib::QString;
-                #[namespace = ""]
-                type QTime = cxx_qt_lib::QTime;
-                #[namespace = ""]
-                type QUrl = cxx_qt_lib::QUrl;
-                #[namespace = ""]
-                type QVariant = cxx_qt_lib::QVariant;
                 #update_requester_type
 
                 #(#cpp_functions)*

--- a/cxx-qt-gen/test_inputs/handlers.rs
+++ b/cxx-qt-gen/test_inputs/handlers.rs
@@ -1,4 +1,10 @@
 mod my_object {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     #[derive(Default)]
     pub struct Data {
         number: i32,

--- a/cxx-qt-gen/test_inputs/invokables.rs
+++ b/cxx-qt-gen/test_inputs/invokables.rs
@@ -1,5 +1,11 @@
 mod my_object {
-    use cxx_qt_lib::QColor;
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QPoint = cxx_qt_lib::QPoint;
+        type QString = cxx_qt_lib::QString;
+    }
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_inputs/properties.rs
+++ b/cxx-qt-gen/test_inputs/properties.rs
@@ -1,5 +1,9 @@
 mod my_object {
-    use cxx_qt_lib::QColor;
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+    }
 
     #[derive(Default)]
     pub struct Data {

--- a/cxx-qt-gen/test_inputs/signals.rs
+++ b/cxx-qt-gen/test_inputs/signals.rs
@@ -1,5 +1,10 @@
 mod my_object {
-    use cxx_qt_lib::QVariant;
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QPoint = cxx_qt_lib::QPoint;
+        type QVariant = cxx_qt_lib::QVariant;
+    }
 
     #[cxx_qt::signals(MyObject)]
     enum MySignals {

--- a/cxx-qt-gen/test_inputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_invokable.rs
@@ -1,4 +1,22 @@
 mod my_object {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QDate = cxx_qt_lib::QDate;
+        type QDateTime = cxx_qt_lib::QDateTime;
+        type QPoint = cxx_qt_lib::QPoint;
+        type QPointF = cxx_qt_lib::QPointF;
+        type QRect = cxx_qt_lib::QRect;
+        type QRectF = cxx_qt_lib::QRectF;
+        type QSize = cxx_qt_lib::QSize;
+        type QSizeF = cxx_qt_lib::QSizeF;
+        type QString = cxx_qt_lib::QString;
+        type QTime = cxx_qt_lib::QTime;
+        type QUrl = cxx_qt_lib::QUrl;
+        type QVariant = cxx_qt_lib::QVariant;
+    }
+
     #[derive(Default)]
     pub struct Data;
 

--- a/cxx-qt-gen/test_inputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_property.rs
@@ -1,4 +1,22 @@
 mod my_object {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QDate = cxx_qt_lib::QDate;
+        type QDateTime = cxx_qt_lib::QDateTime;
+        type QPoint = cxx_qt_lib::QPoint;
+        type QPointF = cxx_qt_lib::QPointF;
+        type QRect = cxx_qt_lib::QRect;
+        type QRectF = cxx_qt_lib::QRectF;
+        type QSize = cxx_qt_lib::QSize;
+        type QSizeF = cxx_qt_lib::QSizeF;
+        type QString = cxx_qt_lib::QString;
+        type QTime = cxx_qt_lib::QTime;
+        type QUrl = cxx_qt_lib::QUrl;
+        type QVariant = cxx_qt_lib::QVariant;
+    }
+
     #[derive(Default)]
     pub struct Data {
         color: UniquePtr<QColor>,

--- a/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/cxx-qt-gen/test_outputs/custom_default.rs
@@ -6,34 +6,6 @@ mod my_object {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        include!("cxx-qt-lib/include/qt_types.h");
-        #[namespace = ""]
-        type QColor = cxx_qt_lib::QColor;
-        #[namespace = ""]
-        type QDate = cxx_qt_lib::QDate;
-        #[namespace = ""]
-        type QDateTime = cxx_qt_lib::QDateTime;
-        #[namespace = ""]
-        type QPoint = cxx_qt_lib::QPoint;
-        #[namespace = ""]
-        type QPointF = cxx_qt_lib::QPointF;
-        #[namespace = ""]
-        type QRect = cxx_qt_lib::QRect;
-        #[namespace = ""]
-        type QRectF = cxx_qt_lib::QRectF;
-        #[namespace = ""]
-        type QSize = cxx_qt_lib::QSize;
-        #[namespace = ""]
-        type QSizeF = cxx_qt_lib::QSizeF;
-        #[namespace = ""]
-        type QString = cxx_qt_lib::QString;
-        #[namespace = ""]
-        type QTime = cxx_qt_lib::QTime;
-        #[namespace = ""]
-        type QUrl = cxx_qt_lib::QUrl;
-        #[namespace = ""]
-        type QVariant = cxx_qt_lib::QVariant;
-
         #[rust_name = "public"]
         fn getPublic(self: &MyObjectQt) -> i32;
         #[rust_name = "set_public"]

--- a/cxx-qt-gen/test_outputs/handlers.rs
+++ b/cxx-qt-gen/test_outputs/handlers.rs
@@ -6,34 +6,6 @@ mod my_object {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        include!("cxx-qt-lib/include/qt_types.h");
-        #[namespace = ""]
-        type QColor = cxx_qt_lib::QColor;
-        #[namespace = ""]
-        type QDate = cxx_qt_lib::QDate;
-        #[namespace = ""]
-        type QDateTime = cxx_qt_lib::QDateTime;
-        #[namespace = ""]
-        type QPoint = cxx_qt_lib::QPoint;
-        #[namespace = ""]
-        type QPointF = cxx_qt_lib::QPointF;
-        #[namespace = ""]
-        type QRect = cxx_qt_lib::QRect;
-        #[namespace = ""]
-        type QRectF = cxx_qt_lib::QRectF;
-        #[namespace = ""]
-        type QSize = cxx_qt_lib::QSize;
-        #[namespace = ""]
-        type QSizeF = cxx_qt_lib::QSizeF;
-        #[namespace = ""]
-        type QString = cxx_qt_lib::QString;
-        #[namespace = ""]
-        type QTime = cxx_qt_lib::QTime;
-        #[namespace = ""]
-        type QUrl = cxx_qt_lib::QUrl;
-        #[namespace = ""]
-        type QVariant = cxx_qt_lib::QVariant;
-
         #[namespace = "rust::cxxqtlib1"]
         type UpdateRequester = cxx_qt_lib::UpdateRequesterCpp;
 
@@ -66,6 +38,12 @@ mod my_object {
 
         #[cxx_name = "handleUpdateRequest"]
         fn call_handle_update_request(self: &mut RustObj, cpp: Pin<&mut MyObjectQt>);
+    }
+
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
     }
 }
 

--- a/cxx-qt-gen/test_outputs/invokables.rs
+++ b/cxx-qt-gen/test_outputs/invokables.rs
@@ -6,34 +6,6 @@ mod my_object {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        include!("cxx-qt-lib/include/qt_types.h");
-        #[namespace = ""]
-        type QColor = cxx_qt_lib::QColor;
-        #[namespace = ""]
-        type QDate = cxx_qt_lib::QDate;
-        #[namespace = ""]
-        type QDateTime = cxx_qt_lib::QDateTime;
-        #[namespace = ""]
-        type QPoint = cxx_qt_lib::QPoint;
-        #[namespace = ""]
-        type QPointF = cxx_qt_lib::QPointF;
-        #[namespace = ""]
-        type QRect = cxx_qt_lib::QRect;
-        #[namespace = ""]
-        type QRectF = cxx_qt_lib::QRectF;
-        #[namespace = ""]
-        type QSize = cxx_qt_lib::QSize;
-        #[namespace = ""]
-        type QSizeF = cxx_qt_lib::QSizeF;
-        #[namespace = ""]
-        type QString = cxx_qt_lib::QString;
-        #[namespace = ""]
-        type QTime = cxx_qt_lib::QTime;
-        #[namespace = ""]
-        type QUrl = cxx_qt_lib::QUrl;
-        #[namespace = ""]
-        type QVariant = cxx_qt_lib::QVariant;
-
         #[namespace = "cxx_qt::nested_object"]
         type NestedObject = crate::cxx_qt_nested_object::FFICppObj;
 
@@ -76,6 +48,14 @@ mod my_object {
         #[cxx_name = "initialiseCpp"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
+
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QPoint = cxx_qt_lib::QPoint;
+        type QString = cxx_qt_lib::QString;
+    }
 }
 
 pub use self::cxx_qt_my_object::*;
@@ -84,8 +64,6 @@ mod cxx_qt_my_object {
 
     pub type FFICppObj = super::my_object::MyObjectQt;
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use cxx_qt_lib::QColor;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/naming.rs
+++ b/cxx-qt-gen/test_outputs/naming.rs
@@ -6,34 +6,6 @@ mod my_object {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        include!("cxx-qt-lib/include/qt_types.h");
-        #[namespace = ""]
-        type QColor = cxx_qt_lib::QColor;
-        #[namespace = ""]
-        type QDate = cxx_qt_lib::QDate;
-        #[namespace = ""]
-        type QDateTime = cxx_qt_lib::QDateTime;
-        #[namespace = ""]
-        type QPoint = cxx_qt_lib::QPoint;
-        #[namespace = ""]
-        type QPointF = cxx_qt_lib::QPointF;
-        #[namespace = ""]
-        type QRect = cxx_qt_lib::QRect;
-        #[namespace = ""]
-        type QRectF = cxx_qt_lib::QRectF;
-        #[namespace = ""]
-        type QSize = cxx_qt_lib::QSize;
-        #[namespace = ""]
-        type QSizeF = cxx_qt_lib::QSizeF;
-        #[namespace = ""]
-        type QString = cxx_qt_lib::QString;
-        #[namespace = ""]
-        type QTime = cxx_qt_lib::QTime;
-        #[namespace = ""]
-        type QUrl = cxx_qt_lib::QUrl;
-        #[namespace = ""]
-        type QVariant = cxx_qt_lib::QVariant;
-
         #[rust_name = "property_name"]
         fn getPropertyName(self: &MyObjectQt) -> i32;
         #[rust_name = "set_property_name"]

--- a/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/cxx-qt-gen/test_outputs/passthrough.rs
@@ -6,34 +6,6 @@ pub mod my_object {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        include!("cxx-qt-lib/include/qt_types.h");
-        #[namespace = ""]
-        type QColor = cxx_qt_lib::QColor;
-        #[namespace = ""]
-        type QDate = cxx_qt_lib::QDate;
-        #[namespace = ""]
-        type QDateTime = cxx_qt_lib::QDateTime;
-        #[namespace = ""]
-        type QPoint = cxx_qt_lib::QPoint;
-        #[namespace = ""]
-        type QPointF = cxx_qt_lib::QPointF;
-        #[namespace = ""]
-        type QRect = cxx_qt_lib::QRect;
-        #[namespace = ""]
-        type QRectF = cxx_qt_lib::QRectF;
-        #[namespace = ""]
-        type QSize = cxx_qt_lib::QSize;
-        #[namespace = ""]
-        type QSizeF = cxx_qt_lib::QSizeF;
-        #[namespace = ""]
-        type QString = cxx_qt_lib::QString;
-        #[namespace = ""]
-        type QTime = cxx_qt_lib::QTime;
-        #[namespace = ""]
-        type QUrl = cxx_qt_lib::QUrl;
-        #[namespace = ""]
-        type QVariant = cxx_qt_lib::QVariant;
-
         #[rust_name = "number"]
         fn getNumber(self: &MyObjectQt) -> i32;
         #[rust_name = "set_number"]

--- a/cxx-qt-gen/test_outputs/properties.rs
+++ b/cxx-qt-gen/test_outputs/properties.rs
@@ -6,34 +6,6 @@ mod my_object {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        include!("cxx-qt-lib/include/qt_types.h");
-        #[namespace = ""]
-        type QColor = cxx_qt_lib::QColor;
-        #[namespace = ""]
-        type QDate = cxx_qt_lib::QDate;
-        #[namespace = ""]
-        type QDateTime = cxx_qt_lib::QDateTime;
-        #[namespace = ""]
-        type QPoint = cxx_qt_lib::QPoint;
-        #[namespace = ""]
-        type QPointF = cxx_qt_lib::QPointF;
-        #[namespace = ""]
-        type QRect = cxx_qt_lib::QRect;
-        #[namespace = ""]
-        type QRectF = cxx_qt_lib::QRectF;
-        #[namespace = ""]
-        type QSize = cxx_qt_lib::QSize;
-        #[namespace = ""]
-        type QSizeF = cxx_qt_lib::QSizeF;
-        #[namespace = ""]
-        type QString = cxx_qt_lib::QString;
-        #[namespace = ""]
-        type QTime = cxx_qt_lib::QTime;
-        #[namespace = ""]
-        type QUrl = cxx_qt_lib::QUrl;
-        #[namespace = ""]
-        type QVariant = cxx_qt_lib::QVariant;
-
         #[rust_name = "primitive"]
         fn getPrimitive(self: &MyObjectQt) -> i32;
         #[rust_name = "set_primitive"]
@@ -66,6 +38,12 @@ mod my_object {
         #[cxx_name = "initialiseCpp"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
+
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+    }
 }
 
 pub use self::cxx_qt_my_object::*;
@@ -74,8 +52,6 @@ mod cxx_qt_my_object {
 
     pub type FFICppObj = super::my_object::MyObjectQt;
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use cxx_qt_lib::QColor;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/signals.rs
+++ b/cxx-qt-gen/test_outputs/signals.rs
@@ -5,33 +5,6 @@ mod my_object {
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;
-        include!("cxx-qt-lib/include/qt_types.h");
-        #[namespace = ""]
-        type QColor = cxx_qt_lib::QColor;
-        #[namespace = ""]
-        type QDate = cxx_qt_lib::QDate;
-        #[namespace = ""]
-        type QDateTime = cxx_qt_lib::QDateTime;
-        #[namespace = ""]
-        type QPoint = cxx_qt_lib::QPoint;
-        #[namespace = ""]
-        type QPointF = cxx_qt_lib::QPointF;
-        #[namespace = ""]
-        type QRect = cxx_qt_lib::QRect;
-        #[namespace = ""]
-        type QRectF = cxx_qt_lib::QRectF;
-        #[namespace = ""]
-        type QSize = cxx_qt_lib::QSize;
-        #[namespace = ""]
-        type QSizeF = cxx_qt_lib::QSizeF;
-        #[namespace = ""]
-        type QString = cxx_qt_lib::QString;
-        #[namespace = ""]
-        type QTime = cxx_qt_lib::QTime;
-        #[namespace = ""]
-        type QUrl = cxx_qt_lib::QUrl;
-        #[namespace = ""]
-        type QVariant = cxx_qt_lib::QVariant;
 
         #[rust_name = "ready"]
         fn ready(self: Pin<&mut MyObjectQt>);
@@ -65,6 +38,13 @@ mod my_object {
         #[cxx_name = "initialiseCpp"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
+
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QPoint = cxx_qt_lib::QPoint;
+        type QVariant = cxx_qt_lib::QVariant;
+    }
 }
 
 pub use self::cxx_qt_my_object::*;
@@ -73,8 +53,6 @@ mod cxx_qt_my_object {
 
     pub type FFICppObj = super::my_object::MyObjectQt;
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use cxx_qt_lib::QVariant;
 
     enum MySignals {
         Ready,

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -6,34 +6,6 @@ mod my_object {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        include!("cxx-qt-lib/include/qt_types.h");
-        #[namespace = ""]
-        type QColor = cxx_qt_lib::QColor;
-        #[namespace = ""]
-        type QDate = cxx_qt_lib::QDate;
-        #[namespace = ""]
-        type QDateTime = cxx_qt_lib::QDateTime;
-        #[namespace = ""]
-        type QPoint = cxx_qt_lib::QPoint;
-        #[namespace = ""]
-        type QPointF = cxx_qt_lib::QPointF;
-        #[namespace = ""]
-        type QRect = cxx_qt_lib::QRect;
-        #[namespace = ""]
-        type QRectF = cxx_qt_lib::QRectF;
-        #[namespace = ""]
-        type QSize = cxx_qt_lib::QSize;
-        #[namespace = ""]
-        type QSizeF = cxx_qt_lib::QSizeF;
-        #[namespace = ""]
-        type QString = cxx_qt_lib::QString;
-        #[namespace = ""]
-        type QTime = cxx_qt_lib::QTime;
-        #[namespace = ""]
-        type QUrl = cxx_qt_lib::QUrl;
-        #[namespace = ""]
-        type QVariant = cxx_qt_lib::QVariant;
-
         #[rust_name = "boolean"]
         fn getBoolean(self: &MyObjectQt) -> bool;
         #[rust_name = "set_boolean"]

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -6,34 +6,6 @@ mod my_object {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        include!("cxx-qt-lib/include/qt_types.h");
-        #[namespace = ""]
-        type QColor = cxx_qt_lib::QColor;
-        #[namespace = ""]
-        type QDate = cxx_qt_lib::QDate;
-        #[namespace = ""]
-        type QDateTime = cxx_qt_lib::QDateTime;
-        #[namespace = ""]
-        type QPoint = cxx_qt_lib::QPoint;
-        #[namespace = ""]
-        type QPointF = cxx_qt_lib::QPointF;
-        #[namespace = ""]
-        type QRect = cxx_qt_lib::QRect;
-        #[namespace = ""]
-        type QRectF = cxx_qt_lib::QRectF;
-        #[namespace = ""]
-        type QSize = cxx_qt_lib::QSize;
-        #[namespace = ""]
-        type QSizeF = cxx_qt_lib::QSizeF;
-        #[namespace = ""]
-        type QString = cxx_qt_lib::QString;
-        #[namespace = ""]
-        type QTime = cxx_qt_lib::QTime;
-        #[namespace = ""]
-        type QUrl = cxx_qt_lib::QUrl;
-        #[namespace = ""]
-        type QVariant = cxx_qt_lib::QVariant;
-
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
@@ -113,6 +85,24 @@ mod my_object {
 
         #[cxx_name = "initialiseCpp"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
+    }
+
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QDate = cxx_qt_lib::QDate;
+        type QDateTime = cxx_qt_lib::QDateTime;
+        type QPoint = cxx_qt_lib::QPoint;
+        type QPointF = cxx_qt_lib::QPointF;
+        type QRect = cxx_qt_lib::QRect;
+        type QRectF = cxx_qt_lib::QRectF;
+        type QSize = cxx_qt_lib::QSize;
+        type QSizeF = cxx_qt_lib::QSizeF;
+        type QString = cxx_qt_lib::QString;
+        type QTime = cxx_qt_lib::QTime;
+        type QUrl = cxx_qt_lib::QUrl;
+        type QVariant = cxx_qt_lib::QVariant;
     }
 }
 

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -6,34 +6,6 @@ mod my_object {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        include!("cxx-qt-lib/include/qt_types.h");
-        #[namespace = ""]
-        type QColor = cxx_qt_lib::QColor;
-        #[namespace = ""]
-        type QDate = cxx_qt_lib::QDate;
-        #[namespace = ""]
-        type QDateTime = cxx_qt_lib::QDateTime;
-        #[namespace = ""]
-        type QPoint = cxx_qt_lib::QPoint;
-        #[namespace = ""]
-        type QPointF = cxx_qt_lib::QPointF;
-        #[namespace = ""]
-        type QRect = cxx_qt_lib::QRect;
-        #[namespace = ""]
-        type QRectF = cxx_qt_lib::QRectF;
-        #[namespace = ""]
-        type QSize = cxx_qt_lib::QSize;
-        #[namespace = ""]
-        type QSizeF = cxx_qt_lib::QSizeF;
-        #[namespace = ""]
-        type QString = cxx_qt_lib::QString;
-        #[namespace = ""]
-        type QTime = cxx_qt_lib::QTime;
-        #[namespace = ""]
-        type QUrl = cxx_qt_lib::QUrl;
-        #[namespace = ""]
-        type QVariant = cxx_qt_lib::QVariant;
-
         #[rust_name = "color"]
         fn getColor(self: &MyObjectQt) -> &QColor;
         #[rust_name = "set_color"]
@@ -112,6 +84,24 @@ mod my_object {
 
         #[cxx_name = "initialiseCpp"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
+    }
+
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QDate = cxx_qt_lib::QDate;
+        type QDateTime = cxx_qt_lib::QDateTime;
+        type QPoint = cxx_qt_lib::QPoint;
+        type QPointF = cxx_qt_lib::QPointF;
+        type QRect = cxx_qt_lib::QRect;
+        type QRectF = cxx_qt_lib::QRectF;
+        type QSize = cxx_qt_lib::QSize;
+        type QSizeF = cxx_qt_lib::QSizeF;
+        type QString = cxx_qt_lib::QString;
+        type QTime = cxx_qt_lib::QTime;
+        type QUrl = cxx_qt_lib::QUrl;
+        type QVariant = cxx_qt_lib::QVariant;
     }
 }
 

--- a/examples/qml_extension_plugin/core/src/lib.rs
+++ b/examples/qml_extension_plugin/core/src/lib.rs
@@ -30,6 +30,12 @@ mod my_object {
 
     const DEFAULT_STR: &str = r#"{"number": 1, "string": "Hello World!"}"#;
 
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     pub struct Data {
         pub number: i32,
         pub string: UniquePtr<QString>,

--- a/examples/qml_features/src/lib.rs
+++ b/examples/qml_features/src/lib.rs
@@ -16,6 +16,12 @@ mod types;
 
 #[cxx_qt::bridge]
 mod my_object {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     pub struct Data {
         number: i32,
         string: UniquePtr<QString>,

--- a/examples/qml_features/src/mock_qt_types.rs
+++ b/examples/qml_features/src/mock_qt_types.rs
@@ -6,10 +6,24 @@
 
 #[cxx_qt::bridge]
 mod mock_qt_types {
-    use cxx_qt_lib::{
-        QColor, QDate, QDateTime, QPoint, QPointF, QRect, QRectF, QSize, QSizeF, QTime, QUrl,
-        QVariant, QVariantValue,
-    };
+    use cxx_qt_lib::QVariantValue;
+
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QDate = cxx_qt_lib::QDate;
+        type QDateTime = cxx_qt_lib::QDateTime;
+        type QPoint = cxx_qt_lib::QPoint;
+        type QPointF = cxx_qt_lib::QPointF;
+        type QRect = cxx_qt_lib::QRect;
+        type QRectF = cxx_qt_lib::QRectF;
+        type QSize = cxx_qt_lib::QSize;
+        type QSizeF = cxx_qt_lib::QSizeF;
+        type QTime = cxx_qt_lib::QTime;
+        type QUrl = cxx_qt_lib::QUrl;
+        type QVariant = cxx_qt_lib::QVariant;
+    }
 
     #[cxx_qt::signals(MyObject)]
     pub enum Signal {

--- a/examples/qml_features/src/serialisation.rs
+++ b/examples/qml_features/src/serialisation.rs
@@ -27,6 +27,12 @@ impl From<Data> for DataSerde {
 mod serialisation {
     use super::DataSerde;
 
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     pub struct Data {
         pub number: i32,
         pub string: UniquePtr<QString>,

--- a/examples/qml_features/src/signals.rs
+++ b/examples/qml_features/src/signals.rs
@@ -6,7 +6,12 @@
 // ANCHOR: book_macro_code
 #[cxx_qt::bridge]
 pub mod signals {
-    use cxx_qt_lib::{QPoint, QVariant};
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QPoint = cxx_qt_lib::QPoint;
+        type QVariant = cxx_qt_lib::QVariant;
+    }
 
     // ANCHOR: book_signals_enum
     #[cxx_qt::signals(MyObject)]

--- a/examples/qml_features/src/sub.rs
+++ b/examples/qml_features/src/sub.rs
@@ -6,6 +6,12 @@
 
 #[cxx_qt::bridge]
 pub mod sub_object {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     pub struct Data {
         number: i32,
         string: UniquePtr<QString>,

--- a/examples/qml_features/src/types.rs
+++ b/examples/qml_features/src/types.rs
@@ -6,7 +6,13 @@
 // ANCHOR: book_macro_code
 #[cxx_qt::bridge]
 mod types {
-    use cxx_qt_lib::{QVariant, QVariantValue};
+    use cxx_qt_lib::QVariantValue;
+
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QVariant = cxx_qt_lib::QVariant;
+    }
 
     pub struct Data {
         variant: UniquePtr<QVariant>,

--- a/examples/qml_minimal/src/lib.rs
+++ b/examples/qml_minimal/src/lib.rs
@@ -11,6 +11,12 @@
 mod my_object {
     // ANCHOR_END: book_bridge_macro
 
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     // ANCHOR: book_data_struct
     pub struct Data {
         number: i32,

--- a/examples/qml_with_threaded_logic/src/lib.rs
+++ b/examples/qml_with_threaded_logic/src/lib.rs
@@ -19,6 +19,12 @@ mod website {
         time::Duration,
     };
 
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     enum Event {
         TitleArrived(String),
     }

--- a/tests/basic_cxx_qt/src/data.rs
+++ b/tests/basic_cxx_qt/src/data.rs
@@ -26,6 +26,12 @@ impl From<Data> for DataSerde {
 mod my_data {
     use super::DataSerde;
 
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     pub struct Data {
         pub number: i32,
         pub string: UniquePtr<QString>,

--- a/tests/basic_cxx_qt/src/lib.rs
+++ b/tests/basic_cxx_qt/src/lib.rs
@@ -10,6 +10,12 @@ mod types;
 
 #[cxx_qt::bridge]
 mod my_object {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     pub struct Data {
         number: i32,
         string: UniquePtr<QString>,

--- a/tests/basic_cxx_qt/src/sub.rs
+++ b/tests/basic_cxx_qt/src/sub.rs
@@ -6,6 +6,12 @@
 
 #[cxx_qt::bridge]
 pub mod sub_object {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QString = cxx_qt_lib::QString;
+    }
+
     pub struct Data {
         number: i32,
         string: UniquePtr<QString>,


### PR DESCRIPTION
Requires #164 and #166