### PR TITLE
cxx-qt-gen: use namespace for internal methods and support no namespace

### DIFF
--- a/book/src/getting-started/2-our-first-cxx-qt-module.md
+++ b/book/src/getting-started/2-our-first-cxx-qt-module.md
@@ -29,10 +29,10 @@ Starting with the module definition:
 {{#include ../../../examples/qml_minimal/src/lib.rs:book_bridge_macro}}
 ```
 
-Because we add the `#[cxx_qt::bridge(namespace = "cxx_qt::my_object")]` macro to the module definition,
+Because we add the `#[cxx_qt::bridge]` macro to the module definition,
 CXX-Qt will look inside the module for further macros which can define the QObject.
 
-For the `#[cxx_qt::bridge(namespace = "cxx_qt::my_object")]` macro to work, we first need to define the data that will live in the new C++ object.
+For the `#[cxx_qt::bridge]` macro to work, we first need to define the data that will live in the new C++ object.
 This is done with the `Data` struct:
 ```rust,ignore
 {{#include ../../../examples/qml_minimal/src/lib.rs:book_data_struct}}

--- a/book/src/getting-started/3-exposing-to-qml.md
+++ b/book/src/getting-started/3-exposing-to-qml.md
@@ -32,8 +32,6 @@ They will always be in the `cxx-qt-gen/include/` include path and use the snake_
 
 The second code snippet then exports the class to QML.
 This works the same as it would for any other QObject subclass, as that is exactly what `MyObject` is, as far as Qt is concerned.
-The only thing to note here is that the class is generated in the `cxx_qt::my_object` namespace.
-Where `my_object` is the name of the Rust module we defined earlier.
 
 As we later want to include our QML GUI in a `main.qml` file inside the [Qt resource system](https://doc.qt.io/qt-5/resources.html), we'll have to add a `qml.qrc` file in the `src` folder as well:
 ```qrc,ignore

--- a/book/src/qobject/macro.md
+++ b/book/src/qobject/macro.md
@@ -9,9 +9,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 We define a module (which becomes our Qt object name) and then add `cxx_qt::bridge(namespace = "cxx_qt::my_object)` as a macro.
 
-The namespace specified is used in C++ to allow segmenting generated code from your application.
-
-Note that currently each QObject needs to be in its own namespace otherwise there will be collisions from generated free functions.
+The namespace is optional and can be used allow segmenting generated C++ code from your application.
 
 The example below would export the struct marked with `#[cxx_qt::qobject]` as `DataStructProperties` to Qt / QML.
 
@@ -19,6 +17,18 @@ Note that the object name needs to be unique to avoid clashes, in the future ful
 
 ```rust,ignore,noplayground
 {{#include ../../../examples/qml_features/src/data_struct_properties.rs:book_macro_code}}
+```
+
+The threaded logic example shows how you can use a namespace to segment the generated C++ code.
+
+```rust,ignore,noplayground
+{{#include ../../../examples/qml_with_threaded_logic/src/lib.rs:book_namespace_macro}}
+```
+
+Then when registering the type you use the type with your namespace as usual.
+
+```rust,ignore,noplayground
+{{#include ../../../examples/qml_with_threaded_logic/src/lib.rs:book_namespace_register}}
 ```
 
 Note: this might change in the future to allow for defining the base class or options when exporting to QML and could become namespaced to `#[cxx_qt::qobject(base = "QAbstractListModel")]` ( [https://github.com/KDAB/cxx-qt/issues/22](https://github.com/KDAB/cxx-qt/issues/22) ).

--- a/cxx-qt-gen/src/gen_cpp.rs
+++ b/cxx-qt-gen/src/gen_cpp.rs
@@ -837,12 +837,25 @@ pub fn generate_qobject_cpp(obj: &QObject) -> Result<CppObject, TokenStream> {
         });
     }
 
+    // Create the namespace for internal use
+    //
+    // TODO: when we move to generator share this with gen_rs
+    let mut namespace_internals = vec![];
+    if !obj.namespace.is_empty() {
+        namespace_internals.push(obj.namespace.to_owned());
+    }
+    namespace_internals.push(format!(
+        "cxx_qt_{}",
+        obj.ident.to_string().to_case(Case::Snake)
+    ));
+
     // For now convert our gen_cpp code into the GeneratedCppBlocks struct
     let generated = GeneratedCppBlocks {
         cxx_stem: struct_ident_str.to_case(Case::Snake),
         ident: struct_ident_str,
         rust_ident: rust_struct_ident,
         namespace: obj.namespace.clone(),
+        namespace_internals: namespace_internals.join("::"),
         metaobjects,
         methods,
         slots,

--- a/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -17,6 +17,8 @@ pub struct GeneratedCppBlocks {
     pub rust_ident: String,
     /// Ident of the namespace of the QObject
     pub namespace: String,
+    /// Ident of the namespace for CXX-Qt internals of the QObject
+    pub namespace_internals: String,
     /// List of Qt Meta Object items (eg Q_PROPERTY)
     pub metaobjects: Vec<String>,
     /// List of public methods for the QObject

--- a/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/cxx-qt-gen/src/writer/cpp/header.rs
@@ -71,16 +71,19 @@ pub fn write_cpp_header(generated: &GeneratedCppBlocks) -> String {
           {members}
         }};
 
+        }} // namespace {namespace}
+
+        namespace {namespace_internals} {{
         std::unique_ptr<{ident}>
         newCppObject();
-
-        }} // namespace {namespace}
+        }} // namespace {namespace_internals}
 
         Q_DECLARE_METATYPE({namespace}::{ident}*)
     "#,
     cxx_stem = generated.cxx_stem,
     ident = generated.ident,
     namespace = generated.namespace,
