### PR TITLE
cxx-qt-lib: Add chrono and time support for {QDate,QDateTime,QTime}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for further types: `QByteArray`, `QCoreApplication`, `QGuiApplication`, `QMargins`, `QMarginsF`, `QModelIndex`, `QPersistentModelIndex`, `QQmlApplicationEngine`, `QQmlEngine`, `QStringList`, `QTimeZone`, `QVector2D`, `QVector3D`, `QVector4D`
 - Support for nesting objects in properties, invokables, and signals with `*mut T`
 - Allow for marking signals as existing in the base class
-- Support for conversions to types in third-party crates: `bytes`, `chrono`, `http`, `rgb`, `url`
+- Support for conversions to types in third-party crates: `bytes`, `chrono`, `http`, `rgb`, `time`, `url`
 - Add several QoL functions to builtin cxx-qt-lib types, including Default constructors, string formatting, std::cmp order and operators
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for further types: `QByteArray`, `QCoreApplication`, `QGuiApplication`, `QMargins`, `QMarginsF`, `QModelIndex`, `QPersistentModelIndex`, `QQmlApplicationEngine`, `QQmlEngine`, `QStringList`, `QTimeZone`, `QVector2D`, `QVector3D`, `QVector4D`
 - Support for nesting objects in properties, invokables, and signals with `*mut T`
 - Allow for marking signals as existing in the base class
-- Support for conversions to types in third-party crates: `bytes`, `http`, `rgb`, `url`
+- Support for conversions to types in third-party crates: `bytes`, `chrono`, `http`, `rgb`, `url`
 - Add several QoL functions to builtin cxx-qt-lib types, including Default constructors, string formatting, std::cmp order and operators
 
 ### Changed

--- a/crates/cxx-qt-lib/Cargo.toml
+++ b/crates/cxx-qt-lib/Cargo.toml
@@ -18,6 +18,7 @@ links = "cxx-qt-lib"
 [dependencies]
 cxx.workspace = true
 bytes = { version = "1.4", optional = true }
+chrono = { version = "0.4.23", optional = true }
 http = { version = "0.2", optional = true }
 rgb = { version = "0.8", optional = true }
 url = { version = "2.3", optional = true }
@@ -30,6 +31,7 @@ qt-build-utils.workspace = true
 [features]
 default = ["qt_gui", "qt_qml"]
 bytes = ["dep:bytes"]
+chrono = ["dep:chrono"]
 http = ["dep:http"]
 rgb = ["dep:rgb"]
 qt_gui = ["cxx-qt-lib-headers/qt_gui"]

--- a/crates/cxx-qt-lib/Cargo.toml
+++ b/crates/cxx-qt-lib/Cargo.toml
@@ -21,6 +21,7 @@ bytes = { version = "1.4", optional = true }
 chrono = { version = "0.4.23", optional = true }
 http = { version = "0.2", optional = true }
 rgb = { version = "0.8", optional = true }
+time = { version = "0.3.20", optional = true }
 url = { version = "2.3", optional = true }
 
 [build-dependencies]
@@ -36,4 +37,5 @@ http = ["dep:http"]
 rgb = ["dep:rgb"]
 qt_gui = ["cxx-qt-lib-headers/qt_gui"]
 qt_qml = ["cxx-qt-lib-headers/qt_qml"]
+time = ["dep:time"]
 url = ["dep:url"]

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -220,6 +220,26 @@ unsafe impl ExternType for QDate {
     type Kind = cxx::kind::Trivial;
 }
 
