### PR TITLE
cxx-qt-lib: Implement Debug+Display for all basic types

### DIFF
--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -200,7 +200,7 @@ fn generate_cxxqt_cpp_files(
     let mut generated_file_paths: Vec<GeneratedCppFilePaths> = Vec::with_capacity(rs_source.len());
     for rs_path in rs_source {
         let cpp_directory = format!("{}/cxx-qt-gen/src", env::var("OUT_DIR").unwrap());
-        let path = format!("{}/{}", manifest_dir, rs_path.display());
+        let path = format!("{manifest_dir}/{}", rs_path.display());
         println!("cargo:rerun-if-changed={path}");
 
         let generated_code = GeneratedCpp::new(&path);
@@ -367,18 +367,18 @@ impl CxxQtBuilder {
         // The include directory needs to be namespaced by crate name when exporting for a C++ build system,
         // but for using cargo build without a C++ build system, OUT_DIR is already namespaced by crate name.
         let header_root = match env::var("CXXQT_EXPORT_DIR") {
-            Ok(export_dir) => format!("{}/{}", export_dir, env::var("CARGO_PKG_NAME").unwrap()),
+            Ok(export_dir) => format!("{export_dir}/{}", env::var("CARGO_PKG_NAME").unwrap()),
             Err(_) => env::var("OUT_DIR").unwrap(),
         };
         self.cc_builder.include(&header_root);
-        let generated_header_dir = format!("{}/cxx-qt-gen", header_root);
+        let generated_header_dir = format!("{header_root}/cxx-qt-gen");
 
-        cxx_qt_lib_headers::write_headers(format!("{}/cxx-qt-lib", header_root));
+        cxx_qt_lib_headers::write_headers(format!("{header_root}/cxx-qt-lib"));
 
         // Write cxx header
-        std::fs::create_dir_all(format!("{}/rust", header_root))
+        std::fs::create_dir_all(format!("{header_root}/rust"))
             .expect("Could not create cxx header directory");
-        let h_path = format!("{}/rust/cxx.h", header_root);
+        let h_path = format!("{header_root}/rust/cxx.h");
         // Wrap the File in a block scope so the file is closed before the compiler is run.
         // Otherwise MSVC fails to open cxx.h because the process for this build script already has it open.
         {

--- a/crates/cxx-qt-gen/src/generator/naming/invokable.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/invokable.rs
@@ -39,7 +39,7 @@ fn name_from_ident(ident: &Ident) -> CombinedIdent {
 
 /// For a given ident generate the Rust and C++ wrapper names
 fn wrapper_from_ident(ident: &Ident) -> CombinedIdent {
-    let ident = format_ident!("{}_wrapper", ident);
+    let ident = format_ident!("{ident}_wrapper");
     CombinedIdent {
         cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
         rust: ident,

--- a/crates/cxx-qt-gen/src/generator/naming/property.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/property.rs
@@ -47,7 +47,7 @@ fn getter_from_ident(ident: &Ident) -> CombinedIdent {
 fn getter_mutable_from_ident(ident: &Ident) -> CombinedIdent {
     CombinedIdent {
         cpp: format_ident!("get{}Mut", ident.to_string().to_case(Case::Pascal)),
-        rust: format_ident!("{}_mut", ident),
+        rust: format_ident!("{ident}_mut"),
     }
 }
 
@@ -61,7 +61,7 @@ fn name_from_ident(ident: &Ident) -> CombinedIdent {
 
 /// For a given ident generate the Rust and C++ notify names
 fn notify_from_ident(ident: &Ident) -> CombinedIdent {
-    let ident = format_ident!("{}_changed", ident);
+    let ident = format_ident!("{ident}_changed");
     CombinedIdent {
         cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
         rust: ident,
@@ -70,7 +70,7 @@ fn notify_from_ident(ident: &Ident) -> CombinedIdent {
 
 /// For a given ident generate the Rust and C++ setter names
 fn setter_from_ident(ident: &Ident) -> CombinedIdent {
-    let ident = format_ident!("set_{}", ident);
+    let ident = format_ident!("set_{ident}");
     CombinedIdent {
         cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
         rust: ident,

--- a/crates/cxx-qt-gen/src/generator/naming/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/qobject.rs
@@ -40,24 +40,24 @@ impl From<&Ident> for QObjectName {
 fn cpp_class_from_ident(ident: &Ident) -> CombinedIdent {
     CombinedIdent {
         cpp: ident.clone(),
-        rust: format_ident!("{}Qt", ident),
+        rust: format_ident!("{ident}Qt"),
     }
 }
 
 /// For a given ident generate the CxxQtThread ident
 fn cxx_qt_thread_class_from_ident(ident: &Ident) -> Ident {
-    format_ident!("{}CxxQtThread", ident)
+    format_ident!("{ident}CxxQtThread")
 }
 
 /// For a given ident generate the CxxQtThreadQueuedFn ident
 fn cxx_qt_thread_queued_fn_struct_from_ident(ident: &Ident) -> Ident {
-    format_ident!("{}CxxQtThreadQueuedFn", ident)
+    format_ident!("{ident}CxxQtThreadQueuedFn")
 }
 
 /// For a given ident generate the Rust and C++ names
 fn rust_struct_from_ident(ident: &Ident) -> CombinedIdent {
     CombinedIdent {
-        cpp: format_ident!("{}Rust", ident),
+        cpp: format_ident!("{ident}Rust"),
         rust: ident.clone(),
     }
 }

--- a/crates/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/rust/mod.rs
@@ -15,10 +15,7 @@ use syn::Ident;
 /// Once static methods are possible in CXX this could be removed
 /// https://github.com/dtolnay/cxx/issues/447
 fn mangle(name: &str, object: &Ident) -> Ident {
-    format_ident!(
-        "{}",
-        format!("{name}_{object}", name = name, object = object).to_case(Case::Snake)
-    )
+    format_ident!("{}", format!("{name}_{object}").to_case(Case::Snake))
 }
 
 /// Return common blocks for CXX bridge which the C++ writer adds as well
@@ -136,7 +133,7 @@ fn cxx_qt_common_blocks(qobject: &GeneratedRustQObject) -> Vec<TokenStream> {
 pub fn write_rust(generated: &GeneratedRustBlocks) -> TokenStream {
     // Build the module idents
     let cxx_mod_ident = &generated.cxx_mod.ident;
-    let cxx_qt_mod_ident = format_ident!("cxx_qt_{}", cxx_mod_ident);
+    let cxx_qt_mod_ident = format_ident!("cxx_qt_{cxx_mod_ident}");
 
     // Retrieve the module contents and namespace
     let mut cxx_mod = generated.cxx_mod.clone();

--- a/crates/cxx-qt-lib-headers/include/common.h
+++ b/crates/cxx-qt-lib-headers/include/common.h
@@ -7,6 +7,9 @@
 
 #pragma once
 
+#include <QtCore/QDebug>
+#include <QtCore/QString>
+
 namespace rust {
 namespace cxxqtlib1 {
 
@@ -22,6 +25,21 @@ void
 drop(T& value)
 {
   value.~T();
+}
+
+template<typename T>
+QString
+toQString(const T& value)
+{
+  // We can't convert value directly into a string.
+  // However most Qt types are able to stream into a QDebug object such as
+  // qDebug() << value We can then construct a QDebug object that outputs into a
+  // string (instead of logging), and return that string Thus we have a pretty
+  // reliable and generic "toString" implementation for most Qt types
+  QString res;
+  QDebug serializer{ &res };
+  serializer << value;
+  return res;
 }
 
 } // namespace cxxqtlib1

--- a/crates/cxx-qt-lib-headers/src/lib.rs
+++ b/crates/cxx-qt-lib-headers/src/lib.rs
@@ -52,7 +52,7 @@ pub fn write_headers(directory: impl AsRef<Path>) {
         (include_str!("../include/qvector4d.h"), "qvector4d.h"),
         (include_str!("../include/std_types.h"), "std_types.h"),
     ] {
-        let h_path = format!("{}/{}", directory.display(), file_name);
+        let h_path = format!("{}/{file_name}", directory.display());
         let mut header = File::create(h_path).expect("Could not create cxx-qt-lib header");
         write!(header, "{}", file_contents).expect("Could not write cxx-qt-lib header");
     }

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -146,7 +146,7 @@ fn main() {
     let mut builder = cxx_build::bridges(
         rust_bridges
             .iter()
-            .map(|bridge| format!("src/types/{}.rs", bridge)),
+            .map(|bridge| format!("src/types/{bridge}.rs")),
     );
 
     let cpp_files = [
@@ -177,7 +177,7 @@ fn main() {
         "qvector4d",
     ];
     for cpp_file in cpp_files {
-        builder.file(format!("src/types/{}.cpp", cpp_file));
+        builder.file(format!("src/types/{cpp_file}.cpp"));
         println!("cargo:rerun-if-changed=src/types/{cpp_file}.cpp");
     }
     builder.file("src/qt_types.cpp");
@@ -186,7 +186,7 @@ fn main() {
 
     // Write this library's manually written C++ headers to files and add them to include paths
     let out_dir = std::env::var("OUT_DIR").unwrap();
-    cxx_qt_lib_headers::write_headers(format!("{}/cxx-qt-lib", out_dir));
+    cxx_qt_lib_headers::write_headers(format!("{out_dir}/cxx-qt-lib"));
     builder.include(out_dir);
 
     // MSVC

--- a/crates/cxx-qt-lib/src/types/qbytearray.rs
+++ b/crates/cxx-qt-lib/src/types/qbytearray.rs
@@ -123,6 +123,12 @@ impl std::fmt::Display for QByteArray {
     }
 }
 
+impl std::fmt::Debug for QByteArray {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
 impl Drop for QByteArray {
     /// Destroys the byte array.
     fn drop(&mut self) {

--- a/crates/cxx-qt-lib/src/types/qcolor.rs
+++ b/crates/cxx-qt-lib/src/types/qcolor.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
@@ -72,6 +73,31 @@ impl Default for QColor {
     /// The alpha value of an invalid color is unspecified.
     fn default() -> Self {
         ffi::qcolor_init_default()
+    }
+}
+
+impl fmt::Display for QColor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let r = self.red();
+        let g = self.green();
+        let b = self.blue();
+        let a = self.alpha();
+        write!(f, "RGBA({r}, {g}, {b}, {a})")
+    }
+}
+
+impl fmt::Debug for QColor {
+    // We use more fancy printing for the Debug formatter
+    // If you dislike this, use the Display formatter instead
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let r = self.red();
+        let g = self.green();
+        let b = self.blue();
+        let a = self.alpha();
+        // very simple heuristic to use a light foreground if background is dark and vice versa
+        let fg = if (r + b + g) < 384 { 255 } else { 0 };
+        // Use terminal escape codes to **actually** print the color
+        write!(f, "\x1b[48;2;{r};{g};{b}m\x1b[38;2;{fg};{fg};{fg}mRGBA({r}, {g}, {b}, {a})\x1b[39m\x1b[49m")
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qdate.rs
+++ b/crates/cxx-qt-lib/src/types/qdate.rs
@@ -4,12 +4,15 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
+        include!("cxx-qt-lib/qstring.h");
         include!("cxx-qt-lib/qdate.h");
 
+        type QString = crate::QString;
         type QDate = super::QDate;
 
         /// Returns the year of this date.
@@ -37,11 +40,14 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qdate_init"]
         fn construct(y: i32, m: i32, d: i32) -> QDate;
+        #[doc(hidden)]
+        #[rust_name = "qdate_to_qstring"]
+        fn toQString(value: &QDate) -> QString;
     }
 }
 
 /// The QDate class provides date functions.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct QDate {
     jd: i64,
@@ -51,6 +57,18 @@ impl Default for QDate {
     /// Constructs a null date. Null dates are invalid.
     fn default() -> Self {
         ffi::qdate_init_default()
+    }
+}
+
+impl fmt::Display for QDate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qdate_to_qstring(self))
+    }
+}
+
+impl fmt::Debug for QDate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/types/qdatetime.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::mem::MaybeUninit;
 
 use crate::{QDate, QTime};
@@ -13,10 +14,12 @@ mod ffi {
         include!("cxx-qt-lib/qdatetime.h");
         include!("cxx-qt-lib/qdate.h");
         include!("cxx-qt-lib/qtime.h");
+        include!("cxx-qt-lib/qstring.h");
 
         type QDate = crate::QDate;
         type QDateTime = super::QDateTime;
         type QTime = crate::QTime;
+        type QString = crate::QString;
 
         /// Returns the date part of the datetime.
         fn date(self: &QDateTime) -> QDate;
@@ -51,6 +54,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qdatetime_set_time"]
         fn qdatetimeSetTime(datetime: &mut QDateTime, time: QTime);
+        #[doc(hidden)]
+        #[rust_name = "qdatetime_to_qstring"]
+        fn toQString(value: &QDateTime) -> QString;
     }
 }
 
@@ -90,6 +96,18 @@ impl Default for QDateTime {
     /// Construct a default null QDateTime
     fn default() -> Self {
         ffi::qdatetime_init_default()
+    }
+}
+
+impl fmt::Display for QDateTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qdatetime_to_qstring(self))
+    }
+}
+
+impl fmt::Debug for QDateTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qmodelindex.rs
+++ b/crates/cxx-qt-lib/src/types/qmodelindex.rs
@@ -3,14 +3,17 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qmodelindex.h");
+        include!("cxx-qt-lib/qstring.h");
 
         type QModelIndex = super::QModelIndex;
+        type QString = crate::QString;
 
         /// Returns the column this model index refers to.
         fn column(self: &QModelIndex) -> i32;
@@ -40,6 +43,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qmodelindex_init_default"]
         fn construct() -> QModelIndex;
+        #[doc(hidden)]
+        #[rust_name = "qmodelindex_to_qstring"]
+        fn toQString(value: &QModelIndex) -> QString;
     }
 }
 
@@ -54,6 +60,18 @@ impl Default for QModelIndex {
     /// Creates a new empty model index. This type of model index is used to indicate that the position in the model is invalid.
     fn default() -> Self {
         ffi::qmodelindex_init_default()
+    }
+}
+
+impl fmt::Display for QModelIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qmodelindex_to_qstring(self))
+    }
+}
+
+impl fmt::Debug for QModelIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qpersistentmodelindex.rs
+++ b/crates/cxx-qt-lib/src/types/qpersistentmodelindex.rs
@@ -3,14 +3,17 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qpersistentmodelindex.h");
+        include!("cxx-qt-lib/qstring.h");
 
         type QPersistentModelIndex = super::QPersistentModelIndex;
+        type QString = crate::QString;
 
         include!("cxx-qt-lib/qmodelindex.h");
         type QModelIndex = crate::QModelIndex;
@@ -44,6 +47,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qpersistentmodelindex_clone"]
         fn construct(other: &QPersistentModelIndex) -> QPersistentModelIndex;
+        #[doc(hidden)]
+        #[rust_name = "qpersistentmodelindex_to_qstring"]
+        fn toQString(value: &QPersistentModelIndex) -> QString;
     }
 }
 
@@ -71,6 +77,18 @@ impl From<&crate::QModelIndex> for QPersistentModelIndex {
     /// Creates a new QPersistentModelIndex that is a copy of the model index.
     fn from(index: &crate::QModelIndex) -> Self {
         ffi::qpersistentmodelindex_from_qmodelindex(index)
+    }
+}
+
+impl fmt::Display for QPersistentModelIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qpersistentmodelindex_to_qstring(self))
+    }
+}
+
+impl fmt::Debug for QPersistentModelIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qpoint.rs
+++ b/crates/cxx-qt-lib/src/types/qpoint.rs
@@ -4,13 +4,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qpoint.h");
+        include!("cxx-qt-lib/qstring.h");
 
         type QPoint = super::QPoint;
+        type QString = crate::QString;
 
         /// Returns the x coordinate of this point.
         fn x(self: &QPoint) -> i32;
@@ -35,6 +38,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qpoint_init"]
         fn construct(x: i32, y: i32) -> QPoint;
+        #[doc(hidden)]
+        #[rust_name = "qpoint_to_qstring"]
+        fn toQString(value: &QPoint) -> QString;
     }
 }
 
@@ -57,6 +63,12 @@ impl Default for QPoint {
     /// Constructs a null point, i.e. with coordinates (0, 0)
     fn default() -> Self {
         ffi::qpoint_init_default()
+    }
+}
+
+impl fmt::Display for QPoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qpoint_to_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qpointf.rs
+++ b/crates/cxx-qt-lib/src/types/qpointf.rs
@@ -5,13 +5,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qpointf.h");
+        include!("cxx-qt-lib/qstring.h");
 
         type QPointF = super::QPointF;
+        type QString = crate::QString;
 
         /// Returns the x coordinate of this point.
         fn x(self: &QPointF) -> f64;
@@ -36,6 +39,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qpointf_init"]
         fn construct(x: f64, y: f64) -> QPointF;
+        #[doc(hidden)]
+        #[rust_name = "qpointf_to_qstring"]
+        fn toQString(value: &QPointF) -> QString;
     }
 }
 
