### PR TITLE
cxx-qt-gen: rename cxx_qt::signals to cxx_qt::qsignals

### DIFF
--- a/book/src/qobject/signals_enum.md
+++ b/book/src/qobject/signals_enum.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 # Signals enum
 
-The `cxx_qt::signals(T)` attribute is used on an enum to define which signals should exist on the QObject `T`. It allows you to define the signal name and the parameters of the signal.
+The `cxx_qt::qsignals(T)` attribute is used on an enum to define which signals should exist on the QObject `T`. It allows you to define the signal name and the parameters of the signal.
 
 ```rust,ignore,noplayground
 {{#include ../../../examples/qml_features/rust/src/signals.rs:book_signals_enum}}

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn test_generate_rust_signals() {
         let e: ItemEnum = tokens_to_syn(quote! {
-            #[cxx_qt::signals(MyObject)]
+            #[cxx_qt::qsignals(MyObject)]
             enum MySignals {
                 Ready,
                 DataChanged {

--- a/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
+++ b/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
@@ -71,8 +71,8 @@ impl ParsedCxxQtData {
     /// Parse a [syn::ItemEnum] into the qobjects if it's a CXX-Qt signal
     /// otherwise return as a [syn::Item] to pass through.
     fn parse_enum(&mut self, item_enum: ItemEnum) -> Result<Option<Item>> {
-        // Check if the enum has cxx_qt::signals(T)
-        if let Some(index) = attribute_find_path(&item_enum.attrs, &["cxx_qt", "signals"]) {
+        // Check if the enum has cxx_qt::qsignals(T)
+        if let Some(index) = attribute_find_path(&item_enum.attrs, &["cxx_qt", "qsignals"]) {
             let ident = attribute_tokens_to_ident(&item_enum.attrs[index])?;
             // Find the matching QObject for the enum
             if let Some(qobject) = self.qobjects.get_mut(&ident) {
@@ -81,7 +81,7 @@ impl ParsedCxxQtData {
             } else {
                 return Err(Error::new(
                     item_enum.span(),
-                    "No matching QObject found for the given cxx_qt::signals<T> enum.",
+                    "No matching QObject found for the given cxx_qt::qsignals<T> enum.",
                 ));
             }
         }
@@ -198,7 +198,7 @@ mod tests {
         let mut cxx_qt_data = create_parsed_cxx_qt_data();
 
         let item: Item = tokens_to_syn(quote! {
-            #[cxx_qt::signals(MyObject)]
+            #[cxx_qt::qsignals(MyObject)]
             enum MySignals {
                 Ready,
             }
@@ -214,7 +214,7 @@ mod tests {
 
         // Valid signals enum but missing QObject
         let item: Item = tokens_to_syn(quote! {
-            #[cxx_qt::signals(UnknownObj)]
+            #[cxx_qt::qsignals(UnknownObj)]
             enum MySignals {
                 Ready,
             }
@@ -241,7 +241,7 @@ mod tests {
         let mut cxx_qt_data = create_parsed_cxx_qt_data();
 
         let item: Item = tokens_to_syn(quote! {
-            #[cxx_qt::signals]
+            #[cxx_qt::qsignals]
             enum MySignals {
                 Ready,
             }

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -161,7 +161,7 @@ mod tests {
                 #[cxx_qt::qobject]
                 struct MyObject;
 
-                #[cxx_qt::signals(MyObject)]
+                #[cxx_qt::qsignals(MyObject)]
                 enum MySignals {
                     Ready,
                 }
@@ -186,7 +186,7 @@ mod tests {
                 #[cxx_qt::qobject]
                 struct MyObject;
 
-                #[cxx_qt::signals(MyObject)]
+                #[cxx_qt::qsignals(MyObject)]
                 enum MySignals {
                     Ready,
                 }
@@ -215,7 +215,7 @@ mod tests {
                 #[cxx_qt::qobject]
                 struct MyObject;
 
-                #[cxx_qt::signals(UnknownObj)]
+                #[cxx_qt::qsignals(UnknownObj)]
                 enum MySignals {
                     Ready,
                 }

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -100,7 +100,7 @@ mod tests {
     #[test]
     fn test_parsed_signals_from_empty() {
         let e: ItemEnum = tokens_to_syn(quote! {
-            #[cxx_qt::signals(MyObject)]
+            #[cxx_qt::qsignals(MyObject)]
             enum MySignals {}
         });
         let signals = ParsedSignalsEnum::from(&e, 0).unwrap();
@@ -113,7 +113,7 @@ mod tests {
     fn test_parsed_signals_from_empty_attrs() {
         let e: ItemEnum = tokens_to_syn(quote! {
             #[before]
-            #[cxx_qt::signals(MyObject)]
+            #[cxx_qt::qsignals(MyObject)]
             #[after]
             enum MySignals {}
         });
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn test_parsed_signals_from_named() {
         let e: ItemEnum = tokens_to_syn(quote! {
-            #[cxx_qt::signals(MyObject)]
+            #[cxx_qt::qsignals(MyObject)]
             enum MySignals {
                 Ready,
                 PointChanged {
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn test_parsed_signals_from_unnamed() {
         let e: ItemEnum = tokens_to_syn(quote! {
-            #[cxx_qt::signals(MyObject)]
+            #[cxx_qt::qsignals(MyObject)]
             enum MySignals {
                 Ready,
                 PointChanged(f64, f64),

--- a/crates/cxx-qt-gen/src/syntax/attribute.rs
+++ b/crates/cxx-qt-gen/src/syntax/attribute.rs
@@ -156,14 +156,14 @@ mod tests {
         let module: ItemMod = tokens_to_syn(quote! {
             #[qinvokable]
             #[cxx_qt::bridge]
-            #[cxx_qt::signals(MyObject)]
+            #[cxx_qt::qsignals(MyObject)]
             #[cxx_qt::bridge(namespace = "my::namespace")]
             mod module;
         });
 
         assert!(attribute_find_path(&module.attrs, &["qinvokable"]).is_some());
         assert!(attribute_find_path(&module.attrs, &["cxx_qt", "bridge"]).is_some());
-        assert!(attribute_find_path(&module.attrs, &["cxx_qt", "signals"]).is_some());
+        assert!(attribute_find_path(&module.attrs, &["cxx_qt", "qsignals"]).is_some());
         assert!(attribute_find_path(&module.attrs, &["cxx_qt", "missing"]).is_none());
     }
 
@@ -172,7 +172,7 @@ mod tests {
         let module: ItemMod = tokens_to_syn(quote! {
             #[qinvokable]
             #[cxx_qt::bridge]
-            #[cxx_qt::signals(MyObject)]
+            #[cxx_qt::qsignals(MyObject)]
             #[cxx_qt::bridge(namespace = "my::namespace")]
             #[cxx_qt::list(A, B, C)]
             #[cxx_qt::empty()]
@@ -196,7 +196,7 @@ mod tests {
         let module: ItemMod = tokens_to_syn(quote! {
             #[qinvokable]
             #[cxx_qt::bridge]
-            #[cxx_qt::signals(MyObject)]
+            #[cxx_qt::qsignals(MyObject)]
             #[cxx_qt::bridge(namespace = "my::namespace")]
             #[cxx_qt::list(A, B, C)]
             #[cxx_qt::list()]
@@ -226,7 +226,7 @@ mod tests {
         let module: ItemMod = tokens_to_syn(quote! {
             #[qinvokable]
             #[cxx_qt::bridge]
-            #[cxx_qt::signals(MyObject)]
+            #[cxx_qt::qsignals(MyObject)]
             #[cxx_qt::bridge(namespace = "my::namespace")]
             #[cxx_qt::list(A, B, C)]
             #[cxx_qt::bridge(a = "b", namespace = "my::namespace")]

--- a/crates/cxx-qt-gen/test_inputs/signals.rs
+++ b/crates/cxx-qt-gen/test_inputs/signals.rs
@@ -6,7 +6,7 @@ mod ffi {
         type QPoint = cxx_qt_lib::QPoint;
     }
 
-    #[cxx_qt::signals(MyObject)]
+    #[cxx_qt::qsignals(MyObject)]
     enum MySignals<'a> {
         Ready,
         DataChanged {

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -61,7 +61,7 @@ pub fn bridge(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[cxx_qt::bridge(namespace = "cxx_qt::my_object")]
 /// mod my_object {
-///     #[cxx_qt::signals(MyObject)]
+///     #[cxx_qt::qsignals(MyObject)]
 ///     enum MySignals {
 ///         Ready,
 ///     }
@@ -69,7 +69,7 @@ pub fn bridge(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn signals(_args: TokenStream, _input: TokenStream) -> TokenStream {
-    unreachable!("cxx_qt::signals should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")
+    unreachable!("cxx_qt::qsignals should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")
 }
 
 /// A macro which describes that a struct should be made into a QObject.

--- a/examples/qml_features/rust/src/serialisation.rs
+++ b/examples/qml_features/rust/src/serialisation.rs
@@ -42,7 +42,7 @@ mod ffi {
         pub string: QString,
     }
 
-    #[cxx_qt::signals(Serialisation)]
+    #[cxx_qt::qsignals(Serialisation)]
     pub enum Connection {
         Error { message: QString },
     }

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -14,7 +14,7 @@ pub mod ffi {
     }
 
     // ANCHOR: book_signals_enum
-    #[cxx_qt::signals(RustSignals)]
+    #[cxx_qt::qsignals(RustSignals)]
     pub enum Connection<'a> {
         Connected { url: &'a QUrl },
         Disconnected,


### PR DESCRIPTION
This then matches the Qt Q_SIGNALS closer and is consistent with qproperty and qinvokable etc.