### PR TITLE
book: remove deleted page from indices

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -29,6 +29,5 @@ SPDX-License-Identifier: MIT OR Apache-2.0
     - [Types](./concepts/types.md)
     - [Type Conversions](./concepts/type-conversions.md)
     - [Build Systems](./concepts/build_systems.md)
-    - [Register Types](./concepts/register_types.md)
     - [Threading](./concepts/threading.md)
     - [Nested Objects](./concepts/nested_objects.md)

--- a/book/src/concepts/index.md
+++ b/book/src/concepts/index.md
@@ -16,7 +16,6 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 ## Build tooling
 
   * [Build Systems](./build_systems.md)
-  * [Register Types](./register_types.md)
 
 ## Advanced Concepts
 


### PR DESCRIPTION
This fixes mdbook automatically creating the missing file, which breaks the reuse check on CI.