+    namespace_internals = generated.namespace_internals,
     rust_ident = generated.rust_ident,
     metaobjects = generated.metaobjects.join("\n  "),
     methods = create_block("public", &generated.methods.iter().map(pair_as_header).collect::<Vec<&str>>()),

--- a/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/cxx-qt-gen/src/writer/cpp/header.rs
@@ -41,13 +41,13 @@ pub fn write_cpp_header(generated: &GeneratedCppBlocks) -> String {
         #include <memory>
         #include <mutex>
 
-        namespace {namespace} {{
+        {namespace_start}
         class {ident};
-        }} // namespace {namespace}
+        {namespace_end}
 
         #include "cxx-qt-gen/include/{cxx_stem}.cxx.h"
 
-        namespace {namespace} {{
+        {namespace_start}
 
         class {ident} : public QObject
         {{
@@ -71,18 +71,27 @@ pub fn write_cpp_header(generated: &GeneratedCppBlocks) -> String {
           {members}
         }};
 
-        }} // namespace {namespace}
+        {namespace_end}
 
         namespace {namespace_internals} {{
         std::unique_ptr<{ident}>
         newCppObject();
         }} // namespace {namespace_internals}
 
-        Q_DECLARE_METATYPE({namespace}::{ident}*)
+        Q_DECLARE_METATYPE({metatype}*)
     "#,
     cxx_stem = generated.cxx_stem,
     ident = generated.ident,
-    namespace = generated.namespace,
+    namespace_start = if generated.namespace.is_empty() {
+        "".to_owned()
+    } else {
+        format!("namespace {namespace} {{", namespace = generated.namespace)
+    },
+    namespace_end = if generated.namespace.is_empty() {
+        "".to_owned()
+    } else {
+        format!("}} // namespace {namespace}", namespace = generated.namespace)
+    },
     namespace_internals = generated.namespace_internals,
     rust_ident = generated.rust_ident,
     metaobjects = generated.metaobjects.join("\n  "),
@@ -90,6 +99,11 @@ pub fn write_cpp_header(generated: &GeneratedCppBlocks) -> String {
     slots = create_block("public Q_SLOTS", &generated.slots.iter().map(pair_as_header).collect::<Vec<&str>>()),
     signals = create_block("Q_SIGNALS", &generated.signals.iter().map(AsRef::as_ref).collect::<Vec<&str>>()),
     members = generated.members.join("\n  "),
+    metatype = if generated.namespace.is_empty() {
+        generated.ident.clone()
+    } else {
+        format!("{namespace}::{ident}", namespace = generated.namespace, ident = generated.ident)
+    },
     }
 }
 
@@ -97,7 +111,10 @@ pub fn write_cpp_header(generated: &GeneratedCppBlocks) -> String {
 mod tests {
     use super::*;
 
-    use crate::writer::cpp::tests::{create_generated_cpp, expected_header};
+    use crate::writer::cpp::tests::{
+        create_generated_cpp, create_generated_cpp_no_namespace, expected_header,
+        expected_header_no_namespace,
+    };
     use indoc::indoc;
     use pretty_assertions::assert_str_eq;
 
@@ -128,5 +145,12 @@ mod tests {
         let generated = create_generated_cpp();
         let output = write_cpp_header(&generated);
         assert_str_eq!(output, expected_header());
+    }
+
+    #[test]
+    fn test_write_cpp_header_no_namespace() {
+        let generated = create_generated_cpp_no_namespace();
+        let output = write_cpp_header(&generated);
+        assert_str_eq!(output, expected_header_no_namespace());
     }
 }

--- a/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -36,6 +36,7 @@ mod tests {
             ident: "MyObject".to_owned(),
             rust_ident: "MyObjectRust".to_owned(),
             namespace: "cxx_qt::my_object".to_owned(),
+            namespace_internals: "cxx_qt::my_object::cxx_qt_my_object".to_owned(),
             metaobjects: vec![
                 "Q_PROPERTY(int count READ count WRITE setCount NOTIFY countChanged)".to_owned(),
                 "Q_PROPERTY(bool longPropertyNameThatWrapsInClangFormat READ getToggle WRITE setToggle NOTIFY toggleChanged)"
@@ -178,10 +179,12 @@ mod tests {
           bool m_toggle;
         };
 
+        } // namespace cxx_qt::my_object
+
+        namespace cxx_qt::my_object::cxx_qt_my_object {
         std::unique_ptr<MyObject>
         newCppObject();
-
-        } // namespace cxx_qt::my_object
+        } // namespace cxx_qt::my_object::cxx_qt_my_object
 
         Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)
         "#}
@@ -196,9 +199,9 @@ mod tests {
 
         MyObject::MyObject(QObject* parent)
           : QObject(parent)
-          , m_rustObj(createRs())
+          , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
         {
-          initialiseCpp(*this);
+          cxx_qt::my_object::cxx_qt_my_object::initialiseCpp(*this);
           m_initialised = true;
         }
 
@@ -260,13 +263,15 @@ mod tests {
           }
         }
 
+        } // namespace cxx_qt::my_object
+
+        namespace cxx_qt::my_object::cxx_qt_my_object {
         std::unique_ptr<MyObject>
         newCppObject()
         {
           return std::make_unique<MyObject>();
         }
-
-        } // namespace cxx_qt::my_object
+        } // namespace cxx_qt::my_object::cxx_qt_my_object
         "#}
     }
 

