### PR TITLE
cargo: bump convert_case and uuid as they are below 1.0

### DIFF
--- a/crates/cxx-qt-build/Cargo.toml
+++ b/crates/cxx-qt-build/Cargo.toml
@@ -19,5 +19,5 @@ cxx-qt-lib-headers = { path = "../cxx-qt-lib-headers", version = "0.4" }
 cxx-qt-gen = { path = "../cxx-qt-gen", version = "0.4" }
 proc-macro2 = "1.0"
 quote = "1.0"
-convert_case = "0.4"
+convert_case = "0.6"
 qt-build-utils = { path = "../qt-build-utils", version = "0.4" }

--- a/crates/cxx-qt-gen/Cargo.toml
+++ b/crates/cxx-qt-gen/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 
 [dependencies]
 clang-format = "0.1"
-convert_case = "0.4"
+convert_case = "0.6"
 indoc = "1.0"
 proc-macro2 = "1.0"
 syn = { version = "1.0", features = ["extra-traits", "full"] }

--- a/examples/demo_threading/rust/Cargo.toml
+++ b/examples/demo_threading/rust/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3"
 futures-timer = "3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "1.2", features = ["serde", "v4"] }
 
 [build-dependencies]
 cxx-qt-build = { path = "../../../crates/cxx-qt-build" }


### PR DESCRIPTION
As per the cargo docs, any versions that are less than 1.0 need bumping a minor version to move to the next series (after 1.0 it's the major version that needs bumping). So bump `convert_case` 0.4 -> 0.6 and `uuid` 0.8 -> 1.2.
```
1.2.3  :=  >=1.2.3, <2.0.0
1.2    :=  >=1.2.0, <2.0.0
1      :=  >=1.0.0, <2.0.0
0.2.3  :=  >=0.2.3, <0.3.0
0.2    :=  >=0.2.0, <0.3.0
0.0.3  :=  >=0.0.3, <0.0.4
0.0    :=  >=0.0.0, <0.1.0
0      :=  >=0.0.0, <1.0.0
```

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio