### PR TITLE
cxx-qt-gen: start a new syntax folder to help processing syntax

### DIFF
--- a/cxx-qt-build/Cargo.toml
+++ b/cxx-qt-build/Cargo.toml
@@ -20,6 +20,5 @@ cxx-qt-gen = { path = "../cxx-qt-gen", version = "0.3" }
 proc-macro2 = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-syn = { version = "1.0", features = ["extra-traits", "full", "parsing"] }
 quote = "1.0"
 convert_case = "0.4"

--- a/cxx-qt-gen/src/extract.rs
+++ b/cxx-qt-gen/src/extract.rs
@@ -794,12 +794,13 @@ fn extract_signals(
 
 /// Parses a module in order to extract a QObject description from it
 pub fn extract_qobject(
-    module: ItemMod,
+    module: &ItemMod,
     cpp_namespace_prefix: &[&str],
 ) -> Result<QObject, TokenStream> {
     // Find the items from the module
     let original_mod = module.to_owned();
     let items = &mut module
+        .to_owned()
         .content
         .expect("Incorrect module format encountered.")
         .1;
@@ -1106,7 +1107,7 @@ mod tests {
         let source = include_str!("../test_inputs/custom_default.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         // Check that it got the invokables and properties
         assert_eq!(qobject.invokables.len(), 0);
@@ -1138,7 +1139,7 @@ mod tests {
         let source = include_str!("../test_inputs/invokables.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         // Check that it got the names right
         assert_eq!(qobject.ident.to_string(), "MyObject");
@@ -1350,7 +1351,7 @@ mod tests {
         let source = include_str!("../test_inputs/naming.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         // Check that it got the properties and that the idents are correct
         assert_eq!(qobject.properties.len(), 1);
@@ -1396,7 +1397,7 @@ mod tests {
         let source = include_str!("../test_inputs/passthrough.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         // Check that it got the names right
         assert_eq!(qobject.ident.to_string(), "MyObject");
@@ -1420,7 +1421,7 @@ mod tests {
         let source = include_str!("../test_inputs/properties.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         // Check that it got the properties and that the idents are correct
         assert_eq!(qobject.properties.len(), 3);
@@ -1509,7 +1510,7 @@ mod tests {
         let source = include_str!("../test_inputs/signals.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         assert_eq!(qobject.properties.len(), 0);
         assert_eq!(qobject.invokables.len(), 1);
@@ -1574,7 +1575,7 @@ mod tests {
         let source = include_str!("../test_inputs/types_primitive_property.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         // Check that it got the inovkables and properties
         assert_eq!(qobject.invokables.len(), 0);

--- a/cxx-qt-gen/src/gen_cpp.rs
+++ b/cxx-qt-gen/src/gen_cpp.rs
@@ -1083,7 +1083,7 @@ mod tests {
         let source = include_str!("../test_inputs/handlers.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_header = clang_format(include_str!("../test_outputs/handlers.h")).unwrap();
         let expected_source = clang_format(include_str!("../test_outputs/handlers.cpp")).unwrap();
@@ -1097,7 +1097,7 @@ mod tests {
         let source = include_str!("../test_inputs/invokables.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_header = clang_format(include_str!("../test_outputs/invokables.h")).unwrap();
         let expected_source = clang_format(include_str!("../test_outputs/invokables.cpp")).unwrap();
@@ -1111,7 +1111,7 @@ mod tests {
         let source = include_str!("../test_inputs/naming.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_header = clang_format(include_str!("../test_outputs/naming.h")).unwrap();
         let expected_source = clang_format(include_str!("../test_outputs/naming.cpp")).unwrap();
@@ -1125,7 +1125,7 @@ mod tests {
         let source = include_str!("../test_inputs/properties.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_header = clang_format(include_str!("../test_outputs/properties.h")).unwrap();
         let expected_source = clang_format(include_str!("../test_outputs/properties.cpp")).unwrap();
@@ -1139,7 +1139,7 @@ mod tests {
         let source = include_str!("../test_inputs/signals.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_header = clang_format(include_str!("../test_outputs/signals.h")).unwrap();
         let expected_source = clang_format(include_str!("../test_outputs/signals.cpp")).unwrap();
@@ -1153,7 +1153,7 @@ mod tests {
         let source = include_str!("../test_inputs/types_primitive_property.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_header =
             clang_format(include_str!("../test_outputs/types_primitive_property.h")).unwrap();
@@ -1169,7 +1169,7 @@ mod tests {
         let source = include_str!("../test_inputs/types_qt_property.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_header =
             clang_format(include_str!("../test_outputs/types_qt_property.h")).unwrap();
@@ -1185,7 +1185,7 @@ mod tests {
         let source = include_str!("../test_inputs/types_qt_invokable.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_header =
             clang_format(include_str!("../test_outputs/types_qt_invokable.h")).unwrap();

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -1232,7 +1232,7 @@ mod tests {
         let source = include_str!("../test_inputs/custom_default.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_output = include_str!("../test_outputs/custom_default.rs");
         let expected_output = format_rs_source(expected_output);
@@ -1250,7 +1250,7 @@ mod tests {
         let source = include_str!("../test_inputs/handlers.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_output = include_str!("../test_outputs/handlers.rs");
         let expected_output = format_rs_source(expected_output);
@@ -1268,7 +1268,7 @@ mod tests {
         let source = include_str!("../test_inputs/invokables.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_output = include_str!("../test_outputs/invokables.rs");
         let expected_output = format_rs_source(expected_output);
@@ -1286,7 +1286,7 @@ mod tests {
         let source = include_str!("../test_inputs/naming.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_output = include_str!("../test_outputs/naming.rs");
         let expected_output = format_rs_source(expected_output);
@@ -1304,7 +1304,7 @@ mod tests {
         let source = include_str!("../test_inputs/passthrough.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_output = include_str!("../test_outputs/passthrough.rs");
         let expected_output = format_rs_source(expected_output);
@@ -1322,7 +1322,7 @@ mod tests {
         let source = include_str!("../test_inputs/properties.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_output = include_str!("../test_outputs/properties.rs");
         let expected_output = format_rs_source(expected_output);
@@ -1340,7 +1340,7 @@ mod tests {
         let source = include_str!("../test_inputs/signals.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_output = include_str!("../test_outputs/signals.rs");
         let expected_output = format_rs_source(expected_output);
@@ -1358,7 +1358,7 @@ mod tests {
         let source = include_str!("../test_inputs/types_primitive_property.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_output = include_str!("../test_outputs/types_primitive_property.rs");
         let expected_output = format_rs_source(expected_output);
@@ -1376,7 +1376,7 @@ mod tests {
         let source = include_str!("../test_inputs/types_qt_property.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_output = include_str!("../test_outputs/types_qt_property.rs");
         let expected_output = format_rs_source(expected_output);
@@ -1394,7 +1394,7 @@ mod tests {
         let source = include_str!("../test_inputs/types_qt_invokable.rs");
         let module: ItemMod = syn::parse_str(source).unwrap();
         let cpp_namespace_prefix = vec!["cxx_qt"];
-        let qobject = extract_qobject(module, &cpp_namespace_prefix).unwrap();
+        let qobject = extract_qobject(&module, &cpp_namespace_prefix).unwrap();
 
         let expected_output = include_str!("../test_outputs/types_qt_invokable.rs");
         let expected_output = format_rs_source(expected_output);

--- a/cxx-qt-gen/src/lib.rs
+++ b/cxx-qt-gen/src/lib.rs
@@ -6,6 +6,7 @@
 mod extract;
 mod gen_cpp;
 mod gen_rs;
+pub mod syntax;
 mod utils;
 
 pub use extract::{extract_qobject, QObject};

--- a/cxx-qt-gen/src/syntax/mod.rs
+++ b/cxx-qt-gen/src/syntax/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+mod qtfile;
+mod qtitem;
+
+pub use qtfile::{parse_qt_file, CxxQtFile};
+pub use qtitem::CxxQtItem;

--- a/cxx-qt-gen/src/syntax/qtfile.rs
+++ b/cxx-qt-gen/src/syntax/qtfile.rs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use super::CxxQtItem;
+use proc_macro2::TokenStream;
+use quote::{ToTokens, TokenStreamExt};
+use syn::parse::{Parse, ParseStream};
+use syn::{AttrStyle, Attribute, Result};
+
+pub struct CxxQtFile {
+    pub attrs: Vec<Attribute>,
+    pub items: Vec<CxxQtItem>,
+}
+
+impl Parse for CxxQtFile {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(CxxQtFile {
+            attrs: input.call(Attribute::parse_inner)?,
+            items: {
+                let mut items = Vec::new();
+                while !input.is_empty() {
+                    items.push(input.parse()?);
+                }
+                items
+            },
+        })
+    }
+}
+
+impl ToTokens for CxxQtFile {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append_all(
+            self.attrs
+                .iter()
+                .filter(|attr| matches!(attr.style, AttrStyle::Inner(_))),
+        );
+        tokens.append_all(&self.items);
+    }
+}
+
+pub fn parse_qt_file(path: &impl AsRef<std::path::Path>) -> Result<CxxQtFile> {
+    let source = std::fs::read_to_string(path.as_ref()).expect("Could not read path {} to string");
+
+    // We drop the shebang from the generated Rust code
+    if source.starts_with("#!") && !source.starts_with("#![") {
+        let shebang_end = source.find('\n').unwrap_or(source.len());
+        syn::parse_str(&source[shebang_end..])
+    } else {
+        syn::parse_str(&source)
+    }
+}

--- a/cxx-qt-gen/src/syntax/qtitem.rs
+++ b/cxx-qt-gen/src/syntax/qtitem.rs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::parse::{Parse, ParseStream};
+use syn::{Attribute, Item, ItemMod, Result, Token, Visibility};
+
+#[derive(Clone, PartialEq)]
+pub enum CxxQtItem {
+    /// A normal syntax item that we pass through
+    Item(Item),
+    /// A CXX module that we need to generate code for
+    Cxx(ItemMod),
+    /// A CxxQt module block that we need to parse and later generate code for
+    CxxQt(ItemMod),
+}
+
+impl std::fmt::Debug for CxxQtItem {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CxxQtItem::Item(v0) => {
+                let mut formatter = formatter.debug_tuple("Item");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            CxxQtItem::Cxx(v0) => {
+                let mut formatter = formatter.debug_tuple("Cxx");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            CxxQtItem::CxxQt(v0) => {
+                let mut formatter = formatter.debug_tuple("CxxQt");
+                formatter.field(v0);
+                formatter.finish()
+            }
+        }
+    }
+}
+
+impl Parse for CxxQtItem {
+    fn parse(input: ParseStream) -> Result<Self> {
+        // Fork and skip over the attributes as we want to read the next token
+        let ahead = input.fork();
+        let attributes = ahead.call(Attribute::parse_outer)?;
+
+        // See if the next token is a mod
+        ahead.parse::<Visibility>()?;
+        ahead.parse::<Option<Token![unsafe]>>()?;
+
+        if ahead.peek(Token![mod]) {
+            for attribute in &attributes {
+                let path = &attribute.path.segments;
+                if path.len() == 2 {
+                    if path[0].ident == "cxx" && path[1].ident == "bridge" {
+                        // TODO: parse namespace here too
+                        return input.parse().map(CxxQtItem::Cxx);
+                    } else if path[0].ident == "cxx_qt" && path[1].ident == "bridge" {
+                        // TODO: parse namespace here too
+                        return input.parse().map(CxxQtItem::CxxQt);
+                    }
+                }
+            }
+        }
+
+        // Fallback to using normal Item
+        input.parse().map(CxxQtItem::Item)
+    }
+}
+
+impl ToTokens for CxxQtItem {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            CxxQtItem::Item(item) => {
+                item.to_tokens(tokens);
+            }
+            CxxQtItem::Cxx(module) => {
+                module.to_tokens(tokens);
+            }
+            CxxQtItem::CxxQt(module) => {
+                module.to_tokens(tokens);
+            }
+        }
+    }
+}

--- a/cxx-qt/src/lib.rs
+++ b/cxx-qt/src/lib.rs
@@ -49,7 +49,7 @@ fn extract_and_generate<'s>(module: ItemMod, cpp_namespace_prefix: &'s [String])
         cpp_namespace_prefix.iter().map(AsRef::as_ref).collect();
 
     // Attempt to extract information about a QObject inside the module
-    let qobject = match extract_qobject(module, &cpp_namespace_prefix_ref) {
+    let qobject = match extract_qobject(&module, &cpp_namespace_prefix_ref) {
         Ok(o) => o,
         Err(e) => return e.into(),
     };


### PR DESCRIPTION
This starts to split up the roles, later there will be more things
in syntax and other separate folders.