### PR TITLE
cxx-qt-gen: have MyObjectRust on C++ side and MyObjectQt on Rust

### DIFF
--- a/cxx-qt-gen/src/extract.rs
+++ b/cxx-qt-gen/src/extract.rs
@@ -227,7 +227,7 @@ fn extract_qt_type(
                 external: false,
                 cpp_type_idents: vec![qt_ident.clone()],
                 cpp_type_idents_string: qt_ident.to_string(),
-                rust_type_idents: vec![qt_ident.clone()],
+                rust_type_idents: vec![quote::format_ident!("{}Qt", qt_ident)],
                 combined_name: qt_ident.clone(),
             }),
             "f32" => Ok(QtTypes::F32),

--- a/cxx-qt-gen/src/gen_cpp.rs
+++ b/cxx-qt-gen/src/gen_cpp.rs
@@ -793,7 +793,7 @@ fn generate_signals_cpp(
 /// Generate a CppObject object containing the header and source of a given rust QObject
 pub fn generate_qobject_cpp(obj: &QObject) -> Result<CppObject, TokenStream> {
     let struct_ident_str = obj.ident.to_string();
-    const RUST_STRUCT_IDENT_STR: &str = "RustObj";
+    let rust_struct_ident = format!("{}Rust", struct_ident_str);
 
     // A helper which allows us to flatten data from vec of properties
     struct CppPropertyHelper {
@@ -1008,7 +1008,7 @@ pub fn generate_qobject_cpp(obj: &QObject) -> Result<CppObject, TokenStream> {
     namespace = namespace,
     properties_meta = properties.headers_meta.join("\n"),
     properties_public = properties.headers_public.join("\n"),
-    rust_struct_ident = RUST_STRUCT_IDENT_STR,
+    rust_struct_ident = rust_struct_ident,
     signals = cpp_signals,
     signal_emitters = signals.headers_public.join("\n"),
     public_slots = public_slots,

--- a/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/cxx-qt-gen/test_outputs/custom_default.rs
@@ -3,7 +3,8 @@ mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-        type MyObject;
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
 
         include!("cxx-qt-lib/include/qt_types.h");
         #[namespace = ""]
@@ -34,22 +35,23 @@ mod my_object {
         type QVariant = cxx_qt_lib::QVariantCpp;
 
         #[rust_name = "public"]
-        fn getPublic(self: &MyObject) -> i32;
+        fn getPublic(self: &MyObjectQt) -> i32;
         #[rust_name = "set_public"]
-        fn setPublic(self: Pin<&mut MyObject>, value: i32);
+        fn setPublic(self: Pin<&mut MyObjectQt>, value: i32);
 
         #[rust_name = "new_cpp_object"]
-        fn newCppObject() -> UniquePtr<MyObject>;
+        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
         type RustObj;
 
         #[cxx_name = "createRs"]
         fn create_rs() -> Box<RustObj>;
 
         #[cxx_name = "initialiseCpp"]
-        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+        fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }
 
@@ -59,7 +61,7 @@ mod cxx_qt_my_object {
 
     use cxx_qt_lib::ToUniquePtr;
 
-    pub type FFICppObj = super::my_object::MyObject;
+    pub type FFICppObj = super::my_object::MyObjectQt;
 
     pub struct RustObj {
         private: i32,

--- a/cxx-qt-gen/test_outputs/handlers.h
+++ b/cxx-qt-gen/test_outputs/handlers.h
@@ -8,7 +8,7 @@
 
 namespace cxx_qt::my_object {
 
-class RustObj;
+class MyObjectRust;
 
 class MyObject : public QObject
 {
@@ -35,7 +35,7 @@ Q_SIGNALS:
   void stringChanged();
 
 private:
-  rust::Box<RustObj> m_rustObj;
+  rust::Box<MyObjectRust> m_rustObj;
   std::mutex m_rustObjMutex;
   bool m_initialised = false;
 

--- a/cxx-qt-gen/test_outputs/handlers.rs
+++ b/cxx-qt-gen/test_outputs/handlers.rs
@@ -3,7 +3,8 @@ mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-        type MyObject;
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
 
         include!("cxx-qt-lib/include/qt_types.h");
         #[namespace = ""]
@@ -37,33 +38,34 @@ mod my_object {
         type UpdateRequester = cxx_qt_lib::UpdateRequesterCpp;
 
         #[rust_name = "number"]
-        fn getNumber(self: &MyObject) -> i32;
+        fn getNumber(self: &MyObjectQt) -> i32;
         #[rust_name = "set_number"]
-        fn setNumber(self: Pin<&mut MyObject>, value: i32);
+        fn setNumber(self: Pin<&mut MyObjectQt>, value: i32);
 
         #[rust_name = "string"]
-        fn getString(self: &MyObject) -> &QString;
+        fn getString(self: &MyObjectQt) -> &QString;
         #[rust_name = "set_string"]
-        fn setString(self: Pin<&mut MyObject>, value: &QString);
+        fn setString(self: Pin<&mut MyObjectQt>, value: &QString);
 
         #[rust_name = "new_cpp_object"]
-        fn newCppObject() -> UniquePtr<MyObject>;
+        fn newCppObject() -> UniquePtr<MyObjectQt>;
 
         #[rust_name = "update_requester"]
-        fn updateRequester(self: Pin<&mut MyObject>) -> UniquePtr<UpdateRequester>;
+        fn updateRequester(self: Pin<&mut MyObjectQt>) -> UniquePtr<UpdateRequester>;
     }
 
     extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
         type RustObj;
 
         #[cxx_name = "createRs"]
         fn create_rs() -> Box<RustObj>;
 
         #[cxx_name = "initialiseCpp"]
-        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+        fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
 
         #[cxx_name = "handleUpdateRequest"]
-        fn call_handle_update_request(self: &mut RustObj, cpp: Pin<&mut MyObject>);
+        fn call_handle_update_request(self: &mut RustObj, cpp: Pin<&mut MyObjectQt>);
     }
 }
 
@@ -74,7 +76,7 @@ mod cxx_qt_my_object {
     use cxx_qt_lib::ToUniquePtr;
     use cxx_qt_lib::UpdateRequestHandler;
 
-    pub type FFICppObj = super::my_object::MyObject;
+    pub type FFICppObj = super::my_object::MyObjectQt;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/invokables.h
+++ b/cxx-qt-gen/test_outputs/invokables.h
@@ -10,7 +10,7 @@
 
 namespace cxx_qt::my_object {
 
-class RustObj;
+class MyObjectRust;
 
 class MyObject : public QObject
 {
@@ -35,7 +35,7 @@ public:
   Q_INVOKABLE QString invokableReturnStatic();
 
 private:
-  rust::Box<RustObj> m_rustObj;
+  rust::Box<MyObjectRust> m_rustObj;
   std::mutex m_rustObjMutex;
   bool m_initialised = false;
 };

--- a/cxx-qt-gen/test_outputs/invokables.rs
+++ b/cxx-qt-gen/test_outputs/invokables.rs
@@ -3,7 +3,8 @@ mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-        type MyObject;
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
 
         include!("cxx-qt-lib/include/qt_types.h");
         #[namespace = ""]
@@ -37,20 +38,21 @@ mod my_object {
         type NestedObject = crate::cxx_qt_nested_object::FFICppObj;
 
         #[rust_name = "new_cpp_object"]
-        fn newCppObject() -> UniquePtr<MyObject>;
+        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
         type RustObj;
 
         #[cxx_name = "invokable"]
         fn invokable(self: &RustObj);
         #[cxx_name = "invokableCppObjWrapper"]
-        fn invokable_cpp_obj_wrapper(self: &RustObj, cpp: Pin<&mut MyObject>);
+        fn invokable_cpp_obj_wrapper(self: &RustObj, cpp: Pin<&mut MyObjectQt>);
         #[cxx_name = "invokableMutable"]
         fn invokable_mutable(self: &mut RustObj);
         #[cxx_name = "invokableMutableCppObjWrapper"]
-        fn invokable_mutable_cpp_obj_wrapper(self: &mut RustObj, cpp: Pin<&mut MyObject>);
+        fn invokable_mutable_cpp_obj_wrapper(self: &mut RustObj, cpp: Pin<&mut MyObjectQt>);
         #[cxx_name = "invokableNestedParameterWrapper"]
         fn invokable_nested_parameter_wrapper(self: &RustObj, nested: Pin<&mut NestedObject>);
         #[cxx_name = "invokableParametersWrapper"]
@@ -64,7 +66,7 @@ mod my_object {
         fn invokable_parameters_cpp_obj_wrapper(
             self: &RustObj,
             primitive: i32,
-            cpp: Pin<&mut MyObject>,
+            cpp: Pin<&mut MyObjectQt>,
         );
         #[cxx_name = "invokableReturnOpaqueWrapper"]
         fn invokable_return_opaque_wrapper(self: &mut RustObj) -> UniquePtr<QColor>;
@@ -77,7 +79,7 @@ mod my_object {
         fn create_rs() -> Box<RustObj>;
 
         #[cxx_name = "initialiseCpp"]
-        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+        fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }
 
@@ -87,7 +89,7 @@ mod cxx_qt_my_object {
 
     use cxx_qt_lib::ToUniquePtr;
 
-    pub type FFICppObj = super::my_object::MyObject;
+    pub type FFICppObj = super::my_object::MyObjectQt;
 
     use cxx_qt_lib::QColor;
 

--- a/cxx-qt-gen/test_outputs/naming.h
+++ b/cxx-qt-gen/test_outputs/naming.h
@@ -6,7 +6,7 @@
 
 namespace cxx_qt::my_object {
 
-class RustObj;
+class MyObjectRust;
 
 class MyObject : public QObject
 {
@@ -29,7 +29,7 @@ Q_SIGNALS:
   void propertyNameChanged();
 
 private:
-  rust::Box<RustObj> m_rustObj;
+  rust::Box<MyObjectRust> m_rustObj;
   std::mutex m_rustObjMutex;
   bool m_initialised = false;
 

--- a/cxx-qt-gen/test_outputs/naming.rs
+++ b/cxx-qt-gen/test_outputs/naming.rs
@@ -3,7 +3,8 @@ mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-        type MyObject;
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
 
         include!("cxx-qt-lib/include/qt_types.h");
         #[namespace = ""]
@@ -34,15 +35,16 @@ mod my_object {
         type QVariant = cxx_qt_lib::QVariantCpp;
 
         #[rust_name = "property_name"]
-        fn getPropertyName(self: &MyObject) -> i32;
+        fn getPropertyName(self: &MyObjectQt) -> i32;
         #[rust_name = "set_property_name"]
-        fn setPropertyName(self: Pin<&mut MyObject>, value: i32);
+        fn setPropertyName(self: Pin<&mut MyObjectQt>, value: i32);
 
         #[rust_name = "new_cpp_object"]
-        fn newCppObject() -> UniquePtr<MyObject>;
+        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
         type RustObj;
 
         #[cxx_name = "invokableName"]
@@ -52,7 +54,7 @@ mod my_object {
         fn create_rs() -> Box<RustObj>;
 
         #[cxx_name = "initialiseCpp"]
-        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+        fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }
 
@@ -62,7 +64,7 @@ mod cxx_qt_my_object {
 
     use cxx_qt_lib::ToUniquePtr;
 
-    pub type FFICppObj = super::my_object::MyObject;
+    pub type FFICppObj = super::my_object::MyObjectQt;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/cxx-qt-gen/test_outputs/passthrough.rs
@@ -3,7 +3,8 @@ pub mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-        type MyObject;
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
 
         include!("cxx-qt-lib/include/qt_types.h");
         #[namespace = ""]
@@ -34,22 +35,23 @@ pub mod my_object {
         type QVariant = cxx_qt_lib::QVariantCpp;
 
         #[rust_name = "number"]
-        fn getNumber(self: &MyObject) -> i32;
+        fn getNumber(self: &MyObjectQt) -> i32;
         #[rust_name = "set_number"]
-        fn setNumber(self: Pin<&mut MyObject>, value: i32);
+        fn setNumber(self: Pin<&mut MyObjectQt>, value: i32);
 
         #[rust_name = "new_cpp_object"]
-        fn newCppObject() -> UniquePtr<MyObject>;
+        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
         type RustObj;
 
         #[cxx_name = "createRs"]
         fn create_rs() -> Box<RustObj>;
 
         #[cxx_name = "initialiseCpp"]
-        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+        fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 
     extern "C" {}
@@ -79,7 +81,7 @@ pub mod cxx_qt_my_object {
 
     use cxx_qt_lib::ToUniquePtr;
 
-    pub type FFICppObj = super::my_object::MyObject;
+    pub type FFICppObj = super::my_object::MyObjectQt;
 
     const MAX: u16 = 65535;
 

--- a/cxx-qt-gen/test_outputs/properties.h
+++ b/cxx-qt-gen/test_outputs/properties.h
@@ -9,7 +9,7 @@
 
 namespace cxx_qt::my_object {
 
-class RustObj;
+class MyObjectRust;
 
 class MyObject : public QObject
 {
@@ -41,7 +41,7 @@ Q_SIGNALS:
   void nestedChanged();
 
 private:
-  rust::Box<RustObj> m_rustObj;
+  rust::Box<MyObjectRust> m_rustObj;
   std::mutex m_rustObjMutex;
   bool m_initialised = false;
 

--- a/cxx-qt-gen/test_outputs/properties.rs
+++ b/cxx-qt-gen/test_outputs/properties.rs
@@ -3,7 +3,8 @@ mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-        type MyObject;
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
 
         include!("cxx-qt-lib/include/qt_types.h");
         #[namespace = ""]
@@ -34,35 +35,36 @@ mod my_object {
         type QVariant = cxx_qt_lib::QVariantCpp;
 
         #[rust_name = "primitive"]
-        fn getPrimitive(self: &MyObject) -> i32;
+        fn getPrimitive(self: &MyObjectQt) -> i32;
         #[rust_name = "set_primitive"]
-        fn setPrimitive(self: Pin<&mut MyObject>, value: i32);
+        fn setPrimitive(self: Pin<&mut MyObjectQt>, value: i32);
 
         #[rust_name = "opaque"]
-        fn getOpaque(self: &MyObject) -> &QColor;
+        fn getOpaque(self: &MyObjectQt) -> &QColor;
         #[rust_name = "set_opaque"]
-        fn setOpaque(self: Pin<&mut MyObject>, value: &QColor);
+        fn setOpaque(self: Pin<&mut MyObjectQt>, value: &QColor);
 
         #[namespace = "cxx_qt::nested_object"]
         type NestedObject = crate::cxx_qt_nested_object::FFICppObj;
 
         #[rust_name = "take_nested"]
-        fn takeNested(self: Pin<&mut MyObject>) -> UniquePtr<NestedObject>;
+        fn takeNested(self: Pin<&mut MyObjectQt>) -> UniquePtr<NestedObject>;
         #[rust_name = "give_nested"]
-        fn giveNested(self: Pin<&mut MyObject>, value: UniquePtr<NestedObject>);
+        fn giveNested(self: Pin<&mut MyObjectQt>, value: UniquePtr<NestedObject>);
 
         #[rust_name = "new_cpp_object"]
-        fn newCppObject() -> UniquePtr<MyObject>;
+        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
         type RustObj;
 
         #[cxx_name = "createRs"]
         fn create_rs() -> Box<RustObj>;
 
         #[cxx_name = "initialiseCpp"]
-        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+        fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }
 
@@ -72,7 +74,7 @@ mod cxx_qt_my_object {
 
     use cxx_qt_lib::ToUniquePtr;
 
-    pub type FFICppObj = super::my_object::MyObject;
+    pub type FFICppObj = super::my_object::MyObjectQt;
 
     use cxx_qt_lib::QColor;
 

--- a/cxx-qt-gen/test_outputs/signals.h
+++ b/cxx-qt-gen/test_outputs/signals.h
@@ -9,7 +9,7 @@
 
 namespace cxx_qt::my_object {
 
-class RustObj;
+class MyObjectRust;
 
 class MyObject : public QObject
 {
@@ -31,7 +31,7 @@ Q_SIGNALS:
   void dataChanged(qint32 first, const QVariant& second, const QPoint& third);
 
 private:
-  rust::Box<RustObj> m_rustObj;
+  rust::Box<MyObjectRust> m_rustObj;
   std::mutex m_rustObjMutex;
   bool m_initialised = false;
 };

--- a/cxx-qt-gen/test_outputs/signals.rs
+++ b/cxx-qt-gen/test_outputs/signals.rs
@@ -3,7 +3,8 @@ mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-        type MyObject;
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
         include!("cxx-qt-lib/include/qt_types.h");
         #[namespace = ""]
         type QColor = cxx_qt_lib::QColorCpp;
@@ -33,35 +34,36 @@ mod my_object {
         type QVariant = cxx_qt_lib::QVariantCpp;
 
         #[rust_name = "ready"]
-        fn ready(self: Pin<&mut MyObject>);
+        fn ready(self: Pin<&mut MyObjectQt>);
         #[rust_name = "emit_ready"]
-        fn emitReady(self: Pin<&mut MyObject>);
+        fn emitReady(self: Pin<&mut MyObjectQt>);
 
         #[rust_name = "data_changed"]
-        fn dataChanged(self: Pin<&mut MyObject>, first: i32, second: &QVariant, third: &QPoint);
+        fn dataChanged(self: Pin<&mut MyObjectQt>, first: i32, second: &QVariant, third: &QPoint);
         #[rust_name = "emit_data_changed"]
         fn emitDataChanged(
-            self: Pin<&mut MyObject>,
+            self: Pin<&mut MyObjectQt>,
             first: i32,
             second: UniquePtr<QVariant>,
             third: QPoint,
         );
 
         #[rust_name = "new_cpp_object"]
-        fn newCppObject() -> UniquePtr<MyObject>;
+        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
         type RustObj;
 
         #[cxx_name = "invokableWrapper"]
-        fn invokable_wrapper(self: &RustObj, cpp: Pin<&mut MyObject>);
+        fn invokable_wrapper(self: &RustObj, cpp: Pin<&mut MyObjectQt>);
 
         #[cxx_name = "createRs"]
         fn create_rs() -> Box<RustObj>;
 
         #[cxx_name = "initialiseCpp"]
-        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+        fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }
 
@@ -71,7 +73,7 @@ mod cxx_qt_my_object {
 
     use cxx_qt_lib::ToUniquePtr;
 
-    pub type FFICppObj = super::my_object::MyObject;
+    pub type FFICppObj = super::my_object::MyObjectQt;
 
     use cxx_qt_lib::QVariant;
 

--- a/cxx-qt-gen/test_outputs/types_primitive_property.h
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.h
@@ -6,7 +6,7 @@
 
 namespace cxx_qt::my_object {
 
-class RustObj;
+class MyObjectRust;
 
 class MyObject : public QObject
 {
@@ -61,7 +61,7 @@ Q_SIGNALS:
   void uint32Changed();
 
 private:
-  rust::Box<RustObj> m_rustObj;
+  rust::Box<MyObjectRust> m_rustObj;
   std::mutex m_rustObjMutex;
   bool m_initialised = false;
 

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -3,7 +3,8 @@ mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-        type MyObject;
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
 
         include!("cxx-qt-lib/include/qt_types.h");
         #[namespace = ""]
@@ -34,62 +35,63 @@ mod my_object {
         type QVariant = cxx_qt_lib::QVariantCpp;
 
         #[rust_name = "boolean"]
-        fn getBoolean(self: &MyObject) -> bool;
+        fn getBoolean(self: &MyObjectQt) -> bool;
         #[rust_name = "set_boolean"]
-        fn setBoolean(self: Pin<&mut MyObject>, value: bool);
+        fn setBoolean(self: Pin<&mut MyObjectQt>, value: bool);
 
         #[rust_name = "float_32"]
-        fn getFloat32(self: &MyObject) -> f32;
+        fn getFloat32(self: &MyObjectQt) -> f32;
         #[rust_name = "set_float_32"]
-        fn setFloat32(self: Pin<&mut MyObject>, value: f32);
+        fn setFloat32(self: Pin<&mut MyObjectQt>, value: f32);
 
         #[rust_name = "float_64"]
-        fn getFloat64(self: &MyObject) -> f64;
+        fn getFloat64(self: &MyObjectQt) -> f64;
         #[rust_name = "set_float_64"]
-        fn setFloat64(self: Pin<&mut MyObject>, value: f64);
+        fn setFloat64(self: Pin<&mut MyObjectQt>, value: f64);
 
         #[rust_name = "int_8"]
-        fn getInt8(self: &MyObject) -> i8;
+        fn getInt8(self: &MyObjectQt) -> i8;
         #[rust_name = "set_int_8"]
-        fn setInt8(self: Pin<&mut MyObject>, value: i8);
+        fn setInt8(self: Pin<&mut MyObjectQt>, value: i8);
 
         #[rust_name = "int_16"]
-        fn getInt16(self: &MyObject) -> i16;
+        fn getInt16(self: &MyObjectQt) -> i16;
         #[rust_name = "set_int_16"]
-        fn setInt16(self: Pin<&mut MyObject>, value: i16);
+        fn setInt16(self: Pin<&mut MyObjectQt>, value: i16);
 
         #[rust_name = "int_32"]
-        fn getInt32(self: &MyObject) -> i32;
+        fn getInt32(self: &MyObjectQt) -> i32;
         #[rust_name = "set_int_32"]
-        fn setInt32(self: Pin<&mut MyObject>, value: i32);
+        fn setInt32(self: Pin<&mut MyObjectQt>, value: i32);
 
         #[rust_name = "uint_8"]
-        fn getUint8(self: &MyObject) -> u8;
+        fn getUint8(self: &MyObjectQt) -> u8;
         #[rust_name = "set_uint_8"]
-        fn setUint8(self: Pin<&mut MyObject>, value: u8);
+        fn setUint8(self: Pin<&mut MyObjectQt>, value: u8);
 
         #[rust_name = "uint_16"]
-        fn getUint16(self: &MyObject) -> u16;
+        fn getUint16(self: &MyObjectQt) -> u16;
         #[rust_name = "set_uint_16"]
-        fn setUint16(self: Pin<&mut MyObject>, value: u16);
+        fn setUint16(self: Pin<&mut MyObjectQt>, value: u16);
 
         #[rust_name = "uint_32"]
-        fn getUint32(self: &MyObject) -> u32;
+        fn getUint32(self: &MyObjectQt) -> u32;
         #[rust_name = "set_uint_32"]
-        fn setUint32(self: Pin<&mut MyObject>, value: u32);
+        fn setUint32(self: Pin<&mut MyObjectQt>, value: u32);
 
         #[rust_name = "new_cpp_object"]
-        fn newCppObject() -> UniquePtr<MyObject>;
+        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
         type RustObj;
 
         #[cxx_name = "createRs"]
         fn create_rs() -> Box<RustObj>;
 
         #[cxx_name = "initialiseCpp"]
-        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+        fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }
 
@@ -99,7 +101,7 @@ mod cxx_qt_my_object {
 
     use cxx_qt_lib::ToUniquePtr;
 
-    pub type FFICppObj = super::my_object::MyObject;
+    pub type FFICppObj = super::my_object::MyObjectQt;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.h
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.h
@@ -20,7 +20,7 @@
 
 namespace cxx_qt::my_object {
 
-class RustObj;
+class MyObjectRust;
 
 class MyObject : public QObject
 {
@@ -45,7 +45,7 @@ public:
   Q_INVOKABLE QVariant testVariant(const QVariant& variant);
 
 private:
-  rust::Box<RustObj> m_rustObj;
+  rust::Box<MyObjectRust> m_rustObj;
   std::mutex m_rustObjMutex;
   bool m_initialised = false;
 };

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -3,7 +3,8 @@ mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-        type MyObject;
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
 
         include!("cxx-qt-lib/include/qt_types.h");
         #[namespace = ""]
@@ -34,72 +35,76 @@ mod my_object {
         type QVariant = cxx_qt_lib::QVariantCpp;
 
         #[rust_name = "new_cpp_object"]
-        fn newCppObject() -> UniquePtr<MyObject>;
+        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
         type RustObj;
 
         #[cxx_name = "testColorWrapper"]
         fn test_color_wrapper(
             self: &RustObj,
-            _cpp: Pin<&mut MyObject>,
+            _cpp: Pin<&mut MyObjectQt>,
             color: &QColor,
         ) -> UniquePtr<QColor>;
 
         #[cxx_name = "testDateWrapper"]
-        fn test_date_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, date: &QDate) -> QDate;
+        fn test_date_wrapper(self: &RustObj, _cpp: Pin<&mut MyObjectQt>, date: &QDate) -> QDate;
 
         #[cxx_name = "testDateTimeWrapper"]
         fn test_date_time_wrapper(
             self: &RustObj,
-            _cpp: Pin<&mut MyObject>,
+            _cpp: Pin<&mut MyObjectQt>,
             dateTime: &QDateTime,
         ) -> UniquePtr<QDateTime>;
 
         #[cxx_name = "testPointWrapper"]
-        fn test_point_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, point: &QPoint) -> QPoint;
+        fn test_point_wrapper(self: &RustObj, _cpp: Pin<&mut MyObjectQt>, point: &QPoint)
+            -> QPoint;
 
         #[cxx_name = "testPointfWrapper"]
         fn test_pointf_wrapper(
             self: &RustObj,
-            _cpp: Pin<&mut MyObject>,
+            _cpp: Pin<&mut MyObjectQt>,
             pointf: &QPointF,
         ) -> QPointF;
 
         #[cxx_name = "testRectWrapper"]
-        fn test_rect_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, rect: &QRect) -> QRect;
+        fn test_rect_wrapper(self: &RustObj, _cpp: Pin<&mut MyObjectQt>, rect: &QRect) -> QRect;
 
         #[cxx_name = "testRectfWrapper"]
-        fn test_rectf_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, rectf: &QRectF) -> QRectF;
+        fn test_rectf_wrapper(self: &RustObj, _cpp: Pin<&mut MyObjectQt>, rectf: &QRectF)
+            -> QRectF;
 
         #[cxx_name = "testSizeWrapper"]
-        fn test_size_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, size: &QSize) -> QSize;
+        fn test_size_wrapper(self: &RustObj, _cpp: Pin<&mut MyObjectQt>, size: &QSize) -> QSize;
 
         #[cxx_name = "testSizefWrapper"]
-        fn test_sizef_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, sizef: &QSizeF) -> QSizeF;
+        fn test_sizef_wrapper(self: &RustObj, _cpp: Pin<&mut MyObjectQt>, sizef: &QSizeF)
+            -> QSizeF;
 
         #[cxx_name = "testStringWrapper"]
         fn test_string_wrapper(
             self: &RustObj,
-            _cpp: Pin<&mut MyObject>,
+            _cpp: Pin<&mut MyObjectQt>,
             string: &QString,
         ) -> UniquePtr<QString>;
 
         #[cxx_name = "testTimeWrapper"]
-        fn test_time_wrapper(self: &RustObj, _cpp: Pin<&mut MyObject>, time: &QTime) -> QTime;
+        fn test_time_wrapper(self: &RustObj, _cpp: Pin<&mut MyObjectQt>, time: &QTime) -> QTime;
 
         #[cxx_name = "testUrlWrapper"]
         fn test_url_wrapper(
             self: &RustObj,
-            _cpp: Pin<&mut MyObject>,
+            _cpp: Pin<&mut MyObjectQt>,
             url: &QUrl,
         ) -> UniquePtr<QUrl>;
 
         #[cxx_name = "testVariantWrapper"]
         fn test_variant_wrapper(
             self: &RustObj,
-            _cpp: Pin<&mut MyObject>,
+            _cpp: Pin<&mut MyObjectQt>,
             variant: &QVariant,
         ) -> UniquePtr<QVariant>;
 
@@ -107,7 +112,7 @@ mod my_object {
         fn create_rs() -> Box<RustObj>;
 
         #[cxx_name = "initialiseCpp"]
-        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+        fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }
 
@@ -117,7 +122,7 @@ mod cxx_qt_my_object {
 
     use cxx_qt_lib::ToUniquePtr;
 
-    pub type FFICppObj = super::my_object::MyObject;
+    pub type FFICppObj = super::my_object::MyObjectQt;
 
     #[derive(Default)]
     pub struct RustObj;

--- a/cxx-qt-gen/test_outputs/types_qt_property.h
+++ b/cxx-qt-gen/test_outputs/types_qt_property.h
@@ -20,7 +20,7 @@
 
 namespace cxx_qt::my_object {
 
-class RustObj;
+class MyObjectRust;
 
 class MyObject : public QObject
 {
@@ -90,7 +90,7 @@ Q_SIGNALS:
   void variantChanged();
 
 private:
-  rust::Box<RustObj> m_rustObj;
+  rust::Box<MyObjectRust> m_rustObj;
   std::mutex m_rustObjMutex;
   bool m_initialised = false;
 

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -3,7 +3,8 @@ mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
-        type MyObject;
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
 
         include!("cxx-qt-lib/include/qt_types.h");
         #[namespace = ""]
@@ -34,82 +35,83 @@ mod my_object {
         type QVariant = cxx_qt_lib::QVariantCpp;
 
         #[rust_name = "color"]
-        fn getColor(self: &MyObject) -> &QColor;
+        fn getColor(self: &MyObjectQt) -> &QColor;
         #[rust_name = "set_color"]
-        fn setColor(self: Pin<&mut MyObject>, value: &QColor);
+        fn setColor(self: Pin<&mut MyObjectQt>, value: &QColor);
 
         #[rust_name = "date"]
-        fn getDate(self: &MyObject) -> &QDate;
+        fn getDate(self: &MyObjectQt) -> &QDate;
         #[rust_name = "set_date"]
-        fn setDate(self: Pin<&mut MyObject>, value: &QDate);
+        fn setDate(self: Pin<&mut MyObjectQt>, value: &QDate);
 
         #[rust_name = "date_time"]
-        fn getDateTime(self: &MyObject) -> &QDateTime;
+        fn getDateTime(self: &MyObjectQt) -> &QDateTime;
         #[rust_name = "set_date_time"]
-        fn setDateTime(self: Pin<&mut MyObject>, value: &QDateTime);
+        fn setDateTime(self: Pin<&mut MyObjectQt>, value: &QDateTime);
 
         #[rust_name = "point"]
-        fn getPoint(self: &MyObject) -> &QPoint;
+        fn getPoint(self: &MyObjectQt) -> &QPoint;
         #[rust_name = "set_point"]
-        fn setPoint(self: Pin<&mut MyObject>, value: &QPoint);
+        fn setPoint(self: Pin<&mut MyObjectQt>, value: &QPoint);
 
         #[rust_name = "pointf"]
-        fn getPointf(self: &MyObject) -> &QPointF;
+        fn getPointf(self: &MyObjectQt) -> &QPointF;
         #[rust_name = "set_pointf"]
-        fn setPointf(self: Pin<&mut MyObject>, value: &QPointF);
+        fn setPointf(self: Pin<&mut MyObjectQt>, value: &QPointF);
 
         #[rust_name = "rect"]
-        fn getRect(self: &MyObject) -> &QRect;
+        fn getRect(self: &MyObjectQt) -> &QRect;
         #[rust_name = "set_rect"]
-        fn setRect(self: Pin<&mut MyObject>, value: &QRect);
+        fn setRect(self: Pin<&mut MyObjectQt>, value: &QRect);
 
         #[rust_name = "rectf"]
-        fn getRectf(self: &MyObject) -> &QRectF;
+        fn getRectf(self: &MyObjectQt) -> &QRectF;
         #[rust_name = "set_rectf"]
-        fn setRectf(self: Pin<&mut MyObject>, value: &QRectF);
+        fn setRectf(self: Pin<&mut MyObjectQt>, value: &QRectF);
 
         #[rust_name = "size"]
-        fn getSize(self: &MyObject) -> &QSize;
+        fn getSize(self: &MyObjectQt) -> &QSize;
         #[rust_name = "set_size"]
-        fn setSize(self: Pin<&mut MyObject>, value: &QSize);
+        fn setSize(self: Pin<&mut MyObjectQt>, value: &QSize);
 
         #[rust_name = "sizef"]
-        fn getSizef(self: &MyObject) -> &QSizeF;
+        fn getSizef(self: &MyObjectQt) -> &QSizeF;
         #[rust_name = "set_sizef"]
-        fn setSizef(self: Pin<&mut MyObject>, value: &QSizeF);
+        fn setSizef(self: Pin<&mut MyObjectQt>, value: &QSizeF);
 
         #[rust_name = "string"]
-        fn getString(self: &MyObject) -> &QString;
+        fn getString(self: &MyObjectQt) -> &QString;
         #[rust_name = "set_string"]
-        fn setString(self: Pin<&mut MyObject>, value: &QString);
+        fn setString(self: Pin<&mut MyObjectQt>, value: &QString);
 
         #[rust_name = "time"]
-        fn getTime(self: &MyObject) -> &QTime;
+        fn getTime(self: &MyObjectQt) -> &QTime;
         #[rust_name = "set_time"]
-        fn setTime(self: Pin<&mut MyObject>, value: &QTime);
+        fn setTime(self: Pin<&mut MyObjectQt>, value: &QTime);
 
         #[rust_name = "url"]
-        fn getUrl(self: &MyObject) -> &QUrl;
+        fn getUrl(self: &MyObjectQt) -> &QUrl;
         #[rust_name = "set_url"]
-        fn setUrl(self: Pin<&mut MyObject>, value: &QUrl);
+        fn setUrl(self: Pin<&mut MyObjectQt>, value: &QUrl);
 
         #[rust_name = "variant"]
-        fn getVariant(self: &MyObject) -> &QVariant;
+        fn getVariant(self: &MyObjectQt) -> &QVariant;
         #[rust_name = "set_variant"]
-        fn setVariant(self: Pin<&mut MyObject>, value: &QVariant);
+        fn setVariant(self: Pin<&mut MyObjectQt>, value: &QVariant);
 
         #[rust_name = "new_cpp_object"]
-        fn newCppObject() -> UniquePtr<MyObject>;
+        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
         type RustObj;
 
         #[cxx_name = "createRs"]
         fn create_rs() -> Box<RustObj>;
 
         #[cxx_name = "initialiseCpp"]
-        fn initialise_cpp(cpp: Pin<&mut MyObject>);
+        fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }
 
@@ -119,7 +121,7 @@ mod cxx_qt_my_object {
 
     use cxx_qt_lib::ToUniquePtr;
 
-    pub type FFICppObj = super::my_object::MyObject;
+    pub type FFICppObj = super::my_object::MyObjectQt;
 
     #[derive(Default)]
     pub struct RustObj;


### PR DESCRIPTION
This helps later to avoid collisions in C++ with RustObj, when the
CXX bridge can be used it is more explicit which type is being used,
and generally makes it more obvious which type is being referred to.