@@ -58,6 +64,12 @@ impl Default for QPointF {
     /// Constructs a null point, i.e. with coordinates (0.0, 0.0)
     fn default() -> Self {
         ffi::qpointf_init_default()
+    }
+}
+
+impl fmt::Display for QPointF {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qpointf_to_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qrect.rs
+++ b/crates/cxx-qt-lib/src/types/qrect.rs
@@ -4,13 +4,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qrect.h");
+        include!("cxx-qt-lib/qstring.h");
 
         type QRect = super::QRect;
+        type QString = crate::QString;
 
         /// Returns the height of the rectangle.
         fn height(self: &QRect) -> i32;
@@ -45,6 +48,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qrect_init"]
         fn construct(x: i32, y: i32, width: i32, height: i32) -> QRect;
+        #[doc(hidden)]
+        #[rust_name = "qrect_to_qstring"]
+        fn toQString(value: &QRect) -> QString;
     }
 }
 
@@ -70,6 +76,12 @@ impl Default for QRect {
     /// Constructs a null rectangle.
     fn default() -> Self {
         ffi::qrect_init_default()
+    }
+}
+
+impl fmt::Display for QRect {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qrect_to_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qrectf.rs
+++ b/crates/cxx-qt-lib/src/types/qrectf.rs
@@ -4,13 +4,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qrectf.h");
+        include!("cxx-qt-lib/qstring.h");
 
         type QRectF = super::QRectF;
+        type QString = crate::QString;
 
         /// Returns the height of the rectangle.
         fn height(self: &QRectF) -> f64;
@@ -45,6 +48,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qrectf_init"]
         fn construct(x: f64, y: f64, width: f64, height: f64) -> QRectF;
+        #[doc(hidden)]
+        #[rust_name = "qrectf_to_qstring"]
+        fn toQString(value: &QRectF) -> QString;
     }
 }
 
