### PR TITLE
cxx-qt-gen: use impl qobject::T to define the C++ context

### DIFF
--- a/book/src/qobject/qobject_struct.md
+++ b/book/src/qobject/qobject_struct.md
@@ -21,7 +21,7 @@ The `#[cxx_qt::qobject]` marked struct allows you to define the following items
 
 ## Invokables
 
-A `impl cxx_qt::QObject<T>` is used to define invokables, the `impl cxx_qt::QObject<T>` defines that the methods are implemented onto the C++ QObject `T`.
+A `impl qobject::T` is used to define invokables, the `impl qobject::T` defines that the methods are implemented onto the C++ QObject `T`.
 Therefore they have access to both C++ and Rust methods. Also CXX-Qt adds wrapper code around your invokables to automatically perform any conversion between the [C++ and Rust types](../concepts/types.md).
 
 To mark a method as invokable simply add the `#[qinvokable]` attribute to the Rust method. This then causes `Q_INVOKABLE` to be set on the C++ definition of the method, allowing QML to call the invokable.
@@ -42,6 +42,6 @@ If you want to provide default values for your QObject, then instead of deriving
 
 Fields within the `#[cxx_qt::qobject]` marked struct that aren't tagged are not exposed as properties to Qt. These can be considered as "private to Rust" fields, and are useful for storing channels for threading or internal information for the QObject.
 
