### PR TITLE
cxx-qt-gen: use recursive mutex for rust object

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/invokable.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/invokable.rs
@@ -191,7 +191,7 @@ mod tests {
             void
             MyObject::voidInvokable() const
             {
-                const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+                const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
                 m_rustObj->voidInvokableWrapper(*this);
             }
             "#}
@@ -207,7 +207,7 @@ mod tests {
             qint32
             MyObject::trivialInvokable(qint32 param) const
             {
-                const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+                const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
                 return rust::cxxqtlib1::cxx_qt_convert<qint32, qint32>{}(m_rustObj->trivialInvokableWrapper(*this, param));
             }
             "#}
@@ -223,7 +223,7 @@ mod tests {
             QColor
             MyObject::opaqueInvokable(const QColor& param)
             {
-                const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+                const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
                 return rust::cxxqtlib1::cxx_qt_convert<QColor, ::std::unique_ptr<QColor>>{}(m_rustObj->opaqueInvokableWrapper(*this, param));
             }
             "#}

--- a/crates/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -16,7 +16,7 @@ use qobject::GeneratedCppQObject;
 use syn::{spanned::Spanned, Error, Result};
 
 pub const RUST_OBJ_MUTEX_LOCK_GUARD: &str =
-    "const std::lock_guard<std::mutex> guard(*m_rustObjMutex);";
+    "const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);";
 pub const CXX_QT_CONVERT: &str = "rust::cxxqtlib1::cxx_qt_convert";
 
 /// Representation of the generated C++ code for a group of QObjects

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -90,7 +90,7 @@ mod tests {
             const qint32&
             MyObject::getTrivialProperty() const
             {
-                const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+                const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
                 return rust::cxxqtlib1::cxx_qt_convert<const qint32&, const qint32&>{}(m_rustObj->getTrivialProperty(*this));
             }
             "#}
@@ -121,7 +121,7 @@ mod tests {
             const QColor&
             MyObject::getOpaqueProperty() const
             {
-                const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+                const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
                 return rust::cxxqtlib1::cxx_qt_convert<const QColor&, const ::std::unique_ptr<QColor>&>{}(m_rustObj->getOpaqueProperty(*this));
             }
             "#}
@@ -154,7 +154,7 @@ mod tests {
             void
             MyObject::setTrivialProperty(const qint32& value)
             {
-                const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+                const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
                 m_rustObj->setTrivialProperty(*this, rust::cxxqtlib1::cxx_qt_convert<qint32, const qint32&>{}(value));
             }
             "#}
@@ -169,7 +169,7 @@ mod tests {
             void
             MyObject::setOpaqueProperty(const QColor& value)
             {
-                const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+                const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
                 m_rustObj->setOpaqueProperty(*this, rust::cxxqtlib1::cxx_qt_convert<::std::unique_ptr<QColor>, const QColor&>{}(value));
             }
             "#}

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -81,7 +81,7 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
             {signals}
             private:
               rust::Box<{rust_ident}> m_rustObj;
-              std::shared_ptr<std::mutex> m_rustObjMutex;
+              std::shared_ptr<std::recursive_mutex> m_rustObjMutex;
               std::shared_ptr<rust::cxxqtlib1::CxxQtGuardedPointer<{ident}>> m_cxxQtThreadObj;
             }};
 

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -286,7 +286,7 @@ mod tests {
 
         private:
           rust::Box<MyObjectRust> m_rustObj;
-          std::shared_ptr<std::mutex> m_rustObjMutex;
+          std::shared_ptr<std::recursive_mutex> m_rustObjMutex;
           std::shared_ptr<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>> m_cxxQtThreadObj;
         };
 
@@ -352,7 +352,7 @@ mod tests {
 
         private:
           rust::Box<FirstObjectRust> m_rustObj;
-          std::shared_ptr<std::mutex> m_rustObjMutex;
+          std::shared_ptr<std::recursive_mutex> m_rustObjMutex;
           std::shared_ptr<rust::cxxqtlib1::CxxQtGuardedPointer<FirstObject>> m_cxxQtThreadObj;
         };
 
@@ -390,7 +390,7 @@ mod tests {
 
         private:
           rust::Box<SecondObjectRust> m_rustObj;
-          std::shared_ptr<std::mutex> m_rustObjMutex;
+          std::shared_ptr<std::recursive_mutex> m_rustObjMutex;
           std::shared_ptr<rust::cxxqtlib1::CxxQtGuardedPointer<SecondObject>> m_cxxQtThreadObj;
         };
 
@@ -457,7 +457,7 @@ mod tests {
 
         private:
           rust::Box<MyObjectRust> m_rustObj;
-          std::shared_ptr<std::mutex> m_rustObjMutex;
+          std::shared_ptr<std::recursive_mutex> m_rustObjMutex;
           std::shared_ptr<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>> m_cxxQtThreadObj;
         };
 
@@ -484,7 +484,7 @@ mod tests {
         MyObject::MyObject(QObject* parent)
           : QStringListModel(parent)
           , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
-          , m_rustObjMutex(std::make_shared<std::mutex>())
+          , m_rustObjMutex(std::make_shared<std::recursive_mutex>())
           , m_cxxQtThreadObj(std::make_shared<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(this))
         {
         }
@@ -572,7 +572,7 @@ mod tests {
         FirstObject::FirstObject(QObject* parent)
           : QStringListModel(parent)
           , m_rustObj(cxx_qt::cxx_qt_first_object::createRs())
-          , m_rustObjMutex(std::make_shared<std::mutex>())
+          , m_rustObjMutex(std::make_shared<std::recursive_mutex>())
           , m_cxxQtThreadObj(std::make_shared<rust::cxxqtlib1::CxxQtGuardedPointer<FirstObject>>(this))
         {
         }
@@ -628,7 +628,7 @@ mod tests {
         SecondObject::SecondObject(QObject* parent)
           : QStringListModel(parent)
           , m_rustObj(cxx_qt::cxx_qt_second_object::createRs())
-          , m_rustObjMutex(std::make_shared<std::mutex>())
+          , m_rustObjMutex(std::make_shared<std::recursive_mutex>())
           , m_cxxQtThreadObj(std::make_shared<rust::cxxqtlib1::CxxQtGuardedPointer<SecondObject>>(this))
         {
         }
@@ -692,7 +692,7 @@ mod tests {
         MyObject::MyObject(QObject* parent)
           : QStringListModel(parent)
           , m_rustObj(cxx_qt_my_object::createRs())
-          , m_rustObjMutex(std::make_shared<std::mutex>())
+          , m_rustObjMutex(std::make_shared<std::recursive_mutex>())
           , m_cxxQtThreadObj(std::make_shared<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(this))
         {
         }

--- a/crates/cxx-qt-gen/src/writer/cpp/source.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/source.rs
@@ -23,7 +23,7 @@ fn qobjects_source(generated: &GeneratedCppBlocks) -> Vec<String> {
             {ident}::{ident}(QObject* parent)
               : {base_class}(parent)
               , m_rustObj({namespace_internals}::createRs())
-              , m_rustObjMutex(std::make_shared<std::mutex>())
+              , m_rustObjMutex(std::make_shared<std::recursive_mutex>())
               , m_cxxQtThreadObj(std::make_shared<rust::cxxqtlib1::CxxQtGuardedPointer<{ident}>>(this))
             {{
             }}

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -5,7 +5,7 @@ namespace cxx_qt::my_object {
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
   , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
-  , m_rustObjMutex(std::make_shared<std::mutex>())
+  , m_rustObjMutex(std::make_shared<std::recursive_mutex>())
   , m_cxxQtThreadObj(
       std::make_shared<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(this))
 {
@@ -39,14 +39,14 @@ MyObject::qtThread() const
 void
 MyObject::invokable() const
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->invokableWrapper(*this);
 }
 
 void
 MyObject::invokableMutable()
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->invokableMutableWrapper(*this);
 }
 
@@ -55,14 +55,14 @@ MyObject::invokableParameters(const QColor& opaque,
                               const QPoint& trivial,
                               qint32 primitive) const
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->invokableParametersWrapper(*this, opaque, trivial, primitive);
 }
 
 Value
 MyObject::invokableReturnOpaque()
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   return rust::cxxqtlib1::cxx_qt_convert<Value, ::std::unique_ptr<Opaque>>{}(
     m_rustObj->invokableReturnOpaqueWrapper(*this));
 }
@@ -70,7 +70,7 @@ MyObject::invokableReturnOpaque()
 QPoint
 MyObject::invokableReturnTrivial()
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   return rust::cxxqtlib1::cxx_qt_convert<QPoint, QPoint>{}(
     m_rustObj->invokableReturnTrivialWrapper(*this));
 }

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -38,7 +38,7 @@ public:
 
 private:
   rust::Box<MyObjectRust> m_rustObj;
-  std::shared_ptr<std::mutex> m_rustObjMutex;
+  std::shared_ptr<std::recursive_mutex> m_rustObjMutex;
   std::shared_ptr<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
     m_cxxQtThreadObj;
 };

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -5,7 +5,7 @@ namespace cxx_qt::my_object {
 MyObject::MyObject(QObject* parent)
   : QStringListModel(parent)
   , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
-  , m_rustObjMutex(std::make_shared<std::mutex>())
+  , m_rustObjMutex(std::make_shared<std::recursive_mutex>())
   , m_cxxQtThreadObj(
       std::make_shared<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(this))
 {
@@ -39,7 +39,7 @@ MyObject::qtThread() const
 const qint32&
 MyObject::getPropertyName() const
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   return rust::cxxqtlib1::cxx_qt_convert<const qint32&, const qint32&>{}(
     m_rustObj->getPropertyName(*this));
 }
@@ -55,14 +55,14 @@ MyObject::emitPropertyNameChanged()
 void
 MyObject::invokableName()
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->invokableNameWrapper(*this);
 }
 
 void
 MyObject::setPropertyName(const qint32& value)
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->setPropertyName(
     *this, rust::cxxqtlib1::cxx_qt_convert<qint32, const qint32&>{}(value));
 }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -42,7 +42,7 @@ Q_SIGNALS:
 
 private:
   rust::Box<MyObjectRust> m_rustObj;
-  std::shared_ptr<std::mutex> m_rustObjMutex;
+  std::shared_ptr<std::recursive_mutex> m_rustObjMutex;
   std::shared_ptr<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
     m_cxxQtThreadObj;
 };

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -5,7 +5,7 @@ namespace cxx_qt::my_object {
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
   , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
-  , m_rustObjMutex(std::make_shared<std::mutex>())
+  , m_rustObjMutex(std::make_shared<std::recursive_mutex>())
   , m_cxxQtThreadObj(
       std::make_shared<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(this))
 {
@@ -39,7 +39,7 @@ MyObject::qtThread() const
 const qint32&
 MyObject::getPrimitive() const
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   return rust::cxxqtlib1::cxx_qt_convert<const qint32&, const qint32&>{}(
     m_rustObj->getPrimitive(*this));
 }
@@ -55,7 +55,7 @@ MyObject::emitPrimitiveChanged()
 const QPoint&
 MyObject::getTrivial() const
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   return rust::cxxqtlib1::cxx_qt_convert<const QPoint&, const QPoint&>{}(
     m_rustObj->getTrivial(*this));
 }
@@ -71,7 +71,7 @@ MyObject::emitTrivialChanged()
 const Value&
 MyObject::getOpaque() const
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   return rust::cxxqtlib1::cxx_qt_convert<const Value&,
                                          const ::std::unique_ptr<Opaque>&>{}(
     m_rustObj->getOpaque(*this));
@@ -88,7 +88,7 @@ MyObject::emitOpaqueChanged()
 void
 MyObject::setPrimitive(const qint32& value)
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->setPrimitive(
     *this, rust::cxxqtlib1::cxx_qt_convert<qint32, const qint32&>{}(value));
 }
@@ -96,7 +96,7 @@ MyObject::setPrimitive(const qint32& value)
 void
 MyObject::setTrivial(const QPoint& value)
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->setTrivial(
     *this, rust::cxxqtlib1::cxx_qt_convert<QPoint, const QPoint&>{}(value));
 }
@@ -104,7 +104,7 @@ MyObject::setTrivial(const QPoint& value)
 void
 MyObject::setOpaque(const Value& value)
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->setOpaque(
     *this,
     rust::cxxqtlib1::cxx_qt_convert<::std::unique_ptr<Opaque>, const Value&>{}(

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -52,7 +52,7 @@ Q_SIGNALS:
 
 private:
   rust::Box<MyObjectRust> m_rustObj;
-  std::shared_ptr<std::mutex> m_rustObjMutex;
+  std::shared_ptr<std::recursive_mutex> m_rustObjMutex;
   std::shared_ptr<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
     m_cxxQtThreadObj;
 };

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -5,7 +5,7 @@ namespace cxx_qt::my_object {
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
   , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
-  , m_rustObjMutex(std::make_shared<std::mutex>())
+  , m_rustObjMutex(std::make_shared<std::recursive_mutex>())
   , m_cxxQtThreadObj(
       std::make_shared<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(this))
 {
@@ -39,7 +39,7 @@ MyObject::qtThread() const
 void
 MyObject::invokable()
 {
-  const std::lock_guard<std::mutex> guard(*m_rustObjMutex);
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->invokableWrapper(*this);
 }
 

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -40,7 +40,7 @@ Q_SIGNALS:
 
 private:
   rust::Box<MyObjectRust> m_rustObj;
-  std::shared_ptr<std::mutex> m_rustObjMutex;
+  std::shared_ptr<std::recursive_mutex> m_rustObjMutex;
   std::shared_ptr<rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
     m_cxxQtThreadObj;
 };

--- a/crates/cxx-qt-lib-headers/include/cxxqt_thread.h
+++ b/crates/cxx-qt-lib-headers/include/cxxqt_thread.h
@@ -37,7 +37,7 @@ class CxxQtThread
 {
 public:
   CxxQtThread(std::shared_ptr<CxxQtGuardedPointer<T>> obj,
-              std::shared_ptr<std::mutex> rustObjMutex)
+              std::shared_ptr<std::recursive_mutex> rustObjMutex)
     : m_obj(obj)
     , m_rustObjMutex(rustObjMutex)
   {
@@ -63,7 +63,7 @@ public:
       const auto guard = std::shared_lock(obj->mutex);
       if (obj->ptr) {
         // Ensure that the rustObj is locked
-        const std::lock_guard<std::mutex> guardRustObj(*rustObjMutex);
+        const std::lock_guard<std::recursive_mutex> guardRustObj(*rustObjMutex);
         func(*obj->ptr);
       } else {
         qWarning()
@@ -80,7 +80,7 @@ public:
 
 private:
   std::shared_ptr<CxxQtGuardedPointer<T>> m_obj;
-  std::shared_ptr<std::mutex> m_rustObjMutex;
+  std::shared_ptr<std::recursive_mutex> m_rustObjMutex;
 };
 
 } // namespace cxxqtlib1


### PR DESCRIPTION
This then allows for methods to trigger signals which are linked on the same thread to invokables.
eg beginInsertRows triggers rowCount().

This is safe because to emit a signal you need a mutable self, which then allows other methods to be called with similar rules in Rust around ownership. And we still protect against other threads from calling the RustObj at the same time.

We also still have queued signals as the "safe" route for now, to ensure that slots are called "later". Obvious C++ code can be written to call on a different thread and cause a deadlock from a method in the base class being called.