### PR TITLE
Migrate to Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 ]
 
 [workspace.package]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/KDAB/cxx-qt/"
 version = "0.4.1"

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -201,7 +201,7 @@ fn generate_cxxqt_cpp_files(
     for rs_path in rs_source {
         let cpp_directory = format!("{}/cxx-qt-gen/src", env::var("OUT_DIR").unwrap());
         let path = format!("{}/{}", manifest_dir, rs_path.display());
-        println!("cargo:rerun-if-changed={}", path);
+        println!("cargo:rerun-if-changed={path}");
 
         let generated_code = GeneratedCpp::new(&path);
         generated_file_paths.push(generated_code.write_to_directories(cpp_directory, &header_dir));

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -101,7 +101,7 @@ fn main() {
         "qvector/qvector_u64",
     ];
     for bridge in rust_bridges {
-        println!("cargo:rerun-if-changed=src/types/{}.rs", bridge);
+        println!("cargo:rerun-if-changed=src/types/{bridge}.rs");
     }
 
     for include_path in qtbuild.include_paths() {
@@ -139,7 +139,7 @@ fn main() {
     ];
     for cpp_file in cpp_files {
         builder.file(format!("src/types/{}.cpp", cpp_file));
-        println!("cargo:rerun-if-changed=src/types/{}.cpp", cpp_file);
+        println!("cargo:rerun-if-changed=src/types/{cpp_file}.cpp");
     }
     builder.file("src/qt_types.cpp");
     println!("cargo:rerun-if-changed=src/qt_types.cpp");

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -231,7 +231,7 @@ impl QtBuild {
     /// Tell Cargo to link each Qt module.
     pub fn cargo_link_libraries(&self) {
         let lib_path = self.qmake_query("QT_INSTALL_LIBS");
-        println!("cargo:rustc-link-search={}", lib_path);
+        println!("cargo:rustc-link-search={lib_path}");
 
         let target = env::var("TARGET");
         let prefix = match &target {
@@ -275,7 +275,7 @@ impl QtBuild {
                 )
             };
 
-            println!("cargo:rustc-link-lib={}", link_lib);
+            println!("cargo:rustc-link-lib={link_lib}");
 
             match std::fs::read_to_string(&prl_path) {
                 Ok(prl) => {

--- a/crates/qt-build-utils/src/parse_cflags.rs
+++ b/crates/qt-build-utils/src/parse_cflags.rs
@@ -122,10 +122,10 @@ pub(crate) fn parse_libs_cflags(name: &str, link_args: &[u8]) {
     for (flag, val) in parts {
         match flag {
             "-L" => {
-                println!("cargo:rustc-link-search=native={}", val);
+                println!("cargo:rustc-link-search=native={val}");
             }
             "-F" => {
-                println!("cargo:rustc-link-search=framework={}", val);
+                println!("cargo:rustc-link-search=framework={val}");
             }
             "-I" => (),
             "-l" => {
@@ -134,7 +134,7 @@ pub(crate) fn parse_libs_cflags(name: &str, link_args: &[u8]) {
                     continue;
                 }
 
-                println!("cargo:rustc-link-lib={}", val);
+                println!("cargo:rustc-link-lib={val}");
             }
             "-D" => (),
             _ => {}
@@ -153,7 +153,7 @@ pub(crate) fn parse_libs_cflags(name: &str, link_args: &[u8]) {
         match part {
             "-framework" => {
                 if let Some(lib) = iter.next() {
-                    println!("cargo:rustc-link-lib=framework={}", lib);
+                    println!("cargo:rustc-link-lib=framework={lib}");
                 }
             }
             "-isystem" | "-iquote" | "-idirafter" => {}
@@ -170,10 +170,10 @@ pub(crate) fn parse_libs_cflags(name: &str, link_args: &[u8]) {
                         match extract_lib_from_filename(target, &file_name.to_string_lossy()) {
                             Some(lib_basename) => {
                                 println!("cargo:rustc-link-search={}", dir.display());
-                                println!("cargo:rustc-link-lib={}", lib_basename);
+                                println!("cargo:rustc-link-lib={lib_basename}");
                             }
                             None => {
-                                println!("cargo:warning=File path {} found in .prl file for {}, but could not extract library base name to pass to linker command line", path.display(), name);
+                                println!("cargo:warning=File path {} found in .prl file for {name}, but could not extract library base name to pass to linker command line", path.display());
                             }
                         }
                     }

--- a/examples/cargo_without_cmake/Cargo.toml
+++ b/examples/cargo_without_cmake/Cargo.toml
@@ -14,7 +14,7 @@ authors = [
   "Gerhard de Clercq <gerhard.declercq@kdab.com>",
   "Leon Matthes <leon.matthes@kdab.com>"
 ]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/examples/demo_threading/rust/Cargo.toml
+++ b/examples/demo_threading/rust/Cargo.toml
@@ -6,7 +6,7 @@
 name = "demo-threading"
 version = "0.1.0"
 authors = ["Andrew Hayzen <andrew.hayzen@kdab.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/examples/qml_extension_plugin/plugin/rust/Cargo.toml
+++ b/examples/qml_extension_plugin/plugin/rust/Cargo.toml
@@ -7,7 +7,7 @@
 name = "qml-extension-plugin"
 version = "0.1.0"
 authors = ["Andrew Hayzen <andrew.hayzen@kdab.com>", "Gerhard de Clercq <gerhard.declercq@kdab.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/examples/qml_features/rust/Cargo.toml
+++ b/examples/qml_features/rust/Cargo.toml
@@ -7,7 +7,7 @@
 name = "qml-features"
 version = "0.1.0"
 authors = ["Andrew Hayzen <andrew.hayzen@kdab.com>", "Gerhard de Clercq <gerhard.declercq@kdab.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/tests/basic_cxx_only/rust/Cargo.toml
+++ b/tests/basic_cxx_only/rust/Cargo.toml
@@ -7,7 +7,7 @@
 name = "basic-cxx-only"
 version = "0.1.0"
 authors = ["Andrew Hayzen <andrew.hayzen@kdab.com>", "Gerhard de Clercq <gerhard.declercq@kdab.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/tests/basic_cxx_qt/rust/Cargo.toml
+++ b/tests/basic_cxx_qt/rust/Cargo.toml
@@ -7,7 +7,7 @@
 name = "basic-cxx-qt"
 version = "0.1.0"
 authors = ["Andrew Hayzen <andrew.hayzen@kdab.com>", "Gerhard de Clercq <gerhard.declercq@kdab.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/tests/qt_types_standalone/rust/Cargo.toml
+++ b/tests/qt_types_standalone/rust/Cargo.toml
@@ -7,7 +7,7 @@
 name = "qt-types-standalone"
 version = "0.1.0"
 authors = ["Andrew Hayzen <andrew.hayzen@kdab.com>", "Gerhard de Clercq <gerhard.declercq@kdab.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]


### PR DESCRIPTION
As detailed in #24, this migrates to Rust 2021 and modernizes the code a bit, by using the new string formating available from Rust 1.58.

Are there any other modernizations you would like to see included in this PR?