-Methods implemented using `impl T` (and not `impl cxx_qt::QObject<T>`) are just normal Rust member methods.
+Methods implemented using `impl T` (and not `impl qobject::T`) are just normal Rust member methods.
 Therefore they do not have access to any C++ or QObject functionality (e.g. emitting Signals, changing properties, etc.)
 You will usually only need to use `impl T` if you want to also use your struct as a normal Rust struct, that is not wrapped in a QObject.

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -89,7 +89,7 @@ impl ParsedQObject {
 
     /// Extract all methods (both invokable and non-invokable) from [syn::ImplItem]'s from each Impl block
     ///
-    /// These will have come from a impl cxx_qt::QObject<T> block
+    /// These will have come from a impl qobject::T block
     pub fn parse_impl_items(&mut self, items: &[ImplItem]) -> Result<()> {
         for item in items {
             // Check if this item is a method

--- a/crates/cxx-qt-gen/test_inputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_inputs/invokables.rs
@@ -12,7 +12,7 @@ mod ffi {
     #[derive(Default)]
     pub struct MyObject;
 
-    impl cxx_qt::QObject<MyObject> {
+    impl qobject::MyObject {
         #[qinvokable]
         pub fn invokable(&self) {
             println!("invokable");

--- a/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
@@ -91,7 +91,7 @@ pub mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<MyObject> {
+    impl qobject::MyObject {
         #[qinvokable]
         pub fn invokable_name(self: Pin<&mut Self>) {
             println!("Bye from Rust!");

--- a/crates/cxx-qt-gen/test_inputs/signals.rs
+++ b/crates/cxx-qt-gen/test_inputs/signals.rs
@@ -22,7 +22,7 @@ mod ffi {
     #[derive(Default)]
     pub struct MyObject;
 
-    impl cxx_qt::QObject<MyObject> {
+    impl qobject::MyObject {
         #[qinvokable]
         pub fn invokable(self: Pin<&mut Self>) {
             self.as_mut().emit(MySignals::DataChanged {

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -259,4 +259,8 @@ mod cxx_qt_ffi {
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
+
+    pub mod qobject {
+        pub type MyObject = super::MyObjectQt;
+    }
 }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -216,4 +216,8 @@ mod cxx_qt_ffi {
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
+
+    pub mod qobject {
+        pub type MyObject = super::MyObjectQt;
+    }
 }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -258,4 +258,8 @@ mod cxx_qt_ffi {
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
+
+    pub mod qobject {
+        pub type MyObject = super::MyObjectQt;
+    }
 }

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -126,4 +126,8 @@ mod cxx_qt_ffi {
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
+
+    pub mod qobject {
+        pub type MyObject = super::MyObjectQt;
+    }
 }

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -22,7 +22,7 @@ use cxx_qt_gen::{write_rust, GeneratedRustBlocks, Parser};
 ///         property: i32,
 ///     }
 ///
-///     impl cxx_qt::QObject<RustObj> {
+///     impl qobject::RustObj {
 ///         #[qinvokable]
 ///         fn invokable(&self, a: i32, b: i32) -> i32 {
 ///             a + b
@@ -104,37 +104,6 @@ pub fn signals(_args: TokenStream, _input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn qobject(_args: TokenStream, _input: TokenStream) -> TokenStream {
     unreachable!("cxx_qt::qobject should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")
-}
-
-/// A macro which describes that the inner methods should be implemented on the C++ QObject.
-/// This allows for defining C++ methods which are Q_INVOKABLE for QML in Rust.
-///
-/// It should not be used by itself and instead should be used inside a cxx_qt::bridge definition.
-///
-/// # Example
-///
-/// ```ignore
-/// #[cxx_qt::bridge]
-/// mod my_object {
-///     #[cxx_qt::qobject]
-///     #[derive(Default)]
-///     struct RustObj {
-///         #[qproperty]
-///         property: i32,
-///     }
-///
-///     impl cxx_qt::QObject<RustObj> {
-///         #[qinvokable]
-///         fn invokable(&self, a: i32, b: i32) -> i32 {
-///             a + b
-///         }
-///     }
-/// }
-/// ```
-#[proc_macro]
-#[allow(non_snake_case)]
-pub fn QObject(_input: TokenStream) -> TokenStream {
-    unreachable!("cxx_qt::QObject should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")
 }
 
 // Take the module and C++ namespace and generate the rust code

--- a/examples/demo_threading/rust/src/lib.rs
+++ b/examples/demo_threading/rust/src/lib.rs
@@ -218,7 +218,7 @@ mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<EnergyUsage> {
+    impl qobject::EnergyUsage {
         #[qinvokable]
         pub fn start_server(self: Pin<&mut Self>) {
             if self.rust().join_handles.is_some() {

--- a/examples/qml_extension_plugin/plugin/rust/src/lib.rs
+++ b/examples/qml_extension_plugin/plugin/rust/src/lib.rs
@@ -60,7 +60,7 @@ mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<MyObject> {
+    impl qobject::MyObject {
         #[qinvokable]
         pub fn increment(self: Pin<&mut Self>) {
             let new_number = self.number() + 1;

--- a/examples/qml_features/rust/src/custom_base.rs
+++ b/examples/qml_features/rust/src/custom_base.rs
@@ -47,7 +47,7 @@ mod ffi {
         vector: Vec<(u32, f64)>,
     }
 
-    impl cxx_qt::QObject<CustomBase> {
+    impl qobject::CustomBase {
         #[qinvokable]
         pub fn add(mut self: Pin<&mut Self>) {
             let count = self.rust().vector.len();
@@ -60,7 +60,7 @@ mod ffi {
     }
 
     // QAbstractListModel implementation
-    impl cxx_qt::QObject<CustomBase> {
+    impl qobject::CustomBase {
         #[qinvokable(cxx_override)]
         fn data(&self, index: &QModelIndex, role: i32) -> QVariant {
             if let Some((id, value)) = self.rust().vector.get(index.row() as usize) {

--- a/examples/qml_features/rust/src/lib.rs
+++ b/examples/qml_features/rust/src/lib.rs
@@ -38,7 +38,7 @@ mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<MyObject> {
+    impl qobject::MyObject {
         #[qinvokable]
         pub fn increment_number_self(mut self: Pin<&mut Self>) {
             let value = self.number() + 1;

--- a/examples/qml_features/rust/src/mock_qt_types.rs
+++ b/examples/qml_features/rust/src/mock_qt_types.rs
@@ -96,7 +96,7 @@ mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<MockQtTypes> {
+    impl qobject::MockQtTypes {
         #[qinvokable]
         pub fn test_signal(mut self: Pin<&mut Self>) {
             self.as_mut().emit(Signal::Ready);

--- a/examples/qml_features/rust/src/rust_obj_invokables.rs
+++ b/examples/qml_features/rust/src/rust_obj_invokables.rs
@@ -23,7 +23,7 @@ pub mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<RustObjInvokables> {
+    impl qobject::RustObjInvokables {
         // ANCHOR: book_cpp_obj
         #[qinvokable]
         pub fn invokable_mutate_cpp(self: Pin<&mut Self>) {

--- a/examples/qml_features/rust/src/serialisation.rs
+++ b/examples/qml_features/rust/src/serialisation.rs
@@ -57,7 +57,7 @@ mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<Serialisation> {
+    impl qobject::Serialisation {
         #[qinvokable]
         pub fn as_json_str(&self) -> QString {
             let data_serde = DataSerde::from(self.rust());

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -35,7 +35,7 @@ pub mod ffi {
     }
 
     // ANCHOR: book_rust_obj_impl
-    impl cxx_qt::QObject<Signals> {
+    impl qobject::Signals {
         #[qinvokable]
         pub fn invokable(mut self: Pin<&mut Self>) {
             self.as_mut().emit(Signal::Ready);

--- a/examples/qml_features/rust/src/threading.rs
+++ b/examples/qml_features/rust/src/threading.rs
@@ -42,7 +42,7 @@ mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<ThreadingWebsite> {
+    impl qobject::ThreadingWebsite {
         /// Swap the URL between kdab.com and github.com
         #[qinvokable]
         pub fn change_url(self: Pin<&mut Self>) {

--- a/examples/qml_features/rust/src/types.rs
+++ b/examples/qml_features/rust/src/types.rs
@@ -27,7 +27,7 @@ mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<Types> {
+    impl qobject::Types {
         #[qinvokable]
         pub fn test_variant_property(mut self: Pin<&mut Self>) {
             match self.variant().value() {

--- a/examples/qml_minimal/rust/src/cxxqt_object.rs
+++ b/examples/qml_minimal/rust/src/cxxqt_object.rs
@@ -37,7 +37,7 @@ mod ffi {
     // ANCHOR_END: book_rustobj_struct
 
     // ANCHOR: book_rustobj_impl
-    impl cxx_qt::QObject<MyObject> {
+    impl qobject::MyObject {
         #[qinvokable]
         pub fn increment_number(self: Pin<&mut Self>) {
             let previous = *self.as_ref().number();

--- a/tests/basic_cxx_qt/rust/src/data.rs
+++ b/tests/basic_cxx_qt/rust/src/data.rs
@@ -57,7 +57,7 @@ mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<MyData> {
+    impl qobject::MyData {
         #[qinvokable]
         pub fn as_json_str(&self) -> QString {
             let data_serde = DataSerde::from(self.rust());

--- a/tests/basic_cxx_qt/rust/src/lib.rs
+++ b/tests/basic_cxx_qt/rust/src/lib.rs
@@ -35,7 +35,7 @@ mod ffi {
         }
     }
 
-    impl cxx_qt::QObject<MyObject> {
+    impl qobject::MyObject {
         #[qinvokable]
         pub fn double_number_self(self: Pin<&mut Self>) {
             let value = self.number() * 2;


### PR DESCRIPTION
This then creates a natural way to add methods to the C++ context.

It also means later with nested objects they can be referred to by crates::module::qobject::MyObject.

And any Rust traits or methods are natural as they are impl A for T, with traits for the C++ object being natural with impl A for qobject::T