### PR TITLE
Implement std::ops for applicable Qt types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for nesting objects in properties, invokables, and signals with `*mut T`
 - Allow for marking signals as existing in the base class
 - Support for conversions to types in third-party crates: `bytes`, `http`, `rgb`, `url`
+- Add several QoL functions to builtin cxx-qt-lib types, including Default constructors, string formatting, std::cmp order and operators
 
 ### Changed
 

--- a/crates/cxx-qt-lib-headers/include/common.h
+++ b/crates/cxx-qt-lib-headers/include/common.h
@@ -59,5 +59,33 @@ operatorCmp(const T& a, const T& b)
   return operatorEq(a, b) ? 0 : (a < b ? -1 : 1);
 }
 
+template<typename A, typename B>
+A
+operatorPlus(const A& a, const B& b)
+{
+  return a + b;
+}
+
+template<typename A, typename B>
+A
+operatorMinus(const A& a, const B& b)
+{
+  return a - b;
+}
+
+template<typename S, typename T>
+T
+operatorMul(const S scalar, const T& t)
+{
+  return scalar * t;
+}
+
+template<typename S, typename T>
+T
+operatorDiv(const S scalar, const T& t)
+{
+  return t / scalar;
+}
+
 } // namespace cxxqtlib1
 } // namespace rust

--- a/crates/cxx-qt-lib-headers/include/core/qstring.h
+++ b/crates/cxx-qt-lib-headers/include/core/qstring.h
@@ -23,6 +23,8 @@ QString
 qstringInitFromRustString(::rust::Str string);
 ::rust::String
 qstringToRustString(const QString& string);
+void
+qstringAppend(QString& a, const QString& b);
 
 }
 }

--- a/crates/cxx-qt-lib/src/core/qmargins.rs
+++ b/crates/cxx-qt-lib/src/core/qmargins.rs
@@ -60,6 +60,30 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qmargins_to_qstring"]
         fn toQString(value: &QMargins) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qmargins_plus"]
+        fn operatorPlus(a: &QMargins, b: &QMargins) -> QMargins;
+        #[doc(hidden)]
+        #[rust_name = "qmargins_plus_i32"]
+        fn operatorPlus(a: &QMargins, b: &i32) -> QMargins;
+        #[doc(hidden)]
+        #[rust_name = "qmargins_minus"]
+        fn operatorMinus(a: &QMargins, b: &QMargins) -> QMargins;
+        #[doc(hidden)]
+        #[rust_name = "qmargins_minus_i32"]
+        fn operatorMinus(a: &QMargins, b: &i32) -> QMargins;
+        #[doc(hidden)]
+        #[rust_name = "qmargins_mul_i32"]
+        fn operatorMul(a: i32, b: &QMargins) -> QMargins;
+        #[doc(hidden)]
+        #[rust_name = "qmargins_mul_f64"]
+        fn operatorMul(a: f64, b: &QMargins) -> QMargins;
+        #[doc(hidden)]
+        #[rust_name = "qmargins_div_i32"]
+        fn operatorDiv(a: i32, b: &QMargins) -> QMargins;
+        #[doc(hidden)]
+        #[rust_name = "qmargins_div_f64"]
+        fn operatorDiv(a: f64, b: &QMargins) -> QMargins;
     }
 }
 
