### PR TITLE
cxx-qt-gen: remove immediate cases as signals will be by value

### DIFF
--- a/book/src/qobject/cpp_object.md
+++ b/book/src/qobject/cpp_object.md
@@ -19,9 +19,9 @@ If the [`cxx_qt::qobject` marked struct](./qobject_struct.md) has a property cal
 {{#include ../../../examples/qml_features/rust/src/rust_obj_invokables.rs:book_cpp_obj}}
 ```
 
-If there is a [`Signals` enum](./signals_enum.md) then you can call `emit_queued(&mut self, Signals)` or `unsafe emit_immediate(&mut self, Signals)` on the `CppObj` to emit a signal.
+If there is a [`Signals` enum](./signals_enum.md) then you can call `emit_queued(&mut self, Signals)` on the `CppObj` to emit a signal.
 
-Note that `emit_immediate` is unsafe as it can cause deadlocks if the `Q_EMIT` is `Qt::DirectConnection` connected to a Rust invokable on the same QObject that has caused the `Q_EMIT`, as this would then try to lock the internal Rust object which is already locked.
+Note that signals are queued to avoid a deadlock if the `Q_EMIT` is `Qt::DirectConnection` connected to a Rust invokable on the same QObject that has caused the `Q_EMIT`, as this would then try to lock the internal Rust object which is already locked.
 
 ```rust,ignore,noplayground
 {{#include ../../../examples/qml_features/rust/src/signals.rs:book_rust_obj_impl}}

--- a/book/src/qobject/signals_enum.md
+++ b/book/src/qobject/signals_enum.md
@@ -15,9 +15,9 @@ The `cxx_qt::signals(T)` attribute is used on an enum to define which signals sh
 
 ## Emitting a signal
 
-To emit a signal from Rust use the [`CppObj`](./cpp_object.md) and call either the `emit_queued(Signal)` or `unsafe emit_immediate(Signal)` method.
+To emit a signal from Rust use the [`CppObj`](./cpp_object.md) and call either the `emit_queued(Signal)` method.
 
-Note that `emit_immediate` is unsafe as it can cause deadlocks if the `Q_EMIT` is `Qt::DirectConnection` connected to a Rust invokable on the same QObject that has caused the `Q_EMIT`, as this would then try to lock the internal Rust object which is already locked.
+Note that signals are queued to avoid a deadlock if the `Q_EMIT` is `Qt::DirectConnection` connected to a Rust invokable on the same QObject that has caused the `Q_EMIT`, as this would then try to lock the internal Rust object which is already locked.
 
 ```rust,ignore,noplayground
 {{#include ../../../examples/qml_features/rust/src/signals.rs:book_rust_obj_impl}}

--- a/crates/cxx-qt-gen/test_inputs/signals.rs
+++ b/crates/cxx-qt-gen/test_inputs/signals.rs
@@ -25,10 +25,6 @@ mod ffi {
     impl cxx_qt::QObject<MyObject> {
         #[qinvokable]
         pub fn invokable(self: Pin<&mut Self>) {
-            unsafe {
-                self.as_mut().emit_immediate(MySignals::Ready);
-            }
-
             self.as_mut().emit_queued(MySignals::DataChanged {
                 first: 1,
                 second: QVariant::from_bool(true),

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -6,13 +6,9 @@ mod ffi {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 
-        #[rust_name = "ready"]
-        fn ready(self: Pin<&mut MyObjectQt>);
         #[rust_name = "emit_ready"]
         fn emitReady(self: Pin<&mut MyObjectQt>);
 
-        #[rust_name = "data_changed"]
-        fn dataChanged(self: Pin<&mut MyObjectQt>, first: i32, second: &QVariant, third: &QPoint);
         #[rust_name = "emit_data_changed"]
         fn emitDataChanged(
             self: Pin<&mut MyObjectQt>,
@@ -99,10 +95,6 @@ mod cxx_qt_ffi {
 
     impl MyObjectQt {
         pub fn invokable(self: Pin<&mut Self>) {
-            unsafe {
-                self.as_mut().emit_immediate(MySignals::Ready);
-            }
-
             self.as_mut().emit_queued(MySignals::DataChanged {
                 first: 1,
                 second: QVariant::from_bool(true),
@@ -118,17 +110,6 @@ mod cxx_qt_ffi {
                     second,
                     third,
                 } => self.emit_data_changed(first, second, third),
-            }
-        }
-
-        pub unsafe fn emit_immediate(self: Pin<&mut Self>, signal: MySignals) {
-            match signal {
-                MySignals::Ready {} => self.ready(),
-                MySignals::DataChanged {
-                    first,
-                    second,
-                    third,
-                } => self.data_changed(first, &second, &third),
             }
         }
     }

--- a/examples/qml_features/rust/src/mock_qt_types.rs
+++ b/examples/qml_features/rust/src/mock_qt_types.rs
@@ -97,16 +97,6 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn test_unsafe_signal(mut self: Pin<&mut Self>) {
-            unsafe {
-                self.as_mut().emit_immediate(Signal::Ready);
-                self.as_mut().emit_immediate(Signal::DataChanged {
-                    variant: QVariant::from(true),
-                });
-            }
-        }
-
-        #[qinvokable]
         pub fn test_color_property(self: Pin<&mut Self>) {
             self.set_color(QColor::from_rgba(0, 0, 255, 255));
         }

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -53,9 +53,7 @@ pub mod ffi {
     impl cxx_qt::QObject<Signals> {
         #[qinvokable]
         pub fn invokable(mut self: Pin<&mut Self>) {
-            unsafe {
-                self.as_mut().emit_immediate(Signal::Ready);
-            }
+            self.as_mut().emit_queued(Signal::Ready);
 
             let signal = Signal::RustDataChanged {
                 data: *self.get_data(),

--- a/examples/qml_features/tests/qttypes/tst_qttypes.qml
+++ b/examples/qml_features/tests/qttypes/tst_qttypes.qml
@@ -64,30 +64,6 @@ TestCase {
         compare(signalArguments[0], true);
     }
 
-    function test_unsafe_signal() {
-        const mock = createTemporaryObject(componentMockQtTypes, null, {});
-        const readySpy = createTemporaryObject(componentSpy, null, {
-            signalName: "ready",
-            target: mock,
-        });
-        const dataChangedSpy = createTemporaryObject(componentSpy, null, {
-            signalName: "dataChanged",
-            target: mock,
-        });
-
-        compare(readySpy.count, 0);
-        compare(dataChangedSpy.count, 0);
-
-        mock.testUnsafeSignal();
-
-        compare(readySpy.count, 1);
-        compare(readySpy.signalArguments[0].length, 0);
-        compare(dataChangedSpy.count, 1);
-        compare(dataChangedSpy.signalArguments[0].length, 1);
-        const signalArguments = dataChangedSpy.signalArguments[0];
-        compare(signalArguments[0], true);
-    }
-
 
     // QColor
 


### PR DESCRIPTION
It is hard to generate UniquePtr<T> to &T in the right places and have the C++ generation correct, so for now always use queued.