### PR TITLE
qml_minimal: explicitly define colors

### DIFF
--- a/examples/cargo_without_cmake/build.rs
+++ b/examples/cargo_without_cmake/build.rs
@@ -13,6 +13,7 @@ fn command_help_output(command: &str) -> std::io::Result<std::process::Output> {
 }
 
 fn main() {
+    println!("cargo:rerun-if-changed=qml/main.qml");
     CxxQtBuilder::new()
         // Link Qt's Qml and Network libraries. Qt Core and Gui are always
         // linked, so there is no need to specify them here.

--- a/examples/qml_minimal/qml/main.qml
+++ b/examples/qml_minimal/qml/main.qml
@@ -18,6 +18,7 @@ Window {
     title: qsTr("Hello World")
     visible: true
     width: 640
+    color: "white"
 
     MyObject {
         id: myObject
@@ -32,16 +33,21 @@ Window {
 
         Label {
             text: "Number: " + myObject.number
+            color: "black"
         }
 
         Label {
             text: "String: " + myObject.string
+            color: "black"
         }
 
         Button {
             text: "Increment Number"
 
             onClicked: myObject.incrementNumber()
+
+            palette.button: "black"
+            palette.buttonText: "white"
         }
 
         Button {
@@ -50,6 +56,9 @@ Window {
             property color red: "red"
 
             onClicked: myObject.sayHi(myObject.string, myObject.number, red)
+
+            palette.button: "black"
+            palette.buttonText: "white"
         }
     }
 }


### PR DESCRIPTION
before with Qt6:
![image](https://user-images.githubusercontent.com/9455094/192851490-44d97ec6-e437-4ce3-b2ff-ef46997d6cd7.png)

after:
![after](https://user-images.githubusercontent.com/9455094/192851364-16050053-90d5-4849-b67e-2d60cacecf51.png)
