### PR TITLE
clippy: fix new 1.65 warnings

### DIFF
--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -123,7 +123,7 @@ impl GeneratedCpp {
         let cpp_directory = cpp_directory.as_ref();
         let header_directory = header_directory.as_ref();
         for directory in [cpp_directory, header_directory] {
-            std::fs::create_dir_all(&directory)
+            std::fs::create_dir_all(directory)
                 .expect("Could not create directory to write cxx-qt generated files");
         }
 

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -46,7 +46,7 @@ mod tests {
         // NOTE: this error handling is pretty rough so should only used for tests
         let mut command = std::process::Command::new("rustfmt");
         let mut child = command
-            .args(&["--emit", "stdout"])
+            .args(["--emit", "stdout"])
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .spawn()

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -110,8 +110,8 @@ impl QtBuild {
         println!("cargo:rerun-if-env-changed=QMAKE");
         println!("cargo:rerun-if-env-changed=QT_VERSION_MAJOR");
         fn verify_candidate(candidate: &str) -> Result<(&str, versions::SemVer), QtBuildError> {
-            match Command::new(&candidate)
-                .args(&["-query", "QT_VERSION"])
+            match Command::new(candidate)
+                .args(["-query", "QT_VERSION"])
                 .output()
             {
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(QtBuildError::QtMissing),
@@ -218,7 +218,7 @@ impl QtBuild {
     pub fn qmake_query(&self, var_name: &str) -> String {
         std::str::from_utf8(
             &Command::new(&self.qmake_executable)
-                .args(&["-query", var_name])
+                .args(["-query", var_name])
                 .output()
                 .unwrap()
                 .stdout,
@@ -300,7 +300,7 @@ impl QtBuild {
             "QT_INSTALL_BINS",
         ] {
             let executable_path = format!("{}/{}", self.qmake_query(qmake_query_var), tool_name);
-            match Command::new(&executable_path).args(&["-help"]).output() {
+            match Command::new(&executable_path).args(["-help"]).output() {
                 Ok(_) => return Ok(executable_path),
                 Err(_) => continue,
             }
@@ -323,7 +323,7 @@ impl QtBuild {
         ));
 
         let _ = Command::new(self.moc_executable.as_ref().unwrap())
-            .args(&[
+            .args([
                 input_path.to_str().unwrap(),
                 "-o",
                 output_path.to_str().unwrap(),
@@ -349,7 +349,7 @@ impl QtBuild {
         ));
 
         let _ = Command::new(self.rcc_executable.as_ref().unwrap())
-            .args(&[
+            .args([
                 input_path.to_str().unwrap(),
                 "-o",
                 output_path.to_str().unwrap(),


### PR DESCRIPTION
Resolves the warning:
The borrowed expression implements the required traits