### PR TITLE
Assert qt type layouts

### DIFF
--- a/crates/cxx-qt-lib-headers/include/qcolor.h
+++ b/crates/cxx-qt-lib-headers/include/qcolor.h
@@ -11,11 +11,14 @@
 
 #include "rust/cxx.h"
 
+// QColor still had copy & move constructors in Qt 5 but they were basically
+// trivial.
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
 template<>
 struct rust::IsRelocatable<QColor> : std::true_type
 {
 };
-static_assert(QTypeInfo<QColor>::isRelocatable);
+#endif
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/qcolor.h
+++ b/crates/cxx-qt-lib-headers/include/qcolor.h
@@ -13,7 +13,7 @@
 
 // QColor still had copy & move constructors in Qt 5 but they were basically
 // trivial.
-#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 template<>
 struct rust::IsRelocatable<QColor> : std::true_type
 {

--- a/crates/cxx-qt-lib-headers/include/qdatetime.h
+++ b/crates/cxx-qt-lib-headers/include/qdatetime.h
@@ -15,7 +15,6 @@ template<>
 struct rust::IsRelocatable<QDateTime> : std::true_type
 {
 };
-static_assert(QTypeInfo<QDateTime>::isRelocatable);
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/qstring.h
+++ b/crates/cxx-qt-lib-headers/include/qstring.h
@@ -15,7 +15,6 @@ template<>
 struct rust::IsRelocatable<QString> : std::true_type
 {
 };
-static_assert(QTypeInfo<QString>::isRelocatable);
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/qurl.h
+++ b/crates/cxx-qt-lib-headers/include/qurl.h
@@ -15,7 +15,6 @@ template<>
 struct rust::IsRelocatable<QUrl> : std::true_type
 {
 };
-static_assert(QTypeInfo<QUrl>::isRelocatable);
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/qvariant.h
+++ b/crates/cxx-qt-lib-headers/include/qvariant.h
@@ -9,7 +9,6 @@
 
 #include <QVariant>
 
-// TODO: Make forward declarations
 #include <QColor>
 #include <QDate>
 #include <QDateTime>
@@ -29,7 +28,6 @@ template<>
 struct rust::IsRelocatable<QVariant> : std::true_type
 {
 };
-static_assert(QTypeInfo<QVariant>::isRelocatable);
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -54,6 +54,7 @@ fn main() {
     }
     builder.file("src/qt_types.cpp");
     println!("cargo:rerun-if-changed=src/qt_types.cpp");
+    println!("cargo:rerun-if-changed=src/types/assertion_utils.h");
 
     // Write this library's manually written C++ headers to files and add them to include paths
     let out_dir = std::env::var("OUT_DIR").unwrap();

--- a/crates/cxx-qt-lib/src/types/assertion_utils.h
+++ b/crates/cxx-qt-lib/src/types/assertion_utils.h
@@ -1,3 +1,10 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+// SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
 #pragma once
 
 #define assert_alignment_and_size(TYPE, ALIGNMENT, SIZE)                       \

--- a/crates/cxx-qt-lib/src/types/assertion_utils.h
+++ b/crates/cxx-qt-lib/src/types/assertion_utils.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define assert_alignment_and_size(TYPE,ALIGNMENT,SIZE) \
+  static_assert(alignof(TYPE) <= (ALIGNMENT), "unexpectedly large " #TYPE " alignment!"); \
+  static_assert(sizeof(TYPE) == (SIZE), "unexpected " #TYPE " size!");

--- a/crates/cxx-qt-lib/src/types/assertion_utils.h
+++ b/crates/cxx-qt-lib/src/types/assertion_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
-#define assert_alignment_and_size(TYPE,ALIGNMENT,SIZE) \
-  static_assert(alignof(TYPE) <= (ALIGNMENT), "unexpectedly large " #TYPE " alignment!"); \
+#define assert_alignment_and_size(TYPE, ALIGNMENT, SIZE)                       \
+  static_assert(alignof(TYPE) <= (ALIGNMENT),                                  \
+                "unexpectedly large " #TYPE " alignment!");                    \
   static_assert(sizeof(TYPE) == (SIZE), "unexpected " #TYPE " size!");

--- a/crates/cxx-qt-lib/src/types/qcolor.cpp
+++ b/crates/cxx-qt-lib/src/types/qcolor.cpp
@@ -16,10 +16,12 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qcolor.h?h=v6.2.4#n237
 assert_alignment_and_size(QColor, alignof(std::size_t), sizeof(std::size_t[2]));
 
-// QColor still had copy constructors in Qt 5 but they could have been trivial
+// QColor still had copy & move constructors in Qt 5 but they were basically
+// trivial.
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-static_assert(std::is_trivially_copy_assignable<QColor>::value);
-static_assert(std::is_trivially_copy_constructible<QColor>::value);
+static_assert(std::is_trivially_copyable<QColor>::value);
+#else
+static_assert(QTypeInfo<QColor>::isRelocatable);
 #endif
 
 static_assert(std::is_trivially_destructible<QColor>::value);

--- a/crates/cxx-qt-lib/src/types/qcolor.cpp
+++ b/crates/cxx-qt-lib/src/types/qcolor.cpp
@@ -7,6 +7,15 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qcolor.h"
 
+#include "assertion_utils.h"
+
+// QColor has an enum with six values and a union with the largest being five
+// ushorts. This results in (5 * std::uint16) + std::uint32_t = 14, then due to
+// compiler padding this results in a sizeof 16 or two pointers.
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qcolor.h?h=v5.15.6-lts-lgpl#n262
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qcolor.h?h=v6.2.4#n237
+assert_alignment_and_size(QColor, alignof(std::size_t), sizeof(std::size_t[2]));
+
 // QColor still had copy constructors in Qt 5 but they could have been trivial
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 static_assert(std::is_trivially_copy_assignable<QColor>::value);
@@ -14,16 +23,6 @@ static_assert(std::is_trivially_copy_constructible<QColor>::value);
 #endif
 
 static_assert(std::is_trivially_destructible<QColor>::value);
-
-// QColor has an enum with six values and a union with the largest being five
-// ushorts. This results in (5 * std::uint16) + std::uint32_t = 14, then due to
-// compiler padding this results in a sizeof 16 or two pointers.
-// https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qcolor.h?h=v5.15.6-lts-lgpl#n262
-// https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qcolor.h?h=v6.2.4#n237
-static_assert(alignof(QColor) <= alignof(std::size_t[2]),
-              "unexpectedly large QColor alignment");
-static_assert(sizeof(QColor) == sizeof(std::size_t[2]),
-              "unexpected QColor size");
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib/src/types/qdate.cpp
+++ b/crates/cxx-qt-lib/src/types/qdate.cpp
@@ -12,15 +12,13 @@
 #include <cstdint>
 
 // QDate has a single 64-Bit integer member
-// https://codebrowser.dev/qt5/qtbase/src/corelib/time/qdatetime.h.html#QDate::jd
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v5.15.6-lts-lgpl#n176
 //
-// https://codebrowser.dev/qt6/qtbase/src/corelib/time/qdatetime.h.html#QDate::jd
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n147
 assert_alignment_and_size(QDate, alignof(std::int64_t), sizeof(std::int64_t));
 
-static_assert(std::is_trivially_copy_assignable<QDate>::value);
-static_assert(std::is_trivially_copy_constructible<QDate>::value);
-
-static_assert(std::is_trivially_destructible<QDate>::value);
+static_assert(std::is_trivially_copyable<QDate>::value,
+              "QDate must be trivially copyable!");
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib/src/types/qdate.cpp
+++ b/crates/cxx-qt-lib/src/types/qdate.cpp
@@ -7,6 +7,21 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qdate.h"
 
+#include "assertion_utils.h"
+
+#include <cstdint>
+
+// QDate has a single 64-Bit integer member
+// https://codebrowser.dev/qt5/qtbase/src/corelib/time/qdatetime.h.html#QDate::jd
+//
+// https://codebrowser.dev/qt6/qtbase/src/corelib/time/qdatetime.h.html#QDate::jd
+assert_alignment_and_size(QDate, alignof(std::int64_t), sizeof(std::int64_t))
+
+  static_assert(std::is_trivially_copy_assignable<QDate>::value);
+static_assert(std::is_trivially_copy_constructible<QDate>::value);
+
+static_assert(std::is_trivially_destructible<QDate>::value);
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qdate.cpp
+++ b/crates/cxx-qt-lib/src/types/qdate.cpp
@@ -15,9 +15,9 @@
 // https://codebrowser.dev/qt5/qtbase/src/corelib/time/qdatetime.h.html#QDate::jd
 //
 // https://codebrowser.dev/qt6/qtbase/src/corelib/time/qdatetime.h.html#QDate::jd
-assert_alignment_and_size(QDate, alignof(std::int64_t), sizeof(std::int64_t))
+assert_alignment_and_size(QDate, alignof(std::int64_t), sizeof(std::int64_t));
 
-  static_assert(std::is_trivially_copy_assignable<QDate>::value);
+static_assert(std::is_trivially_copy_assignable<QDate>::value);
 static_assert(std::is_trivially_copy_constructible<QDate>::value);
 
 static_assert(std::is_trivially_destructible<QDate>::value);

--- a/crates/cxx-qt-lib/src/types/qdatetime.cpp
+++ b/crates/cxx-qt-lib/src/types/qdatetime.cpp
@@ -22,6 +22,8 @@ static_assert(!std::is_trivially_copy_assignable<QDateTime>::value);
 static_assert(!std::is_trivially_copy_constructible<QDateTime>::value);
 static_assert(!std::is_trivially_destructible<QDateTime>::value);
 
+static_assert(QTypeInfo<QDateTime>::isRelocatable);
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qdatetime.cpp
+++ b/crates/cxx-qt-lib/src/types/qdatetime.cpp
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qdatetime.h"
 
+#include "assertion_utils.h"
+
 // QDateTime has a single member, which is a union, with the largest member
 // being a pointer
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v5.15.6-lts-lgpl#n426
@@ -14,10 +16,7 @@
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n394
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n255
-static_assert(alignof(QDateTime) <= alignof(std::size_t),
-              "unexpectedly large QDateTime alignment");
-static_assert(sizeof(QDateTime) == sizeof(std::size_t),
-              "unexpected QDateTime size");
+assert_alignment_and_size(QDateTime, alignof(std::size_t), sizeof(std::size_t));
 
 static_assert(!std::is_trivially_copy_assignable<QDateTime>::value);
 static_assert(!std::is_trivially_copy_constructible<QDateTime>::value);

--- a/crates/cxx-qt-lib/src/types/qpoint.cpp
+++ b/crates/cxx-qt-lib/src/types/qpoint.cpp
@@ -7,6 +7,21 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qpoint.h"
 
+#include "assertion_utils.h"
+
+#include <cstdint>
+
+// QPoint has "int" members - xp and yp
+// Rust represents these as 32-bit integer types.
+// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qpoint.h.html#QPoint::xp
+//
+// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qpoint.h.html#QPoint::xp
+assert_alignment_and_size(QPoint,
+                          alignof(std::int32_t),
+                          sizeof(std::int32_t[2]));
+
+static_assert(std::is_trivially_copyable<QPoint>::value);
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qpoint.cpp
+++ b/crates/cxx-qt-lib/src/types/qpoint.cpp
@@ -13,9 +13,9 @@
 
 // QPoint has "int" members - xp and yp
 // Rust represents these as 32-bit integer types.
-// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qpoint.h.html#QPoint::xp
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qpoint.h?h=v5.15.6-lts-lgpl#n271
 //
-// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qpoint.h.html#QPoint::xp
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qpoint.h?h=v6.2.4#n313
 assert_alignment_and_size(QPoint,
                           alignof(std::int32_t),
                           sizeof(std::int32_t[2]));

--- a/crates/cxx-qt-lib/src/types/qpointf.cpp
+++ b/crates/cxx-qt-lib/src/types/qpointf.cpp
@@ -10,9 +10,9 @@
 #include "assertion_utils.h"
 
 // QPointF has two "qreal" members - xp and yp
-// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qpoint.h.html#QPointF::xp
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qpoint.h?h=v5.15.6-lts-lgpl#n271
 //
-// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qpoint.h.html#QPointF::xp
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qpoint.h?h=v6.2.4#n313
 assert_alignment_and_size(QPointF, alignof(double), sizeof(double[2]));
 
 static_assert(std::is_trivially_copyable<QPointF>::value,

--- a/crates/cxx-qt-lib/src/types/qpointf.cpp
+++ b/crates/cxx-qt-lib/src/types/qpointf.cpp
@@ -7,6 +7,17 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qpointf.h"
 
+#include "assertion_utils.h"
+
+// QPointF has two "qreal" members - xp and yp
+// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qpoint.h.html#QPointF::xp
+//
+// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qpoint.h.html#QPointF::xp
+assert_alignment_and_size(QPointF, alignof(double), sizeof(double[2]));
+
+static_assert(std::is_trivially_copyable<QPointF>::value,
+              "QPointF should be trivially copyable");
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qrect.cpp
+++ b/crates/cxx-qt-lib/src/types/qrect.cpp
@@ -13,9 +13,9 @@
 
 // QRect has 4 int members.
 // Rust represents them as 4 32-bit integers
-// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qrect.h.html#QRect::x1
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qrect.h?h=v5.15.6-lts-lgpl#n161
 //
-// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qrect.h.html#QRect::x1
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qrect.h?h=v6.2.4#n161
 assert_alignment_and_size(QRect,
                           alignof(std::int32_t),
                           sizeof(std::int32_t[4]));

--- a/crates/cxx-qt-lib/src/types/qrect.cpp
+++ b/crates/cxx-qt-lib/src/types/qrect.cpp
@@ -7,6 +7,22 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qrect.h"
 
+#include "assertion_utils.h"
+
+#include <cstdint>
+
+// QRect has 4 int members.
+// Rust represents them as 4 32-bit integers
+// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qrect.h.html#QRect::x1
+//
+// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qrect.h.html#QRect::x1
+assert_alignment_and_size(QRect,
+                          alignof(std::int32_t),
+                          sizeof(std::int32_t[4]));
+
+static_assert(std::is_trivially_copyable<QRect>::value,
+              "QRect must be trivially copyable");
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qrectf.cpp
+++ b/crates/cxx-qt-lib/src/types/qrectf.cpp
@@ -10,9 +10,9 @@
 #include "assertion_utils.h"
 
 // QRectF has 4 double members
-// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qrect.h.html#QRectF::xp
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qrect.h?h=v5.15.6-lts-lgpl#n621
 //
-// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qrect.h.html#QRectF::xp
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qrect.h?h=v6.2.4#n623
 assert_alignment_and_size(QRectF, alignof(double), sizeof(double[4]));
 
 static_assert(std::is_trivially_copyable<QRectF>::value,

--- a/crates/cxx-qt-lib/src/types/qrectf.cpp
+++ b/crates/cxx-qt-lib/src/types/qrectf.cpp
@@ -7,6 +7,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qrectf.h"
 
+#include "assertion_utils.h"
+
+// QRectF has 4 double members
+// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qrect.h.html#QRectF::xp
+//
+// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qrect.h.html#QRectF::xp
+assert_alignment_and_size(QRectF, alignof(double), sizeof(double[4]));
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qrectf.cpp
+++ b/crates/cxx-qt-lib/src/types/qrectf.cpp
@@ -15,6 +15,9 @@
 // https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qrect.h.html#QRectF::xp
 assert_alignment_and_size(QRectF, alignof(double), sizeof(double[4]));
 
+static_assert(std::is_trivially_copyable<QRectF>::value,
+              "QRectF must be trivially copyable");
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qsize.cpp
+++ b/crates/cxx-qt-lib/src/types/qsize.cpp
@@ -7,6 +7,22 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qsize.h"
 
+#include "assertion_utils.h"
+
+#include <cstdint>
+
+// QSize has two "int" members
+// Rust represents these as 32-bit integers.
+// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qsize.h.html#QSize::wd
+//
+// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qsize.h.html#QSize::wd
+assert_alignment_and_size(QSize,
+                          alignof(std::int32_t),
+                          sizeof(std::int32_t[2]));
+
+static_assert(std::is_trivially_copyable<QSize>::value,
+              "QSize must be trivially copyable!");
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qsize.cpp
+++ b/crates/cxx-qt-lib/src/types/qsize.cpp
@@ -13,9 +13,9 @@
 
 // QSize has two "int" members
 // Rust represents these as 32-bit integers.
-// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qsize.h.html#QSize::wd
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qsize.h?h=v5.15.6-lts-lgpl#n104
 //
-// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qsize.h.html#QSize::wd
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qsize.h?h=v6.2.4#n113
 assert_alignment_and_size(QSize,
                           alignof(std::int32_t),
                           sizeof(std::int32_t[2]));

--- a/crates/cxx-qt-lib/src/types/qsizef.cpp
+++ b/crates/cxx-qt-lib/src/types/qsizef.cpp
@@ -7,6 +7,17 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qsizef.h"
 
+#include "assertion_utils.h"
+
+// QSizeF has two qreal members
+// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qsize.h.html#QSizeF::wd
+//
+// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qsize.h.html#QSizeF::wd
+assert_alignment_and_size(QSizeF, alignof(double), sizeof(double[2]));
+
+static_assert(std::is_trivially_copyable<QSizeF>::value,
+              "QSizeF must be trivially copyable!");
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qsizef.cpp
+++ b/crates/cxx-qt-lib/src/types/qsizef.cpp
@@ -10,9 +10,9 @@
 #include "assertion_utils.h"
 
 // QSizeF has two qreal members
-// https://codebrowser.dev/qt5/qtbase/src/corelib/tools/qsize.h.html#QSizeF::wd
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qsize.h?h=v5.15.6-lts-lgpl#n276
 //
-// https://codebrowser.dev/qt6/qtbase/src/corelib/tools/qsize.h.html#QSizeF::wd
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qsize.h?h=v6.2.4#n302
 assert_alignment_and_size(QSizeF, alignof(double), sizeof(double[2]));
 
 static_assert(std::is_trivially_copyable<QSizeF>::value,

--- a/crates/cxx-qt-lib/src/types/qstring.cpp
+++ b/crates/cxx-qt-lib/src/types/qstring.cpp
@@ -20,7 +20,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qarraydatapointer.h?h=v6.2.4#n390
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 assert_alignment_and_size(QString,
-                          alignof(std::size_t[3]),
+                          alignof(std::size_t),
                           sizeof(std::size_t[3]));
 #else
 assert_alignment_and_size(QString, alignof(std::size_t), sizeof(std::size_t));
@@ -30,6 +30,8 @@ static_assert(!std::is_trivially_copy_assignable<QString>::value);
 static_assert(!std::is_trivially_copy_constructible<QString>::value);
 
 static_assert(!std::is_trivially_destructible<QString>::value);
+
+static_assert(QTypeInfo<QString>::isRelocatable);
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib/src/types/qstring.cpp
+++ b/crates/cxx-qt-lib/src/types/qstring.cpp
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qstring.h"
 
+#include "assertion_utils.h"
+
 // The layout has changed between Qt 5 and Qt 6
 //
 // Qt5 QString has one pointer as a member
@@ -17,15 +19,11 @@
 // DataPointer is then a QStringPrivate, which is a QArrayDataPointer<char16_t>
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qarraydatapointer.h?h=v6.2.4#n390
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-static_assert(alignof(QString) <= alignof(std::size_t[3]),
-              "unexpectedly large QString alignment");
-static_assert(sizeof(QString) == sizeof(std::size_t[3]),
-              "unexpected QString size");
+assert_alignment_and_size(QString,
+                          alignof(std::size_t[3]),
+                          sizeof(std::size_t[3]));
 #else
-static_assert(alignof(QString) <= alignof(std::size_t),
-              "unexpectedly large QString alignment");
-static_assert(sizeof(QString) == sizeof(std::size_t),
-              "unexpected QString size");
+assert_alignment_and_size(QString, alignof(std::size_t), sizeof(std::size_t));
 #endif
 
 static_assert(!std::is_trivially_copy_assignable<QString>::value);

--- a/crates/cxx-qt-lib/src/types/qtime.cpp
+++ b/crates/cxx-qt-lib/src/types/qtime.cpp
@@ -11,9 +11,9 @@
 
 #include <cstdint>
 // QTime has one int member
-// https://codebrowser.dev/qt5/qtbase/src/corelib/time/qdatetime.h.html#QTime::mds
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v5.15.6-lts-lgpl#n242
 //
-// https://codebrowser.dev/qt6/qtbase/src/corelib/time/qdatetime.h.html#QTime::mds
+// https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n217
 assert_alignment_and_size(QTime, alignof(std::int32_t), sizeof(std::int32_t));
 
 static_assert(std::is_trivially_copyable<QTime>::value,

--- a/crates/cxx-qt-lib/src/types/qtime.cpp
+++ b/crates/cxx-qt-lib/src/types/qtime.cpp
@@ -7,6 +7,18 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/include/qtime.h"
 
+#include "assertion_utils.h"
+
+#include <cstdint>
+// QTime has one int member
+// https://codebrowser.dev/qt5/qtbase/src/corelib/time/qdatetime.h.html#QTime::mds
+//
+// https://codebrowser.dev/qt6/qtbase/src/corelib/time/qdatetime.h.html#QTime::mds
+assert_alignment_and_size(QTime, alignof(std::int32_t), sizeof(std::int32_t));
+
+static_assert(std::is_trivially_copyable<QTime>::value,
+              "QTime must be trivially copyable!");
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qurl.cpp
+++ b/crates/cxx-qt-lib/src/types/qurl.cpp
@@ -21,6 +21,8 @@ static_assert(!std::is_trivially_copy_constructible<QUrl>::value);
 
 static_assert(!std::is_trivially_destructible<QUrl>::value);
 
+static_assert(QTypeInfo<QUrl>::isRelocatable);
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qurl.cpp
+++ b/crates/cxx-qt-lib/src/types/qurl.cpp
@@ -8,13 +8,13 @@
 #include "cxx-qt-lib/include/qurl.h"
 #include "cxx-qt-lib/include/qstring.h"
 
+#include "assertion_utils.h"
+
 // QUrl has a single pointer as it's member
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/io/qurl.h?h=v5.15.6-lts-lgpl#n367
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/io/qurl.h?h=v6.2.4#n294
-static_assert(alignof(QUrl) <= alignof(std::size_t),
-              "unexpectedly large QUrl alignment");
-static_assert(sizeof(QUrl) == sizeof(std::size_t), "unexpected QUrl size");
+assert_alignment_and_size(QUrl, alignof(std::size_t), sizeof(std::size_t));
 
 static_assert(!std::is_trivially_copy_assignable<QUrl>::value);
 static_assert(!std::is_trivially_copy_constructible<QUrl>::value);

--- a/crates/cxx-qt-lib/src/types/qvariant.cpp
+++ b/crates/cxx-qt-lib/src/types/qvariant.cpp
@@ -40,6 +40,8 @@ static_assert(!std::is_trivially_copy_constructible<QVariant>::value);
 // If this is false then we need to manually implement Drop rather than derive
 static_assert(!std::is_trivially_destructible<QVariant>::value);
 
+static_assert(QTypeInfo<QVariant>::isRelocatable);
+
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/src/types/qvariant.cpp
+++ b/crates/cxx-qt-lib/src/types/qvariant.cpp
@@ -9,6 +9,8 @@
 
 #include <QMetaObject>
 
+#include "assertion_utils.h"
+
 // The layout has changed between Qt 5 and Qt 6
 //
 // Qt5 QVariant has one member, which contains three uints and a union.
@@ -22,15 +24,13 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qvariant.h?h=v6.2.4#n540
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qvariant.h?h=v6.2.4#n474
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-static_assert(alignof(QVariant) <= alignof(std::size_t[4]),
-              "unexpectedly large QVariant alignment");
-static_assert(sizeof(QVariant) == sizeof(std::size_t[4]),
-              "unexpected QVariant size");
+assert_alignment_and_size(QVariant,
+                          alignof(std::size_t),
+                          sizeof(std::size_t[4]));
 #else
-static_assert(alignof(QVariant) <= alignof(std::size_t[2]),
-              "unexpectedly large QVariant alignment");
-static_assert(sizeof(QVariant) == sizeof(std::size_t[2]),
-              "unexpected QVariant size");
+assert_alignment_and_size(QVariant,
+                          alignof(std::size_t),
+                          sizeof(std::size_t[2]));
 #endif
 
 static_assert(!std::is_trivially_copy_assignable<QVariant>::value);


### PR DESCRIPTION
Also splits up the qt_types.h / qt_types.cpp into individual files for the different types.