@@ -69,6 +75,12 @@ impl Default for QRectF {
     /// Constructs a null rectangle.
     fn default() -> Self {
         ffi::qrectf_init_default()
+    }
+}
+
+impl fmt::Display for QRectF {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qrectf_to_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qsize.rs
+++ b/crates/cxx-qt-lib/src/types/qsize.rs
@@ -4,13 +4,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qsize.h");
+        include!("cxx-qt-lib/qstring.h");
 
         type QSize = super::QSize;
+        type QString = crate::QString;
 
         /// Returns the height.
         fn height(self: &QSize) -> i32;
@@ -35,6 +38,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qsize_init"]
         fn construct(w: i32, h: i32) -> QSize;
+        #[doc(hidden)]
+        #[rust_name = "qsize_to_qstring"]
+        fn toQString(value: &QSize) -> QString;
     }
 }
 
@@ -57,6 +63,12 @@ impl Default for QSize {
     /// Constructs a size with an invalid width and height
     fn default() -> Self {
         ffi::qsize_init_default()
+    }
+}
+
+impl fmt::Display for QSize {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qsize_to_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qsizef.rs
+++ b/crates/cxx-qt-lib/src/types/qsizef.rs
@@ -5,13 +5,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qsizef.h");
+        include!("cxx-qt-lib/qstring.h");
 
         type QSizeF = super::QSizeF;
+        type QString = crate::QString;
 
         /// Returns the height.
         fn height(self: &QSizeF) -> f64;
@@ -36,6 +39,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qsizef_init"]
         fn construct(w: f64, h: f64) -> QSizeF;
+        #[doc(hidden)]
+        #[rust_name = "qsizef_to_qstring"]
+        fn toQString(value: &QSizeF) -> QString;
     }
 }
 
