### PR TITLE
cxx-qt-gen: use impl cxx_qt::QObject<T> block for invokables

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ mod my_object {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn increment(&self, cpp: &mut CppObj) {
             cpp.set_number(cpp.number() + 1);

--- a/book/src/getting-started/1-qobjects-in-rust.md
+++ b/book/src/getting-started/1-qobjects-in-rust.md
@@ -48,7 +48,9 @@ These CXX-Qt modules consist of multiple parts:
 - The `impl` of the `RustObj` struct (optional):
     - Contains any Rust code.
     - Functions marked with `#[invokable]` will be callable from QML and C++.
-<!-- TODO: Add Signals enum, once #67 lands -->
+- The `Signal` enum
+    - A normal Rust enum.
+    - Defines signals that are added to the QObject class
 
 CXX-Qt will then expand this Rust module into two separate parts:
 - A C++ subclass of QObject with the same name as the module

--- a/book/src/qobject/cpp_object.md
+++ b/book/src/qobject/cpp_object.md
@@ -24,14 +24,7 @@ If there is a [`Signals` enum](./signals_enum.md) then you can call `emit_queued
 Note that `emit_immediate` is unsafe as it can cause deadlocks if the `Q_EMIT` is `Qt::DirectConnection` connected to a Rust invokable on the same QObject that has caused the `Q_EMIT`, as this would then try to lock the `RustObj` which is already locked.
 
 ```rust,ignore,noplayground
-impl RustObj {
-    #[invokable]
-    fn invokable(&self, cpp: &mut CppObj) {
-        unsafe { cpp.emit_immediate(Signal::Ready); }
-
-        cpp.emit_queued(Signal::DataChanged { data: 1 });
-    }
-}
+{{#include ../../../examples/qml_features/src/signals.rs:book_rust_obj_impl}}
 ```
 
 ## Threading

--- a/book/src/qobject/rustobj_struct.md
+++ b/book/src/qobject/rustobj_struct.md
@@ -20,7 +20,10 @@ The RustObj struct allows you to define the following items
 
 ## Invokables
 
-To define a method which is exposed to QML and C++, add a method on the `RustObj` struct and add the attribute `#[invokable]`. The parameters and return type are then matched to the Qt side. Also CXX-Qt automatically adds wrapper code around your invokable to automatically perform any conversion between the [C++ and Rust types](../concepts/types.md).
+A `impl cxx_qt::QObject<RustObj>` is used to define invokables, the `impl cxx_qt::QObject<RustObj>` defines that the methods are implemented onto the C++ QObject.
+Therefore they have access to both C++ and Rust methods. Also CXX-Qt adds wrapper code around your invokables to automatically perform any conversion between the [C++ and Rust types](../concepts/types.md).
+
+To mark a method as invokable simply add the `#[invokable]` attribute to the Rust method. This then causes `Q_INVOKABLE` to be set on the C++ definition of the method, allowing QML to call the invokable.
 
 Note to access properties on the C++ object use [Cpp Object](./cpp_object.md).
 
@@ -28,4 +31,6 @@ Note to access properties on the C++ object use [Cpp Object](./cpp_object.md).
 
 Unlike the [Data Struct](./data_struct.md) fields which are defined on the `RustObj` struct are not exposed as properties to Qt. These can be considered as "private to Rust" fields, and are useful for storing channels for threading or internal information for the QObject.
 
-Methods implemented on the `RustObj` that do not have an `#[invokable]` attribute are not exposed to C++ and are considered "private to Rust" methods. Similar to fields these are useful for threading and internal information.
+Methods implemented using `impl RustObj` (and not `impl cxx_qt::QObject<RustObj>`) are just normal Rust member methods.
+Therefore they do not have access to any C++ or QObject functionality (e.g. emitting Signals, changing properties, etc.)
+You will usually only need to use `impl RustObj` if you want to also use your RustObj struct as a normal Rust struct, that is not wrapped in a QObject.

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -979,14 +979,14 @@ pub fn generate_qobject_rs(
                 .map(|ident_wrapper| invokable_generate_wrapper(i, &ident_wrapper.rust_ident))
         })
         .collect::<Result<Vec<TokenStream>, TokenStream>>()?;
-
     let invokable_methods = obj
         .invokables
         .iter()
         .map(|m| m.original_method.clone())
         .collect::<Vec<syn::ImplItemMethod>>();
-    let normal_methods = &obj.normal_methods;
 
+    let normal_methods = &obj.normal_methods;
+    let rust_methods = &obj.rust_methods;
     let original_trait_impls = &obj.original_trait_impls;
     let original_passthrough_decls = &obj.original_passthrough_decls;
 
@@ -1019,6 +1019,7 @@ pub fn generate_qobject_rs(
             #(#invokable_method_wrappers)*
             #(#invokable_methods)*
             #(#normal_methods)*
+            #(#rust_methods)*
 
             #handle_update_request
         }

--- a/cxx-qt-gen/test_inputs/invokables.rs
+++ b/cxx-qt-gen/test_inputs/invokables.rs
@@ -10,7 +10,7 @@ mod my_object {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn invokable(&self) {
             println!("invokable");
@@ -66,8 +66,26 @@ mod my_object {
             QString::from_str("static")
         }
 
+        pub fn cpp_context_method(&self) {
+            println!("C++ context method");
+        }
+
+        pub fn cpp_context_method_mutable(&mut self) {
+            println!("mutable method");
+        }
+
+        pub fn cpp_context_method_cpp_obj(&mut self, cpp: &mut CppObj) {
+            println!("cppobj");
+        }
+
+        pub fn cpp_context_method_return_opaque(&self) -> UniquePtr<QColor> {
+            cxx_qt_lib::QColor::from_rgba(255, 0, 0, 0)
+        }
+    }
+
+    impl RustObj {
         pub fn rust_only_method(&self) {
-            println!("QML can't call this :)");
+            println!("QML or C++ can't call this :)");
         }
     }
 }

--- a/cxx-qt-gen/test_inputs/naming.rs
+++ b/cxx-qt-gen/test_inputs/naming.rs
@@ -7,7 +7,7 @@ mod my_object {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn invokable_name(&self) {
             println!("Bye from Rust!");

--- a/cxx-qt-gen/test_inputs/signals.rs
+++ b/cxx-qt-gen/test_inputs/signals.rs
@@ -22,7 +22,7 @@ mod my_object {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn invokable(&self, cpp: &mut CppObj) {
             unsafe {

--- a/cxx-qt-gen/test_inputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_invokable.rs
@@ -23,7 +23,7 @@ mod my_object {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn test_color(&self, _cpp: &mut CppObj, color: &QColor) -> UniquePtr<QColor> {
             color

--- a/cxx-qt-gen/test_outputs/invokables.rs
+++ b/cxx-qt-gen/test_outputs/invokables.rs
@@ -156,8 +156,24 @@ mod cxx_qt_my_object {
             QString::from_str("static")
         }
 
+        pub fn cpp_context_method(&self) {
+            println!("C++ context method");
+        }
+
+        pub fn cpp_context_method_mutable(&mut self) {
+            println!("mutable method");
+        }
+
+        pub fn cpp_context_method_cpp_obj(&mut self, cpp: &mut CppObj) {
+            println!("cppobj");
+        }
+
+        pub fn cpp_context_method_return_opaque(&self) -> UniquePtr<QColor> {
+            cxx_qt_lib::QColor::from_rgba(255, 0, 0, 0)
+        }
+
         pub fn rust_only_method(&self) {
-            println!("QML can't call this :)");
+            println!("QML or C++ can't call this :)");
         }
     }
 

--- a/cxx-qt/src/lib.rs
+++ b/cxx-qt/src/lib.rs
@@ -16,11 +16,15 @@ use cxx_qt_gen::{extract_qobject, generate_qobject_rs};
 /// #[cxx_qt::bridge]
 /// mod my_object {
 ///     #[derive(Default)]
-///     struct MyObject {
+///     struct Data {
 ///         property: i32,
 ///     }
 ///
-///     impl MyObject {
+///     #[derive(Default)]
+///     struct RustObj;
+///
+///     impl cxx_qt::QObject<RustObj> {
+///         #[invokable]
 ///         fn invokable(&self, a: i32, b: i32) -> i32 {
 ///             a + b
 ///         }
@@ -58,6 +62,38 @@ pub fn bridge(_attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn signals(_args: TokenStream, _input: TokenStream) -> TokenStream {
     unreachable!("cxx_qt::signals should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")
+}
+
+/// A macro which describes that the inner methods should be implemented on the C++ QObject.
+/// This allows for defining C++ methods which are Q_INVOKABLE for QML in Rust.
+///
+/// It should not be used by itself and instead should be used inside a cxx_qt::bridge definition.
+///
+/// # Example
+///
+/// ```ignore
+/// #[cxx_qt::bridge]
+/// mod my_object {
+///     #[derive(Default)]
+///     struct Data {
+///         property: i32,
+///     }
+///
+///     #[derive(Default)]
+///     struct RustObj;
+///
+///     impl cxx_qt::QObject<RustObj> {
+///         #[invokable]
+///         fn invokable(&self, a: i32, b: i32) -> i32 {
+///             a + b
+///         }
+///     }
+/// }
+/// ```
+#[proc_macro]
+#[allow(non_snake_case)]
+pub fn QObject(_input: TokenStream) -> TokenStream {
+    unreachable!("cxx_qt::QObject should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")
 }
 
 // Take the module and C++ namespace and generate the rust code

--- a/examples/demo_threading/src/lib.rs
+++ b/examples/demo_threading/src/lib.rs
@@ -214,7 +214,9 @@ mod energy_usage {
                 .ok();
             stream.flush().await.unwrap();
         }
+    }
 
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn start_server(&mut self, cpp: &mut CppObj) {
             if self.join_handles.is_some() {

--- a/examples/qml_extension_plugin/core/src/lib.rs
+++ b/examples/qml_extension_plugin/core/src/lib.rs
@@ -60,7 +60,7 @@ mod my_object {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn increment(&self, cpp: &mut CppObj) {
             cpp.set_number(cpp.number() + 1);

--- a/examples/qml_features/src/lib.rs
+++ b/examples/qml_features/src/lib.rs
@@ -40,7 +40,7 @@ mod my_object {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number() + 1;

--- a/examples/qml_features/src/mock_qt_types.rs
+++ b/examples/qml_features/src/mock_qt_types.rs
@@ -74,7 +74,7 @@ mod mock_qt_types {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn test_signal(&self, cpp: &mut CppObj) {
             cpp.emit_queued(Signal::Ready);

--- a/examples/qml_features/src/nested.rs
+++ b/examples/qml_features/src/nested.rs
@@ -14,7 +14,7 @@ mod nested {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn nested_parameter(
             &self,

--- a/examples/qml_features/src/rust_obj_invokables.rs
+++ b/examples/qml_features/src/rust_obj_invokables.rs
@@ -21,7 +21,7 @@ pub mod rust_obj_invokables {
         }
     }
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         // ANCHOR: book_cpp_obj
         #[invokable]
         pub fn invokable_mutate_cpp(&self, cpp: &mut CppObj) {
@@ -39,7 +39,9 @@ pub mod rust_obj_invokables {
             self.rust_only_method(factor);
             self.rust_only_field
         }
+    }
 
+    impl RustObj {
         fn rust_only_method(&mut self, factor: i32) {
             self.rust_only_field *= factor;
         }

--- a/examples/qml_features/src/serialisation.rs
+++ b/examples/qml_features/src/serialisation.rs
@@ -58,7 +58,7 @@ mod serialisation {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn as_json_str(&self, cpp: &mut CppObj) -> UniquePtr<QString> {
             let data = Data::from(cpp);

--- a/examples/qml_features/src/signals.rs
+++ b/examples/qml_features/src/signals.rs
@@ -43,7 +43,7 @@ pub mod signals {
     pub struct RustObj;
 
     // ANCHOR: book_rust_obj_impl
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn invokable(&self, cpp: &mut CppObj) {
             unsafe {

--- a/examples/qml_features/src/sub.rs
+++ b/examples/qml_features/src/sub.rs
@@ -29,7 +29,7 @@ pub mod sub_object {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number();

--- a/examples/qml_features/src/types.rs
+++ b/examples/qml_features/src/types.rs
@@ -29,7 +29,7 @@ mod types {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn test_variant_property(&self, cpp: &mut CppObj) {
             match cpp.variant().value() {

--- a/examples/qml_minimal/src/lib.rs
+++ b/examples/qml_minimal/src/lib.rs
@@ -40,7 +40,7 @@ mod my_object {
     // ANCHOR_END: book_rustobj_struct
 
     // ANCHOR: book_rustobj_impl
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn increment_number(&self, cpp: &mut CppObj) {
             cpp.set_number(cpp.number() + 1);

--- a/examples/qml_with_threaded_logic/src/lib.rs
+++ b/examples/qml_with_threaded_logic/src/lib.rs
@@ -61,7 +61,7 @@ mod website {
         }
     }
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn change_url(&self, cpp: &mut CppObj) {
             let url = cpp.url().to_string();
@@ -110,15 +110,6 @@ mod website {
             thread::spawn(move || block_on(fetch_title));
         }
 
-        fn process_event(&mut self, event: &Event, cpp: &mut CppObj) {
-            match event {
-                Event::TitleArrived(title) => {
-                    cpp.set_title(QString::from_str(title).as_ref().unwrap());
-                    self.loading.store(false, Ordering::Relaxed);
-                }
-            }
-        }
-
         #[invokable]
         pub fn new_title_value(&mut self) {
             println!("title changed");
@@ -127,6 +118,15 @@ mod website {
         #[invokable]
         pub fn new_url_value(&mut self, cpp: &mut CppObj) {
             self.refresh_title(cpp);
+        }
+
+        fn process_event(&mut self, event: &Event, cpp: &mut CppObj) {
+            match event {
+                Event::TitleArrived(title) => {
+                    cpp.set_title(QString::from_str(title).as_ref().unwrap());
+                    self.loading.store(false, Ordering::Relaxed);
+                }
+            }
         }
     }
 

--- a/tests/basic_cxx_qt/src/data.rs
+++ b/tests/basic_cxx_qt/src/data.rs
@@ -57,7 +57,7 @@ mod my_data {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn as_json_str(&self, cpp: &mut CppObj) -> UniquePtr<QString> {
             let data = Data::from(cpp);

--- a/tests/basic_cxx_qt/src/lib.rs
+++ b/tests/basic_cxx_qt/src/lib.rs
@@ -36,7 +36,7 @@ mod my_object {
         update_call_count: i32,
     }
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn double_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number() * 2;

--- a/tests/basic_cxx_qt/src/sub.rs
+++ b/tests/basic_cxx_qt/src/sub.rs
@@ -29,7 +29,7 @@ pub mod sub_object {
     #[derive(Default)]
     pub struct RustObj;
 
-    impl RustObj {
+    impl cxx_qt::QObject<RustObj> {
         #[invokable]
         pub fn increment_number_self(&self, cpp: &mut CppObj) {
             let value = cpp.number();


### PR DESCRIPTION
This helps later as the invokables are implemented onto a different
struct, so this clearly defines the split between C++ and Rust
methods etc.