### PR TITLE
cxx-qt-gen: add a naming module to the generator phase

### DIFF
--- a/cxx-qt-gen/Cargo.toml
+++ b/cxx-qt-gen/Cargo.toml
@@ -15,7 +15,6 @@ repository = "https://github.com/KDAB/cxx-qt/"
 [dependencies]
 clang-format = "0.1"
 convert_case = "0.4"
-derivative = "2.2"
 indoc = "1.0"
 proc-macro2 = "1.0"
 syn = { version = "1.0", features = ["extra-traits", "full"] }

--- a/cxx-qt-gen/src/generator/mod.rs
+++ b/cxx-qt-gen/src/generator/mod.rs
@@ -4,4 +4,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 pub mod cpp;
+pub mod naming;
 pub mod rust;

--- a/cxx-qt-gen/src/generator/naming/invokable.rs
+++ b/cxx-qt-gen/src/generator/naming/invokable.rs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::generator::naming::CombinedIdent;
+use convert_case::{Case, Casing};
+use quote::format_ident;
+use syn::{Ident, ImplItemMethod};
+
+/// Names for parts of a Q_INVOKABLE
+pub struct QInvokableName {
+    pub name: CombinedIdent,
+    pub wrapper: CombinedIdent,
+}
+
+impl From<&ImplItemMethod> for QInvokableName {
+    fn from(invokable: &ImplItemMethod) -> Self {
+        let ident = &invokable.sig.ident;
+        Self {
+            name: name_from_ident(ident),
+            wrapper: wrapper_from_ident(ident),
+        }
+    }
+}
+
+/// For a given ident generate the Rust and C++ names
+fn name_from_ident(ident: &Ident) -> CombinedIdent {
+    CombinedIdent {
+        cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
+        rust: ident.clone(),
+    }
+}
+
+/// For a given ident generate the Rust and C++ wrapper names
+fn wrapper_from_ident(ident: &Ident) -> CombinedIdent {
+    let ident = format_ident!("{}_wrapper", ident);
+    CombinedIdent {
+        cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
+        rust: ident,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::tests::tokens_to_syn;
+    use quote::quote;
+
+    #[test]
+    fn test_from_impl_method() {
+        let item: ImplItemMethod = tokens_to_syn(quote! {
+            fn my_invokable() {
+
+            }
+        });
+        let invokable = QInvokableName::from(&item);
+        assert_eq!(invokable.name.cpp, format_ident!("myInvokable"));
+        assert_eq!(invokable.name.rust, format_ident!("my_invokable"));
+        assert_eq!(invokable.wrapper.cpp, format_ident!("myInvokableWrapper"));
+        assert_eq!(
+            invokable.wrapper.rust,
+            format_ident!("my_invokable_wrapper")
+        );
+    }
+}

--- a/cxx-qt-gen/src/generator/naming/mod.rs
+++ b/cxx-qt-gen/src/generator/naming/mod.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pub mod invokable;
+pub mod module;
+pub mod namespace;
+pub mod property;
+pub mod qobject;
+pub mod signals;
+
+use syn::Ident;
+
+/// Describes an ident which potentially has a different name in C++ and Rust
+pub struct CombinedIdent {
+    /// The ident for C++
+    pub cpp: Ident,
+    /// The ident for rust
+    pub rust: Ident,
+}

--- a/cxx-qt-gen/src/generator/naming/module.rs
+++ b/cxx-qt-gen/src/generator/naming/module.rs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use convert_case::{Case, Casing};
+use quote::format_ident;
+use syn::Ident;
+
+/// For a given module ident generate the file stem
+//
+// TODO: for now the QObject ident is passed to this
+pub fn cxx_stem_from_ident(ident: &Ident) -> Ident {
+    format_ident!("{}", ident.to_string().to_case(Case::Snake))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cxx_stem_from_ident() {
+        assert_eq!(
+            cxx_stem_from_ident(&format_ident!("MyObject")),
+            format_ident!("my_object")
+        );
+    }
+}

--- a/cxx-qt-gen/src/generator/naming/namespace.rs
+++ b/cxx-qt-gen/src/generator/naming/namespace.rs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+#[cfg(test)]
+use crate::parser::cxxqtdata::ParsedCxxQtData;
+use convert_case::{Case, Casing};
+use syn::Ident;
+
+/// Names for the namespace of this QObject
+pub struct NamespaceName {
+    pub namespace: String,
+    pub internal: String,
+}
+
+impl NamespaceName {
+    /// Build the namespace names from a given module and qobject ident
+    #[cfg(test)]
+    pub fn from_pair(module: &ParsedCxxQtData, ident: &Ident) -> Self {
+        Self {
+            namespace: module.namespace.clone(),
+            internal: namespace_internal_from_pair(&module.namespace, ident),
+        }
+    }
+
+    /// Build the namespace names from a given module and qobject ident
+    pub fn from_pair_str(namespace: &str, ident: &Ident) -> Self {
+        Self {
+            namespace: namespace.to_string(),
+            internal: namespace_internal_from_pair(namespace, ident),
+        }
+    }
+}
+
+/// For a given base namespace and QObject ident generate the internal namespace
+///
+/// The base namespace could be from the module bridge or from the QObject
+fn namespace_internal_from_pair(base: &str, ident: &Ident) -> String {
+    let mut namespace_internals = vec![];
+    if !base.is_empty() {
+        namespace_internals.push(base.to_owned());
+    }
+    namespace_internals.push(format!("cxx_qt_{}", ident.to_string().to_case(Case::Snake)));
+    namespace_internals.join("::")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use quote::format_ident;
+
+    #[test]
+    fn test_namespace_pair() {
+        let module = ParsedCxxQtData {
+            namespace: "cxx_qt".to_owned(),
+            ..Default::default()
+        };
+        let names = NamespaceName::from_pair(&module, &format_ident!("MyObject"));
+        assert_eq!(names.internal, "cxx_qt::cxx_qt_my_object");
+        assert_eq!(names.namespace, "cxx_qt");
+    }
+
+    #[test]
+    fn test_namespace_pair_empty_base() {
+        let module = ParsedCxxQtData::default();
+        let names = NamespaceName::from_pair(&module, &format_ident!("MyObject"));
+        assert_eq!(names.internal, "cxx_qt_my_object");
+        assert_eq!(names.namespace, "");
+    }
+}

--- a/cxx-qt-gen/src/generator/naming/property.rs
+++ b/cxx-qt-gen/src/generator/naming/property.rs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::generator::naming::CombinedIdent;
+use crate::parser::property::ParsedQProperty;
+use convert_case::{Case, Casing};
+use quote::format_ident;
+use syn::Ident;
+
+/// Names for parts of a Q_PROPERTY
+pub struct QPropertyName {
+    pub name: CombinedIdent,
+    pub getter: CombinedIdent,
+    pub setter: CombinedIdent,
+    pub notify: CombinedIdent,
+}
+
+impl From<&Ident> for QPropertyName {
+    fn from(ident: &Ident) -> Self {
+        Self {
+            name: name_from_ident(ident),
+            getter: getter_from_ident(ident),
+            setter: setter_from_ident(ident),
+            notify: notify_from_ident(ident),
+        }
+    }
+}
+
+impl From<&ParsedQProperty> for QPropertyName {
+    fn from(property: &ParsedQProperty) -> Self {
+        Self::from(&property.ident)
+    }
+}
+
+/// For a given ident generate the Rust and C++ getter names
+fn getter_from_ident(ident: &Ident) -> CombinedIdent {
+    CombinedIdent {
+        cpp: format_ident!("get{}", ident.to_string().to_case(Case::Pascal)),
+        rust: ident.clone(),
+    }
+}
+
+/// For a given ident generate the Rust and C++ names
+fn name_from_ident(ident: &Ident) -> CombinedIdent {
+    CombinedIdent {
+        cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
+        rust: ident.clone(),
+    }
+}
+
+/// For a given ident generate the Rust and C++ notify names
+fn notify_from_ident(ident: &Ident) -> CombinedIdent {
+    let ident = format_ident!("{}_changed", ident);
+    CombinedIdent {
+        cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
+        rust: ident,
+    }
+}
+
+/// For a given ident generate the Rust and C++ setter names
+fn setter_from_ident(ident: &Ident) -> CombinedIdent {
+    let ident = format_ident!("set_{}", ident);
+    CombinedIdent {
+        cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
+        rust: ident,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::tests::tokens_to_syn;
+    use quote::quote;
+
+    #[test]
+    fn test_parsed_property() {
+        let ty: syn::Type = tokens_to_syn(quote! { i32 });
+        let property = ParsedQProperty {
+            ident: format_ident!("my_property"),
+            ty,
+            vis: syn::Visibility::Inherited,
+        };
+        let names = QPropertyName::from(&property);
+        assert_eq!(names.name.cpp, format_ident!("myProperty"));
+        assert_eq!(names.name.rust, format_ident!("my_property"));
+        assert_eq!(names.getter.cpp, format_ident!("getMyProperty"));
+        assert_eq!(names.getter.rust, format_ident!("my_property"));
+        assert_eq!(names.setter.cpp, format_ident!("setMyProperty"));
+        assert_eq!(names.setter.rust, format_ident!("set_my_property"));
+        assert_eq!(names.notify.cpp, format_ident!("myPropertyChanged"));
+        assert_eq!(names.notify.rust, format_ident!("my_property_changed"));
+    }
+}

--- a/cxx-qt-gen/src/generator/naming/qobject.rs
+++ b/cxx-qt-gen/src/generator/naming/qobject.rs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::generator::naming::CombinedIdent;
+use crate::parser::qobject::ParsedQObject;
+use quote::format_ident;
+use syn::Ident;
+
+/// Names for parts of a Q_OBJECT
+pub struct QObjectName {
+    /// The name of the C++ class
+    pub cpp_class: CombinedIdent,
+    /// The name of the Rust struct
+    pub rust_struct: CombinedIdent,
+    /// The name of the CxxQtThread
+    pub cxx_qt_thread_class: Ident,
+}
+
+impl From<&ParsedQObject> for QObjectName {
+    fn from(qobject: &ParsedQObject) -> Self {
+        Self::from(&qobject.qobject_struct.as_ref().unwrap().ident)
+    }
+}
+
+impl From<&Ident> for QObjectName {
+    fn from(ident: &Ident) -> Self {
+        Self {
+            cpp_class: cpp_class_from_ident(ident),
+            rust_struct: rust_struct_from_ident(ident),
+            cxx_qt_thread_class: cxx_qt_thread_class_from_ident(ident),
+        }
+    }
+}
+
+/// For a given ident generate the C++ class name
+fn cpp_class_from_ident(ident: &Ident) -> CombinedIdent {
+    CombinedIdent {
+        cpp: ident.clone(),
+        rust: format_ident!("{}Qt", ident),
+    }
+}
+
+/// For a given ident generate the CxxQtThread ident
+fn cxx_qt_thread_class_from_ident(ident: &Ident) -> Ident {
+    format_ident!("{}CxxQtThread", ident)
+}
+
+/// For a given ident generate the Rust and C++ names
+fn rust_struct_from_ident(ident: &Ident) -> CombinedIdent {
+    CombinedIdent {
+        cpp: format_ident!("{}Rust", ident),
+        rust: ident.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::tests::tokens_to_syn;
+    use quote::quote;
+    use syn::ItemStruct;
+
+    #[test]
+    fn test_parsed_property() {
+        let qobject_struct: ItemStruct = tokens_to_syn(quote! {
+            struct MyObject;
+        });
+        let qobject = ParsedQObject {
+            qobject_struct: Some(qobject_struct),
+            ..Default::default()
+        };
+
+        let names = QObjectName::from(&qobject);
+        assert_eq!(names.cpp_class.cpp, format_ident!("MyObject"));
+        assert_eq!(names.cpp_class.rust, format_ident!("MyObjectQt"));
+        assert_eq!(names.rust_struct.cpp, format_ident!("MyObjectRust"));
+        assert_eq!(names.rust_struct.rust, format_ident!("MyObject"));
+        assert_eq!(
+            names.cxx_qt_thread_class,
+            format_ident!("MyObjectCxxQtThread")
+        );
+    }
+}

--- a/cxx-qt-gen/src/generator/naming/signals.rs
+++ b/cxx-qt-gen/src/generator/naming/signals.rs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::generator::naming::CombinedIdent;
+use crate::parser::signals::ParsedSignal;
+use convert_case::{Case, Casing};
+use quote::format_ident;
+use syn::Ident;
+
+/// Names for parts of a Q_SIGNAL
+pub struct QSignalName {
+    pub enum_name: Ident,
+    pub name: CombinedIdent,
+    pub queued_name: CombinedIdent,
+}
+
+impl From<&ParsedSignal> for QSignalName {
+    fn from(signal: &ParsedSignal) -> Self {
+        Self::from(&signal.ident)
+    }
+}
+
+impl From<&Ident> for QSignalName {
+    fn from(ident: &Ident) -> Self {
+        Self {
+            enum_name: ident.clone(),
+            name: name_from_ident(ident),
+            queued_name: queued_name_from_ident(ident),
+        }
+    }
+}
+
+/// For a given signal ident generate the Rust and C++ names
+fn name_from_ident(ident: &Ident) -> CombinedIdent {
+    CombinedIdent {
+        cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
+        // Note that signal names are in camel case so we need to convert to snake and can't clone
+        rust: format_ident!("{}", ident.to_string().to_case(Case::Snake)),
+    }
+}
+
+/// For a given signal ident generate the Rust and C++ queued name
+fn queued_name_from_ident(ident: &Ident) -> CombinedIdent {
+    // Note that signal names are in camel case so we need to convert to snake first
+    let ident = format_ident!("emit_{}", ident.to_string().to_case(Case::Snake));
+    CombinedIdent {
+        cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
+        rust: ident,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parsed_property() {
+        let qsignal = ParsedSignal {
+            ident: format_ident!("DataChanged"),
+            parameters: vec![],
+        };
+
+        let names = QSignalName::from(&qsignal);
+        assert_eq!(names.enum_name, format_ident!("DataChanged"));
+        assert_eq!(names.name.cpp, format_ident!("dataChanged"));
+        assert_eq!(names.name.rust, format_ident!("data_changed"));
+        assert_eq!(names.queued_name.cpp, format_ident!("emitDataChanged"));
+        assert_eq!(names.queued_name.rust, format_ident!("emit_data_changed"));
+    }
+}

--- a/cxx-qt-gen/src/parser/property.rs
+++ b/cxx-qt-gen/src/parser/property.rs
@@ -11,7 +11,7 @@ pub struct ParsedQProperty {
     pub ident: Ident,
     /// The [syn::Type] of the property
     pub ty: Type,
-    /// The [syn::Visiblity] of the property
+    /// The [syn::Visibility] of the property
     pub vis: Visibility,
     // TODO: later this will describe if the property has an attribute
     // stating that the a conversion in C++ needs to occur (eg UniquePtr<T> to T)..

--- a/cxx-qt-gen/src/parser/qobject.rs
+++ b/cxx-qt-gen/src/parser/qobject.rs
@@ -20,6 +20,8 @@ pub struct ParsedQObject {
     /// In the future this will be removed
     pub data_struct: Option<ItemStruct>,
     /// QObject struct that stores the invokables for the QObject
+    //
+    // TODO: this should not be optional
     pub qobject_struct: Option<ItemStruct>,
     /// Representation of the Signals enum that defines the Q_SIGNALS for the QObject
     pub signals: Option<ParsedSignalsEnum>,


### PR DESCRIPTION
This will handle taking the Parser components and then generating
the C++ or Rust idents from them.