### PR TITLE
cxx-qt-lib: use QString instead of String for QVariant

### DIFF
--- a/cxx-qt-lib/include/qt_types.h
+++ b/cxx-qt-lib/include/qt_types.h
@@ -100,7 +100,7 @@ enum class QVariantType : uint8_t
   QRectF = 13,
   QSize = 14,
   QSizeF = 15,
-  String = 16,
+  QString = 16,
   QTime = 17,
   QUrl = 18,
   U8 = 19,
@@ -228,7 +228,7 @@ qvariantInitFromQTime(const QTime& time);
 std::unique_ptr<QVariant>
 qvariantInitFromQUrl(const QUrl& url);
 std::unique_ptr<QVariant>
-qvariantInitFromRustString(rust::Str string);
+qvariantInitFromQString(const QString& string);
 std::unique_ptr<QVariant>
 qvariantInitFromU8(quint8 u8);
 std::unique_ptr<QVariant>
@@ -271,8 +271,8 @@ QTime
 qvariantToQTime(const QVariant& variant);
 std::unique_ptr<QUrl>
 qvariantToQUrl(const QVariant& variant);
-rust::String
-qvariantToRustString(const QVariant& variant);
+std::unique_ptr<QString>
+qvariantToQString(const QVariant& variant);
 quint8
 qvariantToU8(const QVariant& variant);
 quint16

--- a/cxx-qt-lib/src/qt_types.cpp
+++ b/cxx-qt-lib/src/qt_types.cpp
@@ -265,17 +265,9 @@ CXX_QT_VARIANT_INIT_REF(QRect, QRect)
 CXX_QT_VARIANT_INIT_REF(QRectF, QRectF)
 CXX_QT_VARIANT_INIT_REF(QSize, QSize)
 CXX_QT_VARIANT_INIT_REF(QSizeF, QSizeF)
+CXX_QT_VARIANT_INIT_REF(QString, QString)
 CXX_QT_VARIANT_INIT_REF(QTime, QTime)
 CXX_QT_VARIANT_INIT_REF(QUrl, QUrl)
-
-std::unique_ptr<QVariant>
-qvariantInitFromRustString(rust::Str string)
-{
-  // Note that rust::Str here is borrowed
-  // and we convert back from UTF-8 to UTF-16
-  return std::make_unique<QVariant>(qstringFromRustString(string));
-}
-
 CXX_QT_VARIANT_INIT(quint8, U8)
 CXX_QT_VARIANT_INIT(quint16, U16)
 CXX_QT_VARIANT_INIT(quint32, U32)
@@ -321,7 +313,7 @@ qvariantType(const QVariant& variant)
     case QMetaType::QSizeF:
       return types::QVariantType::QSizeF;
     case QMetaType::QString:
-      return types::QVariantType::String;
+      return types::QVariantType::QString;
     case QMetaType::QTime:
       return types::QVariantType::QTime;
     case QMetaType::QUrl:
@@ -367,15 +359,9 @@ CXX_QT_VARIANT_TRIVIAL_VALUE(QRect, QRect)
 CXX_QT_VARIANT_TRIVIAL_VALUE(QRectF, QRectF)
 CXX_QT_VARIANT_TRIVIAL_VALUE(QSize, QSize)
 CXX_QT_VARIANT_TRIVIAL_VALUE(QSizeF, QSizeF)
+CXX_QT_VARIANT_OPAQUE_VALUE(QString, QString)
 CXX_QT_VARIANT_TRIVIAL_VALUE(QTime, QTime)
 CXX_QT_VARIANT_OPAQUE_VALUE(QUrl, QUrl)
-
-rust::String
-qvariantToRustString(const QVariant& variant)
-{
-  return qstringToRustString(variant.toString());
-}
-
 CXX_QT_VARIANT_TRIVIAL_VALUE(quint8, U8)
 CXX_QT_VARIANT_TRIVIAL_VALUE(quint16, U16)
 CXX_QT_VARIANT_TRIVIAL_VALUE(quint32, U32)

