### PR TITLE
cxx-qt-gen: parse any #[property] attributes on struct fields

### DIFF
--- a/cxx-qt-gen/src/parser/mod.rs
+++ b/cxx-qt-gen/src/parser/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod cxxqtdata;
 pub mod parameter;
+pub mod property;
 pub mod qobject;
 pub mod signals;
 
@@ -87,6 +88,12 @@ mod tests {
     use crate::tests::tokens_to_syn;
     use quote::quote;
     use syn::ItemMod;
+    use syn::Type;
+
+    /// Helper which returns a f64 as a [syn::Type]
+    pub fn f64_type() -> Type {
+        tokens_to_syn(quote! { f64 })
+    }
 
     #[test]
     fn test_parser_from_empty_module() {

--- a/cxx-qt-gen/src/parser/property.rs
+++ b/cxx-qt-gen/src/parser/property.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use syn::{Ident, Type, Visibility};
+
+/// Describes a single Q_PROPERTY for a struct
+pub struct ParsedQProperty {
+    /// The [syn::Ident] of the property
+    pub ident: Ident,
+    /// The [syn::Type] of the property
+    pub ty: Type,
+    /// The [syn::Visiblity] of the property
+    pub vis: Visibility,
+    // TODO: later this will describe if the property has an attribute
+    // stating that the a conversion in C++ needs to occur (eg UniquePtr<T> to T)..
+}

--- a/cxx-qt-gen/src/parser/signals.rs
+++ b/cxx-qt-gen/src/parser/signals.rs
@@ -70,15 +70,10 @@ impl ParsedSignalsEnum {
 mod tests {
     use super::*;
 
+    use crate::parser::tests::f64_type;
     use crate::syntax::path::path_compare_str;
     use crate::tests::tokens_to_syn;
     use quote::quote;
-    use syn::Type;
-
-    /// Helper which returns a f64 as a [syn::Type]
-    fn f64_type() -> Type {
-        tokens_to_syn(quote! { f64 })
-    }
 
     #[test]
     fn test_parsed_signals_from_empty() {


### PR DESCRIPTION
Later when Data and RustObj structs are merged, properties will
be defined on the RustObj struct. This adds support for finding
these properties in the parser phase.