@@ -90,6 +114,62 @@ impl Default for QMargins {
 impl fmt::Display for QMargins {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qmargins_to_qstring(self))
+    }
+}
+
+impl std::ops::Add for QMargins {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        ffi::qmargins_plus(&self, &other)
+    }
+}
+
+impl std::ops::Add<i32> for QMargins {
+    type Output = Self;
+    fn add(self, other: i32) -> Self {
+        ffi::qmargins_plus_i32(&self, &other)
+    }
+}
+
+impl std::ops::Sub for QMargins {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        ffi::qmargins_minus(&self, &other)
+    }
+}
+
+impl std::ops::Sub<i32> for QMargins {
+    type Output = Self;
+    fn sub(self, other: i32) -> Self {
+        ffi::qmargins_minus_i32(&self, &other)
+    }
+}
+
+impl std::ops::Mul<i32> for QMargins {
+    type Output = Self;
+    fn mul(self, rhs: i32) -> Self {
+        ffi::qmargins_mul_i32(rhs, &self)
+    }
+}
+
+impl std::ops::Mul<f64> for QMargins {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self {
+        ffi::qmargins_mul_f64(rhs, &self)
+    }
+}
+
+impl std::ops::Div<i32> for QMargins {
+    type Output = Self;
+    fn div(self, rhs: i32) -> Self {
+        ffi::qmargins_div_i32(rhs, &self)
+    }
+}
+
+impl std::ops::Div<f64> for QMargins {
+    type Output = Self;
+    fn div(self, rhs: f64) -> Self {
+        ffi::qmargins_div_f64(rhs, &self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qmarginsf.rs
+++ b/crates/cxx-qt-lib/src/core/qmarginsf.rs
@@ -71,6 +71,24 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qmarginsf_to_qstring"]
         fn toQString(value: &QMarginsF) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qmarginsf_plus"]
+        fn operatorPlus(a: &QMarginsF, b: &QMarginsF) -> QMarginsF;
+        #[doc(hidden)]
+        #[rust_name = "qmarginsf_plus_f64"]
+        fn operatorPlus(a: &QMarginsF, b: &f64) -> QMarginsF;
+        #[doc(hidden)]
+        #[rust_name = "qmarginsf_minus"]
+        fn operatorMinus(a: &QMarginsF, b: &QMarginsF) -> QMarginsF;
+        #[doc(hidden)]
+        #[rust_name = "qmarginsf_minus_f64"]
+        fn operatorMinus(a: &QMarginsF, b: &f64) -> QMarginsF;
+        #[doc(hidden)]
+        #[rust_name = "qmarginsf_mul"]
+        fn operatorMul(a: f64, b: &QMarginsF) -> QMarginsF;
+        #[doc(hidden)]
+        #[rust_name = "qmarginsf_div"]
+        fn operatorDiv(a: f64, b: &QMarginsF) -> QMarginsF;
     }
 }
 
@@ -101,6 +119,48 @@ impl Default for QMarginsF {
 impl fmt::Display for QMarginsF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qmarginsf_to_qstring(self))
+    }
+}
+
+impl std::ops::Add for QMarginsF {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        ffi::qmarginsf_plus(&self, &other)
+    }
+}
+
+impl std::ops::Add<f64> for QMarginsF {
+    type Output = Self;
+    fn add(self, other: f64) -> Self {
+        ffi::qmarginsf_plus_f64(&self, &other)
+    }
+}
+
+impl std::ops::Sub for QMarginsF {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        ffi::qmarginsf_minus(&self, &other)
+    }
+}
+
+impl std::ops::Sub<f64> for QMarginsF {
+    type Output = Self;
+    fn sub(self, other: f64) -> Self {
+        ffi::qmarginsf_minus_f64(&self, &other)
+    }
+}
+
+impl std::ops::Mul<f64> for QMarginsF {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self {
+        ffi::qmarginsf_mul(rhs, &self)
+    }
+}
+
+impl std::ops::Div<f64> for QMarginsF {
+    type Output = Self;
+    fn div(self, rhs: f64) -> Self {
+        ffi::qmarginsf_div(rhs, &self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpoint.rs
+++ b/crates/cxx-qt-lib/src/core/qpoint.rs
@@ -41,6 +41,24 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qpoint_to_qstring"]
         fn toQString(value: &QPoint) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qpoint_plus"]
+        fn operatorPlus(a: &QPoint, b: &QPoint) -> QPoint;
+        #[doc(hidden)]
+        #[rust_name = "qpoint_minus"]
+        fn operatorMinus(a: &QPoint, b: &QPoint) -> QPoint;
+        #[doc(hidden)]
+        #[rust_name = "qpoint_mul_f32"]
+        fn operatorMul(a: f32, b: &QPoint) -> QPoint;
+        #[doc(hidden)]
+        #[rust_name = "qpoint_mul_f64"]
+        fn operatorMul(a: f64, b: &QPoint) -> QPoint;
+        #[doc(hidden)]
+        #[rust_name = "qpoint_mul_i32"]
+        fn operatorMul(a: i32, b: &QPoint) -> QPoint;
+        #[doc(hidden)]
+        #[rust_name = "qpoint_div"]
+        fn operatorDiv(a: f64, b: &QPoint) -> QPoint;
     }
 }
 
@@ -69,6 +87,48 @@ impl Default for QPoint {
 impl fmt::Display for QPoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qpoint_to_qstring(self))
+    }
+}
+
+impl std::ops::Add for QPoint {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        ffi::qpoint_plus(&self, &other)
+    }
+}
+
+impl std::ops::Sub for QPoint {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        ffi::qpoint_minus(&self, &other)
+    }
+}
+
+impl std::ops::Mul<f32> for QPoint {
+    type Output = Self;
+    fn mul(self, rhs: f32) -> Self {
+        ffi::qpoint_mul_f32(rhs, &self)
+    }
+}
+
+impl std::ops::Mul<f64> for QPoint {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self {
+        ffi::qpoint_mul_f64(rhs, &self)
+    }
+}
+
+impl std::ops::Mul<i32> for QPoint {
+    type Output = Self;
+    fn mul(self, rhs: i32) -> Self {
+        ffi::qpoint_mul_i32(rhs, &self)
+    }
+}
+
+impl std::ops::Div<f64> for QPoint {
+    type Output = Self;
+    fn div(self, rhs: f64) -> Self {
+        ffi::qpoint_div(rhs, &self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpointf.rs
+++ b/crates/cxx-qt-lib/src/core/qpointf.rs
@@ -42,6 +42,18 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qpointf_to_qstring"]
         fn toQString(value: &QPointF) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qpointf_plus"]
+        fn operatorPlus(a: &QPointF, b: &QPointF) -> QPointF;
+        #[doc(hidden)]
+        #[rust_name = "qpointf_minus"]
+        fn operatorMinus(a: &QPointF, b: &QPointF) -> QPointF;
+        #[doc(hidden)]
+        #[rust_name = "qpointf_mul"]
+        fn operatorMul(a: f64, b: &QPointF) -> QPointF;
+        #[doc(hidden)]
+        #[rust_name = "qpointf_div"]
+        fn operatorDiv(a: f64, b: &QPointF) -> QPointF;
     }
 }
 
@@ -70,6 +82,34 @@ impl Default for QPointF {
 impl fmt::Display for QPointF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qpointf_to_qstring(self))
+    }
+}
+
+impl std::ops::Add for QPointF {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        ffi::qpointf_plus(&self, &other)
+    }
+}
+
+impl std::ops::Sub for QPointF {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        ffi::qpointf_minus(&self, &other)
+    }
+}
+
+impl std::ops::Mul<f64> for QPointF {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self {
+        ffi::qpointf_mul(rhs, &self)
+    }
+}
+
+impl std::ops::Div<f64> for QPointF {
+    type Output = Self;
+    fn div(self, rhs: f64) -> Self {
+        ffi::qpointf_div(rhs, &self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qrect.rs
+++ b/crates/cxx-qt-lib/src/core/qrect.rs
@@ -11,9 +11,11 @@ mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qrect.h");
         include!("cxx-qt-lib/qstring.h");
+        include!("cxx-qt-lib/qmargins.h");
 
         type QRect = super::QRect;
         type QString = crate::QString;
+        type QMargins = crate::QMargins;
 
         /// Returns the height of the rectangle.
         fn height(self: &QRect) -> i32;
@@ -51,6 +53,12 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qrect_to_qstring"]
         fn toQString(value: &QRect) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qrect_plus"]
+        fn operatorPlus(a: &QRect, b: &QMargins) -> QRect;
+        #[doc(hidden)]
+        #[rust_name = "qrect_minus"]
+        fn operatorMinus(a: &QRect, b: &QMargins) -> QRect;
     }
 }
 
@@ -82,6 +90,21 @@ impl Default for QRect {
 impl fmt::Display for QRect {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qrect_to_qstring(self))
+    }
+}
+
+type QMargins = crate::QMargins;
+impl std::ops::Add<QMargins> for QRect {
+    type Output = Self;
+    fn add(self, other: QMargins) -> Self {
+        ffi::qrect_plus(&self, &other)
+    }
+}
+
+impl std::ops::Sub<QMargins> for QRect {
+    type Output = Self;
+    fn sub(self, other: QMargins) -> Self {
+        ffi::qrect_minus(&self, &other)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qrectf.rs
+++ b/crates/cxx-qt-lib/src/core/qrectf.rs
@@ -11,9 +11,11 @@ mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qrectf.h");
         include!("cxx-qt-lib/qstring.h");
+        include!("cxx-qt-lib/qmarginsf.h");
 
         type QRectF = super::QRectF;
         type QString = crate::QString;
+        type QMarginsF = crate::QMarginsF;
 
         /// Returns the height of the rectangle.
         fn height(self: &QRectF) -> f64;
@@ -51,6 +53,12 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qrectf_to_qstring"]
         fn toQString(value: &QRectF) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qrectf_plus"]
+        fn operatorPlus(a: &QRectF, b: &QMarginsF) -> QRectF;
+        #[doc(hidden)]
+        #[rust_name = "qrectf_minus"]
+        fn operatorMinus(a: &QRectF, b: &QMarginsF) -> QRectF;
     }
 }
 