--- a/cxx-qt-lib/src/types/qvariant.rs
+++ b/cxx-qt-lib/src/types/qvariant.rs
@@ -4,7 +4,9 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{QColor, QDate, QDateTime, QPoint, QPointF, QRect, QRectF, QSize, QSizeF, QTime, QUrl};
+use crate::{
+    QColor, QDate, QDateTime, QPoint, QPointF, QRect, QRectF, QSize, QSizeF, QString, QTime, QUrl,
+};
 
 #[cxx::bridge]
 mod ffi {
@@ -27,7 +29,7 @@ mod ffi {
         QRectF = 13,
         QSize = 14,
         QSizeF = 15,
-        String = 16,
+        QString = 16,
         QTime = 17,
         QUrl = 18,
         U8 = 19,
@@ -47,6 +49,7 @@ mod ffi {
         type QRectF = crate::QRectF;
         type QSize = crate::QSize;
         type QSizeF = crate::QSizeF;
+        type QString = crate::QString;
         type QTime = crate::QTime;
         type QUrl = crate::QUrl;
         type QVariant;
@@ -100,8 +103,8 @@ mod ffi {
         fn qvariantInitFromQTime(time: &QTime) -> UniquePtr<QVariant>;
         #[rust_name = "qvariant_init_from_qurl"]
         fn qvariantInitFromQUrl(url: &QUrl) -> UniquePtr<QVariant>;
-        #[rust_name = "qvariant_init_from_rust_string"]
-        fn qvariantInitFromRustString(string: &str) -> UniquePtr<QVariant>;
+        #[rust_name = "qvariant_init_from_qstring"]
+        fn qvariantInitFromQString(string: &QString) -> UniquePtr<QVariant>;
         #[rust_name = "qvariant_init_from_u8"]
         fn qvariantInitFromU8(u: u8) -> UniquePtr<QVariant>;
         #[rust_name = "qvariant_init_from_u16"]
@@ -143,8 +146,8 @@ mod ffi {
         fn qvariantToQTime(qvariant: &QVariant) -> QTime;
         #[rust_name = "qvariant_to_qurl"]
         fn qvariantToQUrl(qvariant: &QVariant) -> UniquePtr<QUrl>;
-        #[rust_name = "qvariant_to_rust_string"]
-        fn qvariantToRustString(qvariant: &QVariant) -> String;
+        #[rust_name = "qvariant_to_qstring"]
+        fn qvariantToQString(qvariant: &QVariant) -> UniquePtr<QString>;
         #[rust_name = "qvariant_to_u8"]
         fn qvariantToU8(qvariant: &QVariant) -> u8;
         #[rust_name = "qvariant_to_u16"]
@@ -179,10 +182,9 @@ pub enum QVariantValue {
     QRectF(QRectF),
     QSize(QSize),
     QSizeF(QSizeF),
+    QString(cxx::UniquePtr<QString>),
     QTime(QTime),
     QUrl(cxx::UniquePtr<QUrl>),
-    // TODO: should we go to QString so the developer has to invoke the UTF translation?
-    String(String),
     U8(u8),
     U16(u16),
     U32(u32),
@@ -241,8 +243,7 @@ into_qvariant_ref!(QSize, ffi::qvariant_init_from_qsize);
 into_qvariant_ref!(QSizeF, ffi::qvariant_init_from_qsizef);
 into_qvariant_ref!(QTime, ffi::qvariant_init_from_qtime);
 into_qvariant_opaque_ref!(QUrl, ffi::qvariant_init_from_qurl);
-into_qvariant_ref!(String, ffi::qvariant_init_from_rust_string);
-// into_qvariant_opaque_ref!(QString, ffi::qvariant_init_from_rust_string);
+into_qvariant_opaque_ref!(QString, ffi::qvariant_init_from_qstring);
 into_qvariant!(u8, ffi::qvariant_init_from_u8);
 into_qvariant!(u16, ffi::qvariant_init_from_u16);
 into_qvariant!(u32, ffi::qvariant_init_from_u32);
@@ -287,9 +288,9 @@ impl QVariant {
             ffi::QVariantType::QRectF => QVariantValue::QRectF(ffi::qvariant_to_qrectf(self)),
             ffi::QVariantType::QSize => QVariantValue::QSize(ffi::qvariant_to_qsize(self)),
             ffi::QVariantType::QSizeF => QVariantValue::QSizeF(ffi::qvariant_to_qsizef(self)),
+            ffi::QVariantType::QString => QVariantValue::QString(ffi::qvariant_to_qstring(self)),
             ffi::QVariantType::QTime => QVariantValue::QTime(ffi::qvariant_to_qtime(self)),
             ffi::QVariantType::QUrl => QVariantValue::QUrl(ffi::qvariant_to_qurl(self)),
-            ffi::QVariantType::String => QVariantValue::String(ffi::qvariant_to_rust_string(self)),
             ffi::QVariantType::U8 => QVariantValue::U8(ffi::qvariant_to_u8(self)),
             ffi::QVariantType::U16 => QVariantValue::U16(ffi::qvariant_to_u16(self)),
             ffi::QVariantType::U32 => QVariantValue::U32(ffi::qvariant_to_u32(self)),

--- a/examples/qml_features/src/mock_qt_types.rs
+++ b/examples/qml_features/src/mock_qt_types.rs
@@ -380,6 +380,10 @@ mod mock_qt_types {
                             .unwrap(),
                     );
                 }
+                QVariantValue::QString(string) => {
+                    let string = QString::from_str(&(string.to_string() + "/cxx-qt"));
+                    cpp.set_variant(QVariant::from(string.as_ref().unwrap()).as_ref().unwrap());
+                }
                 QVariantValue::QTime(mut time) => {
                     time.set_hms(
                         time.hour() * 2,
@@ -458,6 +462,10 @@ mod mock_qt_types {
                 }
                 QVariantValue::QSizeF(sizef) => {
                     QVariant::from(QSizeF::new(sizef.width() * 2.0, sizef.height() * 2.0))
+                }
+                QVariantValue::QString(string) => {
+                    let string = QString::from_str(&(string.to_string() + "/cxx-qt"));
+                    QVariant::from(string.as_ref().unwrap())
                 }
                 QVariantValue::QTime(mut time) => {
                     time.set_hms(

--- a/examples/qml_features/src/mock_qt_types.rs
+++ b/examples/qml_features/src/mock_qt_types.rs
@@ -20,6 +20,7 @@ mod mock_qt_types {
         type QRectF = cxx_qt_lib::QRectF;
         type QSize = cxx_qt_lib::QSize;
         type QSizeF = cxx_qt_lib::QSizeF;
+        type QString = cxx_qt_lib::QString;
         type QTime = cxx_qt_lib::QTime;
         type QUrl = cxx_qt_lib::QUrl;
         type QVariant = cxx_qt_lib::QVariant;
@@ -41,6 +42,7 @@ mod mock_qt_types {
         rectf: QRectF,
         size: QSize,
         sizef: QSizeF,
+        string: UniquePtr<QString>,
         time: QTime,
         url: UniquePtr<QUrl>,
         variant: UniquePtr<QVariant>,
@@ -61,6 +63,7 @@ mod mock_qt_types {
                 rectf: QRectF::new(1.0, 2.0, 3.0, 4.0),
                 size: QSize::new(1, 3),
                 sizef: QSizeF::new(1.0, 3.0),
+                string: QString::from_str("KDAB"),
                 time: QTime::new(1, 2, 3, 4),
                 url: QUrl::from_str("https://github.com/KDAB"),
                 variant: QVariant::from(1_i32),
@@ -252,6 +255,17 @@ mod mock_qt_types {
             size.set_width(size.width() * 2.0);
             size.set_height(size.height() * 3.0);
             size
+        }
+
+        #[invokable]
+        pub fn test_string_property(&self, cpp: &mut CppObj) {
+            let string = QString::from_str(&(cpp.string().to_string() + "/cxx-qt"));
+            cpp.set_string(string.as_ref().unwrap());
+        }
+
+        #[invokable]
+        pub fn test_string_invokable(&self, string: &QString) -> UniquePtr<QString> {
+            QString::from_str(&(string.to_string() + "/cxx-qt"))
         }
 
         #[invokable]

--- a/examples/qml_features/src/tests/qttypes/tst_qttypes.qml
+++ b/examples/qml_features/src/tests/qttypes/tst_qttypes.qml
@@ -466,6 +466,46 @@ TestCase {
     }
 
 
+    // QString
+
+    // Check that we can adjust the property for the type and it has non default value
+    function test_qstring_property() {
+        const mock = createTemporaryObject(componentMockQtTypes, null, {});
+        const spy = createTemporaryObject(componentSpy, null, {
+            signalName: "stringChanged",
+            target: mock,
+        });
+        compare(mock.string, "KDAB");
+
+        compare(spy.count, 0);
+        mock.string = "KDAB/cxx-qt";
+        tryCompare(spy, "count", 1);
+        compare(mock.string, "KDAB/cxx-qt");
+    }
+
+    // Check that we can pass the type as a parameter and return it back
+    function test_qstring_invokable() {
+        const mock = createTemporaryObject(componentMockQtTypes, null, {});
+        const result = mock.testStringInvokable("KDAB");
+        compare(result, "KDAB/cxx-qt");
+    }
+
+    // Check that an invokable can adjust (read and write) a property for the type
+    function test_qstring_invokable_property() {
+        const mock = createTemporaryObject(componentMockQtTypes, null, {});
+        const spy = createTemporaryObject(componentSpy, null, {
+            signalName: "stringChanged",
+            target: mock,
+        });
+
+        compare(spy.count, 0);
+        compare(mock.string, "KDAB");
+        mock.testStringProperty();
+        compare(mock.string, "KDAB/cxx-qt");
+        tryCompare(spy, "count", 1);
+    }
+
+
     // QTime
 
     // Check that we can adjust the property for the type and it has non default value

--- a/examples/qml_features/src/tests/qttypes/tst_qttypes.qml
+++ b/examples/qml_features/src/tests/qttypes/tst_qttypes.qml
@@ -604,6 +604,9 @@ TestCase {
         result = mock.testVariantInvokable(Qt.size(1.0, 3.0));
         compare(result, Qt.size(2.0, 6.0));
 
+        result = mock.testVariantInvokable("KDAB");
+        compare(result, "KDAB/cxx-qt");
+
         const urlComponent = createTemporaryObject(componentQtObjectUrl, null, {
             value: "https://github.com/KDAB",
         });

--- a/tests/qt_types_standalone/src/lib.rs
+++ b/tests/qt_types_standalone/src/lib.rs
@@ -37,7 +37,7 @@ mod ffi {
         QSizeF,
         QTime,
         QUrl,
-        String,
+        QString,
         U8,
         U16,
         U32,
@@ -245,11 +245,11 @@ fn make_variant(test: VariantTest) -> cxx::UniquePtr<cxx_qt_lib::QVariant> {
         VariantTest::QRectF => QVariant::from(QRectF::new(1.23, 4.56, 2.46, 9.12)),
         VariantTest::QSize => QVariant::from(QSize::new(1, 3)),
         VariantTest::QSizeF => QVariant::from(QSizeF::new(1.0, 3.0)),
+        VariantTest::QString => QVariant::from(QString::from_str("Rust string").as_ref().unwrap()),
         VariantTest::QTime => QVariant::from(QTime::new(1, 2, 3, 4)),
         VariantTest::QUrl => {
             QVariant::from(QUrl::from_str("https://github.com/KDAB").as_ref().unwrap())
         }
-        VariantTest::String => QVariant::from("Rust string".to_owned()),
         VariantTest::U8 => QVariant::from(12_u8),
         VariantTest::U16 => QVariant::from(123_u16),
         VariantTest::U32 => QVariant::from(123_u32),
@@ -347,6 +347,10 @@ fn can_read_qvariant(v: &cxx_qt_lib::QVariant, test: VariantTest) -> bool {
             QVariantValue::QSizeF(sizef) => sizef.width() == 8.0 && sizef.height() == 9.0,
             _others => false,
         },
+        VariantTest::QString => match variant {
+            QVariantValue::QString(s) => s.to_string() == "C++ string",
+            _others => false,
+        },
         VariantTest::QTime => match variant {
             QVariantValue::QTime(time) => {
                 time.hour() == 4 && time.minute() == 3 && time.second() == 2 && time.msec() == 1
@@ -357,10 +361,6 @@ fn can_read_qvariant(v: &cxx_qt_lib::QVariant, test: VariantTest) -> bool {
             QVariantValue::QUrl(url) => {
                 url.as_ref().unwrap().string() == "https://github.com/KDAB/cxx-qt"
             }
-            _others => false,
-        },
-        VariantTest::String => match variant {
-            QVariantValue::String(s) => s == "C++ string",
             _others => false,
         },
         VariantTest::U8 => match variant {

--- a/tests/qt_types_standalone/src/main.cpp
+++ b/tests/qt_types_standalone/src/main.cpp
@@ -169,9 +169,9 @@ TEST_CASE("Can construct a QVariant on the Rust side")
   CHECK(can_construct_qvariant(VariantTest::QRectF));
   CHECK(can_construct_qvariant(VariantTest::QSize));
   CHECK(can_construct_qvariant(VariantTest::QSizeF));
+  CHECK(can_construct_qvariant(VariantTest::QString));
   CHECK(can_construct_qvariant(VariantTest::QTime));
   CHECK(can_construct_qvariant(VariantTest::QUrl));
-  CHECK(can_construct_qvariant(VariantTest::String));
   CHECK(can_construct_qvariant(VariantTest::U8));
   CHECK(can_construct_qvariant(VariantTest::U16));
   CHECK(can_construct_qvariant(VariantTest::U32));
@@ -226,14 +226,14 @@ test_constructed_qvariant(const QVariant& v, VariantTest test)
     case VariantTest::QSizeF:
       return v.value<QSizeF>().width() == 1.0 &&
              v.value<QSize>().height() == 3.0;
+    case VariantTest::QString:
+      return v.toString() == QStringLiteral("Rust string");
     case VariantTest::QTime:
       return v.value<QTime>().hour() == 1 && v.value<QTime>().minute() == 2 &&
              v.value<QTime>().second() == 3 && v.value<QTime>().msec() == 4;
     case VariantTest::QUrl:
       return v.value<QUrl>().toString() ==
              QStringLiteral("https://github.com/KDAB");
-    case VariantTest::String:
-      return v.toString() == QStringLiteral("Rust string");
     case VariantTest::U8:
       return v.value<quint8>() == 12;
     case VariantTest::U16:
@@ -267,9 +267,9 @@ TEST_CASE("Can convert Rust Variant to QVariant")
   CHECK(runTest(VariantTest::QRectF));
   CHECK(runTest(VariantTest::QSize));
   CHECK(runTest(VariantTest::QSizeF));
+  CHECK(runTest(VariantTest::QString));
   CHECK(runTest(VariantTest::QTime));
   CHECK(runTest(VariantTest::QUrl));
-  CHECK(runTest(VariantTest::String));
   CHECK(runTest(VariantTest::U8));
   CHECK(runTest(VariantTest::U16));
   CHECK(runTest(VariantTest::U32));
@@ -304,13 +304,13 @@ TEST_CASE("Can read a QVariant on the Rust side")
                           VariantTest::QSize));
   CHECK(can_read_qvariant(QVariant::fromValue<QSizeF>(QSizeF(8.0, 9.0)),
                           VariantTest::QSizeF));
+  CHECK(can_read_qvariant(QVariant::fromValue(QStringLiteral("C++ string")),
+                          VariantTest::QString));
   CHECK(can_read_qvariant(QVariant::fromValue<QTime>(QTime(4, 3, 2, 1)),
                           VariantTest::QTime));
   CHECK(can_read_qvariant(QVariant::fromValue<QUrl>(QUrl(
                             QStringLiteral("https://github.com/KDAB/cxx-qt"))),
                           VariantTest::QUrl));
-  CHECK(can_read_qvariant(QVariant::fromValue(QStringLiteral("C++ string")),
-                          VariantTest::String));
   CHECK(can_read_qvariant(QVariant::fromValue<quint8>(89), VariantTest::U8));
   CHECK(
     can_read_qvariant(QVariant::fromValue<quint16>(8910), VariantTest::U16));


### PR DESCRIPTION
For now we require users to invoke the Utf8 to Utf16 translation.

Requires #166 