@@ -58,6 +64,12 @@ impl Default for QSizeF {
     /// Constructs an invalid size.
     fn default() -> Self {
         ffi::qsizef_init_default()
+    }
+}
+
+impl fmt::Display for QSizeF {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qsizef_to_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qstring.rs
+++ b/crates/cxx-qt-lib/src/types/qstring.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
@@ -70,12 +71,18 @@ impl Default for QString {
     }
 }
 
-impl std::fmt::Display for QString {
+impl fmt::Display for QString {
     /// Convert the QString to a Rust string
     ///
     /// Note that this converts from UTF-16 to UTF-8
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", <&QString as Into<String>>::into(self))
+    }
+}
+
+impl fmt::Debug for QString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qstringlist.rs
+++ b/crates/cxx-qt-lib/src/types/qstringlist.rs
@@ -53,6 +53,10 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qstringlist_contains"]
         fn qstringlistContains(list: &QStringList, string: &QString) -> bool;
+
+        #[doc(hidden)]
+        #[rust_name = "qstringlist_to_qstring"]
+        fn toQString(value: &QStringList) -> QString;
     }
 }
 
@@ -87,6 +91,18 @@ impl Default for QStringList {
     /// Constructs an empty list.
     fn default() -> Self {
         ffi::qstringlist_default()
+    }
+}
+
+impl std::fmt::Display for QStringList {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", ffi::qstringlist_to_qstring(self))
+    }
+}
+
+impl std::fmt::Debug for QStringList {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{self}")
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qtime.rs
+++ b/crates/cxx-qt-lib/src/types/qtime.rs
@@ -4,13 +4,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qtime.h");
+        include!("cxx-qt-lib/qstring.h");
 
         type QTime = super::QTime;
+        type QString = crate::QString;
 
         /// Returns the hour part (0 to 23) of the time.
         fn hour(self: &QTime) -> i32;
@@ -36,11 +39,14 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qtime_init"]
         fn construct(h: i32, m: i32, s: i32, ms: i32) -> QTime;
+        #[doc(hidden)]
+        #[rust_name = "qtime_to_qstring"]
+        fn toQString(value: &QTime) -> QString;
     }
 }
 
 /// The QTime class provides clock time functions.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct QTime {
     mds: i32,