@@ -81,6 +89,21 @@ impl Default for QRectF {
 impl fmt::Display for QRectF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qrectf_to_qstring(self))
+    }
+}
+
+type QMarginsF = crate::QMarginsF;
+impl std::ops::Add<QMarginsF> for QRectF {
+    type Output = Self;
+    fn add(self, other: QMarginsF) -> Self {
+        ffi::qrectf_plus(&self, &other)
+    }
+}
+
+impl std::ops::Sub<QMarginsF> for QRectF {
+    type Output = Self;
+    fn sub(self, other: QMarginsF) -> Self {
+        ffi::qrectf_minus(&self, &other)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qsize.rs
+++ b/crates/cxx-qt-lib/src/core/qsize.rs
@@ -41,6 +41,18 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qsize_to_qstring"]
         fn toQString(value: &QSize) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qsize_plus"]
+        fn operatorPlus(a: &QSize, b: &QSize) -> QSize;
+        #[doc(hidden)]
+        #[rust_name = "qsize_minus"]
+        fn operatorMinus(a: &QSize, b: &QSize) -> QSize;
+        #[doc(hidden)]
+        #[rust_name = "qsize_mul"]
+        fn operatorMul(a: f64, b: &QSize) -> QSize;
+        #[doc(hidden)]
+        #[rust_name = "qsize_div"]
+        fn operatorDiv(a: f64, b: &QSize) -> QSize;
     }
 }
 
