### PR TITLE
cxx-qt-gen: wrap CxxQtThread::queue() to support Send + 'static closure

### DIFF
--- a/book/src/concepts/threading.md
+++ b/book/src/concepts/threading.md
@@ -27,8 +27,8 @@ To achieve safe multi-threading on the Rust side we use an [`CxxQtThread<T>`](..
 A `CxxQtThread<T>` represents a reference to the Qt thread that the QObject of type `T` lives in.
 When a new Rust thread is started (e.g. in an invokable) the `CxxQtThread<T>` can be moved into the thread to later update the QObject in a thread safe manner.
 
-When the Rust thread needs to update a value in the QObject it can then queue a function pointer to the thread.
-This function pointer will be executed on the thread the QObject lives in.
+When the Rust thread needs to update a value in the QObject it can then queue a closure to the thread.
+This closure will be executed on the thread the QObject lives in.
 Updating the QObject is then thread-safe.
 
 Below is a complete Rust example of a multi-threaded object.

--- a/crates/cxx-qt-gen/src/generator/naming/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/qobject.rs
@@ -15,6 +15,8 @@ pub struct QObjectName {
     pub rust_struct: CombinedIdent,
     /// The name of the CxxQtThread
     pub cxx_qt_thread_class: Ident,
+    /// The name of the Rust closure wrapper to be passed in to CxxQtThread
+    pub cxx_qt_thread_queued_fn_struct: Ident,
 }
 
 impl From<&ParsedQObject> for QObjectName {
@@ -29,6 +31,7 @@ impl From<&Ident> for QObjectName {
             cpp_class: cpp_class_from_ident(ident),
             rust_struct: rust_struct_from_ident(ident),
             cxx_qt_thread_class: cxx_qt_thread_class_from_ident(ident),
+            cxx_qt_thread_queued_fn_struct: cxx_qt_thread_queued_fn_struct_from_ident(ident),
         }
     }
 }
