### PR TITLE
Remove CppObj

### DIFF
--- a/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/cxx-qt-gen/src/writer/rust/mod.rs
@@ -87,9 +87,8 @@ pub fn write_rust(generated: &GeneratedRustBlocks) -> TokenStream {
                 std::default::Default::default()
             }
 
-            pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-                let mut wrapper = CppObj::new(cpp);
-                wrapper.grab_values_from_data(Data::default());
+            pub fn initialise_cpp(cpp: std::pin::Pin<&mut #cpp_struct_ident>) {
+                cpp.grab_values_from_data(Data::default());
             }
         }
     }
@@ -203,9 +202,8 @@ mod tests {
                     std::default::Default::default()
                 }
 
-                pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-                    let mut wrapper = CppObj::new(cpp);
-                    wrapper.grab_values_from_data(Data::default());
+                pub fn initialise_cpp(cpp: std::pin::Pin<&mut MyObjectQt>) {
+                    cpp.grab_values_from_data(Data::default());
                 }
             }
         }

--- a/cxx-qt-gen/test_inputs/handlers.rs
+++ b/cxx-qt-gen/test_inputs/handlers.rs
@@ -16,8 +16,8 @@ mod ffi {
     #[derive(Default)]
     pub struct MyObject;
 
-    impl UpdateRequestHandler<CppObj> for MyObject {
-        fn handle_update_request(&mut self, _cpp: &mut CppObj) {
+    impl UpdateRequestHandler for cxx_qt::QObject<MyObject> {
+        fn handle_update_request(self: Pin<&mut Self>) {
             println!("update")
         }
     }

--- a/cxx-qt-gen/test_inputs/invokables.rs
+++ b/cxx-qt-gen/test_inputs/invokables.rs
@@ -19,17 +19,7 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn invokable_cpp_obj(&self, cpp: &mut CppObj) {
-            println!("cppobj");
-        }
-
-        #[qinvokable]
-        pub fn invokable_mutable(&mut self) {
-            println!("This method is mutable!");
-        }
-
-        #[qinvokable]
-        pub fn invokable_mutable_cpp_obj(&mut self, cpp: &mut CppObj) {
+        pub fn invokable_mutable(self: Pin<&mut Self>) {
             println!("This method is mutable!");
         }
 
@@ -44,22 +34,17 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn invokable_parameters_cpp_obj(&self, primitive: i32, cpp: &mut CppObj) {
-            println!("{}", primitive);
-        }
-
-        #[qinvokable]
-        pub fn invokable_return_opaque(&mut self) -> UniquePtr<QColor> {
+        pub fn invokable_return_opaque(self: Pin<&mut Self>) -> UniquePtr<QColor> {
             cxx_qt_lib::QColor::from_rgba(255, 0, 0, 0)
         }
 
         #[qinvokable]
-        pub fn invokable_return_primitive(&mut self) -> i32 {
+        pub fn invokable_return_primitive(self: Pin<&mut Self>) -> i32 {
             2
         }
 
         #[qinvokable]
-        pub fn invokable_return_static(&mut self) -> UniquePtr<QString> {
+        pub fn invokable_return_static(self: Pin<&mut Self>) -> UniquePtr<QString> {
             QString::from_str("static")
         }
 
@@ -67,12 +52,8 @@ mod ffi {
             println!("C++ context method");
         }
 
-        pub fn cpp_context_method_mutable(&mut self) {
+        pub fn cpp_context_method_mutable(self: Pin<&mut Self>) {
             println!("mutable method");
-        }
-
-        pub fn cpp_context_method_cpp_obj(&mut self, cpp: &mut CppObj) {
-            println!("cppobj");
         }
 
         pub fn cpp_context_method_return_opaque(&self) -> UniquePtr<QColor> {

--- a/cxx-qt-gen/test_inputs/naming.rs
+++ b/cxx-qt-gen/test_inputs/naming.rs
@@ -15,8 +15,9 @@ mod ffi {
 
     impl cxx_qt::QObject<MyObject> {
         #[qinvokable]
-        pub fn invokable_name(&self) {
+        pub fn invokable_name(self: Pin<&mut Self>) {
             println!("Bye from Rust!");
+            self.as_mut().set_property_name(5);
         }
     }
 }

--- a/cxx-qt-gen/test_inputs/signals.rs
+++ b/cxx-qt-gen/test_inputs/signals.rs
@@ -26,12 +26,12 @@ mod ffi {
 
     impl cxx_qt::QObject<MyObject> {
         #[qinvokable]
-        pub fn invokable(&self, cpp: &mut CppObj) {
+        pub fn invokable(self: Pin<&mut Self>) {
             unsafe {
-                cpp.emit_immediate(MySignals::Ready);
+                self.as_mut().emit_immediate(MySignals::Ready);
             }
 
-            cpp.emit_queued(MySignals::DataChanged {
+            self.as_mut().emit_queued(MySignals::DataChanged {
                 first: 1,
                 second: QVariant::from_bool(true),
                 third: QPoint::new(1, 2),

--- a/cxx-qt-gen/test_inputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_inputs/types_qt_invokable.rs
@@ -27,71 +27,67 @@ mod ffi {
 
     impl cxx_qt::QObject<MyObject> {
         #[qinvokable]
-        pub fn test_color(&self, _cpp: &mut CppObj, color: &QColor) -> UniquePtr<QColor> {
+        pub fn test_color(&self, color: &QColor) -> UniquePtr<QColor> {
             color
         }
 
         #[qinvokable]
-        pub fn test_date(&self, _cpp: &mut CppObj, date: &QDate) -> QDate {
+        pub fn test_date(&self, date: &QDate) -> QDate {
             date
         }
 
         #[qinvokable]
-        pub fn test_date_time(
-            &self,
-            _cpp: &mut CppObj,
-            dateTime: &QDateTime,
-        ) -> UniquePtr<QDateTime> {
+        pub fn test_date_time(&self, dateTime: &QDateTime) -> UniquePtr<QDateTime> {
             dateTime
         }
 
         #[qinvokable]
-        pub fn test_point(&self, _cpp: &mut CppObj, point: &QPoint) -> QPoint {
+        pub fn test_point(&self, point: &QPoint) -> QPoint {
             point
         }
 
         #[qinvokable]
-        pub fn test_pointf(&self, _cpp: &mut CppObj, pointf: &QPointF) -> QPointF {
+        pub fn test_pointf(&self, pointf: &QPointF) -> QPointF {
             pointf
         }
 
         #[qinvokable]
-        pub fn test_rect(&self, _cpp: &mut CppObj, rect: &QRect) -> QRect {
+        pub fn test_rect(&self, rect: &QRect) -> QRect {
             rect
         }
 
         #[qinvokable]
-        pub fn test_rectf(&self, _cpp: &mut CppObj, rectf: &QRectF) -> QRectF {
+        pub fn test_rectf(&self, rectf: &QRectF) -> QRectF {
             rectf
         }
 
         #[qinvokable]
-        pub fn test_size(&self, _cpp: &mut CppObj, size: &QSize) -> QSize {
+        pub fn test_size(&self, size: &QSize) -> QSize {
             size
         }
 
         #[qinvokable]
-        pub fn test_sizef(&self, _cpp: &mut CppObj, sizef: &QSizeF) -> QSizeF {
+        pub fn test_sizef(&self, sizef: &QSizeF) -> QSizeF {
             sizef
         }
 
         #[qinvokable]
-        pub fn test_string(&self, _cpp: &mut CppObj, string: &QString) -> UniquePtr<QString> {
+        pub fn test_string(&self, string: &QString) -> UniquePtr<QString> {
             string.to_owned()
         }
 
         #[qinvokable]
-        pub fn test_time(&self, _cpp: &mut CppObj, time: &QTime) -> QTime {
+        pub fn test_time(&self, time: &QTime) -> QTime {
             time
         }
 
         #[qinvokable]
-        pub fn test_url(&self, _cpp: &mut CppObj, url: &QUrl) -> UniquePtr<QUrl> {
+        pub fn test_url(&self, url: &QUrl) -> UniquePtr<QUrl> {
             url
         }
 
         #[qinvokable]
-        pub fn test_variant(&self, _cpp: &mut CppObj, variant: &QVariant) -> UniquePtr<QVariant> {
+        pub fn test_variant(&self, variant: &QVariant) -> UniquePtr<QVariant> {
             variant
         }
     }

--- a/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/cxx-qt-gen/test_outputs/custom_default.rs
@@ -52,31 +52,17 @@ mod cxx_qt_ffi {
     pub type FFICppObj = super::ffi::MyObjectQt;
     type UniquePtr<T> = cxx::UniquePtr<T>;
 
+    use std::pin::Pin;
+
     pub struct MyObject {
         private: i32,
     }
 
     impl MyObject {}
 
-    pub struct CppObj<'a> {
-        cpp: std::pin::Pin<&'a mut FFICppObj>,
-    }
-
-    impl<'a> CppObj<'a> {
-        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
-            Self { cpp }
-        }
-
-        pub fn public(&self) -> i32 {
-            self.cpp.public()
-        }
-
-        pub fn set_public(&mut self, value: i32) {
-            self.cpp.as_mut().set_public(value);
-        }
-
-        pub fn grab_values_from_data(&mut self, mut data: Data) {
-            self.set_public(data.public);
+    impl MyObjectQt {
+        pub fn grab_values_from_data(mut self: Pin<&mut Self>, mut data: Data) {
+            self.as_mut().set_public(data.public);
         }
     }
 
@@ -84,17 +70,11 @@ mod cxx_qt_ffi {
         public: i32,
     }
 
-    impl<'a> From<&CppObj<'a>> for Data {
-        fn from(value: &CppObj<'a>) -> Self {
+    impl From<&MyObjectQt> for Data {
+        fn from(value: &MyObjectQt) -> Self {
             Self {
                 public: value.public().into(),
             }
-        }
-    }
-
-    impl<'a> From<&mut CppObj<'a>> for Data {
-        fn from(value: &mut CppObj<'a>) -> Self {
-            Self::from(&*value)
         }
     }
 
@@ -114,8 +94,7 @@ mod cxx_qt_ffi {
         std::default::Default::default()
     }
 
-    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObj::new(cpp);
-        wrapper.grab_values_from_data(Data::default());
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut MyObjectQt>) {
+        cpp.grab_values_from_data(Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/cxx-qt-gen/test_outputs/invokables.cpp
@@ -28,28 +28,14 @@ void
 MyObject::invokable()
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  m_rustObj->invokable();
-}
-
-void
-MyObject::invokableCppObj()
-{
-  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  m_rustObj->invokableCppObjWrapper(*this);
+  m_rustObj->invokableWrapper(*this);
 }
 
 void
 MyObject::invokableMutable()
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  m_rustObj->invokableMutable();
-}
-
-void
-MyObject::invokableMutableCppObj()
-{
-  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  m_rustObj->invokableMutableCppObjWrapper(*this);
+  m_rustObj->invokableMutableWrapper(*this);
 }
 
 void
@@ -58,14 +44,7 @@ MyObject::invokableParameters(const QColor& opaque,
                               qint32 primitive)
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  m_rustObj->invokableParameters(opaque, trivial, primitive);
-}
-
-void
-MyObject::invokableParametersCppObj(qint32 primitive)
-{
-  const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  m_rustObj->invokableParametersCppObjWrapper(primitive, *this);
+  m_rustObj->invokableParametersWrapper(*this, opaque, trivial, primitive);
 }
 
 QColor
@@ -73,7 +52,7 @@ MyObject::invokableReturnOpaque()
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   return rust::cxxqtlib1::cxx_qt_convert<QColor, std::unique_ptr<QColor>>{}(
-    m_rustObj->invokableReturnOpaqueWrapper());
+    m_rustObj->invokableReturnOpaqueWrapper(*this));
 }
 
 qint32
@@ -81,7 +60,7 @@ MyObject::invokableReturnPrimitive()
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   return rust::cxxqtlib1::cxx_qt_convert<qint32, qint32>{}(
-    m_rustObj->invokableReturnPrimitive());
+    m_rustObj->invokableReturnPrimitiveWrapper(*this));
 }
 
 QString
@@ -89,7 +68,7 @@ MyObject::invokableReturnStatic()
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
   return rust::cxxqtlib1::cxx_qt_convert<QString, std::unique_ptr<QString>>{}(
-    m_rustObj->invokableReturnStaticWrapper());
+    m_rustObj->invokableReturnStaticWrapper(*this));
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/invokables.h
+++ b/cxx-qt-gen/test_outputs/invokables.h
@@ -23,13 +23,10 @@ public:
 
 public:
   Q_INVOKABLE void invokable();
-  Q_INVOKABLE void invokableCppObj();
   Q_INVOKABLE void invokableMutable();
-  Q_INVOKABLE void invokableMutableCppObj();
   Q_INVOKABLE void invokableParameters(const QColor& opaque,
                                        const QPoint& trivial,
                                        qint32 primitive);
-  Q_INVOKABLE void invokableParametersCppObj(qint32 primitive);
   Q_INVOKABLE QColor invokableReturnOpaque();
   Q_INVOKABLE qint32 invokableReturnPrimitive();
   Q_INVOKABLE QString invokableReturnStatic();

--- a/cxx-qt-gen/test_outputs/invokables.rs
+++ b/cxx-qt-gen/test_outputs/invokables.rs
@@ -11,28 +11,33 @@ mod ffi {
         #[cxx_name = "MyObjectRust"]
         type MyObject;
 
-        #[cxx_name = "invokable"]
-        fn invokable(self: &MyObject);
-        #[cxx_name = "invokableCppObjWrapper"]
-        fn invokable_cpp_obj_wrapper(self: &MyObject, cpp: Pin<&mut MyObjectQt>);
-        #[cxx_name = "invokableMutable"]
-        fn invokable_mutable(self: &mut MyObject);
-        #[cxx_name = "invokableMutableCppObjWrapper"]
-        fn invokable_mutable_cpp_obj_wrapper(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>);
-        #[cxx_name = "invokableParameters"]
-        fn invokable_parameters(self: &MyObject, opaque: &QColor, trivial: &QPoint, primitive: i32);
-        #[cxx_name = "invokableParametersCppObjWrapper"]
-        fn invokable_parameters_cpp_obj_wrapper(
+        #[cxx_name = "invokableWrapper"]
+        fn invokable_wrapper(self: &MyObject, cpp: &MyObjectQt);
+        #[cxx_name = "invokableMutableWrapper"]
+        fn invokable_mutable_wrapper(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>);
+        #[cxx_name = "invokableParametersWrapper"]
+        fn invokable_parameters_wrapper(
             self: &MyObject,
+            cpp: &MyObjectQt,
+            opaque: &QColor,
+            trivial: &QPoint,
             primitive: i32,
-            cpp: Pin<&mut MyObjectQt>,
         );
         #[cxx_name = "invokableReturnOpaqueWrapper"]
-        fn invokable_return_opaque_wrapper(self: &mut MyObject) -> UniquePtr<QColor>;
-        #[cxx_name = "invokableReturnPrimitive"]
-        fn invokable_return_primitive(self: &mut MyObject) -> i32;
+        fn invokable_return_opaque_wrapper(
+            self: &mut MyObject,
+            cpp: Pin<&mut MyObjectQt>,
+        ) -> UniquePtr<QColor>;
+        #[cxx_name = "invokableReturnPrimitiveWrapper"]
+        fn invokable_return_primitive_wrapper(
+            self: &mut MyObject,
+            cpp: Pin<&mut MyObjectQt>,
+        ) -> i32;
         #[cxx_name = "invokableReturnStaticWrapper"]
-        fn invokable_return_static_wrapper(self: &mut MyObject) -> UniquePtr<QString>;
+        fn invokable_return_static_wrapper(
+            self: &mut MyObject,
+            cpp: Pin<&mut MyObjectQt>,
+        ) -> UniquePtr<QString>;
     }
 
     #[namespace = ""]
@@ -78,50 +83,58 @@ mod cxx_qt_ffi {
     pub type FFICppObj = super::ffi::MyObjectQt;
     type UniquePtr<T> = cxx::UniquePtr<T>;
 
+    use std::pin::Pin;
+
     #[derive(Default)]
     pub struct MyObject;
 
     impl MyObject {
-        pub fn invokable_cpp_obj_wrapper(&self, cpp: std::pin::Pin<&mut FFICppObj>) {
-            let mut cpp = CppObj::new(cpp);
-            self.invokable_cpp_obj(&mut cpp);
+        pub fn invokable_wrapper(&self, cpp: &FFICppObj) {
+            cpp.invokable();
         }
 
-        pub fn invokable_mutable_cpp_obj_wrapper(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
-            let mut cpp = CppObj::new(cpp);
-            self.invokable_mutable_cpp_obj(&mut cpp);
+        pub fn invokable_mutable_wrapper(&mut self, cpp: std::pin::Pin<&mut FFICppObj>) {
+            cpp.invokable_mutable();
         }
 
-        pub fn invokable_parameters_cpp_obj_wrapper(
+        pub fn invokable_parameters_wrapper(
             &self,
+            cpp: &FFICppObj,
+            opaque: &cxx_qt_lib::QColor,
+            trivial: &cxx_qt_lib::QPoint,
             primitive: i32,
-            cpp: std::pin::Pin<&mut FFICppObj>,
         ) {
-            let mut cpp = CppObj::new(cpp);
-            self.invokable_parameters_cpp_obj(primitive, &mut cpp);
+            cpp.invokable_parameters(opaque, trivial, primitive);
         }
 
-        pub fn invokable_return_opaque_wrapper(&mut self) -> UniquePtr<cxx_qt_lib::QColor> {
-            return self.invokable_return_opaque();
+        pub fn invokable_return_opaque_wrapper(
+            &mut self,
+            cpp: std::pin::Pin<&mut FFICppObj>,
+        ) -> UniquePtr<cxx_qt_lib::QColor> {
+            return cpp.invokable_return_opaque();
         }
 
-        pub fn invokable_return_static_wrapper(&mut self) -> UniquePtr<cxx_qt_lib::QString> {
-            return self.invokable_return_static();
+        pub fn invokable_return_primitive_wrapper(
+            &mut self,
+            cpp: std::pin::Pin<&mut FFICppObj>,
+        ) -> i32 {
+            return cpp.invokable_return_primitive();
         }
 
+        pub fn invokable_return_static_wrapper(
+            &mut self,
+            cpp: std::pin::Pin<&mut FFICppObj>,
+        ) -> UniquePtr<cxx_qt_lib::QString> {
+            return cpp.invokable_return_static();
+        }
+    }
+
+    impl MyObjectQt {
         pub fn invokable(&self) {
             println!("invokable");
         }
 
-        pub fn invokable_cpp_obj(&self, cpp: &mut CppObj) {
-            println!("cppobj");
-        }
-
-        pub fn invokable_mutable(&mut self) {
-            println!("This method is mutable!");
-        }
-
-        pub fn invokable_mutable_cpp_obj(&mut self, cpp: &mut CppObj) {
+        pub fn invokable_mutable(self: Pin<&mut Self>) {
             println!("This method is mutable!");
         }
 
@@ -134,19 +147,15 @@ mod cxx_qt_ffi {
             );
         }
 
-        pub fn invokable_parameters_cpp_obj(&self, primitive: i32, cpp: &mut CppObj) {
-            println!("{}", primitive);
-        }
-
-        pub fn invokable_return_opaque(&mut self) -> UniquePtr<QColor> {
+        pub fn invokable_return_opaque(self: Pin<&mut Self>) -> UniquePtr<QColor> {
             cxx_qt_lib::QColor::from_rgba(255, 0, 0, 0)
         }
 
-        pub fn invokable_return_primitive(&mut self) -> i32 {
+        pub fn invokable_return_primitive(self: Pin<&mut Self>) -> i32 {
             2
         }
 
-        pub fn invokable_return_static(&mut self) -> UniquePtr<QString> {
+        pub fn invokable_return_static(self: Pin<&mut Self>) -> UniquePtr<QString> {
             QString::from_str("static")
         }
 
@@ -154,42 +163,22 @@ mod cxx_qt_ffi {
             println!("C++ context method");
         }
 
-        pub fn cpp_context_method_mutable(&mut self) {
+        pub fn cpp_context_method_mutable(self: Pin<&mut Self>) {
             println!("mutable method");
-        }
-
-        pub fn cpp_context_method_cpp_obj(&mut self, cpp: &mut CppObj) {
-            println!("cppobj");
         }
 
         pub fn cpp_context_method_return_opaque(&self) -> UniquePtr<QColor> {
             cxx_qt_lib::QColor::from_rgba(255, 0, 0, 0)
         }
-    }
 
-    pub struct CppObj<'a> {
-        cpp: std::pin::Pin<&'a mut FFICppObj>,
-    }
-
-    impl<'a> CppObj<'a> {
-        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
-            Self { cpp }
-        }
-
-        pub fn grab_values_from_data(&mut self, mut data: Data) {}
+        pub fn grab_values_from_data(mut self: Pin<&mut Self>, mut data: Data) {}
     }
 
     pub struct Data;
 
-    impl<'a> From<&CppObj<'a>> for Data {
-        fn from(_value: &CppObj<'a>) -> Self {
+    impl From<&MyObjectQt> for Data {
+        fn from(_value: &MyObjectQt) -> Self {
             Self {}
-        }
-    }
-
-    impl<'a> From<&mut CppObj<'a>> for Data {
-        fn from(_value: &mut CppObj<'a>) -> Self {
-            Self::from(&*_value)
         }
     }
 
@@ -203,8 +192,7 @@ mod cxx_qt_ffi {
         std::default::Default::default()
     }
 
-    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObj::new(cpp);
-        wrapper.grab_values_from_data(Data::default());
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut MyObjectQt>) {
+        cpp.grab_values_from_data(Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/naming.cpp
+++ b/cxx-qt-gen/test_outputs/naming.cpp
@@ -49,7 +49,7 @@ void
 MyObject::invokableName()
 {
   const std::lock_guard<std::mutex> guard(m_rustObjMutex);
-  m_rustObj->invokableName();
+  m_rustObj->invokableNameWrapper(*this);
 }
 
 namespace cxx_qt_my_object {

--- a/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/cxx-qt-gen/test_outputs/passthrough.rs
@@ -111,30 +111,16 @@ mod cxx_qt_ffi {
     pub type FFICppObj = super::ffi::MyObjectQt;
     type UniquePtr<T> = cxx::UniquePtr<T>;
 
+    use std::pin::Pin;
+
     #[derive(Default)]
     pub struct MyObject;
 
     impl MyObject {}
 
-    pub struct CppObj<'a> {
-        cpp: std::pin::Pin<&'a mut FFICppObj>,
-    }
-
-    impl<'a> CppObj<'a> {
-        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
-            Self { cpp }
-        }
-
-        pub fn number(&self) -> i32 {
-            self.cpp.number()
-        }
-
-        pub fn set_number(&mut self, value: i32) {
-            self.cpp.as_mut().set_number(value);
-        }
-
-        pub fn grab_values_from_data(&mut self, mut data: Data) {
-            self.set_number(data.number);
+    impl MyObjectQt {
+        pub fn grab_values_from_data(mut self: Pin<&mut Self>, mut data: Data) {
+            self.as_mut().set_number(data.number);
         }
     }
 
@@ -143,17 +129,11 @@ mod cxx_qt_ffi {
         number: i32,
     }
 
-    impl<'a> From<&CppObj<'a>> for Data {
-        fn from(value: &CppObj<'a>) -> Self {
+    impl From<&MyObjectQt> for Data {
+        fn from(value: &MyObjectQt) -> Self {
             Self {
                 number: value.number().into(),
             }
-        }
-    }
-
-    impl<'a> From<&mut CppObj<'a>> for Data {
-        fn from(value: &mut CppObj<'a>) -> Self {
-            Self::from(&*value)
         }
     }
 
@@ -185,8 +165,7 @@ mod cxx_qt_ffi {
         std::default::Default::default()
     }
 
-    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObj::new(cpp);
-        wrapper.grab_values_from_data(Data::default());
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut MyObjectQt>) {
+        cpp.grab_values_from_data(Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -92,102 +92,24 @@ mod cxx_qt_ffi {
     pub type FFICppObj = super::ffi::MyObjectQt;
     type UniquePtr<T> = cxx::UniquePtr<T>;
 
+    use std::pin::Pin;
+
     #[derive(Default)]
     pub struct MyObject;
 
     impl MyObject {}
 
-    pub struct CppObj<'a> {
-        cpp: std::pin::Pin<&'a mut FFICppObj>,
-    }
-
-    impl<'a> CppObj<'a> {
-        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
-            Self { cpp }
-        }
-
-        pub fn boolean(&self) -> bool {
-            self.cpp.boolean()
-        }
-
-        pub fn set_boolean(&mut self, value: bool) {
-            self.cpp.as_mut().set_boolean(value);
-        }
-
-        pub fn float_32(&self) -> f32 {
-            self.cpp.float_32()
-        }
-
-        pub fn set_float_32(&mut self, value: f32) {
-            self.cpp.as_mut().set_float_32(value);
-        }
-
-        pub fn float_64(&self) -> f64 {
-            self.cpp.float_64()
-        }
-
-        pub fn set_float_64(&mut self, value: f64) {
-            self.cpp.as_mut().set_float_64(value);
-        }
-
-        pub fn int_8(&self) -> i8 {
-            self.cpp.int_8()
-        }
-
-        pub fn set_int_8(&mut self, value: i8) {
-            self.cpp.as_mut().set_int_8(value);
-        }
-
-        pub fn int_16(&self) -> i16 {
-            self.cpp.int_16()
-        }
-
-        pub fn set_int_16(&mut self, value: i16) {
-            self.cpp.as_mut().set_int_16(value);
-        }
-
-        pub fn int_32(&self) -> i32 {
-            self.cpp.int_32()
-        }
-
-        pub fn set_int_32(&mut self, value: i32) {
-            self.cpp.as_mut().set_int_32(value);
-        }
-
-        pub fn uint_8(&self) -> u8 {
-            self.cpp.uint_8()
-        }
-
-        pub fn set_uint_8(&mut self, value: u8) {
-            self.cpp.as_mut().set_uint_8(value);
-        }
-
-        pub fn uint_16(&self) -> u16 {
-            self.cpp.uint_16()
-        }
-
-        pub fn set_uint_16(&mut self, value: u16) {
-            self.cpp.as_mut().set_uint_16(value);
-        }
-
-        pub fn uint_32(&self) -> u32 {
-            self.cpp.uint_32()
-        }
-
-        pub fn set_uint_32(&mut self, value: u32) {
-            self.cpp.as_mut().set_uint_32(value);
-        }
-
-        pub fn grab_values_from_data(&mut self, mut data: Data) {
-            self.set_boolean(data.boolean);
-            self.set_float_32(data.float_32);
-            self.set_float_64(data.float_64);
-            self.set_int_8(data.int_8);
-            self.set_int_16(data.int_16);
-            self.set_int_32(data.int_32);
-            self.set_uint_8(data.uint_8);
-            self.set_uint_16(data.uint_16);
-            self.set_uint_32(data.uint_32);
+    impl MyObjectQt {
+        pub fn grab_values_from_data(mut self: Pin<&mut Self>, mut data: Data) {
+            self.as_mut().set_boolean(data.boolean);
+            self.as_mut().set_float_32(data.float_32);
+            self.as_mut().set_float_64(data.float_64);
+            self.as_mut().set_int_8(data.int_8);
+            self.as_mut().set_int_16(data.int_16);
+            self.as_mut().set_int_32(data.int_32);
+            self.as_mut().set_uint_8(data.uint_8);
+            self.as_mut().set_uint_16(data.uint_16);
+            self.as_mut().set_uint_32(data.uint_32);
         }
     }
 
@@ -204,8 +126,8 @@ mod cxx_qt_ffi {
         uint_32: u32,
     }
 
-    impl<'a> From<&CppObj<'a>> for Data {
-        fn from(value: &CppObj<'a>) -> Self {
+    impl From<&MyObjectQt> for Data {
+        fn from(value: &MyObjectQt) -> Self {
             Self {
                 boolean: value.boolean().into(),
                 float_32: value.float_32().into(),
@@ -220,18 +142,11 @@ mod cxx_qt_ffi {
         }
     }
 
-    impl<'a> From<&mut CppObj<'a>> for Data {
-        fn from(value: &mut CppObj<'a>) -> Self {
-            Self::from(&*value)
-        }
-    }
-
     pub fn create_rs() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 
-    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObj::new(cpp);
-        wrapper.grab_values_from_data(Data::default());
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut MyObjectQt>) {
+        cpp.grab_values_from_data(Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -14,75 +14,55 @@ mod ffi {
         #[cxx_name = "testColorWrapper"]
         fn test_color_wrapper(
             self: &MyObject,
-            _cpp: Pin<&mut MyObjectQt>,
+            cpp: &MyObjectQt,
             color: &QColor,
         ) -> UniquePtr<QColor>;
 
         #[cxx_name = "testDateWrapper"]
-        fn test_date_wrapper(self: &MyObject, _cpp: Pin<&mut MyObjectQt>, date: &QDate) -> QDate;
+        fn test_date_wrapper(self: &MyObject, cpp: &MyObjectQt, date: &QDate) -> QDate;
 
         #[cxx_name = "testDateTimeWrapper"]
         fn test_date_time_wrapper(
             self: &MyObject,
-            _cpp: Pin<&mut MyObjectQt>,
+            cpp: &MyObjectQt,
             dateTime: &QDateTime,
         ) -> UniquePtr<QDateTime>;
 
         #[cxx_name = "testPointWrapper"]
-        fn test_point_wrapper(
-            self: &MyObject,
-            _cpp: Pin<&mut MyObjectQt>,
-            point: &QPoint,
-        ) -> QPoint;
+        fn test_point_wrapper(self: &MyObject, cpp: &MyObjectQt, point: &QPoint) -> QPoint;
 
         #[cxx_name = "testPointfWrapper"]
-        fn test_pointf_wrapper(
-            self: &MyObject,
-            _cpp: Pin<&mut MyObjectQt>,
-            pointf: &QPointF,
-        ) -> QPointF;
+        fn test_pointf_wrapper(self: &MyObject, cpp: &MyObjectQt, pointf: &QPointF) -> QPointF;
 
         #[cxx_name = "testRectWrapper"]
-        fn test_rect_wrapper(self: &MyObject, _cpp: Pin<&mut MyObjectQt>, rect: &QRect) -> QRect;
+        fn test_rect_wrapper(self: &MyObject, cpp: &MyObjectQt, rect: &QRect) -> QRect;
 
         #[cxx_name = "testRectfWrapper"]
-        fn test_rectf_wrapper(
-            self: &MyObject,
-            _cpp: Pin<&mut MyObjectQt>,
-            rectf: &QRectF,
-        ) -> QRectF;
+        fn test_rectf_wrapper(self: &MyObject, cpp: &MyObjectQt, rectf: &QRectF) -> QRectF;
 
         #[cxx_name = "testSizeWrapper"]
-        fn test_size_wrapper(self: &MyObject, _cpp: Pin<&mut MyObjectQt>, size: &QSize) -> QSize;
+        fn test_size_wrapper(self: &MyObject, cpp: &MyObjectQt, size: &QSize) -> QSize;
 
         #[cxx_name = "testSizefWrapper"]
-        fn test_sizef_wrapper(
-            self: &MyObject,
-            _cpp: Pin<&mut MyObjectQt>,
-            sizef: &QSizeF,
-        ) -> QSizeF;
+        fn test_sizef_wrapper(self: &MyObject, cpp: &MyObjectQt, sizef: &QSizeF) -> QSizeF;
 
         #[cxx_name = "testStringWrapper"]
         fn test_string_wrapper(
             self: &MyObject,
-            _cpp: Pin<&mut MyObjectQt>,
+            cpp: &MyObjectQt,
             string: &QString,
         ) -> UniquePtr<QString>;
 
         #[cxx_name = "testTimeWrapper"]
-        fn test_time_wrapper(self: &MyObject, _cpp: Pin<&mut MyObjectQt>, time: &QTime) -> QTime;
+        fn test_time_wrapper(self: &MyObject, cpp: &MyObjectQt, time: &QTime) -> QTime;
 
         #[cxx_name = "testUrlWrapper"]
-        fn test_url_wrapper(
-            self: &MyObject,
-            _cpp: Pin<&mut MyObjectQt>,
-            url: &QUrl,
-        ) -> UniquePtr<QUrl>;
+        fn test_url_wrapper(self: &MyObject, cpp: &MyObjectQt, url: &QUrl) -> UniquePtr<QUrl>;
 
         #[cxx_name = "testVariantWrapper"]
         fn test_variant_wrapper(
             self: &MyObject,
-            _cpp: Pin<&mut MyObjectQt>,
+            cpp: &MyObjectQt,
             variant: &QVariant,
         ) -> UniquePtr<QVariant>;
     }
@@ -140,208 +120,179 @@ mod cxx_qt_ffi {
     pub type FFICppObj = super::ffi::MyObjectQt;
     type UniquePtr<T> = cxx::UniquePtr<T>;
 
+    use std::pin::Pin;
+
     #[derive(Default)]
     pub struct MyObject;
 
     impl MyObject {
         pub fn test_color_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             color: &cxx_qt_lib::QColor,
         ) -> UniquePtr<cxx_qt_lib::QColor> {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_color(&mut _cpp, color);
+            return cpp.test_color(color);
         }
 
         pub fn test_date_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             date: &cxx_qt_lib::QDate,
         ) -> cxx_qt_lib::QDate {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_date(&mut _cpp, date);
+            return cpp.test_date(date);
         }
 
         pub fn test_date_time_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             dateTime: &cxx_qt_lib::QDateTime,
         ) -> UniquePtr<cxx_qt_lib::QDateTime> {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_date_time(&mut _cpp, dateTime);
+            return cpp.test_date_time(dateTime);
         }
 
         pub fn test_point_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             point: &cxx_qt_lib::QPoint,
         ) -> cxx_qt_lib::QPoint {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_point(&mut _cpp, point);
+            return cpp.test_point(point);
         }
 
         pub fn test_pointf_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             pointf: &cxx_qt_lib::QPointF,
         ) -> cxx_qt_lib::QPointF {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_pointf(&mut _cpp, pointf);
+            return cpp.test_pointf(pointf);
         }
 
         pub fn test_rect_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             rect: &cxx_qt_lib::QRect,
         ) -> cxx_qt_lib::QRect {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_rect(&mut _cpp, rect);
+            return cpp.test_rect(rect);
         }
 
         pub fn test_rectf_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             rectf: &cxx_qt_lib::QRectF,
         ) -> cxx_qt_lib::QRectF {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_rectf(&mut _cpp, rectf);
+            return cpp.test_rectf(rectf);
         }
 
         pub fn test_size_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             size: &cxx_qt_lib::QSize,
         ) -> cxx_qt_lib::QSize {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_size(&mut _cpp, size);
+            return cpp.test_size(size);
         }
 
         pub fn test_sizef_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             sizef: &cxx_qt_lib::QSizeF,
         ) -> cxx_qt_lib::QSizeF {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_sizef(&mut _cpp, sizef);
+            return cpp.test_sizef(sizef);
         }
 
         pub fn test_string_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             string: &cxx_qt_lib::QString,
         ) -> UniquePtr<cxx_qt_lib::QString> {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_string(&mut _cpp, string);
+            return cpp.test_string(string);
         }
 
         pub fn test_time_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             time: &cxx_qt_lib::QTime,
         ) -> cxx_qt_lib::QTime {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_time(&mut _cpp, time);
+            return cpp.test_time(time);
         }
 
         pub fn test_url_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             url: &cxx_qt_lib::QUrl,
         ) -> UniquePtr<cxx_qt_lib::QUrl> {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_url(&mut _cpp, url);
+            return cpp.test_url(url);
         }
 
         pub fn test_variant_wrapper(
             &self,
-            _cpp: std::pin::Pin<&mut FFICppObj>,
+            cpp: &FFICppObj,
             variant: &cxx_qt_lib::QVariant,
         ) -> UniquePtr<cxx_qt_lib::QVariant> {
-            let mut _cpp = CppObj::new(_cpp);
-            return self.test_variant(&mut _cpp, variant);
+            return cpp.test_variant(variant);
         }
+    }
 
-        pub fn test_color(&self, _cpp: &mut CppObj, color: &QColor) -> UniquePtr<QColor> {
+    impl MyObjectQt {
+        pub fn test_color(&self, color: &QColor) -> UniquePtr<QColor> {
             color
         }
 
-        pub fn test_date(&self, _cpp: &mut CppObj, date: &QDate) -> QDate {
+        pub fn test_date(&self, date: &QDate) -> QDate {
             date
         }
 
-        pub fn test_date_time(
-            &self,
-            _cpp: &mut CppObj,
-            dateTime: &QDateTime,
-        ) -> UniquePtr<QDateTime> {
+        pub fn test_date_time(&self, dateTime: &QDateTime) -> UniquePtr<QDateTime> {
             dateTime
         }
 
-        pub fn test_point(&self, _cpp: &mut CppObj, point: &QPoint) -> QPoint {
+        pub fn test_point(&self, point: &QPoint) -> QPoint {
             point
         }
 
-        pub fn test_pointf(&self, _cpp: &mut CppObj, pointf: &QPointF) -> QPointF {
+        pub fn test_pointf(&self, pointf: &QPointF) -> QPointF {
             pointf
         }
 
-        pub fn test_rect(&self, _cpp: &mut CppObj, rect: &QRect) -> QRect {
+        pub fn test_rect(&self, rect: &QRect) -> QRect {
             rect
         }
 
-        pub fn test_rectf(&self, _cpp: &mut CppObj, rectf: &QRectF) -> QRectF {
+        pub fn test_rectf(&self, rectf: &QRectF) -> QRectF {
             rectf
         }
 
-        pub fn test_size(&self, _cpp: &mut CppObj, size: &QSize) -> QSize {
+        pub fn test_size(&self, size: &QSize) -> QSize {
             size
         }
 
-        pub fn test_sizef(&self, _cpp: &mut CppObj, sizef: &QSizeF) -> QSizeF {
+        pub fn test_sizef(&self, sizef: &QSizeF) -> QSizeF {
             sizef
         }
 
-        pub fn test_string(&self, _cpp: &mut CppObj, string: &QString) -> UniquePtr<QString> {
+        pub fn test_string(&self, string: &QString) -> UniquePtr<QString> {
             string.to_owned()
         }
 
-        pub fn test_time(&self, _cpp: &mut CppObj, time: &QTime) -> QTime {
+        pub fn test_time(&self, time: &QTime) -> QTime {
             time
         }
 
-        pub fn test_url(&self, _cpp: &mut CppObj, url: &QUrl) -> UniquePtr<QUrl> {
+        pub fn test_url(&self, url: &QUrl) -> UniquePtr<QUrl> {
             url
         }
 
-        pub fn test_variant(&self, _cpp: &mut CppObj, variant: &QVariant) -> UniquePtr<QVariant> {
+        pub fn test_variant(&self, variant: &QVariant) -> UniquePtr<QVariant> {
             variant
         }
-    }
 
-    pub struct CppObj<'a> {
-        cpp: std::pin::Pin<&'a mut FFICppObj>,
-    }
-
-    impl<'a> CppObj<'a> {
-        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
-            Self { cpp }
-        }
-
-        pub fn grab_values_from_data(&mut self, mut data: Data) {}
+        pub fn grab_values_from_data(mut self: Pin<&mut Self>, mut data: Data) {}
     }
 
     #[derive(Default)]
     pub struct Data;
 
-    impl<'a> From<&CppObj<'a>> for Data {
-        fn from(_value: &CppObj<'a>) -> Self {
+    impl From<&MyObjectQt> for Data {
+        fn from(_value: &MyObjectQt) -> Self {
             Self {}
-        }
-    }
-
-    impl<'a> From<&mut CppObj<'a>> for Data {
-        fn from(_value: &mut CppObj<'a>) -> Self {
-            Self::from(&*_value)
         }
     }
 
@@ -349,8 +300,7 @@ mod cxx_qt_ffi {
         std::default::Default::default()
     }
 
-    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObj::new(cpp);
-        wrapper.grab_values_from_data(Data::default());
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut MyObjectQt>) {
+        cpp.grab_values_from_data(Data::default());
     }
 }

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -130,138 +130,29 @@ mod cxx_qt_ffi {
     pub type FFICppObj = super::ffi::MyObjectQt;
     type UniquePtr<T> = cxx::UniquePtr<T>;
 
+    use std::pin::Pin;
+
     #[derive(Default)]
     pub struct MyObject;
 
     impl MyObject {}
 
-    pub struct CppObj<'a> {
-        cpp: std::pin::Pin<&'a mut FFICppObj>,
-    }
-
-    impl<'a> CppObj<'a> {
-        pub fn new(cpp: std::pin::Pin<&'a mut FFICppObj>) -> Self {
-            Self { cpp }
-        }
-
-        pub fn color(&self) -> &cxx_qt_lib::QColor {
-            self.cpp.color()
-        }
-
-        pub fn set_color(&mut self, value: &cxx_qt_lib::QColor) {
-            self.cpp.as_mut().set_color(value);
-        }
-
-        pub fn date(&self) -> &cxx_qt_lib::QDate {
-            self.cpp.date()
-        }
-
-        pub fn set_date(&mut self, value: &cxx_qt_lib::QDate) {
-            self.cpp.as_mut().set_date(value);
-        }
-
-        pub fn date_time(&self) -> &cxx_qt_lib::QDateTime {
-            self.cpp.date_time()
-        }
-
-        pub fn set_date_time(&mut self, value: &cxx_qt_lib::QDateTime) {
-            self.cpp.as_mut().set_date_time(value);
-        }
-
-        pub fn point(&self) -> &cxx_qt_lib::QPoint {
-            self.cpp.point()
-        }
-
-        pub fn set_point(&mut self, value: &cxx_qt_lib::QPoint) {
-            self.cpp.as_mut().set_point(value);
-        }
-
-        pub fn pointf(&self) -> &cxx_qt_lib::QPointF {
-            self.cpp.pointf()
-        }
-
-        pub fn set_pointf(&mut self, value: &cxx_qt_lib::QPointF) {
-            self.cpp.as_mut().set_pointf(value);
-        }
-
-        pub fn rect(&self) -> &cxx_qt_lib::QRect {
-            self.cpp.rect()
-        }
-
-        pub fn set_rect(&mut self, value: &cxx_qt_lib::QRect) {
-            self.cpp.as_mut().set_rect(value);
-        }
-
-        pub fn rectf(&self) -> &cxx_qt_lib::QRectF {
-            self.cpp.rectf()
-        }
-
-        pub fn set_rectf(&mut self, value: &cxx_qt_lib::QRectF) {
-            self.cpp.as_mut().set_rectf(value);
-        }
-
-        pub fn size(&self) -> &cxx_qt_lib::QSize {
-            self.cpp.size()
-        }
-
-        pub fn set_size(&mut self, value: &cxx_qt_lib::QSize) {
-            self.cpp.as_mut().set_size(value);
-        }
-
-        pub fn sizef(&self) -> &cxx_qt_lib::QSizeF {
-            self.cpp.sizef()
-        }
-
-        pub fn set_sizef(&mut self, value: &cxx_qt_lib::QSizeF) {
-            self.cpp.as_mut().set_sizef(value);
-        }
-
-        pub fn string(&self) -> &cxx_qt_lib::QString {
-            self.cpp.string()
-        }
-
-        pub fn set_string(&mut self, value: &cxx_qt_lib::QString) {
-            self.cpp.as_mut().set_string(value);
-        }
-
-        pub fn time(&self) -> &cxx_qt_lib::QTime {
-            self.cpp.time()
-        }
-
-        pub fn set_time(&mut self, value: &cxx_qt_lib::QTime) {
-            self.cpp.as_mut().set_time(value);
-        }
-
-        pub fn url(&self) -> &cxx_qt_lib::QUrl {
-            self.cpp.url()
-        }
-
-        pub fn set_url(&mut self, value: &cxx_qt_lib::QUrl) {
-            self.cpp.as_mut().set_url(value);
-        }
-
-        pub fn variant(&self) -> &cxx_qt_lib::QVariant {
-            self.cpp.variant()
-        }
-
-        pub fn set_variant(&mut self, value: &cxx_qt_lib::QVariant) {
-            self.cpp.as_mut().set_variant(value);
-        }
-
-        pub fn grab_values_from_data(&mut self, mut data: Data) {
-            self.set_color(data.color.as_ref().unwrap());
-            self.set_date(&data.date);
-            self.set_date_time(data.date_time.as_ref().unwrap());
-            self.set_point(&data.point);
-            self.set_pointf(&data.pointf);
-            self.set_rect(&data.rect);
-            self.set_rectf(&data.rectf);
-            self.set_size(&data.size);
-            self.set_sizef(&data.sizef);
-            self.set_string(data.string.as_ref().unwrap());
-            self.set_time(&data.time);
-            self.set_url(data.url.as_ref().unwrap());
-            self.set_variant(data.variant.as_ref().unwrap());
+    impl MyObjectQt {
+        pub fn grab_values_from_data(mut self: Pin<&mut Self>, mut data: Data) {
+            self.as_mut().set_color(data.color.as_ref().unwrap());
+            self.as_mut().set_date(&data.date);
+            self.as_mut()
+                .set_date_time(data.date_time.as_ref().unwrap());
+            self.as_mut().set_point(&data.point);
+            self.as_mut().set_pointf(&data.pointf);
+            self.as_mut().set_rect(&data.rect);
+            self.as_mut().set_rectf(&data.rectf);
+            self.as_mut().set_size(&data.size);
+            self.as_mut().set_sizef(&data.sizef);
+            self.as_mut().set_string(data.string.as_ref().unwrap());
+            self.as_mut().set_time(&data.time);
+            self.as_mut().set_url(data.url.as_ref().unwrap());
+            self.as_mut().set_variant(data.variant.as_ref().unwrap());
         }
     }
 
@@ -282,8 +173,8 @@ mod cxx_qt_ffi {
         variant: UniquePtr<QVariant>,
     }
 
-    impl<'a> From<&CppObj<'a>> for Data {
-        fn from(value: &CppObj<'a>) -> Self {
+    impl From<&MyObjectQt> for Data {
+        fn from(value: &MyObjectQt) -> Self {
             Self {
                 color: value.color().into(),
                 date: value.date().into(),
@@ -302,18 +193,11 @@ mod cxx_qt_ffi {
         }
     }
 
-    impl<'a> From<&mut CppObj<'a>> for Data {
-        fn from(value: &mut CppObj<'a>) -> Self {
-            Self::from(&*value)
-        }
-    }
-
     pub fn create_rs() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 
-    pub fn initialise_cpp(cpp: std::pin::Pin<&mut FFICppObj>) {
-        let mut wrapper = CppObj::new(cpp);
-        wrapper.grab_values_from_data(Data::default());
+    pub fn initialise_cpp(cpp: std::pin::Pin<&mut MyObjectQt>) {
+        cpp.grab_values_from_data(Data::default());
     }
 }

--- a/cxx-qt-lib/src/lib.rs
+++ b/cxx-qt-lib/src/lib.rs
@@ -7,6 +7,8 @@
 mod types;
 pub use types::*;
 
-pub trait UpdateRequestHandler<C> {
-    fn handle_update_request(&mut self, cpp: &mut C);
+use std::pin::Pin;
+
+pub trait UpdateRequestHandler {
+    fn handle_update_request(self: Pin<&mut Self>);
 }

--- a/examples/qml_extension_plugin/core/src/lib.rs
+++ b/examples/qml_extension_plugin/core/src/lib.rs
@@ -63,29 +63,30 @@ mod ffi {
 
     impl cxx_qt::QObject<MyObject> {
         #[qinvokable]
-        pub fn increment(&self, cpp: &mut CppObj) {
-            cpp.set_number(cpp.number() + 1);
+        pub fn increment(self: Pin<&mut Self>) {
+            let new_number = self.number() + 1;
+            self.set_number(new_number);
         }
 
         #[qinvokable]
-        pub fn reset(&self, cpp: &mut CppObj) {
+        pub fn reset(self: Pin<&mut Self>) {
             let data: DataSerde = serde_json::from_str(DEFAULT_STR).unwrap();
-            cpp.grab_values_from_data(data.into());
+            self.grab_values_from_data(data.into());
         }
 
         #[qinvokable]
-        pub fn serialize(&self, cpp: &mut CppObj) -> UniquePtr<QString> {
-            let data = Data::from(cpp);
+        pub fn serialize(&self) -> UniquePtr<QString> {
+            let data = Data::from(self);
             let data_serde = DataSerde::from(data);
             let data_string = serde_json::to_string(&data_serde).unwrap();
             QString::from_str(&data_string)
         }
 
         #[qinvokable]
-        pub fn grab_values(&self, cpp: &mut CppObj) {
+        pub fn grab_values(self: Pin<&mut Self>) {
             let string = r#"{"number": 2, "string": "Goodbye!"}"#;
             let data: DataSerde = serde_json::from_str(string).unwrap();
-            cpp.grab_values_from_data(data.into());
+            self.grab_values_from_data(data.into());
         }
     }
 }

--- a/examples/qml_features/src/lib.rs
+++ b/examples/qml_features/src/lib.rs
@@ -40,9 +40,9 @@ mod ffi {
 
     impl cxx_qt::QObject<MyObject> {
         #[qinvokable]
-        pub fn increment_number_self(&self, cpp: &mut CppObj) {
-            let value = cpp.number() + 1;
-            cpp.set_number(value);
+        pub fn increment_number_self(self: Pin<&mut Self>) {
+            let value = self.as_ref().number() + 1;
+            self.set_number(value);
         }
 
         #[qinvokable]

--- a/examples/qml_features/src/mock_qt_types.rs
+++ b/examples/qml_features/src/mock_qt_types.rs
@@ -76,26 +76,26 @@ mod ffi {
 
     impl cxx_qt::QObject<MockQtTypes> {
         #[qinvokable]
-        pub fn test_signal(&self, cpp: &mut CppObj) {
-            cpp.emit_queued(Signal::Ready);
-            cpp.emit_queued(Signal::DataChanged {
+        pub fn test_signal(mut self: Pin<&mut Self>) {
+            self.as_mut().emit_queued(Signal::Ready);
+            self.as_mut().emit_queued(Signal::DataChanged {
                 variant: QVariant::from(true),
             });
         }
 
         #[qinvokable]
-        pub fn test_unsafe_signal(&self, cpp: &mut CppObj) {
+        pub fn test_unsafe_signal(mut self: Pin<&mut Self>) {
             unsafe {
-                cpp.emit_immediate(Signal::Ready);
-                cpp.emit_immediate(Signal::DataChanged {
+                self.as_mut().emit_immediate(Signal::Ready);
+                self.as_mut().emit_immediate(Signal::DataChanged {
                     variant: QVariant::from(true),
                 });
             }
         }
 
         #[qinvokable]
-        pub fn test_color_property(&self, cpp: &mut CppObj) {
-            cpp.set_color(QColor::from_rgba(0, 0, 255, 255).as_ref().unwrap());
+        pub fn test_color_property(self: Pin<&mut Self>) {
+            self.set_color(QColor::from_rgba(0, 0, 255, 255).as_ref().unwrap());
         }
 
         #[qinvokable]
@@ -104,10 +104,10 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_date_property(&self, cpp: &mut CppObj) {
-            let mut date = *cpp.date();
+        pub fn test_date_property(self: Pin<&mut Self>) {
+            let mut date = *self.date();
             date.set_date(2021, 12, 31);
-            cpp.set_date(&date);
+            self.set_date(&date);
         }
 
         #[qinvokable]
@@ -118,8 +118,8 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_date_time_property(&self, cpp: &mut CppObj) {
-            let date_time = cpp.date_time();
+        pub fn test_date_time_property(self: Pin<&mut Self>) {
+            let date_time = self.date_time();
             let new_date_time = QDateTime::from_date_and_time(
                 &QDate::new(2021, 12, 31),
                 &QTime::new(
@@ -129,7 +129,7 @@ mod ffi {
                     date_time.time().msec() * 5,
                 ),
             );
-            cpp.set_date_time(new_date_time.as_ref().unwrap());
+            self.set_date_time(new_date_time.as_ref().unwrap());
         }
 
         #[qinvokable]
@@ -146,11 +146,11 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_point_property(&self, cpp: &mut CppObj) {
-            let mut point = *cpp.point();
+        pub fn test_point_property(self: Pin<&mut Self>) {
+            let mut point = *self.point();
             point.set_x(point.x() * 2);
             point.set_y(point.y() * 3);
-            cpp.set_point(&point);
+            self.set_point(&point);
         }
 
         #[qinvokable]
@@ -162,11 +162,11 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_pointf_property(&self, cpp: &mut CppObj) {
-            let mut point = *cpp.pointf();
+        pub fn test_pointf_property(self: Pin<&mut Self>) {
+            let mut point = *self.pointf();
             point.set_x(point.x() * 2.0);
             point.set_y(point.y() * 3.0);
-            cpp.set_pointf(&point);
+            self.set_pointf(&point);
         }
 
         #[qinvokable]
@@ -178,15 +178,15 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_rect_property(&self, cpp: &mut CppObj) {
-            let mut rect = *cpp.rect();
+        pub fn test_rect_property(self: Pin<&mut Self>) {
+            let mut rect = *self.rect();
             // Copy width and height, otherwise when we adjust the x and y it affects the width and height
             let (width, height) = (rect.width(), rect.height());
             rect.set_x(rect.x() * 2);
             rect.set_y(rect.y() * 3);
             rect.set_width(width * 4);
             rect.set_height(height * 5);
-            cpp.set_rect(&rect);
+            self.set_rect(&rect);
         }
 
         #[qinvokable]
@@ -202,15 +202,15 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_rectf_property(&self, cpp: &mut CppObj) {
-            let mut rect = *cpp.rectf();
+        pub fn test_rectf_property(self: Pin<&mut Self>) {
+            let mut rect = *self.rectf();
             // Copy width and height, otherwise when we adjust the x and y it affects the width and height
             let (width, height) = (rect.width(), rect.height());
             rect.set_x(rect.x() * 2.0);
             rect.set_y(rect.y() * 3.0);
             rect.set_width(width * 4.0);
             rect.set_height(height * 5.0);
-            cpp.set_rectf(&rect);
+            self.set_rectf(&rect);
         }
 
         #[qinvokable]
@@ -226,11 +226,11 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_size_property(&self, cpp: &mut CppObj) {
-            let mut size = *cpp.size();
+        pub fn test_size_property(self: Pin<&mut Self>) {
+            let mut size = *self.size();
             size.set_width(size.width() * 2);
             size.set_height(size.height() * 3);
-            cpp.set_size(&size);
+            self.set_size(&size);
         }
 
         #[qinvokable]
@@ -242,11 +242,11 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_sizef_property(&self, cpp: &mut CppObj) {
-            let mut size = *cpp.sizef();
+        pub fn test_sizef_property(self: Pin<&mut Self>) {
+            let mut size = *self.sizef();
             size.set_width(size.width() * 2.0);
             size.set_height(size.height() * 3.0);
-            cpp.set_sizef(&size);
+            self.set_sizef(&size);
         }
 
         #[qinvokable]
@@ -258,9 +258,9 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_string_property(&self, cpp: &mut CppObj) {
-            let string = QString::from_str(&(cpp.string().to_string() + "/cxx-qt"));
-            cpp.set_string(string.as_ref().unwrap());
+        pub fn test_string_property(self: Pin<&mut Self>) {
+            let string = QString::from_str(&(self.string().to_string() + "/cxx-qt"));
+            self.set_string(string.as_ref().unwrap());
         }
 
         #[qinvokable]
@@ -269,15 +269,15 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_time_property(&self, cpp: &mut CppObj) {
-            let mut time = *cpp.time();
+        pub fn test_time_property(self: Pin<&mut Self>) {
+            let mut time = *self.time();
             time.set_hms(
                 time.hour() * 2,
                 time.minute() * 3,
                 time.second() * 4,
                 time.msec() * 5,
             );
-            cpp.set_time(&time);
+            self.set_time(&time);
         }
 
         #[qinvokable]
@@ -293,9 +293,9 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_url_property(&self, cpp: &mut CppObj) {
-            let url = QUrl::from_str(&(cpp.url().string() + "/cxx-qt"));
-            cpp.set_url(url.as_ref().unwrap());
+        pub fn test_url_property(self: Pin<&mut Self>) {
+            let url = QUrl::from_str(&(self.url().string() + "/cxx-qt"));
+            self.set_url(url.as_ref().unwrap());
         }
 
         #[qinvokable]
@@ -304,14 +304,26 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_variant_property(&self, cpp: &mut CppObj) {
-            match cpp.variant().value() {
-                QVariantValue::Bool(b) => cpp.set_variant(QVariant::from(!b).as_ref().unwrap()),
-                QVariantValue::F32(f) => cpp.set_variant(QVariant::from(f * 2.0).as_ref().unwrap()),
-                QVariantValue::F64(d) => cpp.set_variant(QVariant::from(d * 2.0).as_ref().unwrap()),
-                QVariantValue::I8(i) => cpp.set_variant(QVariant::from(i * 2).as_ref().unwrap()),
-                QVariantValue::I16(i) => cpp.set_variant(QVariant::from(i * 2).as_ref().unwrap()),
-                QVariantValue::I32(i) => cpp.set_variant(QVariant::from(i * 2).as_ref().unwrap()),
+        pub fn test_variant_property(mut self: Pin<&mut Self>) {
+            match self.variant().value() {
+                QVariantValue::Bool(b) => self
+                    .as_mut()
+                    .set_variant(QVariant::from(!b).as_ref().unwrap()),
+                QVariantValue::F32(f) => self
+                    .as_mut()
+                    .set_variant(QVariant::from(f * 2.0).as_ref().unwrap()),
+                QVariantValue::F64(d) => self
+                    .as_mut()
+                    .set_variant(QVariant::from(d * 2.0).as_ref().unwrap()),
+                QVariantValue::I8(i) => self
+                    .as_mut()
+                    .set_variant(QVariant::from(i * 2).as_ref().unwrap()),
+                QVariantValue::I16(i) => self
+                    .as_mut()
+                    .set_variant(QVariant::from(i * 2).as_ref().unwrap()),
+                QVariantValue::I32(i) => self
+                    .as_mut()
+                    .set_variant(QVariant::from(i * 2).as_ref().unwrap()),
                 QVariantValue::QColor(mut color) => {
                     if let Some(mut color) = color.as_mut() {
                         color.as_mut().set_red(0);
@@ -319,11 +331,13 @@ mod ffi {
                         color.as_mut().set_blue(255);
                         color.as_mut().set_alpha(255);
                     }
-                    cpp.set_variant(QVariant::from(color.as_ref().unwrap()).as_ref().unwrap());
+                    self.as_mut()
+                        .set_variant(QVariant::from(color.as_ref().unwrap()).as_ref().unwrap());
                 }
                 QVariantValue::QDate(mut date) => {
                     date.set_date(2021, 12, 31);
-                    cpp.set_variant(QVariant::from(date).as_ref().unwrap());
+                    self.as_mut()
+                        .set_variant(QVariant::from(date).as_ref().unwrap());
                 }
                 QVariantValue::QDateTime(mut date_time) => {
                     if let Some(mut date_time) = date_time.as_mut() {
@@ -336,28 +350,28 @@ mod ffi {
                         );
                         date_time.as_mut().set_time(new_time);
                     }
-                    cpp.set_variant(
+                    self.as_mut().set_variant(
                         QVariant::from(date_time.as_ref().unwrap())
                             .as_ref()
                             .unwrap(),
                     );
                 }
                 QVariantValue::QPoint(point) => {
-                    cpp.set_variant(
+                    self.as_mut().set_variant(
                         QVariant::from(QPoint::new(point.x() * 2, point.y() * 2))
                             .as_ref()
                             .unwrap(),
                     );
                 }
                 QVariantValue::QPointF(pointf) => {
-                    cpp.set_variant(
+                    self.as_mut().set_variant(
                         QVariant::from(QPointF::new(pointf.x() * 2.0, pointf.y() * 2.0))
                             .as_ref()
                             .unwrap(),
                     );
                 }
                 QVariantValue::QRect(rect) => {
-                    cpp.set_variant(
+                    self.as_mut().set_variant(
                         QVariant::from(QRect::new(
                             rect.x() * 2,
                             rect.y() * 3,
@@ -369,7 +383,7 @@ mod ffi {
                     );
                 }
                 QVariantValue::QRectF(rectf) => {
-                    cpp.set_variant(
+                    self.as_mut().set_variant(
                         QVariant::from(QRectF::new(
                             rectf.x() * 2.0,
                             rectf.y() * 3.0,
@@ -381,14 +395,14 @@ mod ffi {
                     );
                 }
                 QVariantValue::QSize(size) => {
-                    cpp.set_variant(
+                    self.as_mut().set_variant(
                         QVariant::from(QSize::new(size.width() * 2, size.height() * 2))
                             .as_ref()
                             .unwrap(),
                     );
                 }
                 QVariantValue::QSizeF(sizef) => {
-                    cpp.set_variant(
+                    self.as_mut().set_variant(
                         QVariant::from(QSizeF::new(sizef.width() * 2.0, sizef.height() * 2.0))
                             .as_ref()
                             .unwrap(),
@@ -396,7 +410,8 @@ mod ffi {
                 }
                 QVariantValue::QString(string) => {
                     let string = QString::from_str(&(string.to_string() + "/cxx-qt"));
-                    cpp.set_variant(QVariant::from(string.as_ref().unwrap()).as_ref().unwrap());
+                    self.as_mut()
+                        .set_variant(QVariant::from(string.as_ref().unwrap()).as_ref().unwrap());
                 }
                 QVariantValue::QTime(mut time) => {
                     time.set_hms(
@@ -405,15 +420,23 @@ mod ffi {
                         time.second() * 4,
                         time.msec() * 5,
                     );
-                    cpp.set_variant(QVariant::from(time).as_ref().unwrap());
+                    self.as_mut()
+                        .set_variant(QVariant::from(time).as_ref().unwrap());
                 }
                 QVariantValue::QUrl(url) => {
                     let url = QUrl::from_str(&(url.string() + "/cxx-qt"));
-                    cpp.set_variant(QVariant::from(url.as_ref().unwrap()).as_ref().unwrap());
+                    self.as_mut()
+                        .set_variant(QVariant::from(url.as_ref().unwrap()).as_ref().unwrap());
                 }
-                QVariantValue::U8(i) => cpp.set_variant(QVariant::from(i * 2).as_ref().unwrap()),
-                QVariantValue::U16(i) => cpp.set_variant(QVariant::from(i * 2).as_ref().unwrap()),
-                QVariantValue::U32(i) => cpp.set_variant(QVariant::from(i * 2).as_ref().unwrap()),
+                QVariantValue::U8(i) => self
+                    .as_mut()
+                    .set_variant(QVariant::from(i * 2).as_ref().unwrap()),
+                QVariantValue::U16(i) => self
+                    .as_mut()
+                    .set_variant(QVariant::from(i * 2).as_ref().unwrap()),
+                QVariantValue::U32(i) => self
+                    .as_mut()
+                    .set_variant(QVariant::from(i * 2).as_ref().unwrap()),
                 _ => panic!("Incorrect variant type!"),
             }
         }

--- a/examples/qml_features/src/rust_obj_invokables.rs
+++ b/examples/qml_features/src/rust_obj_invokables.rs
@@ -25,20 +25,23 @@ pub mod ffi {
     impl cxx_qt::QObject<RustObjInvokables> {
         // ANCHOR: book_cpp_obj
         #[qinvokable]
-        pub fn invokable_mutate_cpp(&self, cpp: &mut CppObj) {
-            cpp.set_number(cpp.number() * 2);
+        pub fn invokable_mutate_cpp(self: Pin<&mut Self>) {
+            let new_number = self.number() * 2;
+            self.set_number(new_number);
         }
         // ANCHOR_END: book_cpp_obj
 
         #[qinvokable]
         pub fn invokable_return(&self) -> i32 {
-            self.rust_only_field
+            self.rust().rust_only_field
         }
 
         #[qinvokable]
-        pub fn invokable_multiply(&mut self, factor: i32) -> i32 {
-            self.rust_only_method(factor);
-            self.rust_only_field
+        pub fn invokable_multiply(mut self: Pin<&mut Self>, factor: i32) -> i32 {
+            unsafe {
+                self.as_mut().rust_mut().rust_only_method(factor);
+            }
+            self.rust().rust_only_field
         }
     }
 

--- a/examples/qml_features/src/serialisation.rs
+++ b/examples/qml_features/src/serialisation.rs
@@ -60,8 +60,8 @@ mod ffi {
 
     impl cxx_qt::QObject<Serialisation> {
         #[qinvokable]
-        pub fn as_json_str(&self, cpp: &mut CppObj) -> UniquePtr<QString> {
-            let data = Data::from(cpp);
+        pub fn as_json_str(&self) -> UniquePtr<QString> {
+            let data = Data::from(self);
             let data_serde = DataSerde::from(data);
             let data_string = serde_json::to_string(&data_serde).unwrap();
             QString::from_str(&data_string)
@@ -69,10 +69,10 @@ mod ffi {
 
         // ANCHOR: book_grab_values
         #[qinvokable]
-        pub fn grab_values(&self, cpp: &mut CppObj) {
+        pub fn grab_values(self: Pin<&mut Self>) {
             let string = r#"{"number": 2, "string": "Goodbye!"}"#;
             let data_serde: DataSerde = serde_json::from_str(string).unwrap();
-            cpp.grab_values_from_data(data_serde.into());
+            self.grab_values_from_data(data_serde.into());
         }
         // ANCHOR_END: book_grab_values
     }

--- a/examples/qml_features/src/signals.rs
+++ b/examples/qml_features/src/signals.rs
@@ -45,18 +45,21 @@ pub mod ffi {
     // ANCHOR: book_rust_obj_impl
     impl cxx_qt::QObject<Signals> {
         #[qinvokable]
-        pub fn invokable(&self, cpp: &mut CppObj) {
+        pub fn invokable(mut self: Pin<&mut Self>) {
             unsafe {
-                cpp.emit_immediate(Signal::Ready);
+                self.as_mut().emit_immediate(Signal::Ready);
             }
 
-            cpp.emit_queued(Signal::RustDataChanged { data: cpp.data() });
-            cpp.emit_queued(Signal::TrivialDataChanged {
-                trivial: *cpp.trivial(),
-            });
-            cpp.emit_queued(Signal::OpaqueDataChanged {
-                opaque: QVariant::from_ref(cpp.opaque()),
-            });
+            let signal = Signal::RustDataChanged { data: self.data() };
+            self.as_mut().emit_queued(signal);
+            let signal = Signal::TrivialDataChanged {
+                trivial: *self.trivial(),
+            };
+            self.as_mut().emit_queued(signal);
+            let signal = Signal::OpaqueDataChanged {
+                opaque: QVariant::from_ref(self.opaque()),
+            };
+            self.as_mut().emit_queued(signal);
         }
     }
     // ANCHOR_END: book_rust_obj_impl

--- a/examples/qml_features/src/types.rs
+++ b/examples/qml_features/src/types.rs
@@ -31,13 +31,15 @@ mod ffi {
 
     impl cxx_qt::QObject<Types> {
         #[qinvokable]
-        pub fn test_variant_property(&self, cpp: &mut CppObj) {
-            match cpp.variant().value() {
+        pub fn test_variant_property(mut self: Pin<&mut Self>) {
+            match self.variant().value() {
                 QVariantValue::Bool(b) => {
-                    cpp.set_variant(QVariant::from(!b).as_ref().unwrap());
+                    self.as_mut()
+                        .set_variant(QVariant::from(!b).as_ref().unwrap());
                 }
                 QVariantValue::I32(i) => {
-                    cpp.set_variant(QVariant::from(i * 2).as_ref().unwrap());
+                    self.as_mut()
+                        .set_variant(QVariant::from(i * 2).as_ref().unwrap());
                 }
                 _ => panic!("Incorrect variant type!"),
             }

--- a/examples/qml_minimal/src/lib.rs
+++ b/examples/qml_minimal/src/lib.rs
@@ -42,8 +42,9 @@ mod ffi {
     // ANCHOR: book_rustobj_impl
     impl cxx_qt::QObject<MyObject> {
         #[qinvokable]
-        pub fn increment_number(&self, cpp: &mut CppObj) {
-            cpp.set_number(cpp.number() + 1);
+        pub fn increment_number(self: Pin<&mut Self>) {
+            let previous = self.as_ref().number();
+            self.set_number(previous + 1);
         }
 
         #[qinvokable]

--- a/tests/basic_cxx_qt/src/data.rs
+++ b/tests/basic_cxx_qt/src/data.rs
@@ -60,18 +60,18 @@ mod ffi {
 
     impl cxx_qt::QObject<MyData> {
         #[qinvokable]
-        pub fn as_json_str(&self, cpp: &mut CppObj) -> UniquePtr<QString> {
-            let data = Data::from(cpp);
+        pub fn as_json_str(&self) -> UniquePtr<QString> {
+            let data = Data::from(self);
             let data_serde = DataSerde::from(data);
             let data_string = serde_json::to_string(&data_serde).unwrap();
             QString::from_str(&data_string)
         }
 
         #[qinvokable]
-        pub fn grab_values(&self, cpp: &mut CppObj) {
+        pub fn grab_values(self: Pin<&mut Self>) {
             let string = r#"{"number": 2, "string": "Goodbye!"}"#;
             let data_serde: DataSerde = serde_json::from_str(string).unwrap();
-            cpp.grab_values_from_data(data_serde.into());
+            self.grab_values_from_data(data_serde.into());
         }
     }
 }


### PR DESCRIPTION
This will move all invokables onto MyObjectQt and remove the need for
the CppObj.