@@ -69,6 +81,34 @@ impl Default for QSize {
 impl fmt::Display for QSize {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qsize_to_qstring(self))
+    }
+}
+
+impl std::ops::Add for QSize {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        ffi::qsize_plus(&self, &other)
+    }
+}
+
+impl std::ops::Sub for QSize {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        ffi::qsize_minus(&self, &other)
+    }
+}
+
+impl std::ops::Mul<f64> for QSize {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self {
+        ffi::qsize_mul(rhs, &self)
+    }
+}
+
+impl std::ops::Div<f64> for QSize {
+    type Output = Self;
+    fn div(self, rhs: f64) -> Self {
+        ffi::qsize_div(rhs, &self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qsizef.rs
+++ b/crates/cxx-qt-lib/src/core/qsizef.rs
@@ -42,6 +42,18 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qsizef_to_qstring"]
         fn toQString(value: &QSizeF) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qsizef_plus"]
+        fn operatorPlus(a: &QSizeF, b: &QSizeF) -> QSizeF;
+        #[doc(hidden)]
+        #[rust_name = "qsizef_minus"]
+        fn operatorMinus(a: &QSizeF, b: &QSizeF) -> QSizeF;
+        #[doc(hidden)]
+        #[rust_name = "qsizef_mul"]
+        fn operatorMul(a: f64, b: &QSizeF) -> QSizeF;
+        #[doc(hidden)]
+        #[rust_name = "qsizef_div"]
+        fn operatorDiv(a: f64, b: &QSizeF) -> QSizeF;
     }
 }
 
@@ -70,6 +82,34 @@ impl Default for QSizeF {
 impl fmt::Display for QSizeF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qsizef_to_qstring(self))
+    }
+}
+
+impl std::ops::Add for QSizeF {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        ffi::qsizef_plus(&self, &other)
+    }
+}
+
+impl std::ops::Sub for QSizeF {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        ffi::qsizef_minus(&self, &other)
+    }
+}
+
+impl std::ops::Mul<f64> for QSizeF {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self {
+        ffi::qsizef_mul(rhs, &self)
+    }
+}
+
+impl std::ops::Div<f64> for QSizeF {
+    type Output = Self;
+    fn div(self, rhs: f64) -> Self {
+        ffi::qsizef_div(rhs, &self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qstring.cpp
+++ b/crates/cxx-qt-lib/src/core/qstring.cpp
@@ -54,5 +54,11 @@ qstringToRustString(const QString& string)
   return ::rust::String(byteArray.constData(), byteArray.size());
 }
 
+void
+qstringAppend(QString& a, const QString& b)
+{
+  a.append(b);
+}
+
 }
 }

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -44,6 +44,10 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qstring_to_rust_string"]
         fn qstringToRustString(string: &QString) -> String;