--- a/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -128,6 +128,14 @@ mod tests {
         }
     }
 
+    /// Helper to create a GeneratedCppBlocks with no namespace for testing
+    pub fn create_generated_cpp_no_namespace() -> GeneratedCppBlocks {
+        let mut generated = create_generated_cpp();
+        generated.namespace = "".to_owned();
+        generated.namespace_internals = "cxx_qt_my_object".to_owned();
+        generated
+    }
+
     /// Helper for the expected header
     pub fn expected_header() -> &'static str {
         indoc! {r#"
@@ -187,6 +195,68 @@ mod tests {
         } // namespace cxx_qt::my_object::cxx_qt_my_object
 
         Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)
+        "#}
+    }
+
+    /// Helper for the expected header with no namespace
+    pub fn expected_header_no_namespace() -> &'static str {
+        indoc! {r#"
+        #pragma once
+
+        #include <memory>
+        #include <mutex>
+
+
+        class MyObject;
+
+
+        #include "cxx-qt-gen/include/cxx_stem.cxx.h"
+
+
+
+        class MyObject : public QObject
+        {
+          Q_OBJECT
+          Q_PROPERTY(int count READ count WRITE setCount NOTIFY countChanged)
+          Q_PROPERTY(bool longPropertyNameThatWrapsInClangFormat READ getToggle WRITE setToggle NOTIFY toggleChanged)
+
+        public:
+          explicit MyObject(QObject* parent = nullptr);
+          ~MyObject();
+          const MyObjectRust& unsafeRust() const;
+          MyObjectRust& unsafeRustMut();
+
+        public:
+          int count() const;
+          bool toggle() const;
+          Q_INVOKABLE void invokable();
+          void cppMethod();
+
+        public Q_SLOTS:
+          void setCount(int count);
+          void setToggle(bool toggle);
+
+        Q_SIGNALS:
+          void countChanged();
+          void toggleChanged();
+
+        private:
+          rust::Box<MyObjectRust> m_rustObj;
+          std::mutex m_rustObjMutex;
+          bool m_initialised = false;
+
+          int m_count;
+          bool m_toggle;
+        };
+
+
+
+        namespace cxx_qt_my_object {
+        std::unique_ptr<MyObject>
+        newCppObject();
+        } // namespace cxx_qt_my_object
+
+        Q_DECLARE_METATYPE(MyObject*)
         "#}
     }
 
@@ -275,11 +345,110 @@ mod tests {
         "#}
     }
 
