### PR TITLE
cxx-qt-gen: remove the cxx_qt::bridge in the parser

### DIFF
--- a/cxx-qt-gen/src/extract.rs
+++ b/cxx-qt-gen/src/extract.rs
@@ -788,7 +788,7 @@ pub fn extract_qobject(
     let (_, qobject) = parser.cxx_qt_data.qobjects.drain().take(1).next().unwrap();
 
     // Find the items from the module
-    let original_mod = module.to_owned();
+    let original_mod = parser.passthrough_module.clone();
 
     // Prepare variables to store struct, invokables, and other data
     //

--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -831,25 +831,8 @@ pub fn generate_qobject_rs(
     obj: &QObject,
     cpp_namespace_prefix: &[&str],
 ) -> Result<TokenStream, TokenStream> {
-    // Load macro attributes that were on the module, excluding #[cxx_qt::bridge]
-    let mod_attrs = obj
-        .original_mod
-        .attrs
-        .iter()
-        .filter_map(|attr| {
-            // Filter out any attributes that are #[cxx_qt::bridge] as that is ourselves
-            //
-            // TODO: what happens if there are multiple macros to start from?
-            // Will generate_qobject_rs only ever come from cxx_qt::bridge?
-            // Otherwise we might need to pass the originating macro from the
-            // calling proc_macro_attribute method.
-            if path_compare_str(&attr.path, &["cxx_qt", "bridge"]) {
-                None
-            } else {
-                Some(attr.to_owned())
-            }
-        })
-        .collect::<Vec<syn::Attribute>>();
+    // Load macro attributes that were on the module
+    let mod_attrs = &obj.original_mod.attrs;
 
     // Cache the original module ident and visibility
     let mod_ident = &obj.original_mod.ident;

--- a/cxx-qt-gen/src/parser/qobject.rs
+++ b/cxx-qt-gen/src/parser/qobject.rs
@@ -88,8 +88,8 @@ impl ParsedCxxQtData {
         Ok(match &item {
             Item::Enum(item_enum) => {
                 // Check if the enum has cxx_qt::signals(T)
-                if let Some(attr) = attribute_find_path(&item_enum.attrs, &["cxx_qt", "signals"]) {
-                    let qobject = attribute_tokens_to_ident(attr)?;
+                if let Some(index) = attribute_find_path(&item_enum.attrs, &["cxx_qt", "signals"]) {
+                    let qobject = attribute_tokens_to_ident(&item_enum.attrs[index])?;
                     // Find the matching QObject for the enum
                     if let Some(entry) = self.qobjects.get_mut(&qobject) {
                         entry.signal_enum = Some(item_enum.clone());

--- a/cxx-qt-gen/src/syntax/attribute.rs
+++ b/cxx-qt-gen/src/syntax/attribute.rs
@@ -31,11 +31,11 @@ impl Parse for AttributeList {
     }
 }
 
-/// Returns the first [syn::Attribute] that matches a given path
-pub fn attribute_find_path<'a>(attrs: &'a [Attribute], path: &[&str]) -> Option<&'a Attribute> {
-    for attr in attrs {
+/// Returns the index of the first [syn::Attribute] that matches a given path
+pub fn attribute_find_path(attrs: &[Attribute], path: &[&str]) -> Option<usize> {
+    for (i, attr) in attrs.iter().enumerate() {
         if path_compare_str(&attr.path, path) {
-            return Some(attr);
+            return Some(i);
         }
     }
 

--- a/cxx-qt-gen/src/syntax/qtitem.rs
+++ b/cxx-qt-gen/src/syntax/qtitem.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::syntax::path::path_compare_str;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
@@ -52,15 +53,10 @@ impl Parse for CxxQtItem {
 
         if ahead.peek(Token![mod]) {
             for attribute in &attributes {
-                let path = &attribute.path.segments;
-                if path.len() == 2 {
-                    if path[0].ident == "cxx" && path[1].ident == "bridge" {
-                        // TODO: parse namespace here too
-                        return input.parse().map(CxxQtItem::Cxx);
-                    } else if path[0].ident == "cxx_qt" && path[1].ident == "bridge" {
-                        // TODO: parse namespace here too
-                        return input.parse().map(CxxQtItem::CxxQt);
-                    }
+                if path_compare_str(&attribute.path, &["cxx", "bridge"]) {
+                    return input.parse().map(CxxQtItem::Cxx);
+                } else if path_compare_str(&attribute.path, &["cxx_qt", "bridge"]) {
+                    return input.parse().map(CxxQtItem::CxxQt);
                 }
             }
         }

--- a/cxx-qt-gen/test_inputs/custom_default.rs
+++ b/cxx-qt-gen/test_inputs/custom_default.rs
@@ -1,3 +1,4 @@
+#[cxx_qt::bridge]
 mod my_object {
     pub struct Data {
         public: i32,

--- a/cxx-qt-gen/test_inputs/handlers.rs
+++ b/cxx-qt-gen/test_inputs/handlers.rs
@@ -1,3 +1,4 @@
+#[cxx_qt::bridge]
 mod my_object {
     #[namespace = ""]
     unsafe extern "C++" {

--- a/cxx-qt-gen/test_inputs/invokables.rs
+++ b/cxx-qt-gen/test_inputs/invokables.rs
@@ -1,3 +1,4 @@
+#[cxx_qt::bridge]
 mod my_object {
     #[namespace = ""]
     unsafe extern "C++" {

--- a/cxx-qt-gen/test_inputs/naming.rs
+++ b/cxx-qt-gen/test_inputs/naming.rs
@@ -1,3 +1,4 @@
+#[cxx_qt::bridge]
 mod my_object {
     #[derive(Default)]
     pub struct Data {

--- a/cxx-qt-gen/test_inputs/properties.rs
+++ b/cxx-qt-gen/test_inputs/properties.rs
@@ -1,3 +1,4 @@
+#[cxx_qt::bridge]
 mod my_object {
     #[namespace = ""]
     unsafe extern "C++" {

--- a/cxx-qt-gen/test_inputs/signals.rs
+++ b/cxx-qt-gen/test_inputs/signals.rs
@@ -1,3 +1,4 @@
+#[cxx_qt::bridge]
 mod my_object {
     #[namespace = ""]
     unsafe extern "C++" {

--- a/cxx-qt-gen/test_inputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_inputs/types_primitive_property.rs
@@ -1,3 +1,4 @@
+#[cxx_qt::bridge]
 mod my_object {
     #[derive(Default)]
     pub struct Data {

--- a/cxx-qt-gen/test_inputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_invokable.rs
@@ -1,3 +1,4 @@
+#[cxx_qt::bridge]
 mod my_object {
     #[namespace = ""]
     unsafe extern "C++" {

--- a/cxx-qt-gen/test_inputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_property.rs
@@ -1,3 +1,4 @@
+#[cxx_qt::bridge]
 mod my_object {
     #[namespace = ""]
     unsafe extern "C++" {


### PR DESCRIPTION
This allows us to process the namespace later and means we don't need
to remove the macro sometimes in the generation.