+
+        #[doc(hidden)]
+        #[rust_name = "qstring_append"]
+        fn qstringAppend(a: &mut QString, b: &QString);
     }
 }
 
@@ -111,6 +115,15 @@ impl fmt::Display for QString {
 impl fmt::Debug for QString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{self}")
+    }
+}
+
+impl std::ops::Add for QString {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        let mut res = ffi::qstring_init_from_qstring(&self);
+        ffi::qstring_append(&mut res, &other);
+        res
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector2d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.rs
@@ -109,6 +109,18 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qvector2d_to_qstring"]
         fn toQString(value: &QVector2D) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qvector2d_plus"]
+        fn operatorPlus(a: &QVector2D, b: &QVector2D) -> QVector2D;
+        #[doc(hidden)]
+        #[rust_name = "qvector2d_minus"]
+        fn operatorMinus(a: &QVector2D, b: &QVector2D) -> QVector2D;
+        #[doc(hidden)]
+        #[rust_name = "qvector2d_mul"]
+        fn operatorMul(a: f32, b: &QVector2D) -> QVector2D;
+        #[doc(hidden)]
+        #[rust_name = "qvector2d_div"]
+        fn operatorDiv(a: f32, b: &QVector2D) -> QVector2D;
     }
 }
 
@@ -149,6 +161,34 @@ impl Default for QVector2D {
 impl std::fmt::Display for QVector2D {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", ffi::qvector2d_to_qstring(self))
+    }
+}
+
+impl std::ops::Add for QVector2D {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        ffi::qvector2d_plus(&self, &other)
+    }
+}
+
+impl std::ops::Sub for QVector2D {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        ffi::qvector2d_minus(&self, &other)
+    }
+}
+
+impl std::ops::Mul<f32> for QVector2D {
+    type Output = Self;
+    fn mul(self, rhs: f32) -> Self {
+        ffi::qvector2d_mul(rhs, &self)
+    }
+}
+
+impl std::ops::Div<f32> for QVector2D {
+    type Output = Self;
+    fn div(self, rhs: f32) -> Self {
+        ffi::qvector2d_div(rhs, &self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector3d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.rs
@@ -117,6 +117,18 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qvector3d_to_qstring"]
         fn toQString(value: &QVector3D) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qvector3d_plus"]
+        fn operatorPlus(a: &QVector3D, b: &QVector3D) -> QVector3D;
+        #[doc(hidden)]
+        #[rust_name = "qvector3d_minus"]
+        fn operatorMinus(a: &QVector3D, b: &QVector3D) -> QVector3D;
+        #[doc(hidden)]
+        #[rust_name = "qvector3d_mul"]
+        fn operatorMul(a: f32, b: &QVector3D) -> QVector3D;
+        #[doc(hidden)]
+        #[rust_name = "qvector3d_div"]
+        fn operatorDiv(a: f32, b: &QVector3D) -> QVector3D;
     }
 }
 
@@ -164,6 +176,34 @@ impl Default for QVector3D {
 impl std::fmt::Display for QVector3D {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", ffi::qvector3d_to_qstring(self))
+    }
+}
+
+impl std::ops::Add for QVector3D {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        ffi::qvector3d_plus(&self, &other)
+    }
+}
+
+impl std::ops::Sub for QVector3D {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        ffi::qvector3d_minus(&self, &other)
+    }
+}
+
+impl std::ops::Mul<f32> for QVector3D {
+    type Output = Self;
+    fn mul(self, rhs: f32) -> Self {
+        ffi::qvector3d_mul(rhs, &self)
+    }
+}
+
+impl std::ops::Div<f32> for QVector3D {
+    type Output = Self;
+    fn div(self, rhs: f32) -> Self {
+        ffi::qvector3d_div(rhs, &self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector4d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.rs
@@ -116,6 +116,18 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qvector4d_to_qstring"]
         fn toQString(value: &QVector4D) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qvector4d_plus"]
+        fn operatorPlus(a: &QVector4D, b: &QVector4D) -> QVector4D;
+        #[doc(hidden)]
+        #[rust_name = "qvector4d_minus"]
+        fn operatorMinus(a: &QVector4D, b: &QVector4D) -> QVector4D;
+        #[doc(hidden)]
+        #[rust_name = "qvector4d_mul"]
+        fn operatorMul(a: f32, b: &QVector4D) -> QVector4D;
+        #[doc(hidden)]
+        #[rust_name = "qvector4d_div"]
+        fn operatorDiv(a: f32, b: &QVector4D) -> QVector4D;
     }
 }
 
@@ -144,6 +156,34 @@ impl Default for QVector4D {
 impl std::fmt::Display for QVector4D {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", ffi::qvector4d_to_qstring(self))
+    }
+}
+
+impl std::ops::Add for QVector4D {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        ffi::qvector4d_plus(&self, &other)
+    }
+}
+
+impl std::ops::Sub for QVector4D {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        ffi::qvector4d_minus(&self, &other)
+    }
+}
+
+impl std::ops::Mul<f32> for QVector4D {
+    type Output = Self;
+    fn mul(self, rhs: f32) -> Self {
+        ffi::qvector4d_mul(rhs, &self)
+    }
+}
+
+impl std::ops::Div<f32> for QVector4D {
+    type Output = Self;
+    fn div(self, rhs: f32) -> Self {
+        ffi::qvector4d_div(rhs, &self)
     }
 }
 


### PR DESCRIPTION
I used the `derive_more` crate for some types, because it allows to derive these operators for simple types.
Let me know if you want to avoid adding this dependency.

Are there any more types, where an operator could be implemented?

ref: #53