+    /// Helper for the expected header with no namespace
+    pub fn expected_source_no_namespace() -> &'static str {
+        indoc! {r#"
+        #include "cxx-qt-gen/include/cxx_stem.cxxqt.h"
+
+
+
+        MyObject::MyObject(QObject* parent)
+          : QObject(parent)
+          , m_rustObj(cxx_qt_my_object::createRs())
+        {
+          cxx_qt_my_object::initialiseCpp(*this);
+          m_initialised = true;
+        }
+
+        MyObject::~MyObject() = default;
+
+        const MyObjectRust&
+        MyObject::unsafeRust() const
+        {
+          return *m_rustObj;
+        }
+
+        MyObjectRust&
+        MyObject::unsafeRustMut()
+        {
+          return *m_rustObj;
+        }
+
+        int
+        MyObject::count() const
+        {
+          return m_count;
+        }
+
+        bool
+        MyObject::toggle() const
+        {
+          return m_count;
+        }
+
+        void
+        MyObject::invokable()
+        {
+          // invokable method
+        }
+
+        void
+        MyObject::cppMethod()
+        {
+          // cpp method
+        }
+
+        void
+        MyObject::setCount(int count) const
+        {
+          if (m_count != count) {
+            m_count = count;
+
+            Q_EMIT countChanged();
+          }
+        }
+
+        void
+        MyObject::setToggle(bool toggle) const
+        {
+          if (m_toggle != toggle) {
+            m_toggle = toggle;
+
+            Q_EMIT toggleChanged();
+          }
+        }
+
+
+
+        namespace cxx_qt_my_object {
+        std::unique_ptr<MyObject>
+        newCppObject()
+        {
+          return std::make_unique<MyObject>();
+        }
+        } // namespace cxx_qt_my_object
+        "#}
+    }
+
     #[test]
     fn test_write_cpp() {
         let generated = create_generated_cpp();
         let result = write_cpp(&generated);
         assert_str_eq!(result.header, clang_format(expected_header()).unwrap());
         assert_str_eq!(result.source, clang_format(expected_source()).unwrap());
+    }
+
+    #[test]
+    fn test_write_cpp_no_namespace() {
+        let generated = create_generated_cpp_no_namespace();
+        let result = write_cpp(&generated);
+        assert_str_eq!(
+            result.header,
+            clang_format(expected_header_no_namespace()).unwrap()
+        );
+        assert_str_eq!(
+            result.source,
+            clang_format(expected_source_no_namespace()).unwrap()
+        );
     }
 }

--- a/cxx-qt-gen/src/writer/cpp/source.rs
+++ b/cxx-qt-gen/src/writer/cpp/source.rs
@@ -20,9 +20,9 @@ pub fn write_cpp_source(generated: &GeneratedCppBlocks) -> String {
 
         {ident}::{ident}(QObject* parent)
           : QObject(parent)
-          , m_rustObj(createRs())
+          , m_rustObj({namespace_internals}::createRs())
         {{
-          initialiseCpp(*this);
+          {namespace_internals}::initialiseCpp(*this);
           m_initialised = true;
         }}
 
@@ -42,17 +42,20 @@ pub fn write_cpp_source(generated: &GeneratedCppBlocks) -> String {
 
         {methods}
         {slots}
+        }} // namespace {namespace}
+
+        namespace {namespace_internals} {{
         std::unique_ptr<{ident}>
         newCppObject()
         {{
           return std::make_unique<{ident}>();
         }}
-
-        }} // namespace {namespace}
+        }} // namespace {namespace_internals}
     "#,
     cxx_stem = generated.cxx_stem,
     ident = generated.ident,
     namespace = generated.namespace,
+    namespace_internals = generated.namespace_internals,
     rust_ident = generated.rust_ident,
     methods = generated.methods.iter().map(pair_as_source).collect::<Vec<String>>().join("\n"),
     slots = generated.slots.iter().map(pair_as_source).collect::<Vec<String>>().join("\n"),

--- a/cxx-qt-gen/test_inputs/naming.rs
+++ b/cxx-qt-gen/test_inputs/naming.rs
@@ -1,4 +1,4 @@
-#[cxx_qt::bridge(namespace = "cxx_qt::my_object")]
+#[cxx_qt::bridge]
 mod ffi {
     #[derive(Default)]
     pub struct Data {

--- a/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/cxx-qt-gen/test_outputs/custom_default.rs
@@ -16,6 +16,7 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
@@ -29,9 +30,11 @@ mod ffi {
         type MyObject;
 
         #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }

--- a/cxx-qt-gen/test_outputs/handlers.cpp
+++ b/cxx-qt-gen/test_outputs/handlers.cpp
@@ -4,9 +4,9 @@ namespace cxx_qt::my_object {
 
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(createRs())
+  , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
 {
-  initialiseCpp(*this);
+  cxx_qt::my_object::cxx_qt_my_object::initialiseCpp(*this);
   m_initialised = true;
 }
 
@@ -84,10 +84,12 @@ MyObject::updateState()
   m_rustObj->handleUpdateRequest(*this);
 }
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject()
 {
   return std::make_unique<MyObject>();
 }
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/cxx-qt-gen/test_outputs/handlers.h
+++ b/cxx-qt-gen/test_outputs/handlers.h
@@ -46,9 +46,11 @@ private:
   QString m_string;
 };
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject();
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object
 
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/handlers.rs
+++ b/cxx-qt-gen/test_outputs/handlers.rs
@@ -25,6 +25,7 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
 
         #[rust_name = "update_requester"]
@@ -41,9 +42,11 @@ mod ffi {
         type MyObject;
 
         #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
 
         #[cxx_name = "handleUpdateRequest"]

--- a/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/cxx-qt-gen/test_outputs/invokables.cpp
@@ -4,9 +4,9 @@ namespace cxx_qt::my_object {
 
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(createRs())
+  , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
 {
-  initialiseCpp(*this);
+  cxx_qt::my_object::cxx_qt_my_object::initialiseCpp(*this);
   m_initialised = true;
 }
 
@@ -92,10 +92,12 @@ MyObject::invokableReturnStatic()
     m_rustObj->invokableReturnStaticWrapper());
 }
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject()
 {
   return std::make_unique<MyObject>();
 }
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/cxx-qt-gen/test_outputs/invokables.h
+++ b/cxx-qt-gen/test_outputs/invokables.h
@@ -40,9 +40,11 @@ private:
   bool m_initialised = false;
 };
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject();
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object
 
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/invokables.rs
+++ b/cxx-qt-gen/test_outputs/invokables.rs
@@ -11,6 +11,7 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
@@ -47,9 +48,11 @@ mod ffi {
         fn invokable_return_static_wrapper(self: &mut MyObject) -> UniquePtr<QString>;
 
         #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 

--- a/cxx-qt-gen/test_outputs/naming.cpp
+++ b/cxx-qt-gen/test_outputs/naming.cpp
@@ -4,9 +4,9 @@ namespace cxx_qt::my_object {
 
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(createRs())
+  , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
 {
-  initialiseCpp(*this);
+  cxx_qt::my_object::cxx_qt_my_object::initialiseCpp(*this);
   m_initialised = true;
 }
 
@@ -54,10 +54,12 @@ MyObject::invokableName()
   m_rustObj->invokableName();
 }
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject()
 {
   return std::make_unique<MyObject>();
 }
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/cxx-qt-gen/test_outputs/naming.cpp
+++ b/cxx-qt-gen/test_outputs/naming.cpp
@@ -1,12 +1,10 @@
 #include "cxx-qt-gen/include/my_object.cxxqt.h"
 
-namespace cxx_qt::my_object {
-
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
+  , m_rustObj(cxx_qt_my_object::createRs())
 {
-  cxx_qt::my_object::cxx_qt_my_object::initialiseCpp(*this);
+  cxx_qt_my_object::initialiseCpp(*this);
   m_initialised = true;
 }
 
@@ -54,12 +52,10 @@ MyObject::invokableName()
   m_rustObj->invokableName();
 }
 
-} // namespace cxx_qt::my_object
-
-namespace cxx_qt::my_object::cxx_qt_my_object {
+namespace cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject()
 {
   return std::make_unique<MyObject>();
 }
-} // namespace cxx_qt::my_object::cxx_qt_my_object
+} // namespace cxx_qt_my_object

