### PR TITLE
cxx-qt-gen: strip lifetimes from CXX definitions for signals

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Ident, Result};
+use syn::{Ident, Result, Type};
 
 pub fn generate_rust_signals(
     signals_enum: &ParsedSignalsEnum,
@@ -44,7 +44,13 @@ pub fn generate_rust_signals(
                 .iter()
                 .map(|parameter| {
                     let ident = &parameter.ident;
-                    let ty = &parameter.ty;
+                    let mut ty = parameter.ty.clone();
+                    // Remove any lifetime from the signal, as this will be related
+                    // to the enum. For the CXX methods these can just be
+                    // normal references with inferred lifetimes.
+                    if let Type::Reference(ty) = &mut ty {
+                        ty.lifetime = None;
+                    }
                     quote! { #ident: #ty }
                 })
                 .collect::<Vec<TokenStream>>();

--- a/crates/cxx-qt-gen/test_inputs/signals.rs
+++ b/crates/cxx-qt-gen/test_inputs/signals.rs
@@ -7,7 +7,7 @@ mod ffi {
     }
 
     #[cxx_qt::signals(MyObject)]
-    enum MySignals {
+    enum MySignals<'a> {
         Ready,
         DataChanged {
             first: i32,
@@ -15,6 +15,7 @@ mod ffi {
             #[cxx_type = "Value"]
             second: UniquePtr<Opaque>,
             third: QPoint,
+            fourth: &'a QPoint,
         },
     }
 
@@ -29,6 +30,7 @@ mod ffi {
                 first: 1,
                 second: Opaque::new(),
                 third: QPoint::new(1, 2),
+                fourth: &QPoint::new(1, 2),
             });
         }
     }

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -52,13 +52,16 @@ MyObject::emitReady()
 void
 MyObject::emitDataChanged(qint32 first,
                           ::std::unique_ptr<Opaque> second,
-                          QPoint third)
+                          QPoint third,
+                          const QPoint& fourth)
 {
   Q_EMIT dataChanged(
     rust::cxxqtlib1::cxx_qt_convert<qint32, qint32>{}(std::move(first)),
     rust::cxxqtlib1::cxx_qt_convert<Value, ::std::unique_ptr<Opaque>>{}(
       std::move(second)),
-    rust::cxxqtlib1::cxx_qt_convert<QPoint, QPoint>{}(std::move(third)));
+    rust::cxxqtlib1::cxx_qt_convert<QPoint, QPoint>{}(std::move(third)),
+    rust::cxxqtlib1::cxx_qt_convert<const QPoint&, const QPoint&>{}(
+      std::move(fourth)));
 }
 
 } // namespace cxx_qt::my_object

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -32,11 +32,15 @@ public:
   void emitReady();
   void emitDataChanged(qint32 first,
                        ::std::unique_ptr<Opaque> second,
-                       QPoint third);
+                       QPoint third,
+                       const QPoint& fourth);
 
 Q_SIGNALS:
   void ready();
-  void dataChanged(qint32 first, Value second, QPoint third);
+  void dataChanged(qint32 first,
+                   Value second,
+                   QPoint third,
+                   const QPoint& fourth);
 
 private:
   rust::Box<MyObjectRust> m_rustObj;

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -43,6 +43,7 @@ mod ffi {
             first: i32,
             second: UniquePtr<Opaque>,
             third: QPoint,
+            fourth: &QPoint,
         );
     }
 
@@ -95,16 +96,18 @@ mod cxx_qt_ffi {
                 first: 1,
                 second: Opaque::new(),
                 third: QPoint::new(1, 2),
+                fourth: &QPoint::new(1, 2),
             });
         }
     }
 
-    enum MySignals {
+    enum MySignals<'a> {
         Ready,
         DataChanged {
             first: i32,
             second: UniquePtr<Opaque>,
             third: QPoint,
+            fourth: &'a QPoint,
         },
     }
 
@@ -116,7 +119,8 @@ mod cxx_qt_ffi {
                     first,
                     second,
                     third,
-                } => self.emit_data_changed(first, second, third),
+                    fourth,
+                } => self.emit_data_changed(first, second, third, fourth),
             }
         }
     }

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -15,11 +15,12 @@ pub mod ffi {
 
     // ANCHOR: book_signals_enum
     #[cxx_qt::signals(Signals)]
-    pub enum Signal {
+    pub enum Signal<'a> {
         Ready,
         RustDataChanged { data: i32 },
         TrivialDataChanged { trivial: QPoint },
         OpaqueDataChanged { opaque: QVariant },
+        ReferenceDataChanged { reference: &'a QPoint },
     }
     // ANCHOR_END: book_signals_enum
 
@@ -50,6 +51,10 @@ pub mod ffi {
                 opaque: self.opaque().clone(),
             };
             self.as_mut().emit(signal);
+
+            let point = QPoint::new(1, 2);
+            self.as_mut()
+                .emit(Signal::ReferenceDataChanged { reference: &point });
         }
     }
     // ANCHOR_END: book_rust_obj_impl


### PR DESCRIPTION
As the lifetime will be the lifetime of the enum. Then we don't need this in the CXX method as it can be inferred.