### PR TITLE
cxx-qt-gen: fix rust getters in C++ to use camelcase

### DIFF
--- a/cxx-qt-gen/src/gen_rs.rs
+++ b/cxx-qt-gen/src/gen_rs.rs
@@ -402,7 +402,7 @@ pub fn generate_qobject_cxx(obj: &QObject) -> Result<ItemMod, TokenStream> {
 
                 #(#cpp_functions)*
 
-                #[cxx_name = "unsafe_rust"]
+                #[cxx_name = "unsafeRust"]
                 fn rust(self: &#rust_class_name_cpp) -> &#rust_class_name;
                 #[rust_name = "new_cpp_object"]
                 fn newCppObject() -> UniquePtr<#rust_class_name_cpp>;
@@ -411,7 +411,7 @@ pub fn generate_qobject_cxx(obj: &QObject) -> Result<ItemMod, TokenStream> {
             }
 
             extern "C++" {
-                #[cxx_name = "unsafe_rust_mut"]
+                #[cxx_name = "unsafeRustMut"]
                 unsafe fn rust_mut(self: Pin<&mut #rust_class_name_cpp>) -> Pin<&mut #rust_class_name>;
             }
 

--- a/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/cxx-qt-gen/src/writer/cpp/header.rs
@@ -57,8 +57,8 @@ pub fn write_cpp_header(generated: &GeneratedCppBlocks) -> String {
         public:
           explicit {ident}(QObject* parent = nullptr);
           ~{ident}();
-          const {rust_ident}& unsafe_rust() const;
-          {rust_ident}& unsafe_rust_mut();
+          const {rust_ident}& unsafeRust() const;
+          {rust_ident}& unsafeRustMut();
 
         {methods}
         {slots}

--- a/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -152,8 +152,8 @@ mod tests {
         public:
           explicit MyObject(QObject* parent = nullptr);
           ~MyObject();
-          const MyObjectRust& unsafe_rust() const;
-          MyObjectRust& unsafe_rust_mut();
+          const MyObjectRust& unsafeRust() const;
+          MyObjectRust& unsafeRustMut();
 
         public:
           int count() const;
@@ -205,13 +205,13 @@ mod tests {
         MyObject::~MyObject() = default;
 
         const MyObjectRust&
-        MyObject::unsafe_rust() const
+        MyObject::unsafeRust() const
         {
           return *m_rustObj;
         }
 
         MyObjectRust&
-        MyObject::unsafe_rust_mut()
+        MyObject::unsafeRustMut()
         {
           return *m_rustObj;
         }

--- a/cxx-qt-gen/src/writer/cpp/source.rs
+++ b/cxx-qt-gen/src/writer/cpp/source.rs
@@ -29,13 +29,13 @@ pub fn write_cpp_source(generated: &GeneratedCppBlocks) -> String {
         {ident}::~{ident}() = default;
 
         const {rust_ident}&
-        {ident}::unsafe_rust() const
+        {ident}::unsafeRust() const
         {{
           return *m_rustObj;
         }}
 
         {rust_ident}&
-        {ident}::unsafe_rust_mut()
+        {ident}::unsafeRustMut()
         {{
           return *m_rustObj;
         }}

--- a/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/cxx-qt-gen/test_outputs/custom_default.rs
@@ -13,14 +13,14 @@ mod ffi {
         #[rust_name = "set_public"]
         fn setPublic(self: Pin<&mut MyObjectQt>, value: i32);
 
-        #[cxx_name = "unsafe_rust"]
+        #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "C++" {
-        #[cxx_name = "unsafe_rust_mut"]
+        #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
 

--- a/cxx-qt-gen/test_outputs/handlers.cpp
+++ b/cxx-qt-gen/test_outputs/handlers.cpp
@@ -13,13 +13,13 @@ MyObject::MyObject(QObject* parent)
 MyObject::~MyObject() = default;
 
 const MyObjectRust&
-MyObject::unsafe_rust() const
+MyObject::unsafeRust() const
 {
   return *m_rustObj;
 }
 
 MyObjectRust&
-MyObject::unsafe_rust_mut()
+MyObject::unsafeRustMut()
 {
   return *m_rustObj;
 }

--- a/cxx-qt-gen/test_outputs/handlers.h
+++ b/cxx-qt-gen/test_outputs/handlers.h
@@ -20,8 +20,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
-  const MyObjectRust& unsafe_rust() const;
-  MyObjectRust& unsafe_rust_mut();
+  const MyObjectRust& unsafeRust() const;
+  MyObjectRust& unsafeRustMut();
 
 public:
   qint32 getNumber() const;

--- a/cxx-qt-gen/test_outputs/handlers.rs
+++ b/cxx-qt-gen/test_outputs/handlers.rs
@@ -22,7 +22,7 @@ mod ffi {
         #[rust_name = "set_string"]
         fn setString(self: Pin<&mut MyObjectQt>, value: &QString);
 
-        #[cxx_name = "unsafe_rust"]
+        #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
@@ -32,7 +32,7 @@ mod ffi {
     }
 
     extern "C++" {
-        #[cxx_name = "unsafe_rust_mut"]
+        #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
 

--- a/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/cxx-qt-gen/test_outputs/invokables.cpp
@@ -13,13 +13,13 @@ MyObject::MyObject(QObject* parent)
 MyObject::~MyObject() = default;
 
 const MyObjectRust&
-MyObject::unsafe_rust() const
+MyObject::unsafeRust() const
 {
   return *m_rustObj;
 }
 
 MyObjectRust&
-MyObject::unsafe_rust_mut()
+MyObject::unsafeRustMut()
 {
   return *m_rustObj;
 }

--- a/cxx-qt-gen/test_outputs/invokables.h
+++ b/cxx-qt-gen/test_outputs/invokables.h
@@ -18,8 +18,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
-  const MyObjectRust& unsafe_rust() const;
-  MyObjectRust& unsafe_rust_mut();
+  const MyObjectRust& unsafeRust() const;
+  MyObjectRust& unsafeRustMut();
 
 public:
   Q_INVOKABLE void invokable();

--- a/cxx-qt-gen/test_outputs/invokables.rs
+++ b/cxx-qt-gen/test_outputs/invokables.rs
@@ -8,14 +8,14 @@ mod ffi {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        #[cxx_name = "unsafe_rust"]
+        #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "C++" {
-        #[cxx_name = "unsafe_rust_mut"]
+        #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
 

--- a/cxx-qt-gen/test_outputs/naming.cpp
+++ b/cxx-qt-gen/test_outputs/naming.cpp
@@ -13,13 +13,13 @@ MyObject::MyObject(QObject* parent)
 MyObject::~MyObject() = default;
 
 const MyObjectRust&
-MyObject::unsafe_rust() const
+MyObject::unsafeRust() const
 {
   return *m_rustObj;
 }
 
 MyObjectRust&
-MyObject::unsafe_rust_mut()
+MyObject::unsafeRustMut()
 {
   return *m_rustObj;
 }

--- a/cxx-qt-gen/test_outputs/naming.h
+++ b/cxx-qt-gen/test_outputs/naming.h
@@ -20,8 +20,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
-  const MyObjectRust& unsafe_rust() const;
-  MyObjectRust& unsafe_rust_mut();
+  const MyObjectRust& unsafeRust() const;
+  MyObjectRust& unsafeRustMut();
 
 public:
   qint32 getPropertyName() const;

--- a/cxx-qt-gen/test_outputs/naming.rs
+++ b/cxx-qt-gen/test_outputs/naming.rs
@@ -13,14 +13,14 @@ mod ffi {
         #[rust_name = "set_property_name"]
         fn setPropertyName(self: Pin<&mut MyObjectQt>, value: i32);
 
-        #[cxx_name = "unsafe_rust"]
+        #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "C++" {
-        #[cxx_name = "unsafe_rust_mut"]
+        #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
 

--- a/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/cxx-qt-gen/test_outputs/passthrough.rs
@@ -15,14 +15,14 @@ pub mod ffi {
         #[rust_name = "set_number"]
         fn setNumber(self: Pin<&mut MyObjectQt>, value: i32);
 
-        #[cxx_name = "unsafe_rust"]
+        #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "C++" {
-        #[cxx_name = "unsafe_rust_mut"]
+        #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
 

--- a/cxx-qt-gen/test_outputs/properties.cpp
+++ b/cxx-qt-gen/test_outputs/properties.cpp
@@ -13,13 +13,13 @@ MyObject::MyObject(QObject* parent)
 MyObject::~MyObject() = default;
 
 const MyObjectRust&
-MyObject::unsafe_rust() const
+MyObject::unsafeRust() const
 {
   return *m_rustObj;
 }
 
 MyObjectRust&
-MyObject::unsafe_rust_mut()
+MyObject::unsafeRustMut()
 {
   return *m_rustObj;
 }

--- a/cxx-qt-gen/test_outputs/properties.h
+++ b/cxx-qt-gen/test_outputs/properties.h
@@ -21,8 +21,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
-  const MyObjectRust& unsafe_rust() const;
-  MyObjectRust& unsafe_rust_mut();
+  const MyObjectRust& unsafeRust() const;
+  MyObjectRust& unsafeRustMut();
 
 public:
   qint32 getPrimitive() const;

--- a/cxx-qt-gen/test_outputs/properties.rs
+++ b/cxx-qt-gen/test_outputs/properties.rs
@@ -18,14 +18,14 @@ mod ffi {
         #[rust_name = "set_opaque"]
         fn setOpaque(self: Pin<&mut MyObjectQt>, value: &QColor);
 
-        #[cxx_name = "unsafe_rust"]
+        #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "C++" {
-        #[cxx_name = "unsafe_rust_mut"]
+        #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
 

--- a/cxx-qt-gen/test_outputs/signals.cpp
+++ b/cxx-qt-gen/test_outputs/signals.cpp
@@ -13,13 +13,13 @@ MyObject::MyObject(QObject* parent)
 MyObject::~MyObject() = default;
 
 const MyObjectRust&
-MyObject::unsafe_rust() const
+MyObject::unsafeRust() const
 {
   return *m_rustObj;
 }
 
 MyObjectRust&
-MyObject::unsafe_rust_mut()
+MyObject::unsafeRustMut()
 {
   return *m_rustObj;
 }

--- a/cxx-qt-gen/test_outputs/signals.h
+++ b/cxx-qt-gen/test_outputs/signals.h
@@ -18,8 +18,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
-  const MyObjectRust& unsafe_rust() const;
-  MyObjectRust& unsafe_rust_mut();
+  const MyObjectRust& unsafeRust() const;
+  MyObjectRust& unsafeRustMut();
 
 public:
   Q_INVOKABLE void invokable();

--- a/cxx-qt-gen/test_outputs/signals.rs
+++ b/cxx-qt-gen/test_outputs/signals.rs
@@ -23,14 +23,14 @@ mod ffi {
             third: QPoint,
         );
 
-        #[cxx_name = "unsafe_rust"]
+        #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "C++" {
-        #[cxx_name = "unsafe_rust_mut"]
+        #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
 

--- a/cxx-qt-gen/test_outputs/types_primitive_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.cpp
@@ -13,13 +13,13 @@ MyObject::MyObject(QObject* parent)
 MyObject::~MyObject() = default;
 
 const MyObjectRust&
-MyObject::unsafe_rust() const
+MyObject::unsafeRust() const
 {
   return *m_rustObj;
 }
 
 MyObjectRust&
-MyObject::unsafe_rust_mut()
+MyObject::unsafeRustMut()
 {
   return *m_rustObj;
 }

--- a/cxx-qt-gen/test_outputs/types_primitive_property.h
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.h
@@ -30,8 +30,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
-  const MyObjectRust& unsafe_rust() const;
-  MyObjectRust& unsafe_rust_mut();
+  const MyObjectRust& unsafeRust() const;
+  MyObjectRust& unsafeRustMut();
 
 public:
   bool getBoolean() const;

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -53,14 +53,14 @@ mod ffi {
         #[rust_name = "set_uint_32"]
         fn setUint32(self: Pin<&mut MyObjectQt>, value: u32);
 
-        #[cxx_name = "unsafe_rust"]
+        #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "C++" {
-        #[cxx_name = "unsafe_rust_mut"]
+        #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
 

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
@@ -13,13 +13,13 @@ MyObject::MyObject(QObject* parent)
 MyObject::~MyObject() = default;
 
 const MyObjectRust&
-MyObject::unsafe_rust() const
+MyObject::unsafeRust() const
 {
   return *m_rustObj;
 }
 
 MyObjectRust&
-MyObject::unsafe_rust_mut()
+MyObject::unsafeRustMut()
 {
   return *m_rustObj;
 }

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.h
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.h
@@ -18,8 +18,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
-  const MyObjectRust& unsafe_rust() const;
-  MyObjectRust& unsafe_rust_mut();
+  const MyObjectRust& unsafeRust() const;
+  MyObjectRust& unsafeRustMut();
 
 public:
   Q_INVOKABLE QColor testColor(const QColor& color);

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -8,14 +8,14 @@ mod ffi {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        #[cxx_name = "unsafe_rust"]
+        #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "C++" {
-        #[cxx_name = "unsafe_rust_mut"]
+        #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
 

--- a/cxx-qt-gen/test_outputs/types_qt_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_property.cpp
@@ -13,13 +13,13 @@ MyObject::MyObject(QObject* parent)
 MyObject::~MyObject() = default;
 
 const MyObjectRust&
-MyObject::unsafe_rust() const
+MyObject::unsafeRust() const
 {
   return *m_rustObj;
 }
 
 MyObjectRust&
-MyObject::unsafe_rust_mut()
+MyObject::unsafeRustMut()
 {
   return *m_rustObj;
 }

--- a/cxx-qt-gen/test_outputs/types_qt_property.h
+++ b/cxx-qt-gen/test_outputs/types_qt_property.h
@@ -33,8 +33,8 @@ class MyObject : public QObject
 public:
   explicit MyObject(QObject* parent = nullptr);
   ~MyObject();
-  const MyObjectRust& unsafe_rust() const;
-  MyObjectRust& unsafe_rust_mut();
+  const MyObjectRust& unsafeRust() const;
+  MyObjectRust& unsafeRustMut();
 
 public:
   const QColor& getColor() const;

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -73,14 +73,14 @@ mod ffi {
         #[rust_name = "set_variant"]
         fn setVariant(self: Pin<&mut MyObjectQt>, value: &QVariant);
 
-        #[cxx_name = "unsafe_rust"]
+        #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
     extern "C++" {
-        #[cxx_name = "unsafe_rust_mut"]
+        #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
 


### PR DESCRIPTION
Requires #204