--- a/cxx-qt-gen/test_outputs/naming.h
+++ b/cxx-qt-gen/test_outputs/naming.h
@@ -3,13 +3,9 @@
 #include <memory>
 #include <mutex>
 
-namespace cxx_qt::my_object {
 class MyObject;
-} // namespace cxx_qt::my_object
 
 #include "cxx-qt-gen/include/my_object.cxx.h"
-
-namespace cxx_qt::my_object {
 
 class MyObject : public QObject
 {
@@ -41,11 +37,9 @@ private:
   qint32 m_propertyName;
 };
 
-} // namespace cxx_qt::my_object
-
-namespace cxx_qt::my_object::cxx_qt_my_object {
+namespace cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject();
-} // namespace cxx_qt::my_object::cxx_qt_my_object
+} // namespace cxx_qt_my_object
 
-Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)
+Q_DECLARE_METATYPE(MyObject*)

--- a/cxx-qt-gen/test_outputs/naming.h
+++ b/cxx-qt-gen/test_outputs/naming.h
@@ -41,9 +41,11 @@ private:
   qint32 m_propertyName;
 };
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject();
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object
 
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/naming.rs
+++ b/cxx-qt-gen/test_outputs/naming.rs
@@ -1,4 +1,4 @@
-#[cxx::bridge(namespace = "cxx_qt::my_object")]
+#[cxx::bridge(namespace = "")]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
@@ -16,7 +16,7 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
-        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        #[namespace = "cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
@@ -33,11 +33,11 @@ mod ffi {
         fn invokable_name(self: &MyObject);
 
         #[cxx_name = "createRs"]
-        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        #[namespace = "cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
-        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        #[namespace = "cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }

--- a/cxx-qt-gen/test_outputs/naming.rs
+++ b/cxx-qt-gen/test_outputs/naming.rs
@@ -16,6 +16,7 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
@@ -32,9 +33,11 @@ mod ffi {
         fn invokable_name(self: &MyObject);
 
         #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }

--- a/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/cxx-qt-gen/test_outputs/passthrough.rs
@@ -18,6 +18,7 @@ pub mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
@@ -31,9 +32,11 @@ pub mod ffi {
         type MyObject;
 
         #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 

--- a/cxx-qt-gen/test_outputs/properties.cpp
+++ b/cxx-qt-gen/test_outputs/properties.cpp
@@ -4,9 +4,9 @@ namespace cxx_qt::my_object {
 
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(createRs())
+  , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
 {
-  initialiseCpp(*this);
+  cxx_qt::my_object::cxx_qt_my_object::initialiseCpp(*this);
   m_initialised = true;
 }
 
@@ -70,10 +70,12 @@ MyObject::setOpaque(const QColor& value)
   }
 }
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject()
 {
   return std::make_unique<MyObject>();
 }
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/cxx-qt-gen/test_outputs/properties.h
+++ b/cxx-qt-gen/test_outputs/properties.h
@@ -45,9 +45,11 @@ private:
   QColor m_opaque;
 };
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject();
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object
 
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/properties.rs
+++ b/cxx-qt-gen/test_outputs/properties.rs
@@ -21,6 +21,7 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
@@ -34,9 +35,11 @@ mod ffi {
         type MyObject;
 
         #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 

--- a/cxx-qt-gen/test_outputs/signals.cpp
+++ b/cxx-qt-gen/test_outputs/signals.cpp
@@ -4,9 +4,9 @@ namespace cxx_qt::my_object {
 
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(createRs())
+  , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
 {
-  initialiseCpp(*this);
+  cxx_qt::my_object::cxx_qt_my_object::initialiseCpp(*this);
   m_initialised = true;
 }
 
@@ -60,10 +60,12 @@ MyObject::emitDataChanged(qint32 first,
   Q_ASSERT(signalSuccess);
 }
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject()
 {
   return std::make_unique<MyObject>();
 }
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/cxx-qt-gen/test_outputs/signals.h
+++ b/cxx-qt-gen/test_outputs/signals.h
@@ -38,9 +38,11 @@ private:
   bool m_initialised = false;
 };
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject();
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object
 
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/signals.rs
+++ b/cxx-qt-gen/test_outputs/signals.rs
@@ -26,6 +26,7 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
@@ -42,9 +43,11 @@ mod ffi {
         fn invokable_wrapper(self: &MyObject, cpp: Pin<&mut MyObjectQt>);
 
         #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 

--- a/cxx-qt-gen/test_outputs/types_primitive_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.cpp
@@ -4,9 +4,9 @@ namespace cxx_qt::my_object {
 
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(createRs())
+  , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
 {
-  initialiseCpp(*this);
+  cxx_qt::my_object::cxx_qt_my_object::initialiseCpp(*this);
   m_initialised = true;
 }
 
@@ -231,10 +231,12 @@ MyObject::setUint32(quint32 value)
   }
 }
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject()
 {
   return std::make_unique<MyObject>();
 }
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/cxx-qt-gen/test_outputs/types_primitive_property.h
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.h
@@ -82,9 +82,11 @@ private:
   quint32 m_uint32;
 };
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject();
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object
 
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -56,6 +56,7 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
@@ -69,9 +70,11 @@ mod ffi {
         type MyObject;
 
         #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 }

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.cpp
@@ -4,9 +4,9 @@ namespace cxx_qt::my_object {
 
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(createRs())
+  , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
 {
-  initialiseCpp(*this);
+  cxx_qt::my_object::cxx_qt_my_object::initialiseCpp(*this);
   m_initialised = true;
 }
 
@@ -129,10 +129,12 @@ MyObject::testVariant(const QVariant& variant)
     m_rustObj->testVariantWrapper(*this, variant));
 }
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject()
 {
   return std::make_unique<MyObject>();
 }
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.h
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.h
@@ -42,9 +42,11 @@ private:
   bool m_initialised = false;
 };
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject();
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object
 
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -11,6 +11,7 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
@@ -99,9 +100,11 @@ mod ffi {
         ) -> UniquePtr<QVariant>;
 
         #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 

