### PR TITLE
Implement equality for map types

### DIFF
--- a/crates/cxx-qt-lib/src/core/qhash/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qhash/mod.rs
@@ -56,6 +56,23 @@ where
     }
 }
 
+impl<T> PartialEq for QHash<T>
+where
+    T: QHashPair,
+    T::Value: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().all(|(k, v)| &T::value(other, k) == v)
+    }
+}
+
+impl<T> Eq for QHash<T>
+where
+    T: QHashPair,
+    T::Value: Eq,
+{
+}
+
 impl<T> QHash<T>
 where
     T: QHashPair,

--- a/crates/cxx-qt-lib/src/core/qmap/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qmap/mod.rs
@@ -50,6 +50,24 @@ where
     }
 }
 
+impl<T> PartialEq for QMap<T>
+where
+    T: QMapPair,
+    T::Value: PartialEq,
+{
+    /// Returns true if both maps contain the same key value pairs
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().all(|(k, v)| &T::value(other, k) == v)
+    }
+}
+
+impl<T> Eq for QMap<T>
+where
+    T: QMapPair,
+    T::Value: Eq,
+{
+}
+
 impl<T> QMap<T>
 where
     T: QMapPair,


### PR DESCRIPTION
This is a small addendum to #423, where map types were left out by accident.

ref: #53