### PR TITLE
cxx-qt-gen: have an explicit error for non public qobjects

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -59,7 +59,7 @@ mod tests {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -76,7 +76,7 @@ mod tests {
             #[cxx_qt::bridge(cxx_file_stem = "my_object")]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -93,7 +93,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -132,7 +132,7 @@ mod tests {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -156,7 +156,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject(base = "QStringListModel")]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -177,7 +177,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_name = "MyQmlElement")]
-                struct MyNamedObject;
+                pub struct MyNamedObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -201,7 +201,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_singleton)]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -226,7 +226,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_uncreatable)]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -71,7 +71,7 @@ mod tests {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -98,7 +98,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -119,7 +119,7 @@ mod tests {
                 use std::collections::HashMap;
 
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -138,7 +138,7 @@ mod tests {
             #[cxx_qt::bridge(cxx_file_stem = "my_object")]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -195,7 +195,7 @@ mod tests {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -218,7 +218,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();
@@ -241,7 +241,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_singleton)]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let parser = Parser::from(module).unwrap();

--- a/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
+++ b/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
@@ -330,7 +330,7 @@ mod tests {
             mod module {
                 struct Other;
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
             }
         });
         let result = cxx_qt_data.find_qobject_structs(&module.content.unwrap().1);
@@ -345,11 +345,11 @@ mod tests {
 
         let module: ItemMod = tokens_to_syn(quote! {
             mod module {
-                struct Other;
+                pub struct Other;
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
                 #[cxx_qt::qobject]
-                struct SecondObject;
+                pub struct SecondObject;
             }
         });
         let result = cxx_qt_data.find_qobject_structs(&module.content.unwrap().1);
@@ -370,11 +370,11 @@ mod tests {
 
         let module: ItemMod = tokens_to_syn(quote! {
             mod module {
-                struct Other;
+                pub struct Other;
                 #[cxx_qt::qobject(namespace = "qobject_namespace")]
-                struct MyObject;
+                pub struct MyObject;
                 #[cxx_qt::qobject]
-                struct SecondObject;
+                pub struct SecondObject;
             }
         });
         cxx_qt_data
@@ -405,8 +405,8 @@ mod tests {
 
         let module: ItemMod = tokens_to_syn(quote! {
             mod module {
-                struct Other;
-                struct MyObject;
+                pub struct Other;
+                pub struct MyObject;
             }
         });
         let result = cxx_qt_data.find_qobject_structs(&module.content.unwrap().1);
@@ -477,7 +477,7 @@ mod tests {
 
         let item: Item = tokens_to_syn(quote! {
             #[cxx_qt::qobject]
-            struct MyObject;
+            pub struct MyObject;
         });
         let result = cxx_qt_data.parse_cxx_qt_item(item).unwrap();
         assert!(result.is_none());

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -163,7 +163,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
 
                 #[cxx_qt::qsignals(MyObject)]
                 enum MySignals {
@@ -188,7 +188,7 @@ mod tests {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
 
                 #[cxx_qt::qsignals(MyObject)]
                 enum MySignals {
@@ -217,7 +217,7 @@ mod tests {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
-                struct MyObject;
+                pub struct MyObject;
 
                 #[cxx_qt::qsignals(UnknownObj)]
                 enum MySignals {


### PR DESCRIPTION
Before this patch if you didn't mark a qobject struct as public the following error would occur.

```
[build] error[E0432]: unresolved import `super`
[build]   --> examples/qml_minimal/rust/src/cxxqt_object.rs:24:12
[build]    |
[build] 24 |     struct MyObject {
[build]    |            ^^^^^^^^ no `MyObject` in `cxxqt_object`
[build]    |
[build] help: consider importing this type alias instead
[build]    |
[build] 24 |     struct crate::cxxqt_object::qobject::MyObject;
[build]    |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

After this patch the error is explicit.

```
[build] error: qobject marked structs must be public
[build]   --> examples/qml_minimal/rust/src/cxxqt_object.rs:24:5
[build]    |
[build] 24 |     struct MyObject {
[build]    |     ^^^^^^
```

Closes #457