--- a/cxx-qt-gen/test_outputs/types_qt_property.cpp
+++ b/cxx-qt-gen/test_outputs/types_qt_property.cpp
@@ -4,9 +4,9 @@ namespace cxx_qt::my_object {
 
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(createRs())
+  , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
 {
-  initialiseCpp(*this);
+  cxx_qt::my_object::cxx_qt_my_object::initialiseCpp(*this);
   m_initialised = true;
 }
 
@@ -323,10 +323,12 @@ MyObject::setVariant(const QVariant& value)
   }
 }
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject()
 {
   return std::make_unique<MyObject>();
 }
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/cxx-qt-gen/test_outputs/types_qt_property.h
+++ b/cxx-qt-gen/test_outputs/types_qt_property.h
@@ -101,9 +101,11 @@ private:
   QVariant m_variant;
 };
 
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object::cxx_qt_my_object {
 std::unique_ptr<MyObject>
 newCppObject();
-
-} // namespace cxx_qt::my_object
+} // namespace cxx_qt::my_object::cxx_qt_my_object
 
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -76,6 +76,7 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
         #[rust_name = "new_cpp_object"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
 
@@ -89,9 +90,11 @@ mod ffi {
         type MyObject;
 
         #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs() -> Box<MyObject>;
 
         #[cxx_name = "initialiseCpp"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn initialise_cpp(cpp: Pin<&mut MyObjectQt>);
     }
 

