### PR TITLE
#332 add `Q_SIGNAL` and `Q_SLOT` to methods definitions

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/fragment.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/fragment.rs
@@ -5,10 +5,19 @@
 
 use crate::generator::cpp::types::CppType;
 
-/// A generic C++ header and source pairing
-pub struct CppFragmentPair {
-    pub header: String,
-    pub source: String,
+pub enum CppFragment {
+    Pair { header: String, source: String },
+    Header(String),
+    Source(String),
+}
+
+impl Default for CppFragment {
+    fn default() -> Self {
+        CppFragment::Pair {
+            header: String::new(),
+            source: String::new(),
+        }
+    }
 }
 
 pub struct CppNamedType {

--- a/crates/cxx-qt-gen/src/generator/cpp/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/getter.rs
@@ -4,13 +4,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::generator::{
-    cpp::{fragment::CppFragmentPair, types::CppType, CXX_QT_CONVERT, RUST_OBJ_MUTEX_LOCK_GUARD},
+    cpp::{fragment::CppFragment, types::CppType, CXX_QT_CONVERT, RUST_OBJ_MUTEX_LOCK_GUARD},
     naming::property::QPropertyName,
 };
 use indoc::formatdoc;
 
-pub fn generate(idents: &QPropertyName, qobject_ident: &str, cxx_ty: &CppType) -> CppFragmentPair {
-    CppFragmentPair {
+pub fn generate(idents: &QPropertyName, qobject_ident: &str, cxx_ty: &CppType) -> CppFragment {
+    CppFragment::Pair {
         header: format!(
             "const {cxx_ty}& {ident_getter}() const;",
             cxx_ty = cxx_ty.as_cxx_ty(),

--- a/crates/cxx-qt-gen/src/generator/cpp/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/setter.rs
@@ -4,15 +4,15 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::generator::{
-    cpp::{fragment::CppFragmentPair, types::CppType, CXX_QT_CONVERT, RUST_OBJ_MUTEX_LOCK_GUARD},
+    cpp::{fragment::CppFragment, types::CppType, CXX_QT_CONVERT, RUST_OBJ_MUTEX_LOCK_GUARD},
     naming::property::QPropertyName,
 };
 use indoc::formatdoc;
 
-pub fn generate(idents: &QPropertyName, qobject_ident: &str, cxx_ty: &CppType) -> CppFragmentPair {
-    CppFragmentPair {
+pub fn generate(idents: &QPropertyName, qobject_ident: &str, cxx_ty: &CppType) -> CppFragment {
+    CppFragment::Pair {
         header: format!(
-            "void {ident_setter}(const {cxx_ty}& value);",
+            "Q_SLOT void {ident_setter}(const {cxx_ty}& value);",
             cxx_ty = cxx_ty.as_cxx_ty(),
             ident_setter = idents.setter.cpp,
         ),

--- a/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
@@ -4,7 +4,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::generator::naming::property::QPropertyName;
+use crate::CppFragment;
 
-pub fn generate(idents: &QPropertyName) -> String {
-    format!("void {ident_notify}();", ident_notify = idents.notify.cpp)
+pub fn generate(idents: &QPropertyName) -> CppFragment {
+    CppFragment::Header(format!(
+        "Q_SIGNAL void {ident_notify}();",
+        ident_notify = idents.notify.cpp
+    ))
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -5,7 +5,7 @@
 
 use crate::generator::{
     cpp::{
-        fragment::CppFragmentPair, invokable::generate_cpp_invokables,
+        fragment::CppFragment, invokable::generate_cpp_invokables,
         property::generate_cpp_properties, signal::generate_cpp_signals,
     },
     naming::{namespace::NamespaceName, qobject::QObjectName},
@@ -18,19 +18,13 @@ pub struct GeneratedCppQObjectBlocks {
     /// List of Qt Meta Object items (eg Q_PROPERTY)
     pub metaobjects: Vec<String>,
     /// List of public methods for the QObject
-    pub methods: Vec<CppFragmentPair>,
-    /// List of public Q_SLOTS for the QObject
-    pub slots: Vec<CppFragmentPair>,
-    /// List of public Q_SIGNALS for the QObject
-    pub signals: Vec<String>,
+    pub methods: Vec<CppFragment>,
 }
 
 impl GeneratedCppQObjectBlocks {
     pub fn append(&mut self, other: &mut Self) {
         self.metaobjects.append(&mut other.metaobjects);
         self.methods.append(&mut other.methods);
-        self.slots.append(&mut other.slots);
-        self.signals.append(&mut other.signals);
     }
 }
 

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -45,6 +45,14 @@ MyObject::getPropertyName() const
 }
 
 void
+MyObject::setPropertyName(const qint32& value)
+{
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
+  m_rustObj->setPropertyName(
+    *this, rust::cxxqtlib1::cxx_qt_convert<qint32, const qint32&>{}(value));
+}
+
+void
 MyObject::invokableName()
 {
   const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
@@ -55,14 +63,6 @@ void
 MyObject::emitReady()
 {
   Q_EMIT ready();
-}
-
-void
-MyObject::setPropertyName(const qint32& value)
-{
-  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->setPropertyName(
-    *this, rust::cxxqtlib1::cxx_qt_convert<qint32, const qint32&>{}(value));
 }
 
 } // namespace cxx_qt::multi_object
@@ -121,6 +121,14 @@ SecondObject::getPropertyName() const
 }
 
 void
+SecondObject::setPropertyName(const qint32& value)
+{
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
+  m_rustObj->setPropertyName(
+    *this, rust::cxxqtlib1::cxx_qt_convert<qint32, const qint32&>{}(value));
+}
+
+void
 SecondObject::invokableName()
 {
   const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
@@ -131,14 +139,6 @@ void
 SecondObject::emitReady()
 {
   Q_EMIT ready();
-}
-
-void
-SecondObject::setPropertyName(const qint32& value)
-{
-  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->setPropertyName(
-    *this, rust::cxxqtlib1::cxx_qt_convert<qint32, const qint32&>{}(value));
 }
 
 } // namespace cxx_qt::multi_object

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -36,15 +36,11 @@ public:
 
 public:
   const qint32& getPropertyName() const;
+  Q_SLOT void setPropertyName(const qint32& value);
+  Q_SIGNAL void propertyNameChanged();
   Q_INVOKABLE void invokableName();
+  Q_SIGNAL void ready();
   void emitReady();
-
-public Q_SLOTS:
-  void setPropertyName(const qint32& value);
-
-Q_SIGNALS:
-  void propertyNameChanged();
-  void ready();
 
 private:
   rust::Box<MyObjectRust> m_rustObj;
@@ -80,15 +76,11 @@ public:
 
 public:
   const qint32& getPropertyName() const;
+  Q_SLOT void setPropertyName(const qint32& value);
+  Q_SIGNAL void propertyNameChanged();
   Q_INVOKABLE void invokableName();
+  Q_SIGNAL void ready();
   void emitReady();
-
-public Q_SLOTS:
-  void setPropertyName(const qint32& value);
-
-Q_SIGNALS:
-  void propertyNameChanged();
-  void ready();
 
 private:
   rust::Box<SecondObjectRust> m_rustObj;

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -44,12 +44,28 @@ MyObject::getPrimitive() const
     m_rustObj->getPrimitive(*this));
 }
 
+void
+MyObject::setPrimitive(const qint32& value)
+{
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
+  m_rustObj->setPrimitive(
+    *this, rust::cxxqtlib1::cxx_qt_convert<qint32, const qint32&>{}(value));
+}
+
 const QPoint&
 MyObject::getTrivial() const
 {
   const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
   return rust::cxxqtlib1::cxx_qt_convert<const QPoint&, const QPoint&>{}(
     m_rustObj->getTrivial(*this));
+}
+
+void
+MyObject::setTrivial(const QPoint& value)
+{
+  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
+  m_rustObj->setTrivial(
+    *this, rust::cxxqtlib1::cxx_qt_convert<QPoint, const QPoint&>{}(value));
 }
 
 const Value&
@@ -59,22 +75,6 @@ MyObject::getOpaque() const
   return rust::cxxqtlib1::cxx_qt_convert<const Value&,
                                          const ::std::unique_ptr<Opaque>&>{}(
     m_rustObj->getOpaque(*this));
-}
-
-void
-MyObject::setPrimitive(const qint32& value)
-{
-  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->setPrimitive(
-    *this, rust::cxxqtlib1::cxx_qt_convert<qint32, const qint32&>{}(value));
-}
-
-void
-MyObject::setTrivial(const QPoint& value)
-{
-  const std::lock_guard<std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->setTrivial(
-    *this, rust::cxxqtlib1::cxx_qt_convert<QPoint, const QPoint&>{}(value));
 }
 
 void

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -34,18 +34,14 @@ public:
 
 public:
   const qint32& getPrimitive() const;
+  Q_SLOT void setPrimitive(const qint32& value);
+  Q_SIGNAL void primitiveChanged();
   const QPoint& getTrivial() const;
+  Q_SLOT void setTrivial(const QPoint& value);
+  Q_SIGNAL void trivialChanged();
   const Value& getOpaque() const;
-
-public Q_SLOTS:
-  void setPrimitive(const qint32& value);
-  void setTrivial(const QPoint& value);
-  void setOpaque(const Value& value);
-
-Q_SIGNALS:
-  void primitiveChanged();
-  void trivialChanged();
-  void opaqueChanged();
+  Q_SLOT void setOpaque(const Value& value);
+  Q_SIGNAL void opaqueChanged();
 
 private:
   rust::Box<MyObjectRust> m_rustObj;

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -29,18 +29,16 @@ public:
 
 public:
   Q_INVOKABLE void invokable();
+  Q_SIGNAL void ready();
   void emitReady();
+  Q_SIGNAL void dataChanged(qint32 first,
+                            Value second,
+                            QPoint third,
+                            const QPoint& fourth);
   void emitDataChanged(qint32 first,
                        ::std::unique_ptr<Opaque> second,
                        QPoint third,
                        const QPoint& fourth);
-
-Q_SIGNALS:
-  void ready();
-  void dataChanged(qint32 first,
-                   Value second,
-                   QPoint third,
-                   const QPoint& fourth);
 
 private:
   rust::Box<MyObjectRust> m_rustObj;

--- a/crates/cxx-qt-lib-headers/src/lib.rs
+++ b/crates/cxx-qt-lib-headers/src/lib.rs
@@ -34,7 +34,7 @@ pub fn write_headers(directory: impl AsRef<Path>) {
     std::fs::create_dir_all(directory).expect("Could not create cxx-qt-lib header directory");
     for (file_contents, file_name) in HEADERS {
         let h_path = format!("{}/{}", directory.display(), file_name);
-        let mut header = File::create(&h_path).expect("Could not create cxx-qt-lib header");
+        let mut header = File::create(h_path).expect("Could not create cxx-qt-lib header");
         write!(header, "{}", file_contents).expect("Could not write cxx-qt-lib header");
     }
 }

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -58,7 +58,7 @@ fn main() {
 
     // Write this library's manually written C++ headers to files and add them to include paths
     let out_dir = std::env::var("OUT_DIR").unwrap();
-    cxx_qt_lib_headers::write_headers(&format!("{}/cxx-qt-lib", out_dir));
+    cxx_qt_lib_headers::write_headers(format!("{}/cxx-qt-lib", out_dir));
     builder.include(out_dir);
 
     // MSVC


### PR DESCRIPTION
## Issue
#332

Using `Q_SIGNAS` and `Q_SLOT` to tag `QObject` methods.

## Question:
What's your opinion about having those methods grouped together?
e.g.
1
```
    public:
      int count() const;
      bool toggle() const;
      Q_INVOKABLE void invokable();
      void cppMethod();

    public:
      Q_SLOT void setCount(int count);
      Q_SLOT void setToggle(bool toggle);

    public:
      Q_SIGNAL void countChanged();
      Q_SIGNAL void toggleChanged();
```
2
or having one group like `Q_INVOKABLE` is expected:
```
    public:
      int count() const;
      bool toggle() const;
      Q_INVOKABLE void invokable();
      void cppMethod();
      Q_SLOT void setCount(int count);
      Q_SLOT void setToggle(bool toggle);
      Q_SIGNAL void countChanged();
      Q_SIGNAL void toggleChanged();
```

This PR provides 1 solution. 
