### PR TITLE
cxx-qt: don't use unwrap and convert to a compile error instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for generating correct C++ code for `Pin<T>` Rust types
 - Support namespace attribute on shared types, QObject struct, and extern blocks
 - Asserts for 32bit platforms such as Wasm
+- Errors from the generation not pointing to the span where they occurred
 
 ## [0.4.1](https://github.com/KDAB/cxx-qt/compare/v0.4.0...v0.4.1) - 2022-11-18
 

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -141,7 +141,9 @@ pub fn inherit(_args: TokenStream, _input: TokenStream) -> TokenStream {
 
 // Take the module and C++ namespace and generate the rust code
 fn extract_and_generate(module: ItemMod) -> TokenStream {
-    let parser = Parser::from(module).unwrap();
-    let generated_rust = GeneratedRustBlocks::from(&parser).unwrap();
-    write_rust(&generated_rust).into()
+    Parser::from(module)
+        .and_then(|parser| GeneratedRustBlocks::from(&parser))
+        .map(|generated_rust| write_rust(&generated_rust))
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }


### PR DESCRIPTION
This improve error messages when our cxx-qt-gen code breaks.

Eg I have added a duplicate attribute key-value in the code, before we used to get this error when compiling.

```
error: custom attribute panicked
  --> examples/cargo_without_cmake/src/cxxqt_object.rs:11:1
   |
11 | #[cxx_qt::bridge]
   | ^^^^^^^^^^^^^^^^^
   |
   = help: message: called `Result::unwrap()` on an `Err` value: Error("Duplicate keys in the attributes")
```

Now we have a much better error that points to the code block that is at fault.

```
error: Duplicate keys in the attributes
  --> examples/cargo_without_cmake/src/cxxqt_object.rs:23:5
   |
23 |     #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0", qml_version = "1.0")]
   |     ^
```

Related to #38