### PR TITLE
cxx-qt-gen: change qobject struct to not be optional in Parser

### DIFF
--- a/crates/cxx-qt-gen/src/generator/naming/namespace.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/namespace.rs
@@ -14,10 +14,7 @@ pub struct NamespaceName {
 
 impl From<&ParsedQObject> for NamespaceName {
     fn from(qobject: &ParsedQObject) -> Self {
-        NamespaceName::from_pair_str(
-            &qobject.namespace,
-            &qobject.qobject_struct.as_ref().unwrap().ident,
-        )
+        NamespaceName::from_pair_str(&qobject.namespace, &qobject.qobject_struct.ident)
     }
 }
 
@@ -47,36 +44,24 @@ fn namespace_internal_from_pair(base: &str, ident: &Ident) -> String {
 mod tests {
     use super::*;
 
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
-    use syn::ItemStruct;
+    use crate::parser::qobject::tests::create_parsed_qobject;
 
     #[test]
     fn test_namespace_pair() {
-        let qobject_struct: ItemStruct = tokens_to_syn(quote! {
-            struct MyObject;
-        });
-        let module = ParsedQObject {
-            namespace: "cxx_qt".to_owned(),
-            qobject_struct: Some(qobject_struct),
-            ..Default::default()
-        };
-        let names = NamespaceName::from(&module);
+        let mut qobject = create_parsed_qobject();
+        qobject.namespace = "cxx_qt".to_owned();
+
+        let names = NamespaceName::from(&qobject);
         assert_eq!(names.internal, "cxx_qt::cxx_qt_my_object");
         assert_eq!(names.namespace, "cxx_qt");
     }
 
     #[test]
     fn test_namespace_pair_empty_base() {
-        let qobject_struct: ItemStruct = tokens_to_syn(quote! {
-            struct MyObject;
-        });
-        let module = ParsedQObject {
-            namespace: "".to_owned(),
-            qobject_struct: Some(qobject_struct),
-            ..Default::default()
-        };
-        let names = NamespaceName::from(&module);
+        let mut qobject = create_parsed_qobject();
+        qobject.namespace = "".to_owned();
+
+        let names = NamespaceName::from(&qobject);
         assert_eq!(names.internal, "cxx_qt_my_object");
         assert_eq!(names.namespace, "");
     }

--- a/crates/cxx-qt-gen/src/generator/naming/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/qobject.rs
@@ -19,7 +19,7 @@ pub struct QObjectName {
 
 impl From<&ParsedQObject> for QObjectName {
     fn from(qobject: &ParsedQObject) -> Self {
-        Self::from(&qobject.qobject_struct.as_ref().unwrap().ident)
+        Self::from(&qobject.qobject_struct.ident)
     }
 }
 
@@ -58,33 +58,15 @@ fn rust_struct_from_ident(ident: &Ident) -> CombinedIdent {
 pub mod tests {
     use super::*;
 
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
-    use syn::ItemStruct;
+    use crate::parser::qobject::tests::create_parsed_qobject;
 
     pub fn create_qobjectname() -> QObjectName {
-        let qobject_struct: ItemStruct = tokens_to_syn(quote! {
-            struct MyObject;
-        });
-        let qobject = ParsedQObject {
-            qobject_struct: Some(qobject_struct),
-            ..Default::default()
-        };
-
-        QObjectName::from(&qobject)
+        QObjectName::from(&create_parsed_qobject())
     }
 
     #[test]
     fn test_parsed_property() {
-        let qobject_struct: ItemStruct = tokens_to_syn(quote! {
-            struct MyObject;
-        });
-        let qobject = ParsedQObject {
-            qobject_struct: Some(qobject_struct),
-            ..Default::default()
-        };
-
-        let names = QObjectName::from(&qobject);
+        let names = QObjectName::from(&create_parsed_qobject());
         assert_eq!(names.cpp_class.cpp, format_ident!("MyObject"));
         assert_eq!(names.cpp_class.rust, format_ident!("MyObjectQt"));
         assert_eq!(names.rust_struct.cpp, format_ident!("MyObjectRust"));

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -69,7 +69,7 @@ impl GeneratedRustQObject {
         generated
             .blocks
             .cxx_qt_mod_contents
-            .push(syn::Item::Struct(qobject.qobject_struct.clone().unwrap()));
+            .push(syn::Item::Struct(qobject.qobject_struct.clone()));
 
         // Generate methods for the properties, invokables, signals
         generated.blocks.append(&mut generate_rust_properties(

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -53,7 +53,7 @@ impl Parser {
         // Check that there are items in the module
         if let Some(mut items) = module.content {
             // Find any QObject structs
-            cxx_qt_data.find_qobject_keys(&items.1)?;
+            cxx_qt_data.find_qobject_structs(&items.1)?;
 
             // Loop through any qobjects that were found
             if !cxx_qt_data.qobjects.is_empty() {


### PR DESCRIPTION
The qobject_struct is not optional so change the parser to remove the Option<T>