### PR TITLE
Implement std::cmp::PartialEq for all Qt types

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -161,6 +161,9 @@ mod tests {
             tokens_to_syn::<syn::Item>(quote! {
                 impl MyObjectQt {
                     pub fn set_trivial_property(mut self: Pin<&mut Self>, value: i32) {
+                        if self.rust().trivial_property == value {
+                            return;
+                        }
                         unsafe {
                             self.as_mut().rust_mut().trivial_property = value;
                         }
@@ -249,6 +252,9 @@ mod tests {
             tokens_to_syn::<syn::Item>(quote! {
                 impl MyObjectQt {
                     pub fn set_opaque_property(mut self: Pin<&mut Self>, value: UniquePtr<QColor>) {
+                        if self.rust().opaque_property == value {
+                            return;
+                        }
                         unsafe {
                             self.as_mut().rust_mut().opaque_property = value;
                         }
@@ -337,6 +343,9 @@ mod tests {
             tokens_to_syn::<syn::Item>(quote! {
                 impl MyObjectQt {
                     pub fn set_unsafe_property(mut self: Pin<&mut Self>, value: *mut T) {
+                        if self.rust().unsafe_property == value {
+                            return;
+                        }
                         unsafe {
                             self.as_mut().rust_mut().unsafe_property = value;
                         }

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -47,6 +47,12 @@ pub fn generate(
             quote! {
                 impl #cpp_class_name_rust {
                     pub fn #setter_rust(mut self: Pin<&mut Self>, value: #ty) {
+                        if self.rust().#ident == value {
+                            // don't want to set the value again and reemit the signal,
+                            // as this can cause binding loops
+                            return;
+                        }
+
                         unsafe {
                             self.as_mut().rust_mut().#ident = value;
                         }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -271,6 +271,9 @@ mod cxx_qt_ffi {
 
     impl MyObjectQt {
         pub fn set_property_name(mut self: Pin<&mut Self>, value: i32) {
+            if self.rust().property_name == value {
+                return;
+            }
             unsafe {
                 self.as_mut().rust_mut().property_name = value;
             }
@@ -368,6 +371,9 @@ mod cxx_qt_ffi {
 
     impl SecondObjectQt {
         pub fn set_property_name(mut self: Pin<&mut Self>, value: i32) {
+            if self.rust().property_name == value {
+                return;
+            }
             unsafe {
                 self.as_mut().rust_mut().property_name = value;
             }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -150,6 +150,9 @@ mod cxx_qt_ffi {
 
     impl MyObjectQt {
         pub fn set_primitive(mut self: Pin<&mut Self>, value: i32) {
+            if self.rust().primitive == value {
+                return;
+            }
             unsafe {
                 self.as_mut().rust_mut().primitive = value;
             }
@@ -183,6 +186,9 @@ mod cxx_qt_ffi {
 
     impl MyObjectQt {
         pub fn set_trivial(mut self: Pin<&mut Self>, value: QPoint) {
+            if self.rust().trivial == value {
+                return;
+            }
             unsafe {
                 self.as_mut().rust_mut().trivial = value;
             }
@@ -216,6 +222,9 @@ mod cxx_qt_ffi {
 
     impl MyObjectQt {
         pub fn set_opaque(mut self: Pin<&mut Self>, value: UniquePtr<Opaque>) {
+            if self.rust().opaque == value {
+                return;
+            }
             unsafe {
                 self.as_mut().rust_mut().opaque = value;
             }

--- a/crates/cxx-qt-lib-headers/include/common.h
+++ b/crates/cxx-qt-lib-headers/include/common.h
@@ -33,9 +33,11 @@ toQString(const T& value)
 {
   // We can't convert value directly into a string.
   // However most Qt types are able to stream into a QDebug object such as
-  // qDebug() << value We can then construct a QDebug object that outputs into a
-  // string (instead of logging), and return that string Thus we have a pretty
-  // reliable and generic "toString" implementation for most Qt types
+  // qDebug() << value
+  //
+  // We can then construct a QDebug object that outputs into a string (instead
+  // of logging), and return that string. Thus we have a pretty reliable and
+  // generic "toString" implementation for most Qt types.
   QString res;
   QDebug serializer{ &res };
   serializer << value;

--- a/crates/cxx-qt-lib-headers/include/common.h
+++ b/crates/cxx-qt-lib-headers/include/common.h
@@ -44,5 +44,12 @@ toQString(const T& value)
   return res;
 }
 
+template<typename T>
+bool
+operatorEq(const T& a, const T& b)
+{
+  return a == b;
+}
+
 } // namespace cxxqtlib1
 } // namespace rust

--- a/crates/cxx-qt-lib/src/core/qbytearray.rs
+++ b/crates/cxx-qt-lib/src/core/qbytearray.rs
@@ -34,6 +34,10 @@ mod ffi {
         fn construct(bytearray: &QByteArray) -> QByteArray;
 
         #[doc(hidden)]
+        #[rust_name = "qbytearray_eq"]
+        fn operatorEq(a: &QByteArray, b: &QByteArray) -> bool;
+
+        #[doc(hidden)]
         #[rust_name = "qbytearray_from_slice_u8"]
         fn qbytearrayFromSliceU8(slice: &[u8]) -> QByteArray;
         #[doc(hidden)]
@@ -109,6 +113,12 @@ impl Default for QByteArray {
     /// Constructs an empty byte array.
     fn default() -> Self {
         ffi::qbytearray_default()
+    }
+}
+
+impl std::cmp::PartialEq for QByteArray {
+    fn eq(&self, other: &Self) -> bool {
+        ffi::qbytearray_eq(self, other)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -47,7 +47,7 @@ mod ffi {
 }
 
 /// The QDate class provides date functions.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 #[repr(C)]
 pub struct QDate {
     jd: i64,

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -55,6 +55,9 @@ mod ffi {
         #[rust_name = "qdatetime_set_time"]
         fn qdatetimeSetTime(datetime: &mut QDateTime, time: QTime);
         #[doc(hidden)]
+        #[rust_name = "qdatetime_eq"]
+        fn operatorEq(a: &QDateTime, b: &QDateTime) -> bool;
+        #[doc(hidden)]
         #[rust_name = "qdatetime_to_qstring"]
         fn toQString(value: &QDateTime) -> QString;
     }
@@ -96,6 +99,12 @@ impl Default for QDateTime {
     /// Construct a default null QDateTime
     fn default() -> Self {
         ffi::qdatetime_init_default()
+    }
+}
+
+impl std::cmp::PartialEq for QDateTime {
+    fn eq(&self, other: &Self) -> bool {
+        ffi::qdatetime_eq(self, other)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.rs
@@ -44,6 +44,9 @@ mod ffi {
         #[rust_name = "qmodelindex_init_default"]
         fn construct() -> QModelIndex;
         #[doc(hidden)]
+        #[rust_name = "qmodelindex_eq"]
+        fn operatorEq(a: &QModelIndex, b: &QModelIndex) -> bool;
+        #[doc(hidden)]
         #[rust_name = "qmodelindex_to_qstring"]
         fn toQString(value: &QModelIndex) -> QString;
     }
@@ -60,6 +63,12 @@ impl Default for QModelIndex {
     /// Creates a new empty model index. This type of model index is used to indicate that the position in the model is invalid.
     fn default() -> Self {
         ffi::qmodelindex_init_default()
+    }
+}
+
+impl std::cmp::PartialEq for QModelIndex {
+    fn eq(&self, other: &Self) -> bool {
+        ffi::qmodelindex_eq(self, other)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
@@ -48,6 +48,9 @@ mod ffi {
         #[rust_name = "qpersistentmodelindex_clone"]
         fn construct(other: &QPersistentModelIndex) -> QPersistentModelIndex;
         #[doc(hidden)]
+        #[rust_name = "qpersistentmodelindex_eq"]
+        fn operatorEq(a: &QPersistentModelIndex, b: &QPersistentModelIndex) -> bool;
+        #[doc(hidden)]
         #[rust_name = "qpersistentmodelindex_to_qstring"]
         fn toQString(value: &QPersistentModelIndex) -> QString;
     }
@@ -77,6 +80,12 @@ impl From<&crate::QModelIndex> for QPersistentModelIndex {
     /// Creates a new QPersistentModelIndex that is a copy of the model index.
     fn from(index: &crate::QModelIndex) -> Self {
         ffi::qpersistentmodelindex_from_qmodelindex(index)
+    }
+}
+
+impl std::cmp::PartialEq for QPersistentModelIndex {
+    fn eq(&self, other: &Self) -> bool {
+        ffi::qpersistentmodelindex_eq(self, other)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpoint.rs
+++ b/crates/cxx-qt-lib/src/core/qpoint.rs
@@ -45,7 +45,7 @@ mod ffi {
 }
 
 /// The QPoint struct defines a point in the plane using integer precision.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QPoint {
     x: i32,

--- a/crates/cxx-qt-lib/src/core/qpointf.rs
+++ b/crates/cxx-qt-lib/src/core/qpointf.rs
@@ -46,7 +46,7 @@ mod ffi {
 }
 
 /// The QPointF struct defines a point in the plane using floating point precision.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QPointF {
     x: f64,

--- a/crates/cxx-qt-lib/src/core/qrect.rs
+++ b/crates/cxx-qt-lib/src/core/qrect.rs
@@ -55,7 +55,7 @@ mod ffi {
 }
 
 /// The QRect struct defines a rectangle in the plane using integer precision.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QRect {
     // Note that Qt stores QRect as two points rather than a point and size (which QRectF is)

--- a/crates/cxx-qt-lib/src/core/qrectf.rs
+++ b/crates/cxx-qt-lib/src/core/qrectf.rs
@@ -55,7 +55,7 @@ mod ffi {
 }
 
 /// The QRectF struct defines a rectangle in the plane using floating point precision.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QRectF {
     xp: f64,

--- a/crates/cxx-qt-lib/src/core/qsize.rs
+++ b/crates/cxx-qt-lib/src/core/qsize.rs
@@ -45,7 +45,7 @@ mod ffi {
 }
 
 /// The QSize struct defines the size of a two-dimensional object using integer point precision.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QSize {
     w: i32,

--- a/crates/cxx-qt-lib/src/core/qsizef.rs
+++ b/crates/cxx-qt-lib/src/core/qsizef.rs
@@ -46,7 +46,7 @@ mod ffi {
 }
 
 /// The QSizeF class defines the size of a two-dimensional object using floating point precision.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QSizeF {
     w: f64,

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -34,6 +34,10 @@ mod ffi {
         fn construct(string: &QString) -> QString;
 
         #[doc(hidden)]
+        #[rust_name = "qstring_eq"]
+        fn operatorEq(a: &QString, b: &QString) -> bool;
+
+        #[doc(hidden)]
         #[rust_name = "qstring_to_rust_string"]
         fn qstringToRustString(string: &QString) -> String;
     }
@@ -68,6 +72,12 @@ impl Default for QString {
     /// Constructs a null string. Null strings are also empty.
     fn default() -> Self {
         ffi::qstring_init_default()
+    }
+}
+
+impl std::cmp::PartialEq for QString {
+    fn eq(&self, other: &Self) -> bool {
+        ffi::qstring_eq(self, other)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qstringlist.rs
+++ b/crates/cxx-qt-lib/src/core/qstringlist.rs
@@ -55,6 +55,10 @@ mod ffi {
         fn qstringlistContains(list: &QStringList, string: &QString) -> bool;
 
         #[doc(hidden)]
+        #[rust_name = "qstringlist_eq"]
+        fn operatorEq(a: &QStringList, b: &QStringList) -> bool;
+
+        #[doc(hidden)]
         #[rust_name = "qstringlist_to_qstring"]
         fn toQString(value: &QStringList) -> QString;
     }
@@ -91,6 +95,12 @@ impl Default for QStringList {
     /// Constructs an empty list.
     fn default() -> Self {
         ffi::qstringlist_default()
+    }
+}
+
+impl std::cmp::PartialEq for QStringList {
+    fn eq(&self, other: &Self) -> bool {
+        ffi::qstringlist_eq(self, other)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qtime.rs
@@ -46,7 +46,7 @@ mod ffi {
 }
 
 /// The QTime class provides clock time functions.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 #[repr(C)]
 pub struct QTime {
     mds: i32,

--- a/crates/cxx-qt-lib/src/core/qurl.rs
+++ b/crates/cxx-qt-lib/src/core/qurl.rs
@@ -40,6 +40,10 @@ mod ffi {
         fn construct(url: &QUrl) -> QUrl;
 
         #[doc(hidden)]
+        #[rust_name = "qurl_eq"]
+        fn operatorEq(a: &QUrl, b: &QUrl) -> bool;
+
+        #[doc(hidden)]
         #[rust_name = "qurl_to_rust_string"]
         fn qurlToRustString(url: &QUrl) -> String;
         #[doc(hidden)]
@@ -83,6 +87,12 @@ impl Default for QUrl {
     /// Constructs an empty QUrl object.
     fn default() -> Self {
         ffi::qurl_init_default()
+    }
+}
+
+impl std::cmp::PartialEq for QUrl {
+    fn eq(&self, other: &Self) -> bool {
+        ffi::qurl_eq(self, other)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qcolor.rs
+++ b/crates/cxx-qt-lib/src/gui/qcolor.rs
@@ -46,6 +46,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qcolor_init_from_rgba"]
         fn construct(red: i32, green: i32, blue: i32, alpha: i32) -> QColor;
+        #[doc(hidden)]
+        #[rust_name = "qcolor_eq"]
+        fn operatorEq(a: &QColor, b: &QColor) -> bool;
     }
 }
 
@@ -73,6 +76,12 @@ impl Default for QColor {
     /// The alpha value of an invalid color is unspecified.
     fn default() -> Self {
         ffi::qcolor_init_default()
+    }
+}
+
+impl std::cmp::PartialEq for QColor {
+    fn eq(&self, other: &Self) -> bool {
+        ffi::qcolor_eq(self, other)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector2d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.rs
@@ -113,7 +113,7 @@ mod ffi {
 }
 
 /// The QVector2D class represents a vector or vertex in 2D space.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QVector2D {
     v: [f32; 2],

--- a/crates/cxx-qt-lib/src/gui/qvector3d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.rs
@@ -121,7 +121,7 @@ mod ffi {
 }
 
 /// The QVector3D class represents a vector or vertex in 3D space.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QVector3D {
     v: [f32; 3],

--- a/crates/cxx-qt-lib/src/gui/qvector4d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.rs
@@ -120,7 +120,7 @@ mod ffi {
 }
 
 /// The QVector4D class represents a vector or vertex in 4D space.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QVector4D {
     v: [f32; 4],

--- a/examples/qml_features/tests/tst_containers.qml
+++ b/examples/qml_features/tests/tst_containers.qml
@@ -40,12 +40,12 @@ TestCase {
         obj.insertHash("A3", 3);
         obj.insertHash("A3", 3);
 
-        compare(spy.count, 4);
+        compare(spy.count, 2);
         // Order of Hash is not consistent
         verify(obj.stringHash === "A1 => 1, A3 => 3" || obj.stringHash === "A3 => 3, A1 => 1");
 
         obj.reset();
-        compare(spy.count, 5);
+        compare(spy.count, 3);
         compare(obj.stringHash, "");
     }
 
@@ -85,11 +85,11 @@ TestCase {
         obj.insertMap("A3", 3);
         obj.insertMap("A3", 3);
 
-        compare(spy.count, 4);
+        compare(spy.count, 2);
         compare(obj.stringMap, "A1 => 1, A3 => 3");
 
         obj.reset();
-        compare(spy.count, 5);
+        compare(spy.count, 3);
         compare(obj.stringMap, "");
     }
 
@@ -107,12 +107,12 @@ TestCase {
         obj.insertSet(3);
         obj.insertSet(3);
 
-        compare(spy.count, 4);
+        compare(spy.count, 2);
         // Order of Set is not consistent
         verify(obj.stringSet === "1, 3" || obj.stringSet === "3, 1");
 
         obj.reset();
-        compare(spy.count, 5);
+        compare(spy.count, 3);
         compare(obj.stringSet, "");
     }
 

--- a/examples/qml_features/tests/tst_properties.qml
+++ b/examples/qml_features/tests/tst_properties.qml
@@ -56,7 +56,7 @@ TestCase {
         obj.connect("https://kdab.com");
         compare(connectedSpy.count, 1);
         compare(connectedUrlSpy.count, 1);
-        compare(previousConnectedUrlSpy.count, 1);
+        compare(previousConnectedUrlSpy.count, 0);
         compare(statusSpy.count, 1);
         compare(obj.connected, true);
         compare(obj.connectedUrl, kdabUrl);
@@ -64,33 +64,46 @@ TestCase {
         compare(obj.statusMessage, "Connected");
 
         obj.connect("https://kdab.com/about");
-        compare(connectedSpy.count, 2);
+        compare(connectedSpy.count, 1);
         compare(connectedUrlSpy.count, 2);
-        compare(previousConnectedUrlSpy.count, 2);
-        compare(statusSpy.count, 2);
+        compare(previousConnectedUrlSpy.count, 1);
+        compare(statusSpy.count, 1);
         compare(obj.connected, true);
         compare(obj.connectedUrl, kdabAboutUrl);
         compare(obj.previousConnectedUrl, kdabUrl);
         compare(obj.statusMessage, "Connected");
 
         obj.disconnect();
-        compare(connectedSpy.count, 3);
+        compare(connectedSpy.count, 2);
         compare(connectedUrlSpy.count, 3);
-        compare(previousConnectedUrlSpy.count, 3);
-        compare(statusSpy.count, 3);
+        compare(previousConnectedUrlSpy.count, 2);
+        compare(statusSpy.count, 2);
         compare(obj.connected, false);
         compare(obj.connectedUrl, "");
         compare(obj.previousConnectedUrl, kdabAboutUrl);
         compare(obj.statusMessage, "Disconnected");
 
         obj.connect("https://github.com/kdab/cxx-qt");
-        compare(connectedSpy.count, 4);
+        compare(connectedSpy.count, 2);
         compare(connectedUrlSpy.count, 3);
-        compare(previousConnectedUrlSpy.count, 3);
-        compare(statusSpy.count, 4);
+        compare(previousConnectedUrlSpy.count, 2);
+        compare(statusSpy.count, 3);
         compare(obj.connected, false);
         compare(obj.connectedUrl, "");
         compare(obj.previousConnectedUrl, kdabAboutUrl);
         compare(obj.statusMessage, "URL does not start with https://kdab.com");
+    }
+
+    function test_signal_fired_only_when_changed() {
+        const obj = createTemporaryObject(componentProperties, null, {});
+        const connectedSpy = createTemporaryObject(componentSpy, null, {
+            signalName: "connectedChanged",
+            target: obj,
+        });
+
+        compare(obj.connected, false);
+        obj.disconnect();
+        // signals should not be emitted when the value doesn't actually change
+        compare(connectedSpy.count, 0);
     }
 }


### PR DESCRIPTION
This also allows us to trigger `changed()` signals only when the value really changed.

After this we can also implement std::cmp::PartialOrd for selected types, but it does not make sense for all types (e.g. not for `QByteArray`)

See #53