### PR TITLE
cxx-qt-gen: prepare for gen_rs removal and generating rust

### DIFF
--- a/crates/cxx-qt-gen/src/gen_rs.rs
+++ b/crates/cxx-qt-gen/src/gen_rs.rs
@@ -559,7 +559,6 @@ pub fn generate_qobject_rs(obj: &QObject) -> Result<TokenStream, TokenStream> {
         .collect::<Result<Vec<TokenStream>, TokenStream>>()?;
 
     let methods = &obj.methods;
-    let original_passthrough_decls = &obj.original_passthrough_decls;
 
     // Build our filtered rust struct
     let rust_struct = build_struct_with_fields(
@@ -602,8 +601,6 @@ pub fn generate_qobject_rs(obj: &QObject) -> Result<TokenStream, TokenStream> {
             #rust_struct_impl
 
             #qobject_impl
-
-            #(#original_passthrough_decls)*
         }
     })
     .map_err(|err| err.to_compile_error())?;
@@ -622,6 +619,7 @@ pub fn generate_qobject_rs(obj: &QObject) -> Result<TokenStream, TokenStream> {
 
     let generated = GeneratedRustBlocks {
         cxx_mod: obj.original_mod.clone(),
+        cxx_qt_mod_contents: obj.original_passthrough_decls.clone(),
         namespace: obj.namespace.to_owned(),
         qobjects,
     };

--- a/crates/cxx-qt-gen/src/gen_rs.rs
+++ b/crates/cxx-qt-gen/src/gen_rs.rs
@@ -11,7 +11,10 @@ use crate::extract::{Invokable, Property, QObject, QtTypes};
 use crate::generator::{
     naming,
     naming::{property::QPropertyName, qobject::QObjectName},
-    rust::{qobject::GeneratedRustQObjectBlocks, GeneratedRustBlocks},
+    rust::{
+        qobject::{GeneratedRustQObject, GeneratedRustQObjectBlocks},
+        GeneratedRustBlocks,
+    },
 };
 use crate::writer::rust::write_rust;
 
@@ -609,16 +612,18 @@ pub fn generate_qobject_rs(obj: &QObject) -> Result<TokenStream, TokenStream> {
     })
     .map_err(|err| err.to_compile_error())?;
 
