### PR TITLE
Implement {PartialEq,Eq} for container types

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/types.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/types.rs
@@ -154,7 +154,7 @@ fn to_cpp_string(ty: &Type, cxx_mapping: &ParsedCxxMappings) -> Result<String> {
         // void which fails in C++
         _others => Err(Error::new(
             ty.span(),
-            format!("Unsupported type: {:?}", _others),
+            format!("Unsupported type: {_others:?}"),
         )),
     }
 }

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -55,7 +55,7 @@ mod tests {
         // Scope stdin to force an automatic flush
         {
             let mut stdin = child.stdin.take().unwrap();
-            write!(stdin, "{}", rs_code).unwrap();
+            write!(stdin, "{rs_code}").unwrap();
         }
 
         let output = child.wait_with_output().unwrap();

--- a/crates/cxx-qt-lib-headers/src/lib.rs
+++ b/crates/cxx-qt-lib-headers/src/lib.rs
@@ -80,6 +80,6 @@ pub fn write_headers(directory: impl AsRef<Path>) {
     ] {
         let h_path = format!("{}/{file_name}", directory.display());
         let mut header = File::create(h_path).expect("Could not create cxx-qt-lib header");
-        write!(header, "{}", file_contents).expect("Could not write cxx-qt-lib header");
+        write!(header, "{file_contents}").expect("Could not write cxx-qt-lib header");
     }
 }

--- a/crates/cxx-qt-lib/src/core/qbytearray.rs
+++ b/crates/cxx-qt-lib/src/core/qbytearray.rs
@@ -128,7 +128,7 @@ impl std::fmt::Display for QByteArray {
     /// Convert the QByteArray to a Rust string
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if let Ok(string) = String::from_utf8(self.into()) {
-            write!(f, "{}", string)
+            write!(f, "{string}")
         } else {
             write!(f, "{:?}", self.as_slice())
         }

--- a/crates/cxx-qt-lib/src/core/qlist/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qlist/mod.rs
@@ -88,6 +88,16 @@ where
     }
 }
 
+impl<T> PartialEq for QList<T>
+where
+    T: QListElement + PartialEq,
+{
+    /// Returns true if both lists contain the same elements in the same order
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().zip(other.iter()).all(|(a, b)| a == b)
+    }
+}
+
 impl<T> QList<T>
 where
     T: QListElement,

--- a/crates/cxx-qt-lib/src/core/qlist/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qlist/mod.rs
@@ -98,6 +98,8 @@ where
     }
 }
 
+impl<T> Eq for QList<T> where T: QListElement + Eq {}
+
 impl<T> QList<T>
 where
     T: QListElement,

--- a/crates/cxx-qt-lib/src/core/qset/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qset/mod.rs
@@ -68,6 +68,16 @@ where
     }
 }
 
+impl<T> PartialEq for QSet<T>
+where
+    T: QSetElement + PartialEq,
+{
+    /// Returns true if both sets contain the same elements
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().all(|x| other.contains(x))
+    }
+}
+
 impl<T> QSet<T>
 where
     T: QSetElement,

--- a/crates/cxx-qt-lib/src/core/qset/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qset/mod.rs
@@ -78,6 +78,8 @@ where
     }
 }
 
+impl<T> Eq for QSet<T> where T: QSetElement + PartialEq {}
+
 impl<T> QSet<T>
 where
     T: QSetElement,

--- a/crates/cxx-qt-lib/src/core/qvector/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qvector/mod.rs
@@ -98,6 +98,8 @@ where
     }
 }
 
+impl<T> Eq for QVector<T> where T: QVectorElement + Eq {}
+
 impl<T> QVector<T>
 where
     T: QVectorElement,

--- a/crates/cxx-qt-lib/src/core/qvector/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qvector/mod.rs
@@ -88,6 +88,16 @@ where
     }
 }
 
+impl<T> PartialEq for QVector<T>
+where
+    T: QVectorElement + PartialEq,
+{
+    /// Returns true if both vectors contain the same elements in the same order
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().zip(other.iter()).all(|(a, b)| a == b)
+    }
+}
+
 impl<T> QVector<T>
 where
     T: QVectorElement,

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -313,10 +313,7 @@ impl QtBuild {
             let (link_lib, prl_path) = if framework {
                 (
                     format!("framework=Qt{qt_module}"),
-                    format!(
-                        "{}/Qt{}.framework/Resources/Qt{}.prl",
-                        lib_path, qt_module, qt_module
-                    ),
+                    format!("{lib_path}/Qt{qt_module}.framework/Resources/Qt{qt_module}.prl"),
                 )
             } else {
                 (

--- a/examples/qml_minimal/rust/src/cxxqt_object.rs
+++ b/examples/qml_minimal/rust/src/cxxqt_object.rs
@@ -48,10 +48,7 @@ mod my_object {
 
         #[qinvokable]
         pub fn say_hi(&self, string: &QString, number: i32) {
-            println!(
-                "Hi from Rust! String is '{}' and number is {}",
-                string, number
-            );
+            println!("Hi from Rust! String is '{string}' and number is {number}");
         }
     }
     // ANCHOR_END: book_rustobj_impl

--- a/tests/basic_cxx_qt/rust/src/lib.rs
+++ b/tests/basic_cxx_qt/rust/src/lib.rs
@@ -50,10 +50,7 @@ mod ffi {
 
         #[qinvokable]
         pub fn say_hi(&self, string: &QString, number: i32) {
-            println!(
-                "Hi from Rust! String is {} and number is {}",
-                string, number
-            );
+            println!("Hi from Rust! String is {string} and number is {number}");
         }
 
         #[qinvokable]


### PR DESCRIPTION
Another one for #53

As discussed, `Ord` probably doesn't make much sense for container types, but `Eq` does (as long as the element types are `Eq` as well).