### PR TITLE
cxx-qt-gen: mangle free rust functions names in writer

### DIFF
--- a/crates/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/crates/cxx-qt-gen/test_outputs/custom_default.rs
@@ -34,7 +34,7 @@ mod ffi {
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
         fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
 
-        #[rust_name = "new_cpp_object"]
+        #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
@@ -47,7 +47,7 @@ mod ffi {
     extern "Rust" {
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn create_rs() -> Box<MyObject>;
+        fn create_rs_my_object() -> Box<MyObject>;
     }
 }
 
@@ -98,7 +98,7 @@ mod cxx_qt_ffi {
         }
     }
 
-    pub fn create_rs() -> std::boxed::Box<MyObject> {
+    pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -62,7 +62,7 @@ mod ffi {
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
         fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
 
-        #[rust_name = "new_cpp_object"]
+        #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
@@ -75,7 +75,7 @@ mod ffi {
     extern "Rust" {
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn create_rs() -> Box<MyObject>;
+        fn create_rs_my_object() -> Box<MyObject>;
     }
 }
 
@@ -182,7 +182,7 @@ mod cxx_qt_ffi {
         }
     }
 
-    pub fn create_rs() -> std::boxed::Box<MyObject> {
+    pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/naming.rs
@@ -41,7 +41,7 @@ mod ffi {
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
         fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
 
-        #[rust_name = "new_cpp_object"]
+        #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
@@ -54,7 +54,7 @@ mod ffi {
     extern "Rust" {
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt_my_object"]
-        fn create_rs() -> Box<MyObject>;
+        fn create_rs_my_object() -> Box<MyObject>;
     }
 }
 
@@ -105,7 +105,7 @@ mod cxx_qt_ffi {
         }
     }
 
-    pub fn create_rs() -> std::boxed::Box<MyObject> {
+    pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough.rs
@@ -92,7 +92,7 @@ pub mod ffi {
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
         fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
 
-        #[rust_name = "new_cpp_object"]
+        #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
@@ -105,7 +105,7 @@ pub mod ffi {
     extern "Rust" {
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn create_rs() -> Box<MyObject>;
+        fn create_rs_my_object() -> Box<MyObject>;
     }
 }
 
@@ -165,7 +165,7 @@ mod cxx_qt_ffi {
         }
     }
 
-    pub fn create_rs() -> std::boxed::Box<MyObject> {
+    pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -55,7 +55,7 @@ mod ffi {
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
         fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
 
-        #[rust_name = "new_cpp_object"]
+        #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
@@ -68,7 +68,7 @@ mod ffi {
     extern "Rust" {
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn create_rs() -> Box<MyObject>;
+        fn create_rs_my_object() -> Box<MyObject>;
     }
 }
 
@@ -150,7 +150,7 @@ mod cxx_qt_ffi {
         }
     }
 
-    pub fn create_rs() -> std::boxed::Box<MyObject> {
+    pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -47,7 +47,7 @@ mod ffi {
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
         fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
 
-        #[rust_name = "new_cpp_object"]
+        #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
@@ -60,7 +60,7 @@ mod ffi {
     extern "Rust" {
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn create_rs() -> Box<MyObject>;
+        fn create_rs_my_object() -> Box<MyObject>;
     }
 }
 
@@ -113,7 +113,7 @@ mod cxx_qt_ffi {
         }
     }
 
-    pub fn create_rs() -> std::boxed::Box<MyObject> {
+    pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -98,7 +98,7 @@ mod ffi {
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
         fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
 
-        #[rust_name = "new_cpp_object"]
+        #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
@@ -111,7 +111,7 @@ mod ffi {
     extern "Rust" {
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn create_rs() -> Box<MyObject>;
+        fn create_rs_my_object() -> Box<MyObject>;
     }
 }
 
@@ -313,7 +313,7 @@ mod cxx_qt_ffi {
         }
     }
 
-    pub fn create_rs() -> std::boxed::Box<MyObject> {
+    pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -99,7 +99,7 @@ mod ffi {
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
         fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
 
-        #[rust_name = "new_cpp_object"]
+        #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
@@ -112,7 +112,7 @@ mod ffi {
     extern "Rust" {
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn create_rs() -> Box<MyObject>;
+        fn create_rs_my_object() -> Box<MyObject>;
     }
 }
 
@@ -289,7 +289,7 @@ mod cxx_qt_ffi {
         }
     }
 
-    pub fn create_rs() -> std::boxed::Box<MyObject> {
+    pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -159,7 +159,7 @@ mod ffi {
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
         fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
 
-        #[rust_name = "new_cpp_object"]
+        #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
@@ -172,7 +172,7 @@ mod ffi {
     extern "Rust" {
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn create_rs() -> Box<MyObject>;
+        fn create_rs_my_object() -> Box<MyObject>;
     }
 }
 
@@ -453,7 +453,7 @@ mod cxx_qt_ffi {
             self.as_mut().emit_variant_changed();
         }
     }
-    pub fn create_rs() -> std::boxed::Box<MyObject> {
+    pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
 }


### PR DESCRIPTION
We need to do this to avoid collisions when there are multiple QObjects