@@ -44,6 +47,11 @@ fn cpp_class_from_ident(ident: &Ident) -> CombinedIdent {
 /// For a given ident generate the CxxQtThread ident
 fn cxx_qt_thread_class_from_ident(ident: &Ident) -> Ident {
     format_ident!("{}CxxQtThread", ident)
+}
+
+/// For a given ident generate the CxxQtThreadQueuedFn ident
+fn cxx_qt_thread_queued_fn_struct_from_ident(ident: &Ident) -> Ident {
+    format_ident!("{}CxxQtThreadQueuedFn", ident)
 }
 
 /// For a given ident generate the Rust and C++ names
@@ -74,6 +82,10 @@ pub mod tests {
         assert_eq!(
             names.cxx_qt_thread_class,
             format_ident!("MyObjectCxxQtThread")
+        );
+        assert_eq!(
+            names.cxx_qt_thread_queued_fn_struct,
+            format_ident!("MyObjectCxxQtThreadQueuedFn")
         );
     }
 }

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -38,6 +38,8 @@ pub struct GeneratedRustQObject {
     pub cpp_struct_ident: Ident,
     /// Ident of the CxxQtThread object
     pub cxx_qt_thread_ident: Ident,
+    /// Ident of the Rust closure wrapper to be passed in to CxxQtThread
+    pub cxx_qt_thread_queued_fn_ident: Ident,
     /// Ident of the namespace for CXX-Qt internals of the QObject
     pub namespace_internals: String,
     /// Ident of the Rust name for the Rust object
@@ -54,6 +56,7 @@ impl GeneratedRustQObject {
         let mut generated = GeneratedRustQObject {
             cpp_struct_ident: qobject_idents.cpp_class.rust.clone(),
             cxx_qt_thread_ident: qobject_idents.cxx_qt_thread_class.clone(),
+            cxx_qt_thread_queued_fn_ident: qobject_idents.cxx_qt_thread_queued_fn_struct.clone(),
             namespace_internals: namespace_idents.internal,
             rust_struct_ident: qobject_idents.rust_struct.rust.clone(),
             blocks: GeneratedRustQObjectBlocks {
@@ -179,6 +182,10 @@ mod tests {
             .unwrap();
         assert_eq!(rust.cpp_struct_ident, "MyObjectQt");
         assert_eq!(rust.cxx_qt_thread_ident, "MyObjectCxxQtThread");
+        assert_eq!(
+            rust.cxx_qt_thread_queued_fn_ident,
+            "MyObjectCxxQtThreadQueuedFn"
+        );
         assert_eq!(rust.namespace_internals, "cxx_qt_my_object");
         assert_eq!(rust.rust_struct_ident, "MyObject");
     }
@@ -198,6 +205,10 @@ mod tests {
             .unwrap();
         assert_eq!(rust.cpp_struct_ident, "MyObjectQt");
         assert_eq!(rust.cxx_qt_thread_ident, "MyObjectCxxQtThread");
+        assert_eq!(
+            rust.cxx_qt_thread_queued_fn_ident,
+            "MyObjectCxxQtThreadQueuedFn"
+        );
         assert_eq!(rust.namespace_internals, "cxx_qt::cxx_qt_my_object");
         assert_eq!(rust.rust_struct_ident, "MyObject");
     }

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -101,6 +101,9 @@ mod ffi {
     }
 
     extern "Rust" {
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        type MyObjectCxxQtThreadQueuedFn;
+
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
@@ -255,6 +258,10 @@ mod cxx_qt_ffi {
     }
 
     unsafe impl Send for MyObjectCxxQtThread {}
+
+    pub struct MyObjectCxxQtThreadQueuedFn {
+        inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
+    }
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -88,7 +88,13 @@ mod ffi {
 
         #[cxx_name = "qtThread"]
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
-        fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
+
+        #[cxx_name = "queue"]
+        fn queue_boxed_fn(
+            self: &MyObjectCxxQtThread,
+            func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
+            arg: Box<MyObjectCxxQtThreadQueuedFn>,
+        ) -> Result<()>;
 
         #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
@@ -258,6 +264,26 @@ mod cxx_qt_ffi {
     }
 
     unsafe impl Send for MyObjectCxxQtThread {}
+
+    impl MyObjectCxxQtThread {
+        pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
+        where
+            F: FnOnce(std::pin::Pin<&mut MyObjectQt>),
+            F: Send + 'static,
+        {
+            #[allow(clippy::boxed_local)]
+            fn func(
+                obj: std::pin::Pin<&mut MyObjectQt>,
+                arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
+            ) {
+                (arg.inner)(obj)
+            }
+            let arg = MyObjectCxxQtThreadQueuedFn {
+                inner: std::boxed::Box::new(f),
+            };
+            self.queue_boxed_fn(func, std::boxed::Box::new(arg))
+        }
+    }
 
     pub struct MyObjectCxxQtThreadQueuedFn {
         inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -124,6 +124,9 @@ pub mod ffi {
     }
 
     extern "Rust" {
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        type MyObjectCxxQtThreadQueuedFn;
+
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
@@ -212,6 +215,10 @@ mod cxx_qt_ffi {
     }
 
     unsafe impl Send for MyObjectCxxQtThread {}
+
+    pub struct MyObjectCxxQtThreadQueuedFn {
+        inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
+    }
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -111,7 +111,13 @@ pub mod ffi {
 
         #[cxx_name = "qtThread"]
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
-        fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
+
+        #[cxx_name = "queue"]
+        fn queue_boxed_fn(
+            self: &MyObjectCxxQtThread,
+            func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
+            arg: Box<MyObjectCxxQtThreadQueuedFn>,
+        ) -> Result<()>;
 
         #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
@@ -215,6 +221,26 @@ mod cxx_qt_ffi {
     }
 
     unsafe impl Send for MyObjectCxxQtThread {}
+
+    impl MyObjectCxxQtThread {
+        pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
+        where
+            F: FnOnce(std::pin::Pin<&mut MyObjectQt>),
+            F: Send + 'static,
+        {
+            #[allow(clippy::boxed_local)]
+            fn func(
+                obj: std::pin::Pin<&mut MyObjectQt>,
+                arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
+            ) {
+                (arg.inner)(obj)
+            }
+            let arg = MyObjectCxxQtThreadQueuedFn {
+                inner: std::boxed::Box::new(f),
+            };
+            self.queue_boxed_fn(func, std::boxed::Box::new(arg))
+        }
+    }
 
     pub struct MyObjectCxxQtThreadQueuedFn {
         inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -79,7 +79,13 @@ mod ffi {
 
         #[cxx_name = "qtThread"]
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
-        fn queue(self: &MyObjectCxxQtThread, func: fn(ctx: Pin<&mut MyObjectQt>)) -> Result<()>;
+
+        #[cxx_name = "queue"]
+        fn queue_boxed_fn(
+            self: &MyObjectCxxQtThread,
+            func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
+            arg: Box<MyObjectCxxQtThreadQueuedFn>,
+        ) -> Result<()>;
 
         #[rust_name = "new_cpp_object_my_object_qt"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
@@ -257,6 +263,26 @@ mod cxx_qt_ffi {
     }
 
     unsafe impl Send for MyObjectCxxQtThread {}
+
+    impl MyObjectCxxQtThread {
+        pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
+        where
+            F: FnOnce(std::pin::Pin<&mut MyObjectQt>),
+            F: Send + 'static,
+        {
+            #[allow(clippy::boxed_local)]
+            fn func(
+                obj: std::pin::Pin<&mut MyObjectQt>,
+                arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
+            ) {
+                (arg.inner)(obj)
+            }
+            let arg = MyObjectCxxQtThreadQueuedFn {
+                inner: std::boxed::Box::new(f),
+            };
+            self.queue_boxed_fn(func, std::boxed::Box::new(arg))
+        }
+    }
 
     pub struct MyObjectCxxQtThreadQueuedFn {
         inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -92,6 +92,9 @@ mod ffi {
     }
 
     extern "Rust" {
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        type MyObjectCxxQtThreadQueuedFn;
+
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
@@ -254,6 +257,10 @@ mod cxx_qt_ffi {
     }
 
     unsafe impl Send for MyObjectCxxQtThread {}
+
+    pub struct MyObjectCxxQtThreadQueuedFn {
+        inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
+    }
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -68,6 +68,9 @@ mod ffi {
     }
 
     extern "Rust" {
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        type MyObjectCxxQtThreadQueuedFn;
+
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
@@ -126,6 +129,10 @@ mod cxx_qt_ffi {
     }
 
     unsafe impl Send for MyObjectCxxQtThread {}
+
+    pub struct MyObjectCxxQtThreadQueuedFn {
+        inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
+    }
 
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()


### PR DESCRIPTION
The idea is to pass a `(callback fn, Send + 'static closure)` pair in to
`QMetaObject::invokeMethod()`, and invoke the callback fn with that closure
as an argument. The callback fn just invokes the passed closure. This way,
we can queue Rust closure back to QObject thread.

    thread::spawn(move || {
        ...
        let response = String::new();
        qt_thread.queue(move |qobject| qobject.emit(Finished { response }));
    });

This should be simpler and less error-prone than sending result back via
a separate channel.