### PR TITLE
cxx-qt-gen: rearrange includes so that we use CXX include's

### DIFF
--- a/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/cxx-qt-gen/test_outputs/custom_default.rs
@@ -2,6 +2,8 @@
 mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        include!("cxx-qt-lib/include/convert.h");
+        include ! (< QtCore / QObject >);
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;

--- a/cxx-qt-gen/test_outputs/handlers.cpp
+++ b/cxx-qt-gen/test_outputs/handlers.cpp
@@ -1,4 +1,3 @@
-#include "cxx-qt-gen/include/my_object.cxx.h"
 #include "cxx-qt-gen/include/my_object.cxxqt.h"
 
 namespace cxx_qt::my_object {

--- a/cxx-qt-gen/test_outputs/handlers.h
+++ b/cxx-qt-gen/test_outputs/handlers.h
@@ -1,14 +1,15 @@
 #pragma once
 
+#include <memory>
 #include <mutex>
 
-#include "cxx-qt-lib/include/qt_types.h"
+namespace cxx_qt::my_object {
+class MyObject;
+} // namespace cxx_qt::my_object
 
-#include <QtCore/QString>
+#include "cxx-qt-gen/include/my_object.cxx.h"
 
 namespace cxx_qt::my_object {
-
-class MyObjectRust;
 
 class MyObject : public QObject
 {

--- a/cxx-qt-gen/test_outputs/handlers.rs
+++ b/cxx-qt-gen/test_outputs/handlers.rs
@@ -2,6 +2,9 @@
 mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        include!("cxx-qt-lib/include/convert.h");
+        include!("cxx-qt-lib/include/update_requester.h");
+        include ! (< QtCore / QObject >);
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;

--- a/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/cxx-qt-gen/test_outputs/invokables.cpp
@@ -1,4 +1,3 @@
-#include "cxx-qt-gen/include/my_object.cxx.h"
 #include "cxx-qt-gen/include/my_object.cxxqt.h"
 
 namespace cxx_qt::my_object {

--- a/cxx-qt-gen/test_outputs/invokables.h
+++ b/cxx-qt-gen/test_outputs/invokables.h
@@ -1,15 +1,15 @@
 #pragma once
 
+#include <memory>
 #include <mutex>
 
-#include "cxx-qt-lib/include/qt_types.h"
+namespace cxx_qt::my_object {
+class MyObject;
+} // namespace cxx_qt::my_object
 
-#include <QtCore/QPoint>
-#include <QtGui/QColor>
+#include "cxx-qt-gen/include/my_object.cxx.h"
 
 namespace cxx_qt::my_object {
-
-class MyObjectRust;
 
 class MyObject : public QObject
 {

--- a/cxx-qt-gen/test_outputs/invokables.rs
+++ b/cxx-qt-gen/test_outputs/invokables.rs
@@ -2,6 +2,8 @@
 mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        include!("cxx-qt-lib/include/convert.h");
+        include ! (< QtCore / QObject >);
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;

--- a/cxx-qt-gen/test_outputs/naming.cpp
+++ b/cxx-qt-gen/test_outputs/naming.cpp
@@ -1,4 +1,3 @@
-#include "cxx-qt-gen/include/my_object.cxx.h"
 #include "cxx-qt-gen/include/my_object.cxxqt.h"
 
 namespace cxx_qt::my_object {

--- a/cxx-qt-gen/test_outputs/naming.h
+++ b/cxx-qt-gen/test_outputs/naming.h
@@ -1,12 +1,15 @@
 #pragma once
 
+#include <memory>
 #include <mutex>
 
-#include "cxx-qt-lib/include/qt_types.h"
+namespace cxx_qt::my_object {
+class MyObject;
+} // namespace cxx_qt::my_object
+
+#include "cxx-qt-gen/include/my_object.cxx.h"
 
 namespace cxx_qt::my_object {
-
-class MyObjectRust;
 
 class MyObject : public QObject
 {

--- a/cxx-qt-gen/test_outputs/naming.rs
+++ b/cxx-qt-gen/test_outputs/naming.rs
@@ -2,6 +2,8 @@
 mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        include!("cxx-qt-lib/include/convert.h");
+        include ! (< QtCore / QObject >);
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;

--- a/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/cxx-qt-gen/test_outputs/passthrough.rs
@@ -2,6 +2,8 @@
 pub mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        include!("cxx-qt-lib/include/convert.h");
+        include ! (< QtCore / QObject >);
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;

--- a/cxx-qt-gen/test_outputs/properties.cpp
+++ b/cxx-qt-gen/test_outputs/properties.cpp
@@ -1,4 +1,3 @@
-#include "cxx-qt-gen/include/my_object.cxx.h"
 #include "cxx-qt-gen/include/my_object.cxxqt.h"
 
 namespace cxx_qt::my_object {

--- a/cxx-qt-gen/test_outputs/properties.h
+++ b/cxx-qt-gen/test_outputs/properties.h
@@ -1,14 +1,15 @@
 #pragma once
 
+#include <memory>
 #include <mutex>
 
-#include "cxx-qt-lib/include/qt_types.h"
+namespace cxx_qt::my_object {
+class MyObject;
+} // namespace cxx_qt::my_object
 
-#include <QtGui/QColor>
+#include "cxx-qt-gen/include/my_object.cxx.h"
 
 namespace cxx_qt::my_object {
-
-class MyObjectRust;
 
 class MyObject : public QObject
 {

--- a/cxx-qt-gen/test_outputs/properties.rs
+++ b/cxx-qt-gen/test_outputs/properties.rs
@@ -2,6 +2,8 @@
 mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        include!("cxx-qt-lib/include/convert.h");
+        include ! (< QtCore / QObject >);
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;

--- a/cxx-qt-gen/test_outputs/signals.cpp
+++ b/cxx-qt-gen/test_outputs/signals.cpp
@@ -1,4 +1,3 @@
-#include "cxx-qt-gen/include/my_object.cxx.h"
 #include "cxx-qt-gen/include/my_object.cxxqt.h"
 
 namespace cxx_qt::my_object {

--- a/cxx-qt-gen/test_outputs/signals.h
+++ b/cxx-qt-gen/test_outputs/signals.h
@@ -1,15 +1,15 @@
 #pragma once
 
+#include <memory>
 #include <mutex>
 
-#include "cxx-qt-lib/include/qt_types.h"
+namespace cxx_qt::my_object {
+class MyObject;
+} // namespace cxx_qt::my_object
 
-#include <QtCore/QPoint>
-#include <QtCore/QVariant>
+#include "cxx-qt-gen/include/my_object.cxx.h"
 
 namespace cxx_qt::my_object {
-
-class MyObjectRust;
 
 class MyObject : public QObject
 {

--- a/cxx-qt-gen/test_outputs/signals.rs
+++ b/cxx-qt-gen/test_outputs/signals.rs
@@ -2,6 +2,8 @@
 mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        include!("cxx-qt-lib/include/convert.h");
+        include ! (< QtCore / QObject >);
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;

--- a/cxx-qt-gen/test_outputs/types_primitive_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.cpp
@@ -1,4 +1,3 @@
-#include "cxx-qt-gen/include/my_object.cxx.h"
 #include "cxx-qt-gen/include/my_object.cxxqt.h"
 
 namespace cxx_qt::my_object {

--- a/cxx-qt-gen/test_outputs/types_primitive_property.h
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.h
@@ -1,12 +1,15 @@
 #pragma once
 
+#include <memory>
 #include <mutex>
 
-#include "cxx-qt-lib/include/qt_types.h"
+namespace cxx_qt::my_object {
+class MyObject;
+} // namespace cxx_qt::my_object
+
+#include "cxx-qt-gen/include/my_object.cxx.h"
 
 namespace cxx_qt::my_object {
-
-class MyObjectRust;
 
 class MyObject : public QObject
 {

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -2,6 +2,8 @@
 mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        include!("cxx-qt-lib/include/convert.h");
+        include ! (< QtCore / QObject >);
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
@@ -1,4 +1,3 @@
-#include "cxx-qt-gen/include/my_object.cxx.h"
 #include "cxx-qt-gen/include/my_object.cxxqt.h"
 
 namespace cxx_qt::my_object {

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.h
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.h
@@ -1,26 +1,15 @@
 #pragma once
 
+#include <memory>
 #include <mutex>
 
-#include "cxx-qt-lib/include/qt_types.h"
+namespace cxx_qt::my_object {
+class MyObject;
+} // namespace cxx_qt::my_object
 
-#include <QtCore/QDate>
-#include <QtCore/QDateTime>
-#include <QtCore/QPoint>
-#include <QtCore/QPointF>
-#include <QtCore/QRect>
-#include <QtCore/QRectF>
-#include <QtCore/QSize>
-#include <QtCore/QSizeF>
-#include <QtCore/QString>
-#include <QtCore/QTime>
-#include <QtCore/QUrl>
-#include <QtCore/QVariant>
-#include <QtGui/QColor>
+#include "cxx-qt-gen/include/my_object.cxx.h"
 
 namespace cxx_qt::my_object {
-
-class MyObjectRust;
 
 class MyObject : public QObject
 {

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -2,6 +2,8 @@
 mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        include!("cxx-qt-lib/include/convert.h");
+        include ! (< QtCore / QObject >);
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;

--- a/cxx-qt-gen/test_outputs/types_qt_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_property.cpp
@@ -1,4 +1,3 @@
-#include "cxx-qt-gen/include/my_object.cxx.h"
 #include "cxx-qt-gen/include/my_object.cxxqt.h"
 
 namespace cxx_qt::my_object {

--- a/cxx-qt-gen/test_outputs/types_qt_property.h
+++ b/cxx-qt-gen/test_outputs/types_qt_property.h
@@ -1,26 +1,15 @@
 #pragma once
 
+#include <memory>
 #include <mutex>
 
-#include "cxx-qt-lib/include/qt_types.h"
+namespace cxx_qt::my_object {
+class MyObject;
+} // namespace cxx_qt::my_object
 
-#include <QtCore/QDate>
-#include <QtCore/QDateTime>
-#include <QtCore/QPoint>
-#include <QtCore/QPointF>
-#include <QtCore/QRect>
-#include <QtCore/QRectF>
-#include <QtCore/QSize>
-#include <QtCore/QSizeF>
-#include <QtCore/QString>
-#include <QtCore/QTime>
-#include <QtCore/QUrl>
-#include <QtCore/QVariant>
-#include <QtGui/QColor>
+#include "cxx-qt-gen/include/my_object.cxx.h"
 
 namespace cxx_qt::my_object {
-
-class MyObjectRust;
 
 class MyObject : public QObject
 {

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -2,6 +2,8 @@
 mod my_object {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+        include!("cxx-qt-lib/include/convert.h");
+        include ! (< QtCore / QObject >);
 
         #[cxx_name = "MyObject"]
         type MyObjectQt;

--- a/cxx-qt-lib/include/convert.h
+++ b/cxx-qt-lib/include/convert.h
@@ -1,0 +1,58 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+namespace rust {
+namespace cxxqtlib1 {
+
+template<typename R, typename T>
+struct cxx_qt_convert
+{
+  static_assert(std::is_convertible_v<T, R>, R"(
+
+CXXQt: No viable conversion between types found.
+Consider defining your own type conversion.
+See: https://kdab.github.io/cxx-qt/book/concepts/type-conversions.html
+)");
+  R operator()(T val) { return val; }
+};
+
+template<typename R, typename T>
+struct cxx_qt_convert<R&, T>
+{
+  R& operator()(T& val) { return val; }
+};
+
+template<typename R, typename T>
+struct cxx_qt_convert<const R&, T>
+{
+  const R& operator()(const T& val) { return val; }
+};
+
+template<typename R, typename T>
+struct cxx_qt_convert<R, std::unique_ptr<T>>
+{
+  R operator()(std::unique_ptr<T> ptr) { return std::move(*ptr); }
+};
+
+template<typename R, typename T>
+struct cxx_qt_convert<R&, std::unique_ptr<T>>
+{
+  R& operator()(std::unique_ptr<T>& ptr) { return *ptr; }
+};
+
+template<typename R, typename T>
+struct cxx_qt_convert<const R&, std::unique_ptr<T>>
+{
+  const R& operator()(const std::unique_ptr<T>& ptr) { return *ptr; }
+};
+
+} // namespace cxxqtlib1
+} // namespace rust

--- a/cxx-qt-lib/include/qt_types.h
+++ b/cxx-qt-lib/include/qt_types.h
@@ -1,6 +1,7 @@
-// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group
-// company <info@kdab.com> SPDX-FileContributor: Andrew Hayzen
-// <andrew.hayzen@kdab.com>
+// clang-format off
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
@@ -12,7 +13,6 @@
 #include <QDateTime>
 #include <QPoint>
 #include <QPointF>
-#include <QPointer>
 #include <QRect>
 #include <QRectF>
 #include <QSize>
@@ -26,59 +26,6 @@
 
 namespace rust {
 namespace cxxqtlib1 {
-
-template<typename R, typename T>
-struct cxx_qt_convert
-{
-  static_assert(std::is_convertible_v<T, R>, R"(
-
-CXXQt: No viable conversion between types found.
-Consider defining your own type conversion.
-See: https://kdab.github.io/cxx-qt/book/concepts/type-conversions.html
-)");
-  R operator()(T val) { return val; }
-};
-
-template<typename R, typename T>
-struct cxx_qt_convert<R&, T>
-{
-  R& operator()(T& val) { return val; }
-};
-
-template<typename R, typename T>
-struct cxx_qt_convert<const R&, T>
-{
-  const R& operator()(const T& val) { return val; }
-};
-
-template<typename R, typename T>
-struct cxx_qt_convert<R, std::unique_ptr<T>>
-{
-  R operator()(std::unique_ptr<T> ptr) { return std::move(*ptr); }
-};
-
-template<typename R, typename T>
-struct cxx_qt_convert<R&, std::unique_ptr<T>>
-{
-  R& operator()(std::unique_ptr<T>& ptr) { return *ptr; }
-};
-
-template<typename R, typename T>
-struct cxx_qt_convert<const R&, std::unique_ptr<T>>
-{
-  const R& operator()(const std::unique_ptr<T>& ptr) { return *ptr; }
-};
-
-class UpdateRequester
-{
-public:
-  UpdateRequester(QPointer<QObject> obj, const char* method);
-  bool requestUpdate() const;
-
-private:
-  const char* m_method;
-  QPointer<QObject> m_obj;
-};
 
 namespace types {
 

--- a/cxx-qt-lib/include/update_requester.h
+++ b/cxx-qt-lib/include/update_requester.h
@@ -1,0 +1,27 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtCore/QPointer>
+
+namespace rust {
+namespace cxxqtlib1 {
+
+class UpdateRequester
+{
+public:
+  UpdateRequester(QPointer<QObject> obj, const char* method);
+  bool requestUpdate() const;
+
+private:
+  const char* m_method;
+  QPointer<QObject> m_obj;
+};
+
+} // namespace cxxqtlib1
+} // namespace rust

--- a/cxx-qt-lib/src/qt_types.cpp
+++ b/cxx-qt-lib/src/qt_types.cpp
@@ -1,6 +1,7 @@
-// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group
-// company <info@kdab.com> SPDX-FileContributor: Andrew Hayzen
-// <andrew.hayzen@kdab.com>
+// clang-format off
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
@@ -10,22 +11,6 @@
 
 namespace rust {
 namespace cxxqtlib1 {
-
-UpdateRequester::UpdateRequester(QPointer<QObject> obj, const char* method)
-  : m_method(method)
-  , m_obj(obj)
-{
-}
-
-bool
-UpdateRequester::requestUpdate() const
-{
-  if (m_obj == nullptr) {
-    return false;
-  }
-
-  return QMetaObject::invokeMethod(m_obj, m_method, Qt::QueuedConnection);
-}
 
 std::unique_ptr<QColor>
 qcolorInit()
@@ -366,5 +351,5 @@ CXX_QT_VARIANT_TRIVIAL_VALUE(quint8, U8)
 CXX_QT_VARIANT_TRIVIAL_VALUE(quint16, U16)
 CXX_QT_VARIANT_TRIVIAL_VALUE(quint32, U32)
 
-}
-}
+} // namespace cxxqtlib1
+} // namespace rust

--- a/cxx-qt-lib/src/types/update_requester.rs
+++ b/cxx-qt-lib/src/types/update_requester.rs
@@ -7,7 +7,7 @@
 mod ffi {
     #[namespace = "rust::cxxqtlib1"]
     unsafe extern "C++" {
-        include!("cxx-qt-lib/include/qt_types.h");
+        include!("cxx-qt-lib/include/update_requester.h");
 
         type UpdateRequester;
 

--- a/cxx-qt-lib/src/update_requester.cpp
+++ b/cxx-qt-lib/src/update_requester.cpp
@@ -1,0 +1,32 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#include "cxx-qt-lib/include/update_requester.h"
+
+#include <QtCore/QMetaObject>
+
+namespace rust {
+namespace cxxqtlib1 {
+
+UpdateRequester::UpdateRequester(QPointer<QObject> obj, const char* method)
+  : m_method(method)
+  , m_obj(obj)
+{
+}
+
+bool
+UpdateRequester::requestUpdate() const
+{
+  if (m_obj == nullptr) {
+    return false;
+  }
+
+  return QMetaObject::invokeMethod(m_obj, m_method, Qt::QueuedConnection);
+}
+
+} // namespace cxxqtlib1
+} // namespace rust

--- a/tests/basic_cxx_only/include/main.h
+++ b/tests/basic_cxx_only/include/main.h
@@ -7,5 +7,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #pragma once
 
+#include "cxx-qt-gen/include/ffi.cxx.h"
+
 int
 get_cpp_number();

--- a/tests/basic_cxx_only/src/main.cpp
+++ b/tests/basic_cxx_only/src/main.cpp
@@ -8,7 +8,6 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-#include "cxx-qt-gen/include/ffi.cxx.h"
 #include "main.h"
 
 int hidden_num = 100;


### PR DESCRIPTION
This then allows us later to have include!(<QAbstractListModel>)
and this will be included into our .cxxqt.h via the .cxx.h