### PR TITLE
Use assert_str_eq! for file comparisons

### DIFF
--- a/cxx-qt-gen/Cargo.toml
+++ b/cxx-qt-gen/Cargo.toml
@@ -23,4 +23,4 @@ quote = "1.0"
 
 [dev-dependencies]
 ctor = "0.1"
-pretty_assertions = "0.7"
+pretty_assertions = "1.2"

--- a/cxx-qt-gen/src/gen_cpp.rs
+++ b/cxx-qt-gen/src/gen_cpp.rs
@@ -1099,7 +1099,7 @@ mod tests {
 
     use crate::extract_qobject;
 
-    use pretty_assertions::assert_eq;
+    use pretty_assertions::assert_str_eq;
     use syn::ItemMod;
 
     #[test]
@@ -1112,8 +1112,8 @@ mod tests {
         let expected_header = clang_format(include_str!("../test_outputs/handlers.h")).unwrap();
         let expected_source = clang_format(include_str!("../test_outputs/handlers.cpp")).unwrap();
         let cpp_object = generate_qobject_cpp(&qobject).unwrap();
-        assert_eq!(cpp_object.header, expected_header);
-        assert_eq!(cpp_object.source, expected_source);
+        assert_str_eq!(cpp_object.header, expected_header);
+        assert_str_eq!(cpp_object.source, expected_source);
     }
 
     #[test]
@@ -1126,8 +1126,8 @@ mod tests {
         let expected_header = clang_format(include_str!("../test_outputs/invokables.h")).unwrap();
         let expected_source = clang_format(include_str!("../test_outputs/invokables.cpp")).unwrap();
         let cpp_object = generate_qobject_cpp(&qobject).unwrap();
-        assert_eq!(cpp_object.header, expected_header);
-        assert_eq!(cpp_object.source, expected_source);
+        assert_str_eq!(cpp_object.header, expected_header);
+        assert_str_eq!(cpp_object.source, expected_source);
     }
 
     #[test]
@@ -1140,8 +1140,8 @@ mod tests {
         let expected_header = clang_format(include_str!("../test_outputs/naming.h")).unwrap();
         let expected_source = clang_format(include_str!("../test_outputs/naming.cpp")).unwrap();
         let cpp_object = generate_qobject_cpp(&qobject).unwrap();
-        assert_eq!(cpp_object.header, expected_header);
-        assert_eq!(cpp_object.source, expected_source);
+        assert_str_eq!(cpp_object.header, expected_header);
+        assert_str_eq!(cpp_object.source, expected_source);
     }
 
     #[test]
@@ -1154,8 +1154,8 @@ mod tests {
         let expected_header = clang_format(include_str!("../test_outputs/properties.h")).unwrap();
         let expected_source = clang_format(include_str!("../test_outputs/properties.cpp")).unwrap();
         let cpp_object = generate_qobject_cpp(&qobject).unwrap();
-        assert_eq!(cpp_object.header, expected_header);
-        assert_eq!(cpp_object.source, expected_source);
+        assert_str_eq!(cpp_object.header, expected_header);
+        assert_str_eq!(cpp_object.source, expected_source);
     }
 
     #[test]
@@ -1168,8 +1168,8 @@ mod tests {
         let expected_header = clang_format(include_str!("../test_outputs/signals.h")).unwrap();
         let expected_source = clang_format(include_str!("../test_outputs/signals.cpp")).unwrap();
         let cpp_object = generate_qobject_cpp(&qobject).unwrap();
-        assert_eq!(cpp_object.header, expected_header);
-        assert_eq!(cpp_object.source, expected_source);
+        assert_str_eq!(cpp_object.header, expected_header);
+        assert_str_eq!(cpp_object.source, expected_source);
     }
 
     #[test]
@@ -1184,8 +1184,8 @@ mod tests {
         let expected_source =
             clang_format(include_str!("../test_outputs/types_primitive_property.cpp")).unwrap();
         let cpp_object = generate_qobject_cpp(&qobject).unwrap();
-        assert_eq!(cpp_object.header, expected_header);
-        assert_eq!(cpp_object.source, expected_source);
+        assert_str_eq!(cpp_object.header, expected_header);
+        assert_str_eq!(cpp_object.source, expected_source);
     }
 
     #[test]
@@ -1200,8 +1200,8 @@ mod tests {
         let expected_source =
             clang_format(include_str!("../test_outputs/types_qt_property.cpp")).unwrap();
         let cpp_object = generate_qobject_cpp(&qobject).unwrap();
-        assert_eq!(cpp_object.header, expected_header);
-        assert_eq!(cpp_object.source, expected_source);
+        assert_str_eq!(cpp_object.header, expected_header);
+        assert_str_eq!(cpp_object.source, expected_source);
     }
 
     #[test]
@@ -1216,7 +1216,7 @@ mod tests {
         let expected_source =
             clang_format(include_str!("../test_outputs/types_qt_invokable.cpp")).unwrap();
         let cpp_object = generate_qobject_cpp(&qobject).unwrap();
-        assert_eq!(cpp_object.header, expected_header);
-        assert_eq!(cpp_object.source, expected_source);
+        assert_str_eq!(cpp_object.header, expected_header);
+        assert_str_eq!(cpp_object.source, expected_source);
     }
 }

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -1144,7 +1144,7 @@ mod tests {
     use super::*;
     use crate::extract_qobject;
 
-    use pretty_assertions::assert_eq;
+    use pretty_assertions::assert_str_eq;
     use std::{
         io::Write,
         process::{Command, Stdio},
@@ -1190,7 +1190,7 @@ mod tests {
             .to_string();
         let generated_rs = format_rs_source(&generated_rs);
 
-        assert_eq!(generated_rs, expected_output);
+        assert_str_eq!(generated_rs, expected_output);
     }
 
     #[test]
@@ -1208,7 +1208,7 @@ mod tests {
             .to_string();
         let generated_rs = format_rs_source(&generated_rs);
 
-        assert_eq!(generated_rs, expected_output);
+        assert_str_eq!(generated_rs, expected_output);
     }
 
     #[test]
@@ -1226,7 +1226,7 @@ mod tests {
             .to_string();
         let generated_rs = format_rs_source(&generated_rs);
 
-        assert_eq!(generated_rs, expected_output);
+        assert_str_eq!(generated_rs, expected_output);
     }
 
     #[test]
@@ -1244,7 +1244,7 @@ mod tests {
             .to_string();
         let generated_rs = format_rs_source(&generated_rs);
 
-        assert_eq!(generated_rs, expected_output);
+        assert_str_eq!(generated_rs, expected_output);
     }
 
     #[test]
@@ -1262,7 +1262,7 @@ mod tests {
             .to_string();
         let generated_rs = format_rs_source(&generated_rs);
 
-        assert_eq!(generated_rs, expected_output);
+        assert_str_eq!(generated_rs, expected_output);
     }
 
     #[test]
@@ -1280,7 +1280,7 @@ mod tests {
             .to_string();
         let generated_rs = format_rs_source(&generated_rs);
 
-        assert_eq!(generated_rs, expected_output);
+        assert_str_eq!(generated_rs, expected_output);
     }
 
     #[test]
@@ -1298,7 +1298,7 @@ mod tests {
             .to_string();
         let generated_rs = format_rs_source(&generated_rs);
 
-        assert_eq!(generated_rs, expected_output);
+        assert_str_eq!(generated_rs, expected_output);
     }
 
     #[test]
@@ -1316,7 +1316,7 @@ mod tests {
             .to_string();
         let generated_rs = format_rs_source(&generated_rs);
 
-        assert_eq!(generated_rs, expected_output);
+        assert_str_eq!(generated_rs, expected_output);
     }
 
     #[test]
@@ -1334,7 +1334,7 @@ mod tests {
             .to_string();
         let generated_rs = format_rs_source(&generated_rs);
 
-        assert_eq!(generated_rs, expected_output);
+        assert_str_eq!(generated_rs, expected_output);
     }
 
     #[test]
@@ -1352,6 +1352,6 @@ mod tests {
             .to_string();
         let generated_rs = format_rs_source(&generated_rs);
 
-        assert_eq!(generated_rs, expected_output);
+        assert_str_eq!(generated_rs, expected_output);
     }
 }


### PR DESCRIPTION
Enables proper multi-line diffing.

Before:
![Screenshot from 2022-08-05 12-00-00](https://user-images.githubusercontent.com/84974957/183057162-ddf722dc-ded9-4280-9dde-642c560e9a01.png)

After:
![Screenshot from 2022-08-05 12-08-12](https://user-images.githubusercontent.com/84974957/183057177-8c31f0d5-e9ee-41f3-8a5f-84e89b2de9b0.png)

Need I say more? ;)