@@ -57,6 +63,18 @@ impl Default for QTime {
     /// Constructs a null time object.
     fn default() -> Self {
         ffi::qtime_init_default()
+    }
+}
+
+impl fmt::Display for QTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qtime_to_qstring(self))
+    }
+}
+
+impl fmt::Debug for QTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qurl.rs
+++ b/crates/cxx-qt-lib/src/types/qurl.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::mem::MaybeUninit;
 
 use crate::QString;
@@ -43,7 +44,7 @@ mod ffi {
         fn qurlToRustString(url: &QUrl) -> String;
         #[doc(hidden)]
         #[rust_name = "qurl_to_qstring"]
-        fn qurlToQString(url: &QUrl) -> QString;
+        fn toQString(url: &QUrl) -> QString;
     }
 }
 
@@ -85,12 +86,18 @@ impl Default for QUrl {
     }
 }
 
-impl std::fmt::Display for QUrl {
+impl fmt::Display for QUrl {
     /// Convert the QUrl to a Rust string
     ///
     /// Note that this converts from UTF-16 to UTF-8
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", ffi::qurl_to_rust_string(self))
+    }
+}
+
+impl fmt::Debug for QUrl {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qvector2d.rs
+++ b/crates/cxx-qt-lib/src/types/qvector2d.rs
@@ -12,6 +12,8 @@ mod ffi {
         type QPoint = crate::QPoint;
         include!("cxx-qt-lib/qpointf.h");
         type QPointF = crate::QPointF;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
 
         include!("cxx-qt-lib/qvector2d.h");
         type QVector2D = super::QVector2D;
@@ -104,6 +106,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qvector2d_distance_to_point"]
         fn qvector2DDistanceToPoint(vector: &QVector2D, point: QVector2D) -> f32;
+        #[doc(hidden)]
+        #[rust_name = "qvector2d_to_qstring"]
+        fn toQString(value: &QVector2D) -> QString;
     }
 }
 
