### PR TITLE
cxx-qt-gen: remove CppObj type alias from C++ side

### DIFF
--- a/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/cxx-qt-gen/src/writer/cpp/header.rs
@@ -71,14 +71,12 @@ pub fn write_cpp_header(generated: &GeneratedCppBlocks) -> String {
           {members}
         }};
 
-        typedef {ident} CppObj;
-
-        std::unique_ptr<CppObj>
+        std::unique_ptr<{ident}>
         newCppObject();
 
         }} // namespace {namespace}
 
-        Q_DECLARE_METATYPE({namespace}::CppObj*)
+        Q_DECLARE_METATYPE({namespace}::{ident}*)
     "#,
     cxx_stem = generated.cxx_stem,
     ident = generated.ident,

--- a/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -178,14 +178,12 @@ mod tests {
           bool m_toggle;
         };
 
-        typedef MyObject CppObj;
-
-        std::unique_ptr<CppObj>
+        std::unique_ptr<MyObject>
         newCppObject();
 
         } // namespace cxx_qt::my_object
 
-        Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)
+        Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)
         "#}
     }
 
@@ -262,10 +260,10 @@ mod tests {
           }
         }
 
-        std::unique_ptr<CppObj>
+        std::unique_ptr<MyObject>
         newCppObject()
         {
-          return std::make_unique<CppObj>();
+          return std::make_unique<MyObject>();
         }
 
         } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/src/writer/cpp/source.rs
+++ b/cxx-qt-gen/src/writer/cpp/source.rs
@@ -42,10 +42,10 @@ pub fn write_cpp_source(generated: &GeneratedCppBlocks) -> String {
 
         {methods}
         {slots}
-        std::unique_ptr<CppObj>
+        std::unique_ptr<{ident}>
         newCppObject()
         {{
-          return std::make_unique<CppObj>();
+          return std::make_unique<{ident}>();
         }}
 
         }} // namespace {namespace}

--- a/cxx-qt-gen/test_outputs/handlers.cpp
+++ b/cxx-qt-gen/test_outputs/handlers.cpp
@@ -84,10 +84,10 @@ MyObject::updateState()
   m_rustObj->handleUpdateRequest(*this);
 }
 
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject()
 {
-  return std::make_unique<CppObj>();
+  return std::make_unique<MyObject>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/handlers.h
+++ b/cxx-qt-gen/test_outputs/handlers.h
@@ -46,11 +46,9 @@ private:
   QString m_string;
 };
 
-typedef MyObject CppObj;
-
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject();
 
 } // namespace cxx_qt::my_object
 
-Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)
+Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/cxx-qt-gen/test_outputs/invokables.cpp
@@ -92,10 +92,10 @@ MyObject::invokableReturnStatic()
     m_rustObj->invokableReturnStaticWrapper());
 }
 
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject()
 {
-  return std::make_unique<CppObj>();
+  return std::make_unique<MyObject>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/invokables.h
+++ b/cxx-qt-gen/test_outputs/invokables.h
@@ -40,11 +40,9 @@ private:
   bool m_initialised = false;
 };
 
-typedef MyObject CppObj;
-
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject();
 
 } // namespace cxx_qt::my_object
 
-Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)
+Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/naming.cpp
+++ b/cxx-qt-gen/test_outputs/naming.cpp
@@ -54,10 +54,10 @@ MyObject::invokableName()
   m_rustObj->invokableName();
 }
 
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject()
 {
-  return std::make_unique<CppObj>();
+  return std::make_unique<MyObject>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/naming.h
+++ b/cxx-qt-gen/test_outputs/naming.h
@@ -41,11 +41,9 @@ private:
   qint32 m_propertyName;
 };
 
-typedef MyObject CppObj;
-
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject();
 
 } // namespace cxx_qt::my_object
 
-Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)
+Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/properties.cpp
+++ b/cxx-qt-gen/test_outputs/properties.cpp
@@ -70,10 +70,10 @@ MyObject::setOpaque(const QColor& value)
   }
 }
 
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject()
 {
-  return std::make_unique<CppObj>();
+  return std::make_unique<MyObject>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/properties.h
+++ b/cxx-qt-gen/test_outputs/properties.h
@@ -45,11 +45,9 @@ private:
   QColor m_opaque;
 };
 
-typedef MyObject CppObj;
-
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject();
 
 } // namespace cxx_qt::my_object
 
-Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)
+Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/signals.cpp
+++ b/cxx-qt-gen/test_outputs/signals.cpp
@@ -60,10 +60,10 @@ MyObject::emitDataChanged(qint32 first,
   Q_ASSERT(signalSuccess);
 }
 
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject()
 {
-  return std::make_unique<CppObj>();
+  return std::make_unique<MyObject>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/signals.h
+++ b/cxx-qt-gen/test_outputs/signals.h
@@ -38,11 +38,9 @@ private:
   bool m_initialised = false;
 };
 
-typedef MyObject CppObj;
-
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject();
 
 } // namespace cxx_qt::my_object
 
-Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)
+Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/types_primitive_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.cpp
@@ -231,10 +231,10 @@ MyObject::setUint32(quint32 value)
   }
 }
 
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject()
 {
-  return std::make_unique<CppObj>();
+  return std::make_unique<MyObject>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/types_primitive_property.h
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.h
@@ -82,11 +82,9 @@ private:
   quint32 m_uint32;
 };
 
-typedef MyObject CppObj;
-
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject();
 
 } // namespace cxx_qt::my_object
 
-Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)
+Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
@@ -129,10 +129,10 @@ MyObject::testVariant(const QVariant& variant)
     m_rustObj->testVariantWrapper(*this, variant));
 }
 
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject()
 {
-  return std::make_unique<CppObj>();
+  return std::make_unique<MyObject>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.h
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.h
@@ -42,11 +42,9 @@ private:
   bool m_initialised = false;
 };
 
-typedef MyObject CppObj;
-
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject();
 
 } // namespace cxx_qt::my_object
 
-Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)
+Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/types_qt_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_property.cpp
@@ -323,10 +323,10 @@ MyObject::setVariant(const QVariant& value)
   }
 }
 
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject()
 {
-  return std::make_unique<CppObj>();
+  return std::make_unique<MyObject>();
 }
 
 } // namespace cxx_qt::my_object

--- a/cxx-qt-gen/test_outputs/types_qt_property.h
+++ b/cxx-qt-gen/test_outputs/types_qt_property.h
@@ -101,11 +101,9 @@ private:
   QVariant m_variant;
 };
 
-typedef MyObject CppObj;
-
-std::unique_ptr<CppObj>
+std::unique_ptr<MyObject>
 newCppObject();
 
 } // namespace cxx_qt::my_object
 
-Q_DECLARE_METATYPE(cxx_qt::my_object::CppObj*)
+Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)


### PR DESCRIPTION
Requires #204