### PR TITLE
cxx-qt-gen: remove clippy allow as it isn't required anymore

### DIFF
--- a/crates/cxx-qt-gen/src/syntax/qtitem.rs
+++ b/crates/cxx-qt-gen/src/syntax/qtitem.rs
@@ -12,7 +12,6 @@ use syn::{Attribute, Item, ItemMod, Result, Token, Visibility};
 #[derive(Clone, PartialEq, Eq)]
 // This warning is triggered when running clippy on crates that depend on cxx-qt-gen,
 // but not when running clippy on cxx-qt-gen.
-#[allow(clippy::large_enum_variant)]
 pub enum CxxQtItem {
     /// A normal syntax item that we pass through
     Item(Item),


### PR DESCRIPTION
Before we needed to have #[allow(clippy::large_enum_variant)] otherwise when running clippy via a dependency, eg by running cxx-qt-build clippy or the whole workspace it would fail. Even though clippy would pass individually for cxx-qt-gen.

This now doesn't happen with the latest clippy version, so remove this workaround.

Closes #225