### PR TITLE
remove connections to QQmlApplicationEngine::objectCreated

### DIFF
--- a/examples/cargo_without_cmake/src/cpp/run.cpp
+++ b/examples/cargo_without_cmake/src/cpp/run.cpp
@@ -40,15 +40,6 @@ run_cpp(int argc, char* argv[])
   QQmlApplicationEngine engine;
 
   const QUrl url(QStringLiteral("qrc:/main.qml"));
-  QObject::connect(
-    &engine,
-    &QQmlApplicationEngine::objectCreated,
-    &app,
-    [url](QObject* obj, const QUrl& objUrl) {
-      if (!obj && url == objUrl)
-        QCoreApplication::exit(-1);
-    },
-    Qt::QueuedConnection);
 
   qmlRegisterType<MyObject>("com.kdab.cxx_qt.demo", 1, 0, "MyObject");
 

--- a/examples/demo_threading/cpp/main.cpp
+++ b/examples/demo_threading/cpp/main.cpp
@@ -17,15 +17,6 @@ main(int argc, char* argv[])
   QQmlApplicationEngine engine;
 
   const QUrl url(QStringLiteral("qrc:/main.qml"));
-  QObject::connect(
-    &engine,
-    &QQmlApplicationEngine::objectCreated,
-    &app,
-    [url](QObject* obj, const QUrl& objUrl) {
-      if (!obj && url == objUrl)
-        QCoreApplication::exit(-1);
-    },
-    Qt::QueuedConnection);
 
   qmlRegisterType<cxx_qt::energy_usage::EnergyUsage>(
     "com.kdab.energy", 1, 0, "EnergyUsage");

--- a/examples/qml_extension_plugin/cpp/main.cpp
+++ b/examples/qml_extension_plugin/cpp/main.cpp
@@ -22,15 +22,6 @@ main(int argc, char* argv[])
   // ANCHOR_END: book_extension_plugin_register
 
   const QUrl url(QStringLiteral("qrc:/qml/main.qml"));
-  QObject::connect(
-    &engine,
-    &QQmlApplicationEngine::objectCreated,
-    &app,
-    [url](QObject* obj, const QUrl& objUrl) {
-      if (!obj && url == objUrl)
-        QCoreApplication::exit(-1);
-    },
-    Qt::QueuedConnection);
 
   engine.load(url);
 

--- a/examples/qml_features/cpp/main.cpp
+++ b/examples/qml_features/cpp/main.cpp
@@ -22,15 +22,6 @@ main(int argc, char* argv[])
   QQmlApplicationEngine engine;
 
   const QUrl url(QStringLiteral("qrc:/main.qml"));
-  QObject::connect(
-    &engine,
-    &QQmlApplicationEngine::objectCreated,
-    &app,
-    [url](QObject* obj, const QUrl& objUrl) {
-      if (!obj && url == objUrl)
-        QCoreApplication::exit(-1);
-    },
-    Qt::QueuedConnection);
 
   qmlRegisterType<CustomBase>("com.kdab.cxx_qt.demo", 1, 0, "CustomBase");
   qmlRegisterType<StructProperties>(

--- a/examples/qml_minimal/cpp/main.cpp
+++ b/examples/qml_minimal/cpp/main.cpp
@@ -22,15 +22,6 @@ main(int argc, char* argv[])
   QQmlApplicationEngine engine;
 
   const QUrl url(QStringLiteral("qrc:/main.qml"));
-  QObject::connect(
-    &engine,
-    &QQmlApplicationEngine::objectCreated,
-    &app,
-    [url](QObject* obj, const QUrl& objUrl) {
-      if (!obj && url == objUrl)
-        QCoreApplication::exit(-1);
-    },
-    Qt::QueuedConnection);
 
   // ANCHOR: book_qml_register
   qmlRegisterType<MyObject>("com.kdab.cxx_qt.demo", 1, 0, "MyObject");

--- a/examples/qml_with_threaded_logic/cpp/main.cpp
+++ b/examples/qml_with_threaded_logic/cpp/main.cpp
@@ -18,15 +18,6 @@ main(int argc, char* argv[])
   QQmlApplicationEngine engine;
 
   const QUrl url(QStringLiteral("qrc:/main.qml"));
-  QObject::connect(
-    &engine,
-    &QQmlApplicationEngine::objectCreated,
-    &app,
-    [url](QObject* obj, const QUrl& objUrl) {
-      if (!obj && url == objUrl)
-        QCoreApplication::exit(-1);
-    },
-    Qt::QueuedConnection);
 
   // ANCHOR: book_namespace_register
   qmlRegisterType<cxx_qt::website::Website>(


### PR DESCRIPTION
I don't know why these were there. The applications run fine without them.