@@ -138,6 +143,12 @@ impl Default for QVector2D {
     /// Constructs a null vector, i.e. with coordinates (0, 0).
     fn default() -> Self {
         ffi::qvector2d_init_default()
+    }
+}
+
+impl std::fmt::Display for QVector2D {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", ffi::qvector2d_to_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qvector3d.rs
+++ b/crates/cxx-qt-lib/src/types/qvector3d.rs
@@ -12,6 +12,8 @@ mod ffi {
         type QPoint = crate::QPoint;
         include!("cxx-qt-lib/qpointf.h");
         type QPointF = crate::QPointF;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
 
         include!("cxx-qt-lib/qvector2d.h");
         type QVector2D = crate::QVector2D;
@@ -112,6 +114,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qvector3d_distance_to_point"]
         fn qvector3DDistanceToPoint(vector: &QVector3D, point: QVector3D) -> f32;
+        #[doc(hidden)]
+        #[rust_name = "qvector3d_to_qstring"]
+        fn toQString(value: &QVector3D) -> QString;
     }
 }
 
@@ -153,6 +158,12 @@ impl Default for QVector3D {
     /// Constructs a null vector, i.e. with coordinates (0, 0, 0).
     fn default() -> Self {
         ffi::qvector3d_init_default()
+    }
+}
+
+impl std::fmt::Display for QVector3D {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", ffi::qvector3d_to_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/types/qvector4d.rs
+++ b/crates/cxx-qt-lib/src/types/qvector4d.rs
@@ -12,6 +12,8 @@ mod ffi {
         type QPoint = crate::QPoint;
         include!("cxx-qt-lib/qpointf.h");
         type QPointF = crate::QPointF;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
 
         include!("cxx-qt-lib/qvector2d.h");
         type QVector2D = crate::QVector2D;
@@ -110,6 +112,10 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qvector4d_init_default"]
         fn construct() -> QVector4D;
+
+        #[doc(hidden)]
+        #[rust_name = "qvector4d_to_qstring"]
+        fn toQString(value: &QVector4D) -> QString;
     }
 }
 
