### PR TITLE
cxx-qt-gen: add support for multiple qobjects in rust writer

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -3,22 +3,16 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use syn::{Ident, Item, ItemMod};
+use syn::ItemMod;
+
+pub mod qobject;
 
 /// Representation of the generated Rust code for a QObject
 pub struct GeneratedRustBlocks {
-    /// Module for the CXX bridge
+    /// Module for the CXX bridge with passthrough items
     pub cxx_mod: ItemMod,
-    /// Items for the CXX-Qt module
-    pub cxx_qt_mod_contents: Vec<Item>,
-    /// Ident of the Rust name for the C++ object
-    pub cpp_struct_ident: Ident,
-    /// Ident of the CxxQtThread object
-    pub cxx_qt_thread_ident: Ident,
     /// Ident of the namespace of the QObject
     pub namespace: String,
-    /// Ident of the namespace for CXX-Qt internals of the QObject
-    pub namespace_internals: String,
-    /// Ident of the Rust name for the Rust object
-    pub rust_struct_ident: Ident,
+    /// Generated QObject blocks
+    pub qobjects: Vec<qobject::GeneratedRustQObjectBlocks>,
 }

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use syn::{Ident, Item};
+
+pub struct GeneratedRustQObjectBlocks {
+    /// Module for the CXX bridge
+    pub cxx_mod_contents: Vec<Item>,
+    /// Items for the CXX-Qt module
+    pub cxx_qt_mod_contents: Vec<Item>,
+    /// Ident of the Rust name for the C++ object
+    pub cpp_struct_ident: Ident,
+    /// Ident of the CxxQtThread object
+    pub cxx_qt_thread_ident: Ident,
+    /// Ident of the namespace for CXX-Qt internals of the QObject
+    pub namespace_internals: String,
+    /// Ident of the Rust name for the Rust object
+    pub rust_struct_ident: Ident,
+}