-    let qobjects = vec![GeneratedRustQObjectBlocks {
-        cxx_mod_contents,
-        cxx_qt_mod_contents: cxx_qt_mod_fake
-            .content
-            .unwrap_or((syn::token::Brace::default(), vec![]))
-            .1,
+    let qobjects = vec![GeneratedRustQObject {
         cpp_struct_ident: cpp_class_name_rust,
         cxx_qt_thread_ident,
         namespace_internals,
         rust_struct_ident: obj.ident.clone(),
+        blocks: GeneratedRustQObjectBlocks {
+            cxx_mod_contents,
+            cxx_qt_mod_contents: cxx_qt_mod_fake
+                .content
+                .unwrap_or((syn::token::Brace::default(), vec![]))
+                .1,
+        },
     }];
 
     let generated = GeneratedRustBlocks {

--- a/crates/cxx-qt-gen/src/gen_rs.rs
+++ b/crates/cxx-qt-gen/src/gen_rs.rs
@@ -595,8 +595,6 @@ pub fn generate_qobject_rs(obj: &QObject) -> Result<TokenStream, TokenStream> {
     // later this code will be moved into a generator phase
     let cxx_qt_mod_fake: ItemMod = syn::parse2::<ItemMod>(quote! {
         mod fake {
-            use std::pin::Pin;
-
             #signal_enum
 
             #rust_struct

--- a/crates/cxx-qt-gen/src/generator/cpp/invokable.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/invokable.rs
@@ -144,16 +144,19 @@ mod tests {
         let invokables = vec![
             ParsedQInvokable {
                 method: tokens_to_syn(quote! { fn void_invokable(&self) {} }),
+                mutable: false,
                 return_cxx_type: None,
             },
             ParsedQInvokable {
                 method: tokens_to_syn(quote! { fn trivial_invokable(&self, param: i32) -> i32 {} }),
+                mutable: false,
                 return_cxx_type: None,
             },
             ParsedQInvokable {
                 method: tokens_to_syn(
                     quote! { fn opaque_invokable(self: Pin<&mut Self>, param: &QColor) -> UniquePtr<QColor> {} },
                 ),
+                mutable: true,
                 return_cxx_type: Some("QColor".to_owned()),
             },
         ];

--- a/crates/cxx-qt-gen/src/generator/cpp/invokable.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/invokable.rs
@@ -134,10 +134,11 @@ mod tests {
     use super::*;
 
     use crate::generator::naming::qobject::tests::create_qobjectname;
+    use crate::parser::parameter::ParsedFunctionParameter;
     use crate::tests::tokens_to_syn;
     use indoc::indoc;
     use pretty_assertions::assert_str_eq;
-    use quote::quote;
+    use quote::{format_ident, quote};
 
     #[test]
     fn test_generate_cpp_invokables() {
@@ -145,11 +146,17 @@ mod tests {
             ParsedQInvokable {
                 method: tokens_to_syn(quote! { fn void_invokable(&self) {} }),
                 mutable: false,
+                parameters: vec![],
                 return_cxx_type: None,
             },
             ParsedQInvokable {
                 method: tokens_to_syn(quote! { fn trivial_invokable(&self, param: i32) -> i32 {} }),
                 mutable: false,
+                parameters: vec![ParsedFunctionParameter {
+                    ident: format_ident!("param"),
+                    ty: tokens_to_syn::<syn::Type>(quote! { i32 }),
+                    cxx_type: None,
+                }],
                 return_cxx_type: None,
             },
             ParsedQInvokable {
@@ -157,6 +164,11 @@ mod tests {
                     quote! { fn opaque_invokable(self: Pin<&mut Self>, param: &QColor) -> UniquePtr<QColor> {} },
                 ),
                 mutable: true,
+                parameters: vec![ParsedFunctionParameter {
+                    ident: format_ident!("param"),
+                    ty: tokens_to_syn::<syn::Type>(quote! { &QColor }),
+                    cxx_type: None,
+                }],
                 return_cxx_type: Some("QColor".to_owned()),
             },
         ];

--- a/crates/cxx-qt-gen/src/generator/naming/invokable.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/invokable.rs
@@ -63,6 +63,7 @@ mod tests {
         let parsed = ParsedQInvokable {
             method: item,
             mutable: false,
+            parameters: vec![],
             return_cxx_type: None,
         };
 

--- a/crates/cxx-qt-gen/src/generator/naming/invokable.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/invokable.rs
@@ -62,6 +62,7 @@ mod tests {
         });
         let parsed = ParsedQInvokable {
             method: item,
+            mutable: false,
             return_cxx_type: None,
         };
 

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -11,6 +11,8 @@ use syn::{Item, ItemMod};
 pub struct GeneratedRustBlocks {
     /// Module for the CXX bridge with passthrough items
     pub cxx_mod: ItemMod,
+    /// Any global extra items for the CXX bridge
+    pub cxx_mod_contents: Vec<Item>,
     /// Any global passthrough items for the implementation
     pub cxx_qt_mod_contents: Vec<Item>,
     /// Ident of the namespace of the QObject

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -18,5 +18,5 @@ pub struct GeneratedRustBlocks {
     /// Ident of the namespace of the QObject
     pub namespace: String,
     /// Generated QObject blocks
-    pub qobjects: Vec<qobject::GeneratedRustQObjectBlocks>,
+    pub qobjects: Vec<qobject::GeneratedRustQObject>,
 }

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -3,14 +3,16 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use syn::ItemMod;
-
 pub mod qobject;
+
+use syn::{Item, ItemMod};
 
 /// Representation of the generated Rust code for a QObject
 pub struct GeneratedRustBlocks {
     /// Module for the CXX bridge with passthrough items
     pub cxx_mod: ItemMod,
+    /// Any global passthrough items for the implementation
+    pub cxx_qt_mod_contents: Vec<Item>,
     /// Ident of the namespace of the QObject
     pub namespace: String,
     /// Generated QObject blocks

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -5,11 +5,7 @@
 
 use syn::{Ident, Item};
 
-pub struct GeneratedRustQObjectBlocks {
-    /// Module for the CXX bridge
-    pub cxx_mod_contents: Vec<Item>,
-    /// Items for the CXX-Qt module
-    pub cxx_qt_mod_contents: Vec<Item>,
+pub struct GeneratedRustQObject {
     /// Ident of the Rust name for the C++ object
     pub cpp_struct_ident: Ident,
     /// Ident of the CxxQtThread object
@@ -18,4 +14,13 @@ pub struct GeneratedRustQObjectBlocks {
     pub namespace_internals: String,
     /// Ident of the Rust name for the Rust object
     pub rust_struct_ident: Ident,
+    /// The blocks for this QObject
+    pub blocks: GeneratedRustQObjectBlocks,
+}
+
+pub struct GeneratedRustQObjectBlocks {
+    /// Module for the CXX bridge
+    pub cxx_mod_contents: Vec<Item>,
+    /// Items for the CXX-Qt module
+    pub cxx_qt_mod_contents: Vec<Item>,
 }

--- a/crates/cxx-qt-gen/src/parser/invokable.rs
+++ b/crates/cxx-qt-gen/src/parser/invokable.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::parser::parameter::ParsedFunctionParameter;
 use syn::ImplItemMethod;
 
 /// Describes a single Q_INVOKABLE for a struct
@@ -13,4 +14,6 @@ pub struct ParsedQInvokable {
     pub mutable: bool,
     /// The name of the C++ type for the return type if one has been specified
     pub return_cxx_type: Option<String>,
+    /// The parameters of the invokable
+    pub parameters: Vec<ParsedFunctionParameter>,
 }

--- a/crates/cxx-qt-gen/src/parser/invokable.rs
+++ b/crates/cxx-qt-gen/src/parser/invokable.rs
@@ -9,6 +9,8 @@ use syn::ImplItemMethod;
 pub struct ParsedQInvokable {
     /// The original [syn::ImplItemMethod] of the invokable
     pub method: ImplItemMethod,
+    /// Whether this invokable is mutable
+    pub mutable: bool,
     /// The name of the C++ type for the return type if one has been specified
     pub return_cxx_type: Option<String>,
 }

--- a/crates/cxx-qt-gen/src/syntax/implitemmethod.rs
+++ b/crates/cxx-qt-gen/src/syntax/implitemmethod.rs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use syn::{
+    FnArg, GenericArgument, ImplItemMethod, Pat, PatIdent, PatType, PathArguments, Receiver, Type,
+    TypePath, TypeReference,
+};
+
+/// Return whether the first parameter of a method is a mutable self argument
+//
+// Note that self: Box<Self> is parsed as FnArg::Typed not FnArg::Receiver so will be false
+// but we don't use this case with CXX, so this can be ignored.
+pub fn is_method_mutable(method: &ImplItemMethod) -> bool {
+    match method.sig.inputs.first() {
+        Some(FnArg::Receiver(Receiver { mutability, .. })) => mutability.is_some(),
+        Some(FnArg::Typed(PatType { ty, pat, .. })) => {
+            // Check if the parameter name is self, if it isn't then ignore
+            if let Pat::Ident(PatIdent { ident, .. }) = pat.as_ref() {
+                if ident != "self" {
+                    return false;
+                }
+            }
+
+            if let Type::Path(TypePath { path, .. }) = ty.as_ref() {
+                // If we aren't a `self: Pin<T>` then ignore
+                //
+                // TODO: do we need to handle `self: &mut Self` or `self: mut Self` etc?
+                if !crate::syntax::path::path_compare_str(path, &["Pin"]) {
+                    return false;
+                }
+
+                // Read the contents of the T
+                if let Some(last) = path.segments.last() {
+                    if let PathArguments::AngleBracketed(args) = &last.arguments {
+                        // TODO: Maybe check that the reference is of type `Self`.
+                        //
+                        // TODO: we only handle the Pin being a reference, do we need to handle other cases?
+                        if let Some(GenericArgument::Type(Type::Reference(TypeReference {
+                            mutability: Some(_),
+                            ..
+                        }))) = args.args.first()
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::tests::tokens_to_syn;
+    use quote::quote;
+
+    #[test]
+    fn test_is_method_mutable_self() {
+        assert!(!is_method_mutable(&tokens_to_syn(quote! {
+            fn invokable(&self) {}
+        })));
+
+        assert!(is_method_mutable(&tokens_to_syn(quote! {
+            fn invokable_with_return_cxx_type(self: Pin<&mut Self>) -> f64 {}
+        })));
+    }
+
+    #[test]
+    fn test_is_method_mutable_value() {
+        assert!(!is_method_mutable(&tokens_to_syn(quote! {
+            fn invokable(value: T) {}
+        })));
+
+        assert!(!is_method_mutable(&tokens_to_syn(quote! {
+            fn invokable_with_return_cxx_type(value: Pin<&mut T>) -> f64 {}
+        })));
+
+        assert!(!is_method_mutable(&tokens_to_syn(quote! {
+            fn invokable_with_return_cxx_type(mut value: T) -> f64 {}
+        })));
+    }
+}

--- a/crates/cxx-qt-gen/src/syntax/mod.rs
+++ b/crates/cxx-qt-gen/src/syntax/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod attribute;
 pub mod fields;
+pub mod implitemmethod;
 pub mod path;
 mod qtfile;
 mod qtitem;

--- a/crates/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/rust/mod.rs
@@ -7,7 +7,7 @@ use crate::generator::rust::{qobject::GeneratedRustQObjectBlocks, GeneratedRustB
 use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
-use syn::{Ident, Item};
+use syn::Ident;
 
 /// Mangle an input name with an object name
 ///
@@ -96,7 +96,7 @@ pub fn write_rust(generated: &GeneratedRustBlocks) -> TokenStream {
 
     // Retrieve the module contents and namespace
     let mut cxx_mod = generated.cxx_mod.clone();
-    let mut cxx_qt_mod_contents: Vec<Item> = vec![];
+    let mut cxx_qt_mod_contents = generated.cxx_qt_mod_contents.clone();
     let namespace = &generated.namespace;
 
     // Add comment includes for all objects
@@ -163,6 +163,9 @@ mod tests {
             cxx_mod: tokens_to_syn(quote! {
                 mod ffi {}
             }),
+            cxx_qt_mod_contents: vec![tokens_to_syn(quote! {
+                use module::Struct;
+            })],
             namespace: "cxx_qt::my_object".to_owned(),
             qobjects: vec![GeneratedRustQObjectBlocks {
                 cxx_mod_contents: vec![
@@ -206,6 +209,9 @@ mod tests {
             cxx_mod: tokens_to_syn(quote! {
                 mod ffi {}
             }),
+            cxx_qt_mod_contents: vec![tokens_to_syn(quote! {
+                use module::Struct;
+            })],
             namespace: "cxx_qt".to_owned(),
             qobjects: vec![
                 GeneratedRustQObjectBlocks {
@@ -333,6 +339,8 @@ mod tests {
 
                 type UniquePtr<T> = cxx::UniquePtr<T>;
 
+                use module::Struct;
+
                 #[derive(Default)]
                 pub struct MyObject;
 
@@ -442,6 +450,8 @@ mod tests {
                 use std::pin::Pin;
 
                 type UniquePtr<T> = cxx::UniquePtr<T>;
+
+                use module::Struct;
 
                 #[derive(Default)]
                 pub struct FirstObject;

--- a/crates/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/rust/mod.rs
@@ -139,6 +139,7 @@ pub fn write_rust(generated: &GeneratedRustBlocks) -> TokenStream {
         pub use self::#cxx_qt_mod_ident::*;
         mod #cxx_qt_mod_ident {
             use super::#cxx_mod_ident::*;
+            use std::pin::Pin;
 
             type UniquePtr<T> = cxx::UniquePtr<T>;
 
@@ -328,6 +329,7 @@ mod tests {
             pub use self::cxx_qt_ffi::*;
             mod cxx_qt_ffi {
                 use super::ffi::*;
+                use std::pin::Pin;
 
                 type UniquePtr<T> = cxx::UniquePtr<T>;
 
@@ -437,6 +439,7 @@ mod tests {
             pub use self::cxx_qt_ffi::*;
             mod cxx_qt_ffi {
                 use super::ffi::*;
+                use std::pin::Pin;
 
                 type UniquePtr<T> = cxx::UniquePtr<T>;
 

--- a/crates/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/crates/cxx-qt-gen/test_outputs/custom_default.rs
@@ -56,10 +56,10 @@ mod ffi {
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use std::pin::Pin;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
 
-    use std::pin::Pin;
 
     pub struct MyObject {
         public: i32,

--- a/crates/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/crates/cxx-qt-gen/test_outputs/custom_default.rs
@@ -8,7 +8,9 @@ mod ffi {
 
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+    }
 
+    unsafe extern "C++" {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 

--- a/crates/cxx-qt-gen/test_outputs/custom_default.rs
+++ b/crates/cxx-qt-gen/test_outputs/custom_default.rs
@@ -60,6 +60,14 @@ mod cxx_qt_ffi {
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
 
+    impl Default for MyObject {
+        fn default() -> Self {
+            Self {
+                public: 32,
+                private: 64,
+            }
+        }
+    }
 
     pub struct MyObject {
         public: i32,
@@ -86,15 +94,6 @@ mod cxx_qt_ffi {
                 self.as_mut().rust_mut().public = value;
             }
             self.as_mut().emit_public_changed();
-        }
-    }
-
-    impl Default for MyObject {
-        fn default() -> Self {
-            Self {
-                public: 32,
-                private: 64,
-            }
         }
     }
 

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -84,10 +84,9 @@ mod ffi {
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use std::pin::Pin;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use std::pin::Pin;
 
     #[derive(Default)]
     pub struct MyObject;

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -16,7 +16,9 @@ mod ffi {
 
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+    }
 
+    unsafe extern "C++" {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
     }

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -88,6 +88,12 @@ mod cxx_qt_ffi {
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
 
+    impl MyObject {
+        pub fn rust_only_method(&self) {
+            println!("QML or C++ can't call this :)");
+        }
+    }
+
     #[derive(Default)]
     pub struct MyObject;
 
@@ -172,12 +178,6 @@ mod cxx_qt_ffi {
 
         pub fn cpp_context_method_return_opaque(&self) -> UniquePtr<QColor> {
             cxx_qt_lib::QColor::from_rgba(255, 0, 0, 0)
-        }
-    }
-
-    impl MyObject {
-        pub fn rust_only_method(&self) {
-            println!("QML or C++ can't call this :)");
         }
     }
 

--- a/crates/cxx-qt-gen/test_outputs/naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/naming.rs
@@ -12,7 +12,9 @@ mod ffi {
 
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+    }
 
+    unsafe extern "C++" {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 

--- a/crates/cxx-qt-gen/test_outputs/naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/naming.rs
@@ -63,10 +63,9 @@ mod ffi {
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use std::pin::Pin;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use std::pin::Pin;
 
     #[derive(Default)]
     pub struct MyObject {

--- a/crates/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough.rs
@@ -114,10 +114,9 @@ pub mod ffi {
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use std::pin::Pin;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use std::pin::Pin;
 
     #[derive(Default)]
     pub struct MyObject {

--- a/crates/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough.rs
@@ -118,6 +118,24 @@ mod cxx_qt_ffi {
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
 
+    use super::MyTrait;
+
+    impl MyObject {
+        fn test_angled(&self, optional: Option<bool>) -> Option<bool> {
+            optional
+        }
+
+        fn test_unknown(&self, unknown: MyType) -> MyType {
+            unknown
+        }
+    }
+
+    impl MyTrait for MyObject {
+        fn my_func() -> String {
+            "Hello".to_owned()
+        }
+    }
+
     #[derive(Default)]
     pub struct MyObject {
         number: i32,
@@ -143,24 +161,6 @@ mod cxx_qt_ffi {
                 self.as_mut().rust_mut().number = value;
             }
             self.as_mut().emit_number_changed();
-        }
-    }
-
-    use super::MyTrait;
-
-    impl MyObject {
-        fn test_angled(&self, optional: Option<bool>) -> Option<bool> {
-            optional
-        }
-
-        fn test_unknown(&self, unknown: MyType) -> MyType {
-            unknown
-        }
-    }
-
-    impl MyTrait for MyObject {
-        fn my_func() -> String {
-            "Hello".to_owned()
         }
     }
 

--- a/crates/cxx-qt-gen/test_outputs/passthrough.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough.rs
@@ -67,7 +67,9 @@ pub mod ffi {
 
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+    }
 
+    unsafe extern "C++" {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -15,7 +15,9 @@ mod ffi {
 
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+    }
 
+    unsafe extern "C++" {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -77,10 +77,9 @@ mod ffi {
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use std::pin::Pin;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use std::pin::Pin;
 
     #[derive(Default)]
     pub struct MyObject {

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -15,7 +15,9 @@ mod ffi {
 
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+    }
 
+    unsafe extern "C++" {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -69,10 +69,9 @@ mod ffi {
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use std::pin::Pin;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use std::pin::Pin;
 
     enum MySignals {
         Ready,

--- a/crates/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -8,7 +8,9 @@ mod ffi {
 
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+    }
 
+    unsafe extern "C++" {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 

--- a/crates/cxx-qt-gen/test_outputs/types_primitive_property.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_primitive_property.rs
@@ -120,10 +120,9 @@ mod ffi {
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use std::pin::Pin;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use std::pin::Pin;
 
     #[derive(Default)]
     pub struct MyObject {

--- a/crates/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -121,10 +121,9 @@ mod ffi {
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use std::pin::Pin;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use std::pin::Pin;
 
     #[derive(Default)]
     pub struct MyObject;

--- a/crates/cxx-qt-gen/test_outputs/types_qt_invokable.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_qt_invokable.rs
@@ -26,7 +26,9 @@ mod ffi {
 
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+    }
 
+    unsafe extern "C++" {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
     }

--- a/crates/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -26,7 +26,9 @@ mod ffi {
 
     unsafe extern "C++" {
         include!("cxx-qt-gen/include/my_object.cxxqt.h");
+    }
 
+    unsafe extern "C++" {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
 

--- a/crates/cxx-qt-gen/test_outputs/types_qt_property.rs
+++ b/crates/cxx-qt-gen/test_outputs/types_qt_property.rs
@@ -181,10 +181,9 @@ mod ffi {
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use std::pin::Pin;
 
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
-    use std::pin::Pin;
 
     #[derive(Default)]
     pub struct MyObject {


### PR DESCRIPTION
This has various commits which help the new Rust generation later, but can be landed separately.