### PR TITLE
cargo_without_cmake: Fix '-fuse-ld=/usr/bin/mold' error

### DIFF
--- a/examples/cargo_without_cmake/CMakeLists.txt
+++ b/examples/cargo_without_cmake/CMakeLists.txt
@@ -19,20 +19,6 @@ if(NOT Qt6_FOUND)
 endif()
 get_target_property(QMAKE Qt::qmake IMPORTED_LOCATION)
 
-# Use Corrosion to create a target for the crate that can be built without CMake.
-# This allows it to share built dependencies with the other crates in the workspace.
-find_package(Corrosion QUIET)
-if(NOT Corrosion_FOUND)
-    include(FetchContent)
-    FetchContent_Declare(
-        Corrosion
-        GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.3.0
-    )
-
-    FetchContent_MakeAvailable(Corrosion)
-endif()
-
-set(CRATE qml-minimal-no-cmake)
-corrosion_import_crate(MANIFEST_PATH Cargo.toml CRATES ${CRATE})
-corrosion_set_env_vars(${CRATE} "QMAKE=${QMAKE}")
+add_custom_target(qml-minimal-no-cmake ALL
+    cargo build -p qml-minimal-no-cmake
+    COMMENT "Building qml-minimal-no-cmake using cargo")


### PR DESCRIPTION
For some reason upgrading corrosion in commit
224baad9c59e085bcc0b24d82be126073ebef1a0 broke the build for me with the linker error:
```
note: c++: error: unrecognized command-line option '-fuse-ld=/usr/bin/mold'
```

Something about setting up the cargo-only project using corrosion is causing issues.
This was fixed by simply using a custom target.