### PR TITLE
cxx-qt-gen: use cxx_qt::signals attribute to define signals

### DIFF
--- a/book/src/qobject/signals_enum.md
+++ b/book/src/qobject/signals_enum.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 # Signals enum
 
-The signals enum defines which signals should exist on the QObject. It allows you to define the signal name and the parameters of the signal.
+The `cxx_qt::signals(T)` attribute is used on an enum to define which signals should exist on the QObject `T`. It allows you to define the signal name and the parameters of the signal.
 
 ```rust,ignore,noplayground
 {{#include ../../../examples/qml_features/src/signals.rs:book_signals_enum}}

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -715,6 +715,7 @@ fn generate_signal_methods_rs(obj: &QObject) -> Result<Vec<TokenStream>, TokenSt
     let mut signal_methods = Vec::new();
     let mut queued_cases = Vec::new();
     let mut immediate_cases = Vec::new();
+    let ident = &obj.signal_ident;
 
     for signal in &obj.signals {
         let emit_ident = &signal.emit_ident.rust_ident;
@@ -753,17 +754,17 @@ fn generate_signal_methods_rs(obj: &QObject) -> Result<Vec<TokenStream>, TokenSt
         let signal_ident = &signal.signal_ident.rust_ident;
 
         queued_cases.push(quote! {
-            Signal::#enum_ident { #(#parameters),* } => self.cpp.as_mut().#emit_ident(#(#parameters_to_value_queued),*),
+            #ident::#enum_ident { #(#parameters),* } => self.cpp.as_mut().#emit_ident(#(#parameters_to_value_queued),*),
         });
 
         immediate_cases.push(quote! {
-            Signal::#enum_ident { #(#parameters),* } => self.cpp.as_mut().#signal_ident(#(#parameters_to_value_immediate),*),
+            #ident::#enum_ident { #(#parameters),* } => self.cpp.as_mut().#signal_ident(#(#parameters_to_value_immediate),*),
         });
     }
 
     if !queued_cases.is_empty() {
         signal_methods.push(quote! {
-            pub fn emit_queued(&mut self, signal: Signal) {
+            pub fn emit_queued(&mut self, signal: #ident) {
                 match signal {
                     #(#queued_cases)*
                 }
@@ -773,7 +774,7 @@ fn generate_signal_methods_rs(obj: &QObject) -> Result<Vec<TokenStream>, TokenSt
 
     if !immediate_cases.is_empty() {
         signal_methods.push(quote! {
-            pub unsafe fn emit_immediate(&mut self, signal: Signal) {
+            pub unsafe fn emit_immediate(&mut self, signal: #ident) {
                 match signal {
                     #(#immediate_cases)*
                 }

--- a/cxx-qt-gen/test_inputs/signals.rs
+++ b/cxx-qt-gen/test_inputs/signals.rs
@@ -1,7 +1,8 @@
 mod my_object {
     use cxx_qt_lib::QVariant;
 
-    enum Signal {
+    #[cxx_qt::signals(MyObject)]
+    enum MySignals {
         Ready,
         DataChanged {
             first: i32,
@@ -20,10 +21,10 @@ mod my_object {
         #[invokable]
         pub fn invokable(&self, cpp: &mut CppObj) {
             unsafe {
-                cpp.emit_immediate(Signal::Ready);
+                cpp.emit_immediate(MySignals::Ready);
             }
 
-            cpp.emit_queued(Signal::DataChanged {
+            cpp.emit_queued(MySignals::DataChanged {
                 first: 1,
                 second: QVariant::from_bool(true),
                 third: QPoint::new(1, 2),

--- a/cxx-qt-gen/test_outputs/signals.rs
+++ b/cxx-qt-gen/test_outputs/signals.rs
@@ -77,7 +77,7 @@ mod cxx_qt_my_object {
 
     use cxx_qt_lib::QVariant;
 
-    enum Signal {
+    enum MySignals {
         Ready,
         DataChanged {
             first: i32,
@@ -97,10 +97,10 @@ mod cxx_qt_my_object {
 
         pub fn invokable(&self, cpp: &mut CppObj) {
             unsafe {
-                cpp.emit_immediate(Signal::Ready);
+                cpp.emit_immediate(MySignals::Ready);
             }
 
-            cpp.emit_queued(Signal::DataChanged {
+            cpp.emit_queued(MySignals::DataChanged {
                 first: 1,
                 second: QVariant::from_bool(true),
                 third: QPoint::new(1, 2),
@@ -117,10 +117,10 @@ mod cxx_qt_my_object {
             Self { cpp }
         }
 
-        pub fn emit_queued(&mut self, signal: Signal) {
+        pub fn emit_queued(&mut self, signal: MySignals) {
             match signal {
-                Signal::Ready {} => self.cpp.as_mut().emit_ready(),
-                Signal::DataChanged {
+                MySignals::Ready {} => self.cpp.as_mut().emit_ready(),
+                MySignals::DataChanged {
                     first,
                     second,
                     third,
@@ -131,10 +131,10 @@ mod cxx_qt_my_object {
             }
         }
 
-        pub unsafe fn emit_immediate(&mut self, signal: Signal) {
+        pub unsafe fn emit_immediate(&mut self, signal: MySignals) {
             match signal {
-                Signal::Ready {} => self.cpp.as_mut().ready(),
-                Signal::DataChanged {
+                MySignals::Ready {} => self.cpp.as_mut().ready(),
+                MySignals::DataChanged {
                     first,
                     second,
                     third,

--- a/cxx-qt/src/lib.rs
+++ b/cxx-qt/src/lib.rs
@@ -40,6 +40,25 @@ pub fn bridge(_attr: TokenStream, input: TokenStream) -> TokenStream {
     extract_and_generate(module, &cpp_namespace_prefix)
 }
 
+/// A macro which describes that an enum the definition of signals for a QObject
+///
+/// It should not be used by itself and instead should be used inside a cxx_qt::bridge definition.
+///
+/// # Example
+///
+/// ```ignore
+/// #[cxx_qt::bridge]
+/// mod my_object {
+///     #[cxx_qt::signals(MyObject)]
+///     enum MySignals {
+///         Ready,
+///     }
+/// }
+#[proc_macro_attribute]
+pub fn signals(_args: TokenStream, _input: TokenStream) -> TokenStream {
+    unreachable!("cxx_qt::signals should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")
+}
+
 // Take the module and C++ namespace and generate the rust code
 //
 // Note that wee need a separate function here, as we need to annotate the lifetimes to allow

--- a/examples/qml_features/src/mock_qt_types.rs
+++ b/examples/qml_features/src/mock_qt_types.rs
@@ -12,6 +12,7 @@ mod mock_qt_types {
     };
     use std::str::FromStr;
 
+    #[cxx_qt::signals(MyObject)]
     pub enum Signal {
         Ready,
         DataChanged { variant: QVariant },

--- a/examples/qml_features/src/signals.rs
+++ b/examples/qml_features/src/signals.rs
@@ -9,6 +9,7 @@ pub mod signals {
     use cxx_qt_lib::{QPoint, QVariant};
 
     // ANCHOR: book_signals_enum
+    #[cxx_qt::signals(MyObject)]
     pub enum Signal {
         Ready,
         RustDataChanged { data: i32 },


### PR DESCRIPTION
This allows us later to pick which QObject signals refer to and
easily allows us to determine which blocks are cxx_qt and which
are for CXX.