+#[cfg(feature = "chrono")]
+use chrono::Datelike;
+
+#[cfg(feature = "chrono")]
+impl From<chrono::NaiveDate> for QDate {
+    fn from(value: chrono::NaiveDate) -> Self {
+        QDate::new(value.year(), value.month() as i32, value.day() as i32)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TryFrom<QDate> for chrono::NaiveDate {
+    type Error = &'static str;
+
+    fn try_from(value: QDate) -> Result<Self, Self::Error> {
+        chrono::NaiveDate::from_ymd_opt(value.year(), value.month() as u32, value.day() as u32)
+            .ok_or("out-of-range date, invalid month and/or day")
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -236,5 +256,21 @@ mod test {
         let date_a = QDate::from_julian_day(1000);
         let date_b = QDate::from_julian_day(1010);
         assert_eq!(date_a.days_to(date_b), 10);
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn qdate_from_chrono_naive() {
+        let naive = chrono::NaiveDate::from_ymd_opt(2023, 1, 1).unwrap();
+        let qdate = QDate::new(2023, 1, 1);
+        assert_eq!(QDate::from(naive), qdate);
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn qdate_to_chrono_naive() {
+        let naive = chrono::NaiveDate::from_ymd_opt(2023, 1, 1).unwrap();
+        let qdate = QDate::new(2023, 1, 1);
+        assert_eq!(chrono::NaiveDate::try_from(qdate).unwrap(), naive);
     }
 }

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -240,6 +240,30 @@ impl TryFrom<QDate> for chrono::NaiveDate {
     }
 }
 
+#[cfg(feature = "time")]
+impl From<time::Date> for QDate {
+    fn from(value: time::Date) -> Self {
+        QDate::new(
+            value.year(),
+            Into::<u8>::into(value.month()) as i32,
+            value.day() as i32,
+        )
+    }
+}
+
+#[cfg(feature = "time")]
+impl TryFrom<QDate> for time::Date {
+    type Error = time::error::ComponentRange;
+
+    fn try_from(value: QDate) -> Result<Self, Self::Error> {
+        time::Date::from_calendar_date(
+            value.year(),
+            time::Month::try_from(value.month() as u8)?,
+            value.day() as u8,
+        )
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -272,5 +296,21 @@ mod test {
         let naive = chrono::NaiveDate::from_ymd_opt(2023, 1, 1).unwrap();
         let qdate = QDate::new(2023, 1, 1);
         assert_eq!(chrono::NaiveDate::try_from(qdate).unwrap(), naive);
+    }
+
+    #[cfg(feature = "time")]
+    #[test]
+    fn qdate_from_time_date() {
+        let time_date = time::Date::from_calendar_date(2023, time::Month::January, 1).unwrap();
+        let qdate = QDate::new(2023, 1, 1);
+        assert_eq!(QDate::from(time_date), qdate);
+    }
+
+    #[cfg(feature = "time")]
+    #[test]
+    fn qdate_to_time_date() {
+        let time_date = time::Date::from_calendar_date(2023, time::Month::January, 1).unwrap();
+        let qdate = QDate::new(2023, 1, 1);
+        assert_eq!(time::Date::try_from(qdate).unwrap(), time_date);
     }
 }

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -490,11 +490,10 @@ unsafe impl ExternType for QDateTime {
 }
 
 #[cfg(test)]
-mod test {
-    #[cfg(any(feature = "chrono", feature = "time"))]
+#[cfg(feature = "chrono")]
+mod test_chrono {
     use super::*;
 
-    #[cfg(feature = "chrono")]
     #[test]
     fn qdatetime_from_chrono() {
         let datetime_east = {
@@ -514,7 +513,6 @@ mod test {
         assert_eq!(QDateTime::from(datetime_east), qdatetime);
     }
 
-    #[cfg(feature = "chrono")]
     #[test]
     fn qdatetime_to_chrono_fixed_offset() {
         let datetime_east = {
@@ -537,7 +535,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "chrono")]
     #[test]
     fn qdatetime_to_chrono_utc() {
         let datetime_utc = {
@@ -559,7 +556,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "chrono")]
     #[test]
     fn qdatetime_to_chrono_utc_with_offset() {
         let datetime_utc = {
@@ -581,8 +577,13 @@ mod test {
             datetime_utc
         );
     }
+}
 
-    #[cfg(feature = "time")]
+#[cfg(test)]
+#[cfg(feature = "time")]
+mod test_time {
+    use super::*;
+
     #[test]
     fn qdatetime_to_time_offsetdatetime() {
         let time_offsetdatetime = time::Date::from_calendar_date(2023, time::Month::January, 1)
@@ -602,7 +603,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "time")]
     #[test]
     fn qdatetime_to_time_primitivedatetime() {
         let time_offsetdatetime = time::Date::from_calendar_date(2023, time::Month::January, 1)
@@ -621,7 +621,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "time")]
     #[test]
     fn qdatetime_from_time_offsetdatetime() {
         let time_offsetdatetime = time::Date::from_calendar_date(2023, time::Month::January, 1)
@@ -638,7 +637,6 @@ mod test {
         assert_eq!(QDateTime::from(time_offsetdatetime), qdatetime);
     }
 
-    #[cfg(feature = "time")]
     #[test]
     fn qdatetime_from_time_primitivedatetime() {
         let time_offsetdatetime = time::Date::from_calendar_date(2023, time::Month::January, 1)

--- a/crates/cxx-qt-lib/src/core/qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qtime.rs
@@ -250,11 +250,10 @@ unsafe impl ExternType for QTime {
 }
 
 #[cfg(test)]
-mod test {
-    #[cfg(any(feature = "chrono", feature = "time"))]
+#[cfg(feature = "chrono")]
+mod test_chrono {
     use super::*;
 
-    #[cfg(feature = "chrono")]
     #[test]
     fn qtime_from_chrono_naive() {
         let naive = chrono::NaiveTime::from_hms_milli_opt(1, 2, 3, 4).unwrap();
@@ -262,7 +261,6 @@ mod test {
         assert_eq!(QTime::from(naive), qtime);
     }
 
-    #[cfg(feature = "chrono")]
     #[test]
     fn qtime_from_chrono_naive_leap_second() {
         let naive = chrono::NaiveTime::from_hms_milli_opt(1, 2, 3, 1_000).unwrap();
@@ -270,15 +268,19 @@ mod test {
         assert_eq!(QTime::from(naive), qtime);
     }
 
-    #[cfg(feature = "chrono")]
     #[test]
     fn qtime_to_chrono_naive() {
         let naive = chrono::NaiveTime::from_hms_milli_opt(1, 2, 3, 4).unwrap();
         let qtime = QTime::new(1, 2, 3, 4);
         assert_eq!(chrono::NaiveTime::try_from(qtime).unwrap(), naive);
     }
+}
 
-    #[cfg(feature = "time")]
+#[cfg(test)]
+#[cfg(feature = "time")]
+mod test_time {
+    use super::*;
+
     #[test]
     fn qtime_from_time_time() {
         let time_time = time::Time::from_hms_milli(1, 2, 3, 4).unwrap();
@@ -286,7 +288,6 @@ mod test {
         assert_eq!(QTime::from(time_time), qtime);
     }
 
-    #[cfg(feature = "time")]
     #[test]
     fn qtime_to_time_time() {
         let time_time = time::Time::from_hms_milli(1, 2, 3, 4).unwrap();


### PR DESCRIPTION
Requires #416

Related to #292 