--- a/crates/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/crates/cxx-qt-gen/test_outputs/custom_default.rs
@@ -1,6 +1,12 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod ffi {
     unsafe extern "C++" {
+        include ! (< QtCore / QObject >);
+        include!("cxx-qt-lib/include/convert.h");
+        include!("cxx-qt-lib/include/cxxqt_thread.h");
+    }
+
+    unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
         #[cxx_name = "MyObject"]
@@ -21,10 +27,6 @@ mod ffi {
     }
 
     unsafe extern "C++" {
-        include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/include/convert.h");
-        include!("cxx-qt-lib/include/cxxqt_thread.h");
-
         type MyObjectCxxQtThread;
 
         #[cxx_name = "unsafeRust"]
@@ -56,8 +58,6 @@ mod cxx_qt_ffi {
     use super::ffi::*;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    unsafe impl Send for MyObjectCxxQtThread {}
 
     use std::pin::Pin;
 
@@ -97,6 +97,8 @@ mod cxx_qt_ffi {
             }
         }
     }
+
+    unsafe impl Send for MyObjectCxxQtThread {}
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -1,5 +1,19 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod ffi {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QPoint = cxx_qt_lib::QPoint;
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "C++" {
+        include ! (< QtCore / QObject >);
+        include!("cxx-qt-lib/include/convert.h");
+        include!("cxx-qt-lib/include/cxxqt_thread.h");
+    }
+
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
@@ -40,19 +54,7 @@ mod ffi {
         ) -> UniquePtr<QString>;
     }
 
-    #[namespace = ""]
     unsafe extern "C++" {
-        include!("cxx-qt-lib/include/qt_types.h");
-        type QColor = cxx_qt_lib::QColor;
-        type QPoint = cxx_qt_lib::QPoint;
-        type QString = cxx_qt_lib::QString;
-    }
-
-    unsafe extern "C++" {
-        include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/include/convert.h");
-        include!("cxx-qt-lib/include/cxxqt_thread.h");
-
         type MyObjectCxxQtThread;
 
         #[cxx_name = "unsafeRust"]
@@ -84,8 +86,6 @@ mod cxx_qt_ffi {
     use super::ffi::*;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    unsafe impl Send for MyObjectCxxQtThread {}
 
     use std::pin::Pin;
 
@@ -181,6 +181,8 @@ mod cxx_qt_ffi {
             println!("QML or C++ can't call this :)");
         }
     }
+
+    unsafe impl Send for MyObjectCxxQtThread {}
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/naming.rs
@@ -1,6 +1,16 @@
 #[cxx::bridge(namespace = "")]
 mod ffi {
     unsafe extern "C++" {
+        include ! (< QtCore / QStringListModel >);
+    }
+
+    unsafe extern "C++" {
+        include ! (< QtCore / QObject >);
+        include!("cxx-qt-lib/include/convert.h");
+        include!("cxx-qt-lib/include/cxxqt_thread.h");
+    }
+
+    unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
         #[cxx_name = "MyObject"]
@@ -24,14 +34,6 @@ mod ffi {
     }
 
     unsafe extern "C++" {
-        include ! (< QtCore / QStringListModel >);
-    }
-
-    unsafe extern "C++" {
-        include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/include/convert.h");
-        include!("cxx-qt-lib/include/cxxqt_thread.h");
-
         type MyObjectCxxQtThread;
 
         #[cxx_name = "unsafeRust"]
@@ -63,8 +65,6 @@ mod cxx_qt_ffi {
     use super::ffi::*;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    unsafe impl Send for MyObjectCxxQtThread {}
 
     use std::pin::Pin;
 
@@ -104,6 +104,8 @@ mod cxx_qt_ffi {
             self.as_mut().set_property_name(5);
         }
     }
+
+    unsafe impl Send for MyObjectCxxQtThread {}
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough.rs
@@ -2,25 +2,6 @@
 #[attrA]
 #[attrB]
 pub mod ffi {
-    unsafe extern "C++" {
-        include!("cxx-qt-gen/include/my_object.cxxqt.h");
-
-        #[cxx_name = "MyObject"]
-        type MyObjectQt;
-
-        #[rust_name = "emit_number_changed"]
-        fn emitNumberChanged(self: Pin<&mut MyObjectQt>);
-    }
-
-    extern "Rust" {
-        #[cxx_name = "MyObjectRust"]
-        type MyObject;
-        #[cxx_name = "getNumber"]
-        unsafe fn get_number<'a>(self: &'a MyObject, cpp: &'a MyObjectQt) -> &'a i32;
-        #[cxx_name = "setNumber"]
-        fn set_number(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: i32);
-    }
-
     const MAX: u16 = 65535;
 
     enum Event {
@@ -82,7 +63,28 @@ pub mod ffi {
         include ! (< QtCore / QObject >);
         include!("cxx-qt-lib/include/convert.h");
         include!("cxx-qt-lib/include/cxxqt_thread.h");
+    }
 
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/include/my_object.cxxqt.h");
+
+        #[cxx_name = "MyObject"]
+        type MyObjectQt;
+
+        #[rust_name = "emit_number_changed"]
+        fn emitNumberChanged(self: Pin<&mut MyObjectQt>);
+    }
+
+    extern "Rust" {
+        #[cxx_name = "MyObjectRust"]
+        type MyObject;
+        #[cxx_name = "getNumber"]
+        unsafe fn get_number<'a>(self: &'a MyObject, cpp: &'a MyObjectQt) -> &'a i32;
+        #[cxx_name = "setNumber"]
+        fn set_number(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: i32);
+    }
+
+    unsafe extern "C++" {
         type MyObjectCxxQtThread;
 
         #[cxx_name = "unsafeRust"]
@@ -114,8 +116,6 @@ mod cxx_qt_ffi {
     use super::ffi::*;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    unsafe impl Send for MyObjectCxxQtThread {}
 
     use std::pin::Pin;
 
@@ -164,6 +164,8 @@ mod cxx_qt_ffi {
             "Hello".to_owned()
         }
     }
+
+    unsafe impl Send for MyObjectCxxQtThread {}
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -1,5 +1,18 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod ffi {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QPoint = cxx_qt_lib::QPoint;
+    }
+
+    unsafe extern "C++" {
+        include ! (< QtCore / QObject >);
+        include!("cxx-qt-lib/include/convert.h");
+        include!("cxx-qt-lib/include/cxxqt_thread.h");
+    }
+
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
@@ -34,18 +47,7 @@ mod ffi {
         fn set_opaque(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: UniquePtr<QColor>);
     }
 
-    #[namespace = ""]
     unsafe extern "C++" {
-        include!("cxx-qt-lib/include/qt_types.h");
-        type QColor = cxx_qt_lib::QColor;
-        type QPoint = cxx_qt_lib::QPoint;
-    }
-
-    unsafe extern "C++" {
-        include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/include/convert.h");
-        include!("cxx-qt-lib/include/cxxqt_thread.h");
-
         type MyObjectCxxQtThread;
 
         #[cxx_name = "unsafeRust"]
@@ -77,8 +79,6 @@ mod cxx_qt_ffi {
     use super::ffi::*;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    unsafe impl Send for MyObjectCxxQtThread {}
 
     use std::pin::Pin;
 
@@ -149,6 +149,8 @@ mod cxx_qt_ffi {
             self.as_mut().emit_opaque_changed();
         }
     }
+
+    unsafe impl Send for MyObjectCxxQtThread {}
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -1,5 +1,18 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod ffi {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QPoint = cxx_qt_lib::QPoint;
+        type QVariant = cxx_qt_lib::QVariant;
+    }
+
+    unsafe extern "C++" {
+        include ! (< QtCore / QObject >);
+        include!("cxx-qt-lib/include/convert.h");
+        include!("cxx-qt-lib/include/cxxqt_thread.h");
+    }
+
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
@@ -26,18 +39,7 @@ mod ffi {
         fn invokable_wrapper(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>);
     }
 
-    #[namespace = ""]
     unsafe extern "C++" {
-        include!("cxx-qt-lib/include/qt_types.h");
-        type QPoint = cxx_qt_lib::QPoint;
-        type QVariant = cxx_qt_lib::QVariant;
-    }
-
-    unsafe extern "C++" {
-        include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/include/convert.h");
-        include!("cxx-qt-lib/include/cxxqt_thread.h");
-
         type MyObjectCxxQtThread;
 
         #[cxx_name = "unsafeRust"]
@@ -69,8 +71,6 @@ mod cxx_qt_ffi {
     use super::ffi::*;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    unsafe impl Send for MyObjectCxxQtThread {}
 
     use std::pin::Pin;
 
@@ -112,6 +112,8 @@ mod cxx_qt_ffi {
             }
         }
     }
+
+    unsafe impl Send for MyObjectCxxQtThread {}
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -1,6 +1,12 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod ffi {
     unsafe extern "C++" {
+        include ! (< QtCore / QObject >);
+        include!("cxx-qt-lib/include/convert.h");
+        include!("cxx-qt-lib/include/cxxqt_thread.h");
+    }
+
+    unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
         #[cxx_name = "MyObject"]
@@ -85,10 +91,6 @@ mod ffi {
     }
 
     unsafe extern "C++" {
-        include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/include/convert.h");
-        include!("cxx-qt-lib/include/cxxqt_thread.h");
-
         type MyObjectCxxQtThread;
 
         #[cxx_name = "unsafeRust"]
@@ -120,8 +122,6 @@ mod cxx_qt_ffi {
     use super::ffi::*;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    unsafe impl Send for MyObjectCxxQtThread {}
 
     use std::pin::Pin;
 
@@ -312,6 +312,8 @@ mod cxx_qt_ffi {
             self.as_mut().emit_uint_32_changed();
         }
     }
+
+    unsafe impl Send for MyObjectCxxQtThread {}
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -1,5 +1,29 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod ffi {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QDate = cxx_qt_lib::QDate;
+        type QDateTime = cxx_qt_lib::QDateTime;
+        type QPoint = cxx_qt_lib::QPoint;
+        type QPointF = cxx_qt_lib::QPointF;
+        type QRect = cxx_qt_lib::QRect;
+        type QRectF = cxx_qt_lib::QRectF;
+        type QSize = cxx_qt_lib::QSize;
+        type QSizeF = cxx_qt_lib::QSizeF;
+        type QString = cxx_qt_lib::QString;
+        type QTime = cxx_qt_lib::QTime;
+        type QUrl = cxx_qt_lib::QUrl;
+        type QVariant = cxx_qt_lib::QVariant;
+    }
+
+    unsafe extern "C++" {
+        include ! (< QtCore / QObject >);
+        include!("cxx-qt-lib/include/convert.h");
+        include!("cxx-qt-lib/include/cxxqt_thread.h");
+    }
+
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
@@ -67,29 +91,7 @@ mod ffi {
         ) -> UniquePtr<QVariant>;
     }
 
-    #[namespace = ""]
     unsafe extern "C++" {
-        include!("cxx-qt-lib/include/qt_types.h");
-        type QColor = cxx_qt_lib::QColor;
-        type QDate = cxx_qt_lib::QDate;
-        type QDateTime = cxx_qt_lib::QDateTime;
-        type QPoint = cxx_qt_lib::QPoint;
-        type QPointF = cxx_qt_lib::QPointF;
-        type QRect = cxx_qt_lib::QRect;
-        type QRectF = cxx_qt_lib::QRectF;
-        type QSize = cxx_qt_lib::QSize;
-        type QSizeF = cxx_qt_lib::QSizeF;
-        type QString = cxx_qt_lib::QString;
-        type QTime = cxx_qt_lib::QTime;
-        type QUrl = cxx_qt_lib::QUrl;
-        type QVariant = cxx_qt_lib::QVariant;
-    }
-
-    unsafe extern "C++" {
-        include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/include/convert.h");
-        include!("cxx-qt-lib/include/cxxqt_thread.h");
-
         type MyObjectCxxQtThread;
 
         #[cxx_name = "unsafeRust"]
@@ -121,8 +123,6 @@ mod cxx_qt_ffi {
     use super::ffi::*;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    unsafe impl Send for MyObjectCxxQtThread {}
 
     use std::pin::Pin;
 
@@ -288,6 +288,8 @@ mod cxx_qt_ffi {
             variant
         }
     }
+
+    unsafe impl Send for MyObjectCxxQtThread {}
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -1,5 +1,29 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
 mod ffi {
+    #[namespace = ""]
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/include/qt_types.h");
+        type QColor = cxx_qt_lib::QColor;
+        type QDate = cxx_qt_lib::QDate;
+        type QDateTime = cxx_qt_lib::QDateTime;
+        type QPoint = cxx_qt_lib::QPoint;
+        type QPointF = cxx_qt_lib::QPointF;
+        type QRect = cxx_qt_lib::QRect;
+        type QRectF = cxx_qt_lib::QRectF;
+        type QSize = cxx_qt_lib::QSize;
+        type QSizeF = cxx_qt_lib::QSizeF;
+        type QString = cxx_qt_lib::QString;
+        type QTime = cxx_qt_lib::QTime;
+        type QUrl = cxx_qt_lib::QUrl;
+        type QVariant = cxx_qt_lib::QVariant;
+    }
+
+    unsafe extern "C++" {
+        include ! (< QtCore / QObject >);
+        include!("cxx-qt-lib/include/convert.h");
+        include!("cxx-qt-lib/include/cxxqt_thread.h");
+    }
+
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
 
@@ -127,29 +151,7 @@ mod ffi {
         fn set_variant(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: UniquePtr<QVariant>);
     }
 
-    #[namespace = ""]
     unsafe extern "C++" {
-        include!("cxx-qt-lib/include/qt_types.h");
-        type QColor = cxx_qt_lib::QColor;
-        type QDate = cxx_qt_lib::QDate;
-        type QDateTime = cxx_qt_lib::QDateTime;
-        type QPoint = cxx_qt_lib::QPoint;
-        type QPointF = cxx_qt_lib::QPointF;
-        type QRect = cxx_qt_lib::QRect;
-        type QRectF = cxx_qt_lib::QRectF;
-        type QSize = cxx_qt_lib::QSize;
-        type QSizeF = cxx_qt_lib::QSizeF;
-        type QString = cxx_qt_lib::QString;
-        type QTime = cxx_qt_lib::QTime;
-        type QUrl = cxx_qt_lib::QUrl;
-        type QVariant = cxx_qt_lib::QVariant;
-    }
-
-    unsafe extern "C++" {
-        include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/include/convert.h");
-        include!("cxx-qt-lib/include/cxxqt_thread.h");
-
         type MyObjectCxxQtThread;
 
         #[cxx_name = "unsafeRust"]
@@ -181,8 +183,6 @@ mod cxx_qt_ffi {
     use super::ffi::*;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    unsafe impl Send for MyObjectCxxQtThread {}
 
     use std::pin::Pin;
 
@@ -453,6 +453,9 @@ mod cxx_qt_ffi {
             self.as_mut().emit_variant_changed();
         }
     }
+
+    unsafe impl Send for MyObjectCxxQtThread {}
+
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }


### PR DESCRIPTION
Requires #249 #251 