### PR TITLE
set minimum CMake version to 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# TODO: figure out what the actual hard minimum is
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug")

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Ensure that you have the following installed
 
   * C++ compiler
   * [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
-  * [CMake v3.16+](https://cmake.org/)
+  * [CMake](https://cmake.org/)
   * [Qt 5 and/or Qt 6](https://www.qt.io/)
   * [Rust toolchain](https://www.rust-lang.org/)
   * [mold](https://github.com/rui314/mold), [lld](https://lld.llvm.org/), or GNU ld.gold for Linux (lld is included in the XCode toolchain on macOS)

--- a/examples/demo_threading/CMakeLists.txt
+++ b/examples/demo_threading/CMakeLists.txt
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# TODO: figure out what the actual hard minimum is
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 project(demo_threading)
 set(APP_NAME ${PROJECT_NAME})

--- a/examples/qml_extension_plugin/CMakeLists.txt
+++ b/examples/qml_extension_plugin/CMakeLists.txt
@@ -4,8 +4,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# TODO: figure out what the actual hard minimum is
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 project(example_qml_extension_plugin)
 set(APP_NAME ${PROJECT_NAME})

--- a/examples/qml_features/CMakeLists.txt
+++ b/examples/qml_features/CMakeLists.txt
@@ -4,8 +4,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# TODO: figure out what the actual hard minimum is
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 project(example_qml_features)
 set(APP_NAME ${PROJECT_NAME})

--- a/examples/qml_minimal/CMakeLists.txt
+++ b/examples/qml_minimal/CMakeLists.txt
@@ -4,9 +4,8 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# TODO: figure out what the actual hard minimum is
 # ANCHOR: book_cmake_setup
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 project(example_qml_minimal)
 set(APP_NAME ${PROJECT_NAME})

--- a/tests/basic_cxx_only/CMakeLists.txt
+++ b/tests/basic_cxx_only/CMakeLists.txt
@@ -4,8 +4,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# TODO: figure out what the actual hard minimum is
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 project(tests_basic_cxx_only)
 set(APP_NAME ${PROJECT_NAME})

--- a/tests/basic_cxx_qt/CMakeLists.txt
+++ b/tests/basic_cxx_qt/CMakeLists.txt
@@ -4,8 +4,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# TODO: figure out what the actual hard minimum is
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 project(tests_basic_cxx_qt)
 set(APP_NAME ${PROJECT_NAME})

--- a/tests/qt_types_standalone/CMakeLists.txt
+++ b/tests/qt_types_standalone/CMakeLists.txt
@@ -4,8 +4,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# TODO: figure out what the actual hard minimum is
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 project(tests_qt_types_standalone)
 set(APP_NAME ${PROJECT_NAME})


### PR DESCRIPTION
required for linking with WHOLE_ARCHIVE
https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html?highlight=whole_archive#genex:LINK_LIBRARY
https://github.com/KDAB/cxx-qt/issues/442