### PR TITLE
cxx-qt-gen: add prop/prop_mut/set_prop for Rust fields as well

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/field.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/field.rs
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{
+    generator::{
+        naming::{property::QPropertyName, qobject::QObjectName},
+        rust::{fragment::RustFragmentPair, qobject::GeneratedRustQObjectBlocks},
+    },
+    parser::property::ParsedRustField,
+};
+use quote::quote;
+use syn::Result;
+
+pub fn generate_rust_fields(
+    fields: &Vec<ParsedRustField>,
+    qobject_idents: &QObjectName,
+) -> Result<GeneratedRustQObjectBlocks> {
+    let mut generated = GeneratedRustQObjectBlocks::default();
+    let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
+
+    for field in fields {
+        let idents = QPropertyName::from(&field.ident);
+        let getter_rust = &idents.getter.rust;
+        let getter_mutable_rust = &idents.getter_mutable.rust;
+        let setter_rust = &idents.setter.rust;
+        let ident = &idents.name.rust;
+        let ty = &field.ty;
+        let vis = &field.vis;
+
+        let fragment = RustFragmentPair {
+            cxx_bridge: vec![],
+            implementation: vec![
+                quote! {
+                    impl #cpp_class_name_rust {
+                        #vis fn #getter_rust(&self) -> &#ty {
+                            &self.rust().#ident
+                        }
+                    }
+                },
+                quote! {
+                    impl #cpp_class_name_rust {
+                        #vis fn #getter_mutable_rust<'a>(mut self: Pin<&'a mut Self>) -> &'a mut #ty {
+                            unsafe { &mut self.rust_mut().get_unchecked_mut().#ident }
+                        }
+                    }
+                },
+                quote! {
+                    impl #cpp_class_name_rust {
+                        #vis fn #setter_rust(mut self: Pin<&mut Self>, value: #ty) {
+                            unsafe {
+                                self.rust_mut().#ident = value;
+                            }
+                        }
+                    }
+                },
+            ],
+        };
+
+        generated
+            .cxx_qt_mod_contents
+            .append(&mut fragment.implementation_as_items()?);
+    }
+
+    Ok(generated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{
+        generator::naming::qobject::tests::create_qobjectname,
+        tests::{assert_tokens_eq, tokens_to_syn},
+    };
+    use quote::{format_ident, quote};
+
+    #[test]
+    fn test_generate_rust_properties() {
+        let properties = vec![
+            ParsedRustField {
+                ident: format_ident!("private_field"),
+                ty: tokens_to_syn::<syn::Type>(quote! { i32 }),
+                vis: syn::Visibility::Inherited,
+            },
+            ParsedRustField {
+                ident: format_ident!("public_field"),
+                ty: tokens_to_syn::<syn::Type>(quote! { f64 }),
+                vis: tokens_to_syn::<syn::Visibility>(quote! { pub }),
+            },
+        ];
+        let qobject_idents = create_qobjectname();
+
+        let generated = generate_rust_fields(&properties, &qobject_idents).unwrap();
+
+        // Check that we have the expected number of blocks
+        assert_eq!(generated.cxx_mod_contents.len(), 0);
+        assert_eq!(generated.cxx_qt_mod_contents.len(), 6);
+
+        // Private Field
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[0],
+            quote! {
+                impl MyObjectQt {
+                    fn private_field(&self) -> &i32 {
+                        &self.rust().private_field
+                    }
+                }
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[1],
+            quote! {
+                impl MyObjectQt {
+                    fn private_field_mut<'a>(mut self: Pin<&'a mut Self>) -> &'a mut i32 {
+                        unsafe { &mut self.rust_mut().get_unchecked_mut().private_field }
+                    }
+                }
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[2],
+            quote! {
+                impl MyObjectQt {
+                    fn set_private_field(mut self: Pin<&mut Self>, value: i32) {
+                        unsafe {
+                            self.rust_mut().private_field = value;
+                        }
+                    }
+                }
+            },
+        );
+
+        // Public Field
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[3],
+            quote! {
+                impl MyObjectQt {
+                    pub fn public_field(&self) -> &f64 {
+                        &self.rust().public_field
+                    }
+                }
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[4],
+            quote! {
+                impl MyObjectQt {
+                    pub fn public_field_mut<'a>(mut self: Pin<&'a mut Self>) -> &'a mut f64 {
+                        unsafe { &mut self.rust_mut().get_unchecked_mut().public_field }
+                    }
+                }
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[5],
+            quote! {
+                impl MyObjectQt {
+                    pub fn set_public_field(mut self: Pin<&mut Self>, value: f64) {
+                        unsafe {
+                            self.rust_mut().public_field = value;
+                        }
+                    }
+                }
+            },
+        );
+    }
+}

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+pub mod field;
 pub mod fragment;
 pub mod invokable;
 pub mod property;

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -7,8 +7,9 @@ use crate::{
     generator::{
         naming::{namespace::NamespaceName, qobject::QObjectName},
         rust::{
-            fragment::RustFragmentPair, invokable::generate_rust_invokables,
-            property::generate_rust_properties, signals::generate_rust_signals,
+            field::generate_rust_fields, fragment::RustFragmentPair,
+            invokable::generate_rust_invokables, property::generate_rust_properties,
+            signals::generate_rust_signals,
         },
     },
     parser::qobject::ParsedQObject,
@@ -71,11 +72,14 @@ impl GeneratedRustQObject {
             .cxx_qt_mod_contents
             .push(syn::Item::Struct(qobject.qobject_struct.clone()));
 
-        // Generate methods for the properties, invokables, signals
+        // Generate methods for the properties, fields, invokables, signals
         generated.blocks.append(&mut generate_rust_properties(
             &qobject.properties,
             &qobject_idents,
         )?);
+        generated
+            .blocks
+            .append(&mut generate_rust_fields(&qobject.fields, &qobject_idents)?);
         generated.blocks.append(&mut generate_rust_invokables(
             &qobject.invokables,
             &qobject_idents,

--- a/crates/cxx-qt-gen/src/parser/property.rs
+++ b/crates/cxx-qt-gen/src/parser/property.rs
@@ -5,6 +5,16 @@
 
 use syn::{Ident, Type, Visibility};
 
+/// Describes a single field for a struct
+pub struct ParsedRustField {
+    /// The [syn::Ident] of the field
+    pub ident: Ident,
+    /// The [syn::Type] of the field
+    pub ty: Type,
+    /// The [syn::Visibility] of the field
+    pub vis: Visibility,
+}
+
 /// Describes a single Q_PROPERTY for a struct
 pub struct ParsedQProperty {
     /// The [syn::Ident] of the property

--- a/crates/cxx-qt-gen/test_inputs/properties.rs
+++ b/crates/cxx-qt-gen/test_inputs/properties.rs
@@ -16,5 +16,8 @@ mod ffi {
         // Value and Opaque are not real types that would compile; these are only testing the code generation
         #[qproperty(cxx_type = "Value")]
         opaque: UniquePtr<Opaque>,
+
+        private_rust_field: i32,
+        pub public_rust_field: f64,
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -110,6 +110,8 @@ mod cxx_qt_ffi {
         primitive: i32,
         trivial: QPoint,
         opaque: UniquePtr<Opaque>,
+        private_rust_field: i32,
+        pub public_rust_field: f64,
     }
 
     impl MyObject {
@@ -208,6 +210,46 @@ mod cxx_qt_ffi {
                 self.as_mut().rust_mut().opaque = value;
             }
             self.as_mut().emit_opaque_changed();
+        }
+    }
+
+    impl MyObjectQt {
+        fn private_rust_field(&self) -> &i32 {
+            &self.rust().private_rust_field
+        }
+    }
+
+    impl MyObjectQt {
+        fn private_rust_field_mut<'a>(mut self: Pin<&'a mut Self>) -> &'a mut i32 {
+            unsafe { &mut self.rust_mut().get_unchecked_mut().private_rust_field }
+        }
+    }
+
+    impl MyObjectQt {
+        fn set_private_rust_field(mut self: Pin<&mut Self>, value: i32) {
+            unsafe {
+                self.rust_mut().private_rust_field = value;
+            }
+        }
+    }
+
+    impl MyObjectQt {
+        pub fn public_rust_field(&self) -> &f64 {
+            &self.rust().public_rust_field
+        }
+    }
+
+    impl MyObjectQt {
+        pub fn public_rust_field_mut<'a>(mut self: Pin<&'a mut Self>) -> &'a mut f64 {
+            unsafe { &mut self.rust_mut().get_unchecked_mut().public_rust_field }
+        }
+    }
+
+    impl MyObjectQt {
+        pub fn set_public_rust_field(mut self: Pin<&mut Self>, value: f64) {
+            unsafe {
+                self.rust_mut().public_rust_field = value;
+            }
         }
     }
 

--- a/tests/basic_cxx_qt/cpp/main.cpp
+++ b/tests/basic_cxx_qt/cpp/main.cpp
@@ -103,34 +103,34 @@ private Q_SLOTS:
   void test_queue_request()
   {
     cxx_qt::my_object::MyObject obj;
-    QCOMPARE(obj.updateCallCount(), 0);
+    QCOMPARE(obj.fetchUpdateCallCount(), 0);
     obj.queueTest();
-    QCOMPARE(obj.updateCallCount(), 0);
+    QCOMPARE(obj.fetchUpdateCallCount(), 0);
     QCoreApplication::processEvents();
-    QCOMPARE(obj.updateCallCount(), 1);
+    QCOMPARE(obj.fetchUpdateCallCount(), 1);
   }
 
   // CXX-Qt allows Rust code to queue multiple requests
   void test_queue_multiple_requests()
   {
     cxx_qt::my_object::MyObject obj;
-    QCOMPARE(obj.updateCallCount(), 0);
+    QCOMPARE(obj.fetchUpdateCallCount(), 0);
     obj.queueTest();
     obj.queueTest();
-    QCOMPARE(obj.updateCallCount(), 0);
+    QCOMPARE(obj.fetchUpdateCallCount(), 0);
     QCoreApplication::processEvents();
-    QCOMPARE(obj.updateCallCount(), 2);
+    QCOMPARE(obj.fetchUpdateCallCount(), 2);
   }
 
   // CXX-Qt allows Rust code to queue requests in multiple threads
   void test_queue_requests_multiple_threads()
   {
     cxx_qt::my_object::MyObject obj;
-    QCOMPARE(obj.updateCallCount(), 0);
+    QCOMPARE(obj.fetchUpdateCallCount(), 0);
     obj.queueTestMultiThread();
-    QCOMPARE(obj.updateCallCount(), 0);
+    QCOMPARE(obj.fetchUpdateCallCount(), 0);
     QCoreApplication::processEvents();
-    QCOMPARE(obj.updateCallCount(), 100);
+    QCOMPARE(obj.fetchUpdateCallCount(), 100);
   }
 
   // CXX-Qt types are exposed to C++ correctly

--- a/tests/basic_cxx_qt/rust/src/lib.rs
+++ b/tests/basic_cxx_qt/rust/src/lib.rs
@@ -59,8 +59,8 @@ mod ffi {
         pub fn queue_test(self: Pin<&mut Self>) {
             let qt_thread = self.qt_thread();
             qt_thread
-                .queue(|ctx| unsafe {
-                    ctx.rust_mut().update_call_count += 1;
+                .queue(|ctx| {
+                    *ctx.update_call_count_mut() += 1;
                 })
                 .unwrap();
         }
@@ -75,11 +75,9 @@ mod ffi {
             for _ in 0..N_THREADS {
                 let qt_thread = self.qt_thread();
                 handles.push(std::thread::spawn(move || {
-                    // TODO: for now we use the unsafe rust_mut() API
-                    // later there will be getters and setters for the properties
                     qt_thread
-                        .queue(|ctx| unsafe {
-                            ctx.rust_mut().update_call_count += 1;
+                        .queue(|ctx| {
+                            *ctx.update_call_count_mut() += 1;
                         })
                         .unwrap();
                     N_REQUESTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -98,7 +96,7 @@ mod ffi {
         }
 
         #[qinvokable]
-        pub fn update_call_count(&self) -> i32 {
+        pub fn fetch_update_call_count(&self) -> i32 {
             self.rust().update_call_count
         }
     }


### PR DESCRIPTION
Note that the prop_mut is not unsafe as there is no signal that should be emitted.

Requires #267