### PR TITLE
Draft: Add support for attributes to #[qproperty]

### DIFF
--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -407,7 +407,7 @@ impl CxxQtBuilder {
         // Use a separate cc::Build for the little amount of code that needs to be linked with +whole-archive
         // to avoid bloating the binary.
         let mut cc_builder_whole_archive = cc::Build::new();
-        cc_builder_whole_archive.link_lib_modifier("+whole-archive");
+        //cc_builder_whole_archive.link_lib_modifier("+whole-archive");
         for builder in [&mut self.cc_builder, &mut cc_builder_whole_archive] {
             builder.cpp(true);
             // MSVC

--- a/crates/cxx-qt-gen/src/generator/cpp/property/meta.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/meta.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::generator::{cpp::types::CppType, naming::property::QPropertyName};
-use crate::parser::property::{ParsedQProperty, MaybeCustomFn};
+use crate::parser::property::ParsedQProperty;
 
 /// Generate the metaobject line for a given property
 pub fn generate(idents: &QPropertyName, property: &ParsedQProperty, cxx_ty: &CppType) -> String {

--- a/crates/cxx-qt-gen/src/generator/cpp/property/meta.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/meta.rs
@@ -4,15 +4,30 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::generator::{cpp::types::CppType, naming::property::QPropertyName};
+use crate::parser::property::{ParsedQProperty, MaybeCustomFn};
 
 /// Generate the metaobject line for a given property
-pub fn generate(idents: &QPropertyName, cxx_ty: &CppType) -> String {
+pub fn generate(idents: &QPropertyName, property: &ParsedQProperty, cxx_ty: &CppType) -> String {
+    let getter_setter_not_explicit = property.get.is_none() && property.set.is_none();
+
+    let getter = if getter_setter_not_explicit || property.get.is_some() {
+        format!("READ {ident_getter}", ident_getter = idents.getter.cpp)
+    } else {
+        String::new()
+    };
+
+    let setter = if getter_setter_not_explicit || property.set.is_some() {
+        format!("WRITE {ident_setter}", ident_setter = idents.setter.cpp)
+    } else {
+        String::new()
+    };
+
     format!(
-        "Q_PROPERTY({ty} {ident} READ {ident_getter} WRITE {ident_setter} NOTIFY {ident_notify})",
+        "Q_PROPERTY({ty} {ident} {getter} {setter} NOTIFY {ident_notify})",
         ty = cxx_ty.as_cxx_ty(),
         ident = idents.name.cpp,
-        ident_getter = idents.getter.cpp,
-        ident_setter = idents.setter.cpp,
+        getter = getter,
+        setter = setter,
         ident_notify = idents.notify.cpp,
     )
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -7,7 +7,7 @@ use crate::generator::{
     cpp::{qobject::GeneratedCppQObjectBlocks, types::CppType},
     naming::{property::QPropertyName, qobject::QObjectName},
 };
-use crate::parser::{cxxqtdata::ParsedCxxMappings, property::{ParsedQProperty, MaybeCustomFn}};
+use crate::parser::{cxxqtdata::ParsedCxxMappings, property::ParsedQProperty};
 use syn::Result;
 
 mod getter;
@@ -39,10 +39,6 @@ pub fn generate_cpp_properties(
         }
 
         // Setters
-        let default_setter = match property.set {
-            Some(MaybeCustomFn::Default) => true,
-            _ => false,
-        };
         if getter_setter_not_explicit || property.set.is_some() {
             generated
                 .methods

--- a/crates/cxx-qt-gen/src/generator/naming/property.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/property.rs
@@ -93,6 +93,8 @@ pub mod tests {
             ty,
             vis: syn::Visibility::Inherited,
             cxx_type: None,
+            get: None,
+            set: None,
         };
         QPropertyName::from(&property)
     }

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -8,7 +8,7 @@ use crate::generator::{
     rust::fragment::RustFragmentPair,
 };
 use quote::quote;
-use syn::Type;
+use syn::{Type, Expr};
 
 pub fn generate(
     idents: &QPropertyName,
@@ -48,6 +48,52 @@ pub fn generate(
                 impl #cpp_class_name_rust {
                     pub unsafe fn #getter_mutable_rust<'a>(mut self: Pin<&'a mut Self>) -> &'a mut #ty {
                         &mut self.rust_mut().get_unchecked_mut().#ident
+                    }
+                }
+            },
+        ],
+    }
+}
+
+pub fn generate_custom(
+    idents: &QPropertyName,
+    qobject_idents: &QObjectName,
+    expr: &Expr,
+    ty: &Type,
+) -> RustFragmentPair {
+    let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
+    let rust_struct_name_rust = &qobject_idents.rust_struct.rust;
+    let getter_cpp = idents.getter.cpp.to_string();
+    let getter_rust = &idents.getter.rust;
+    let getter_mutable_rust = &idents.getter_mutable.rust;
+    let ident = &idents.name.rust;
+
+    RustFragmentPair {
+        cxx_bridge: vec![quote! {
+            extern "Rust" {
+                #[cxx_name = #getter_cpp]
+                unsafe fn #getter_rust<'a>(self: &'a #rust_struct_name_rust, cpp: &'a #cpp_class_name_rust) -> &'a #ty;
+            }
+        }],
+        implementation: vec![
+            quote! {
+                impl #rust_struct_name_rust {
+                    pub fn #getter_rust<'a>(&'a self, cpp: &'a #cpp_class_name_rust) -> &'a #ty {
+                        cpp.#getter_rust()
+                    }
+                }
+            },
+            quote! {
+                impl #cpp_class_name_rust {
+                    pub fn #getter_rust(&self) -> &#ty {
+                        (#expr)(&self.rust())
+                    }
+                }
+            },
+            quote! {
+                impl #cpp_class_name_rust {
+                    pub unsafe fn #getter_mutable_rust<'a>(mut self: Pin<&'a mut Self>) -> &'a mut #ty {
+                        (#expr)(&mut self.rust_mut().get_unchecked_mut())
                     }
                 }
             },

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -66,34 +66,33 @@ pub fn generate_custom(
     let getter_cpp = idents.getter.cpp.to_string();
     let getter_rust = &idents.getter.rust;
     let getter_mutable_rust = &idents.getter_mutable.rust;
-    let ident = &idents.name.rust;
 
     RustFragmentPair {
         cxx_bridge: vec![quote! {
             extern "Rust" {
                 #[cxx_name = #getter_cpp]
-                unsafe fn #getter_rust<'a>(self: &'a #rust_struct_name_rust, cpp: &'a #cpp_class_name_rust) -> &'a #ty;
+                unsafe fn #getter_rust<'a>(self: &'a #rust_struct_name_rust, cpp: &'a #cpp_class_name_rust) -> #ty;
             }
         }],
         implementation: vec![
             quote! {
                 impl #rust_struct_name_rust {
-                    pub fn #getter_rust<'a>(&'a self, cpp: &'a #cpp_class_name_rust) -> &'a #ty {
+                    pub fn #getter_rust<'a>(&'a self, cpp: &'a #cpp_class_name_rust) -> #ty {
                         cpp.#getter_rust()
                     }
                 }
             },
             quote! {
                 impl #cpp_class_name_rust {
-                    pub fn #getter_rust(&self) -> &#ty {
-                        (#expr)(&self.rust())
+                    pub fn #getter_rust(&self) -> #ty {
+                        (#expr)(self)
                     }
                 }
             },
             quote! {
                 impl #cpp_class_name_rust {
-                    pub unsafe fn #getter_mutable_rust<'a>(mut self: Pin<&'a mut Self>) -> &'a mut #ty {
-                        (#expr)(&mut self.rust_mut().get_unchecked_mut())
+                    pub unsafe fn #getter_mutable_rust<'a>(mut self: Pin<&'a mut Self>) -> #ty {
+                        (#expr)(&mut self)
                     }
                 }
             },

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -17,7 +17,7 @@ use crate::{
 use quote::quote;
 use syn::{Ident, ImplItemMethod, Item, Result};
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct GeneratedRustQObjectBlocks {
     /// Module for the CXX bridge
     pub cxx_mod_contents: Vec<Item>,
@@ -33,6 +33,7 @@ impl GeneratedRustQObjectBlocks {
     }
 }
 
+#[derive(Debug)]
 pub struct GeneratedRustQObject {
     /// Ident of the Rust name for the C++ object
     pub cpp_struct_ident: Ident,

--- a/crates/cxx-qt-gen/src/parser/property.rs
+++ b/crates/cxx-qt-gen/src/parser/property.rs
@@ -1,9 +1,25 @@
 // SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+// SPDX-FileContributor: Carl Schwan <carl.schwan@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use syn::{Ident, Type, Visibility};
+use syn::{Ident, Type, Visibility, Expr};
+
+#[derive(Debug)]
+pub enum MaybeCustomFn {
+    Custom(Box<Expr>),
+    Default,
+}
+
+impl std::convert::From<Option<Expr>> for MaybeCustomFn {
+    fn from(item: Option<Expr>) -> Self {
+        match item {
+            Some(expr) => Self::Custom(Box::new(expr)),
+            None => Self::Default,
+        }
+    }
+}
 
 /// Describes a single field for a struct
 pub struct ParsedRustField {
@@ -25,4 +41,14 @@ pub struct ParsedQProperty {
     pub vis: Visibility,
     /// The name of the C++ type if one has been specified
     pub cxx_type: Option<String>,
+    /// The custom getter [syn::Expr] of the property
+    ///
+    /// If this is not set and not custom setter was specified, both a
+    /// default getter and setter will be generated.
+    pub get: Option<MaybeCustomFn>,
+    /// The custom setter [syn::Expr] of the property
+    ///
+    /// If this is not set and not custom setter was specified, both a
+    /// default getter and setter will be generated.
+    pub set: Option<MaybeCustomFn>,
 }

--- a/examples/qml_features/rust/src/properties.rs
+++ b/examples/qml_features/rust/src/properties.rs
@@ -26,6 +26,15 @@ mod ffi {
 
         #[qproperty]
         status_message: QString,
+
+        #[qproperty(get)]
+        readonly_prop: QString,
+
+        #[qproperty(get = Self::custom_prop_fn)]
+        custom_prop: bool,
+
+        #[qproperty(get = Self::custom_prop_str_fn)]
+        readonly_prop_str: QString,
     }
     // ANCHOR_END: book_properties_struct
 
@@ -37,6 +46,9 @@ mod ffi {
                 connected_url: QUrl::default(),
                 previous_connected_url: QUrl::default(),
                 status_message: QString::from("Disconnected"),
+                readonly_prop: QString::from("Read only"),
+                custom_prop: false,
+                readonly_prop_str: QString::from("Not read"),
             }
         }
     }
@@ -75,6 +87,14 @@ mod ffi {
             let previous_url = self.as_ref().connected_url().clone();
             self.as_mut().set_previous_connected_url(previous_url);
             self.set_connected_url(QUrl::default());
+        }
+
+        pub fn custom_prop_fn(&self) -> bool {
+            true
+        }
+
+        pub fn custom_prop_str_fn(&self) -> QString {
+            QString::from("hello")
         }
     }
 }


### PR DESCRIPTION
Make it possible to define if only a getter should be generated or only a setter and/or define special getter and setter.

Syntax is as follow

```rust
struct MyObject {
    #[qproperty]
    prop1: f32, // generate default getter and setter

    #[qproperty(get)]
    prop2: f32, // generate default getter only

    #[qproperty(set)]
    prop3: f32, // generate default setter only

    #[qproperty(get = Self::prop4_fn)]
    prop4: f32, // use prop4_fn as getter
}
```

WIP since the custom getter part doesn't work yet