### PR TITLE
cxx-qt-gen: add rust getters for immutable and mutable access

### DIFF
--- a/cxx-qt-gen/src/gen_cpp.rs
+++ b/cxx-qt-gen/src/gen_cpp.rs
@@ -973,6 +973,8 @@ pub fn generate_qobject_cpp(obj: &QObject) -> Result<CppObject, TokenStream> {
         public:
             explicit {ident}(QObject *parent = nullptr);
             ~{ident}();
+            const {rust_struct_ident}& unsafe_rust() const;
+            {rust_struct_ident}& unsafe_rust_mut();
 
         {properties_public}
 
@@ -1041,6 +1043,18 @@ pub fn generate_qobject_cpp(obj: &QObject) -> Result<CppObject, TokenStream> {
 
         {ident}::~{ident}() = default;
 
+        const {rust_struct_ident}&
+        {ident}::unsafe_rust() const
+        {{
+          return *m_rustObj;
+        }}
+
+        {rust_struct_ident}&
+        {ident}::unsafe_rust_mut()
+        {{
+          return *m_rustObj;
+        }}
+
         {properties}
 
         {invokables}
@@ -1062,6 +1076,7 @@ pub fn generate_qobject_cpp(obj: &QObject) -> Result<CppObject, TokenStream> {
         namespace = namespace,
         properties = properties.sources.join("\n"),
         public_method_sources = public_method_sources.join("\n"),
+        rust_struct_ident = rust_struct_ident,
         signals = signals.sources.join("\n"),
     };
 

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -537,10 +537,17 @@ pub fn generate_qobject_cxx(
 
                 #(#cpp_functions)*
 
+                #[cxx_name = "unsafe_rust"]
+                fn rust(self: &#rust_class_name_cpp) -> &#rust_class_name;
                 #[rust_name = "new_cpp_object"]
                 fn newCppObject() -> UniquePtr<#rust_class_name_cpp>;
 
                 #request_updater_method
+            }
+
+            extern "C++" {
+                #[cxx_name = "unsafe_rust_mut"]
+                unsafe fn rust_mut(self: Pin<&mut #rust_class_name_cpp>) -> Pin<&mut #rust_class_name>;
             }
 
             extern "Rust" {

--- a/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/cxx-qt-gen/test_outputs/custom_default.rs
@@ -11,8 +11,15 @@ mod my_object {
         #[rust_name = "set_public"]
         fn setPublic(self: Pin<&mut MyObjectQt>, value: i32);
 
+        #[cxx_name = "unsafe_rust"]
+        fn rust(self: &MyObjectQt) -> &RustObj;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
+    }
+
+    extern "C++" {
+        #[cxx_name = "unsafe_rust_mut"]
+        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut RustObj>;
     }
 
     extern "Rust" {

--- a/cxx-qt-gen/test_outputs/handlers.cpp
+++ b/cxx-qt-gen/test_outputs/handlers.cpp
@@ -13,6 +13,18 @@ MyObject::MyObject(QObject* parent)
 
 MyObject::~MyObject() = default;
 
+const MyObjectRust&
+MyObject::unsafe_rust() const
+{
+  return *m_rustObj;
+}
+
+MyObjectRust&
+MyObject::unsafe_rust_mut()
+{
+  return *m_rustObj;
+}
+
 qint32
 MyObject::getNumber() const
 {

--- a/cxx-qt-gen/test_outputs/handlers.h
+++ b/cxx-qt-gen/test_outputs/handlers.h
@@ -19,6 +19,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
+  const MyObjectRust& unsafe_rust() const;
+  MyObjectRust& unsafe_rust_mut();
 
   qint32 getNumber() const;
   const QString& getString() const;

--- a/cxx-qt-gen/test_outputs/handlers.rs
+++ b/cxx-qt-gen/test_outputs/handlers.rs
@@ -19,11 +19,18 @@ mod my_object {
         #[rust_name = "set_string"]
         fn setString(self: Pin<&mut MyObjectQt>, value: &QString);
 
+        #[cxx_name = "unsafe_rust"]
+        fn rust(self: &MyObjectQt) -> &RustObj;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
 
         #[rust_name = "update_requester"]
         fn updateRequester(self: Pin<&mut MyObjectQt>) -> UniquePtr<UpdateRequester>;
+    }
+
+    extern "C++" {
+        #[cxx_name = "unsafe_rust_mut"]
+        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut RustObj>;
     }
 
     extern "Rust" {

--- a/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/cxx-qt-gen/test_outputs/invokables.cpp
@@ -13,6 +13,18 @@ MyObject::MyObject(QObject* parent)
 
 MyObject::~MyObject() = default;
 
+const MyObjectRust&
+MyObject::unsafe_rust() const
+{
+  return *m_rustObj;
+}
+
+MyObjectRust&
+MyObject::unsafe_rust_mut()
+{
+  return *m_rustObj;
+}
+
 void
 MyObject::invokable()
 {

--- a/cxx-qt-gen/test_outputs/invokables.h
+++ b/cxx-qt-gen/test_outputs/invokables.h
@@ -19,6 +19,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
+  const MyObjectRust& unsafe_rust() const;
+  MyObjectRust& unsafe_rust_mut();
 
   Q_INVOKABLE void invokable();
   Q_INVOKABLE void invokableCppObj();

--- a/cxx-qt-gen/test_outputs/invokables.rs
+++ b/cxx-qt-gen/test_outputs/invokables.rs
@@ -9,8 +9,15 @@ mod my_object {
         #[namespace = "cxx_qt::nested_object"]
         type NestedObject = crate::cxx_qt_nested_object::FFICppObj;
 
+        #[cxx_name = "unsafe_rust"]
+        fn rust(self: &MyObjectQt) -> &RustObj;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
+    }
+
+    extern "C++" {
+        #[cxx_name = "unsafe_rust_mut"]
+        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut RustObj>;
     }
 
     extern "Rust" {

--- a/cxx-qt-gen/test_outputs/naming.cpp
+++ b/cxx-qt-gen/test_outputs/naming.cpp
@@ -13,6 +13,18 @@ MyObject::MyObject(QObject* parent)
 
 MyObject::~MyObject() = default;
 
+const MyObjectRust&
+MyObject::unsafe_rust() const
+{
+  return *m_rustObj;
+}
+
+MyObjectRust&
+MyObject::unsafe_rust_mut()
+{
+  return *m_rustObj;
+}
+
 qint32
 MyObject::getPropertyName() const
 {

--- a/cxx-qt-gen/test_outputs/naming.h
+++ b/cxx-qt-gen/test_outputs/naming.h
@@ -17,6 +17,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
+  const MyObjectRust& unsafe_rust() const;
+  MyObjectRust& unsafe_rust_mut();
 
   qint32 getPropertyName() const;
 

--- a/cxx-qt-gen/test_outputs/naming.rs
+++ b/cxx-qt-gen/test_outputs/naming.rs
@@ -11,8 +11,15 @@ mod my_object {
         #[rust_name = "set_property_name"]
         fn setPropertyName(self: Pin<&mut MyObjectQt>, value: i32);
 
+        #[cxx_name = "unsafe_rust"]
+        fn rust(self: &MyObjectQt) -> &RustObj;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
+    }
+
+    extern "C++" {
+        #[cxx_name = "unsafe_rust_mut"]
+        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut RustObj>;
     }
 
     extern "Rust" {

--- a/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/cxx-qt-gen/test_outputs/passthrough.rs
@@ -11,8 +11,15 @@ pub mod my_object {
         #[rust_name = "set_number"]
         fn setNumber(self: Pin<&mut MyObjectQt>, value: i32);
 
+        #[cxx_name = "unsafe_rust"]
+        fn rust(self: &MyObjectQt) -> &RustObj;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
+    }
+
+    extern "C++" {
+        #[cxx_name = "unsafe_rust_mut"]
+        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut RustObj>;
     }
 
     extern "Rust" {

--- a/cxx-qt-gen/test_outputs/properties.cpp
+++ b/cxx-qt-gen/test_outputs/properties.cpp
@@ -13,6 +13,18 @@ MyObject::MyObject(QObject* parent)
 
 MyObject::~MyObject() = default;
 
+const MyObjectRust&
+MyObject::unsafe_rust() const
+{
+  return *m_rustObj;
+}
+
+MyObjectRust&
+MyObject::unsafe_rust_mut()
+{
+  return *m_rustObj;
+}
+
 qint32
 MyObject::getPrimitive() const
 {

--- a/cxx-qt-gen/test_outputs/properties.h
+++ b/cxx-qt-gen/test_outputs/properties.h
@@ -23,6 +23,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
+  const MyObjectRust& unsafe_rust() const;
+  MyObjectRust& unsafe_rust_mut();
 
   qint32 getPrimitive() const;
   const QColor& getOpaque() const;

--- a/cxx-qt-gen/test_outputs/properties.rs
+++ b/cxx-qt-gen/test_outputs/properties.rs
@@ -24,8 +24,15 @@ mod my_object {
         #[rust_name = "give_nested"]
         fn giveNested(self: Pin<&mut MyObjectQt>, value: UniquePtr<NestedObject>);
 
+        #[cxx_name = "unsafe_rust"]
+        fn rust(self: &MyObjectQt) -> &RustObj;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
+    }
+
+    extern "C++" {
+        #[cxx_name = "unsafe_rust_mut"]
+        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut RustObj>;
     }
 
     extern "Rust" {

--- a/cxx-qt-gen/test_outputs/signals.cpp
+++ b/cxx-qt-gen/test_outputs/signals.cpp
@@ -13,6 +13,18 @@ MyObject::MyObject(QObject* parent)
 
 MyObject::~MyObject() = default;
 
+const MyObjectRust&
+MyObject::unsafe_rust() const
+{
+  return *m_rustObj;
+}
+
+MyObjectRust&
+MyObject::unsafe_rust_mut()
+{
+  return *m_rustObj;
+}
+
 void
 MyObject::invokable()
 {

--- a/cxx-qt-gen/test_outputs/signals.h
+++ b/cxx-qt-gen/test_outputs/signals.h
@@ -18,6 +18,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
+  const MyObjectRust& unsafe_rust() const;
+  MyObjectRust& unsafe_rust_mut();
 
   Q_INVOKABLE void invokable();
 

--- a/cxx-qt-gen/test_outputs/signals.rs
+++ b/cxx-qt-gen/test_outputs/signals.rs
@@ -21,8 +21,15 @@ mod my_object {
             third: QPoint,
         );
 
+        #[cxx_name = "unsafe_rust"]
+        fn rust(self: &MyObjectQt) -> &RustObj;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
+    }
+
+    extern "C++" {
+        #[cxx_name = "unsafe_rust_mut"]
+        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut RustObj>;
     }
 
     extern "Rust" {

--- a/cxx-qt-gen/test_outputs/types_primitive_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.cpp
@@ -13,6 +13,18 @@ MyObject::MyObject(QObject* parent)
 
 MyObject::~MyObject() = default;
 
+const MyObjectRust&
+MyObject::unsafe_rust() const
+{
+  return *m_rustObj;
+}
+
+MyObjectRust&
+MyObject::unsafe_rust_mut()
+{
+  return *m_rustObj;
+}
+
 bool
 MyObject::getBoolean() const
 {

--- a/cxx-qt-gen/test_outputs/types_primitive_property.h
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.h
@@ -27,6 +27,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
+  const MyObjectRust& unsafe_rust() const;
+  MyObjectRust& unsafe_rust_mut();
 
   bool getBoolean() const;
   float getFloat32() const;

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -51,8 +51,15 @@ mod my_object {
         #[rust_name = "set_uint_32"]
         fn setUint32(self: Pin<&mut MyObjectQt>, value: u32);
 
+        #[cxx_name = "unsafe_rust"]
+        fn rust(self: &MyObjectQt) -> &RustObj;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
+    }
+
+    extern "C++" {
+        #[cxx_name = "unsafe_rust_mut"]
+        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut RustObj>;
     }
 
     extern "Rust" {

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
@@ -13,6 +13,18 @@ MyObject::MyObject(QObject* parent)
 
 MyObject::~MyObject() = default;
 
+const MyObjectRust&
+MyObject::unsafe_rust() const
+{
+  return *m_rustObj;
+}
+
+MyObjectRust&
+MyObject::unsafe_rust_mut()
+{
+  return *m_rustObj;
+}
+
 QColor
 MyObject::testColor(const QColor& color)
 {

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.h
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.h
@@ -29,6 +29,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
+  const MyObjectRust& unsafe_rust() const;
+  MyObjectRust& unsafe_rust_mut();
 
   Q_INVOKABLE QColor testColor(const QColor& color);
   Q_INVOKABLE QDate testDate(const QDate& date);

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -6,8 +6,15 @@ mod my_object {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
+        #[cxx_name = "unsafe_rust"]
+        fn rust(self: &MyObjectQt) -> &RustObj;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
+    }
+
+    extern "C++" {
+        #[cxx_name = "unsafe_rust_mut"]
+        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut RustObj>;
     }
 
     extern "Rust" {

--- a/cxx-qt-gen/test_outputs/types_qt_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_property.cpp
@@ -13,6 +13,18 @@ MyObject::MyObject(QObject* parent)
 
 MyObject::~MyObject() = default;
 
+const MyObjectRust&
+MyObject::unsafe_rust() const
+{
+  return *m_rustObj;
+}
+
+MyObjectRust&
+MyObject::unsafe_rust_mut()
+{
+  return *m_rustObj;
+}
+
 const QColor&
 MyObject::getColor() const
 {

--- a/cxx-qt-gen/test_outputs/types_qt_property.h
+++ b/cxx-qt-gen/test_outputs/types_qt_property.h
@@ -44,6 +44,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
+  const MyObjectRust& unsafe_rust() const;
+  MyObjectRust& unsafe_rust_mut();
 
   const QColor& getColor() const;
   const QDate& getDate() const;

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -71,8 +71,15 @@ mod my_object {
         #[rust_name = "set_variant"]
         fn setVariant(self: Pin<&mut MyObjectQt>, value: &QVariant);
 
+        #[cxx_name = "unsafe_rust"]
+        fn rust(self: &MyObjectQt) -> &RustObj;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
+    }
+
+    extern "C++" {
+        #[cxx_name = "unsafe_rust_mut"]
+        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut RustObj>;
     }
 
     extern "Rust" {


### PR DESCRIPTION
This helps later when invokables use a pointer to the C++ object
rather than the Rust object, as then they can use self.rust().prop
or unsafe { self.as_mut().rust_mut().prop = value; } etc.

There will also be helpers implemented onto the C++ object so that
for normal usecases they use set_prop and get_prop etc.