### PR TITLE
cxx-qt-gen: generate C++ types for Pin<T> correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed linking Qt with macOS frameworks. This allows using Qt from Homebrew.
 
+### Fixed
+
+- Support for generating correct C++ code for `Pin<T>` Rust types
+
 ## [0.4.0](https://github.com/KDAB/cxx-qt/compare/v0.3.0...v0.4.0) - 2022-10-28
 
 ### Added


### PR DESCRIPTION
Related to #328 

This adds missing support in our generation for having `Pin<T>` as a type.