--- a/examples/qml_extension_plugin/core/plugin.cpp
+++ b/examples/qml_extension_plugin/core/plugin.cpp
@@ -19,7 +19,7 @@ class CoreQmlpluginPlugin : public QQmlExtensionPlugin
 public:
   void registerTypes(const char* uri) override
   {
-    qmlRegisterType<cxx_qt::my_object::MyObject>(uri, 1, 0, "MyObject");
+    qmlRegisterType<core::MyObject>(uri, 1, 0, "MyObject");
   }
 };
 

--- a/examples/qml_extension_plugin/core/src/lib.rs
+++ b/examples/qml_extension_plugin/core/src/lib.rs
@@ -26,7 +26,7 @@ impl From<Data> for DataSerde {
 
 const DEFAULT_STR: &str = r#"{"number": 1, "string": "Hello World!"}"#;
 
-#[cxx_qt::bridge(namespace = "cxx_qt::my_object")]
+#[cxx_qt::bridge(namespace = "core")]
 mod ffi {
     use super::{DataSerde, DEFAULT_STR};
 

--- a/examples/qml_features/src/data_struct_properties.rs
+++ b/examples/qml_features/src/data_struct_properties.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 // ANCHOR: book_macro_code
-#[cxx_qt::bridge(namespace = "cxx_qt::data_struct_properties")]
+#[cxx_qt::bridge]
 mod ffi {
     #[derive(Default)]
     pub struct Data {

--- a/examples/qml_features/src/empty.rs
+++ b/examples/qml_features/src/empty.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#[cxx_qt::bridge(namespace = "cxx_qt::empty")]
+#[cxx_qt::bridge]
 mod ffi {
     #[derive(Default)]
     pub struct Data;

--- a/examples/qml_features/src/lib.rs
+++ b/examples/qml_features/src/lib.rs
@@ -12,9 +12,8 @@ mod serialisation;
 mod signals;
 mod types;
 
-#[cxx_qt::bridge(namespace = "cxx_qt::my_object")]
+#[cxx_qt::bridge]
 mod ffi {
-    #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/include/qt_types.h");
         type QString = cxx_qt_lib::QString;

--- a/examples/qml_features/src/main.cpp
+++ b/examples/qml_features/src/main.cpp
@@ -31,13 +31,11 @@ main(int argc, char* argv[])
     },
     Qt::QueuedConnection);
 
-  qmlRegisterType<cxx_qt::data_struct_properties::DataStructProperties>(
+  qmlRegisterType<DataStructProperties>(
     "com.kdab.cxx_qt.demo", 1, 0, "DataStructProperties");
-  qmlRegisterType<cxx_qt::my_object::MyObject>(
-    "com.kdab.cxx_qt.demo", 1, 0, "MyObject");
-  qmlRegisterType<cxx_qt::serialisation::Serialisation>(
-    "com.kdab.cxx_qt.demo", 1, 0, "Serialisation");
-  qmlRegisterType<cxx_qt::types::Types>("com.kdab.cxx_qt.demo", 1, 0, "Types");
+  qmlRegisterType<MyObject>("com.kdab.cxx_qt.demo", 1, 0, "MyObject");
+  qmlRegisterType<Serialisation>("com.kdab.cxx_qt.demo", 1, 0, "Serialisation");
+  qmlRegisterType<Types>("com.kdab.cxx_qt.demo", 1, 0, "Types");
 
   engine.load(url);
 

--- a/examples/qml_features/src/mock_qt_types.rs
+++ b/examples/qml_features/src/mock_qt_types.rs
@@ -4,11 +4,10 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#[cxx_qt::bridge(namespace = "cxx_qt::mock_qt_types")]
+#[cxx_qt::bridge]
 mod ffi {
     use cxx_qt_lib::QVariantValue;
 
-    #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/include/qt_types.h");
         type QColor = cxx_qt_lib::QColor;

--- a/examples/qml_features/src/rust_obj_invokables.rs
+++ b/examples/qml_features/src/rust_obj_invokables.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 // ANCHOR: book_macro_code
-#[cxx_qt::bridge(namespace = "cxx_qt::rust_obj_invokables")]
+#[cxx_qt::bridge]
 pub mod ffi {
     #[derive(Default)]
     pub struct Data {

--- a/examples/qml_features/src/serialisation.rs
+++ b/examples/qml_features/src/serialisation.rs
@@ -23,11 +23,10 @@ impl From<Data> for DataSerde {
     }
 }
 
-#[cxx_qt::bridge(namespace = "cxx_qt::serialisation")]
+#[cxx_qt::bridge]
 mod ffi {
     use super::DataSerde;
 
-    #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/include/qt_types.h");
         type QString = cxx_qt_lib::QString;

--- a/examples/qml_features/src/signals.rs
+++ b/examples/qml_features/src/signals.rs
@@ -4,9 +4,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 // ANCHOR: book_macro_code
-#[cxx_qt::bridge(namespace = "cxx_qt::signals")]
+#[cxx_qt::bridge]
 pub mod ffi {
-    #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/include/qt_types.h");
         type QPoint = cxx_qt_lib::QPoint;

--- a/examples/qml_features/src/tests/myobject/tst_myobject.cpp
+++ b/examples/qml_features/src/tests/myobject/tst_myobject.cpp
@@ -18,8 +18,7 @@ class Setup : public QObject
 public:
   Setup()
   {
-    qmlRegisterType<cxx_qt::my_object::MyObject>(
-      "com.kdab.cxx_qt.demo", 1, 0, "MyObject");
+    qmlRegisterType<MyObject>("com.kdab.cxx_qt.demo", 1, 0, "MyObject");
   }
 };
 

--- a/examples/qml_features/src/tests/qttypes/tst_qttypes.cpp
+++ b/examples/qml_features/src/tests/qttypes/tst_qttypes.cpp
@@ -18,8 +18,7 @@ class Setup : public QObject
 public:
   Setup()
   {
-    qmlRegisterType<cxx_qt::mock_qt_types::MockQtTypes>(
-      "com.kdab.cxx_qt.demo", 1, 0, "MockQtTypes");
+    qmlRegisterType<MockQtTypes>("com.kdab.cxx_qt.demo", 1, 0, "MockQtTypes");
   }
 };
 

--- a/examples/qml_features/src/tests/serialisation/tst_serialisation.cpp
+++ b/examples/qml_features/src/tests/serialisation/tst_serialisation.cpp
@@ -18,7 +18,7 @@ class Setup : public QObject
 public:
   Setup()
   {
-    qmlRegisterType<cxx_qt::serialisation::Serialisation>(
+    qmlRegisterType<Serialisation>(
       "com.kdab.cxx_qt.demo", 1, 0, "Serialisation");
   }
 };

--- a/examples/qml_features/src/types.rs
+++ b/examples/qml_features/src/types.rs
@@ -4,11 +4,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 // ANCHOR: book_macro_code
-#[cxx_qt::bridge(namespace = "cxx_qt::types")]
+#[cxx_qt::bridge]
 mod ffi {
     use cxx_qt_lib::QVariantValue;
 
-    #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/include/qt_types.h");
         type QVariant = cxx_qt_lib::QVariant;

--- a/examples/qml_minimal/src/lib.rs
+++ b/examples/qml_minimal/src/lib.rs
@@ -7,11 +7,10 @@
 // ANCHOR: book_cxx_qt_module
 // ANCHOR: book_bridge_macro
 
-#[cxx_qt::bridge(namespace = "cxx_qt::my_object")]
+#[cxx_qt::bridge]
 mod ffi {
     // ANCHOR_END: book_bridge_macro
 
-    #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/include/qt_types.h");
         type QString = cxx_qt_lib::QString;

--- a/examples/qml_minimal/src/main.cpp
+++ b/examples/qml_minimal/src/main.cpp
@@ -33,8 +33,7 @@ main(int argc, char* argv[])
     Qt::QueuedConnection);
 
   // ANCHOR: book_qml_register
-  qmlRegisterType<cxx_qt::my_object::MyObject>(
-    "com.kdab.cxx_qt.demo", 1, 0, "MyObject");
+  qmlRegisterType<MyObject>("com.kdab.cxx_qt.demo", 1, 0, "MyObject");
   // ANCHOR_END: book_qml_register
 
   engine.load(url);

--- a/examples/qml_minimal/src/tests/myobject/tst_myobject.cpp
+++ b/examples/qml_minimal/src/tests/myobject/tst_myobject.cpp
@@ -18,8 +18,7 @@ class Setup : public QObject
 public:
   Setup()
   {
-    qmlRegisterType<cxx_qt::my_object::MyObject>(
-      "com.kdab.cxx_qt.demo", 1, 0, "MyObject");
+    qmlRegisterType<MyObject>("com.kdab.cxx_qt.demo", 1, 0, "MyObject");
   }
 };
 

--- a/examples/qml_with_threaded_logic/src/lib.rs
+++ b/examples/qml_with_threaded_logic/src/lib.rs
@@ -9,8 +9,11 @@ enum Event {
     TitleArrived(String),
 }
 
+// ANCHOR: book_namespace_macro
 #[cxx_qt::bridge(namespace = "cxx_qt::website")]
 mod ffi {
+    // ANCHOR_END: book_namespace_macro
+
     use super::Event;
     use futures::{
         channel::mpsc::{UnboundedReceiver, UnboundedSender},

--- a/examples/qml_with_threaded_logic/src/main.cpp
+++ b/examples/qml_with_threaded_logic/src/main.cpp
@@ -28,8 +28,10 @@ main(int argc, char* argv[])
     },
     Qt::QueuedConnection);
 
+  // ANCHOR: book_namespace_register
   qmlRegisterType<cxx_qt::website::Website>(
     "com.kdab.cxx_qt.demo", 1, 0, "Website");
+  // ANCHOR: book_namespace_register
 
   engine.load(url);
 


### PR DESCRIPTION
Requires #204 #206 #207