@@ -132,6 +138,12 @@ impl Default for QVector4D {
     /// Constructs a null vector, i.e. with coordinates (0, 0, 0, 0).
     fn default() -> Self {
         ffi::qvector4d_init_default()
+    }
+}
+
+impl std::fmt::Display for QVector4D {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", ffi::qvector4d_to_qstring(self))
     }
 }
 

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -44,7 +44,7 @@ pub fn bridge(args: TokenStream, input: TokenStream) -> TokenStream {
     //
     // To keep the inputs to the parser consistent for all code paths,
     // add the attribute to the module before giving it to the parser.
-    let args_input = format!("#[cxx_qt::bridge({})] mod dummy;", args);
+    let args_input = format!("#[cxx_qt::bridge({args})] mod dummy;");
     let attrs = syn::parse_str::<ItemMod>(&args_input).unwrap().attrs;
     module.attrs = attrs.into_iter().chain(module.attrs.into_iter()).collect();
 

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -302,7 +302,7 @@ impl QtBuild {
             let framework = match &target {
                 Ok(target) => {
                     if target.contains("apple") {
-                        Path::new(&format!("{}/Qt{}.framework", lib_path, qt_module)).exists()
+                        Path::new(&format!("{lib_path}/Qt{qt_module}.framework")).exists()
                     } else {
                         false
                     }
@@ -312,7 +312,7 @@ impl QtBuild {
 
             let (link_lib, prl_path) = if framework {
                 (
-                    format!("framework=Qt{}", qt_module),
+                    format!("framework=Qt{qt_module}"),
                     format!(
                         "{}/Qt{}.framework/Resources/Qt{}.prl",
                         lib_path, qt_module, qt_module
@@ -320,7 +320,7 @@ impl QtBuild {
                 )
             } else {
                 (
-                    format!("Qt{}{}", self.version.major, qt_module),
+                    format!("Qt{}{qt_module}", self.version.major),
                     format!(
                         "{}/{}Qt{}{}.prl",
                         lib_path, prefix, self.version.major, qt_module
@@ -335,7 +335,7 @@ impl QtBuild {
                     for line in prl.lines() {
                         if let Some(line) = line.strip_prefix("QMAKE_PRL_LIBS = ") {
                             parse_cflags::parse_libs_cflags(
-                                &format!("Qt{}{}", self.version.major, qt_module),
+                                &format!("Qt{}{qt_module}", self.version.major),
                                 line.replace(r"$$[QT_INSTALL_LIBS]", &lib_path)
                                     .replace(r"$$[QT_INSTALL_PREFIX]", &lib_path)
                                     .as_bytes(),
@@ -359,7 +359,7 @@ impl QtBuild {
         let root_path = self.qmake_query("QT_INSTALL_HEADERS");
         let mut paths = Vec::new();
         for qt_module in &self.qt_modules {
-            paths.push(format!("{}/Qt{}", root_path, qt_module));
+            paths.push(format!("{root_path}/Qt{qt_module}"));
         }
         paths.push(root_path);
         paths.iter().map(PathBuf::from).collect()
@@ -379,7 +379,7 @@ impl QtBuild {
             "QT_INSTALL_LIBEXECS",
             "QT_INSTALL_BINS",
         ] {
-            let executable_path = format!("{}/{}", self.qmake_query(qmake_query_var), tool_name);
+            let executable_path = format!("{}/{tool_name}", self.qmake_query(qmake_query_var));
             match Command::new(&executable_path).args(["-help"]).output() {
                 Ok(_) => return Ok(executable_path),
                 Err(_) => continue,

--- a/examples/qml_features/rust/src/containers.rs
+++ b/examples/qml_features/rust/src/containers.rs
@@ -97,7 +97,7 @@ mod ffi {
                 .iter()
                 .map(|(key, value)| {
                     let value = value.value::<i32>().unwrap_or(0);
-                    format!("{} => {}", key, value)
+                    format!("{key} => {value}")
                 })
                 .collect::<Vec<String>>()
                 .join(", ");
@@ -118,7 +118,7 @@ mod ffi {
                 .iter()
                 .map(|(key, value)| {
                     let value = value.value::<i32>().unwrap_or(0);
-                    format!("{} => {}", key, value)
+                    format!("{key} => {value}")
                 })
                 .collect::<Vec<String>>()
                 .join(", ");


### PR DESCRIPTION
This completes the second item of #53.

Fixes #369

For some types I have implemented particularly fancy pretty printing, for example `QColor` **actually** prints the color via terminal escape codes, please let me know if that is "too fancy":

![Screenshot_20221221_183105](https://user-images.githubusercontent.com/21310755/209141573-41bcc48c-a6c7-43a7-838f-cbd948e89feb.png)
