### PR TITLE
Bump actions/cache to v3

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -139,7 +139,7 @@ jobs:
         toolchain: stable
 
     - name: "Rust tools cache"
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: rust-tools-cache
       with:
         path: |
@@ -152,7 +152,7 @@ jobs:
       run: cargo install sccache mdbook mdbook-linkcheck
 
     - name: "Compiler cache"
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ matrix.compiler_cache_path }}
         key: ${{ matrix.name }}-${{ github.head_ref }}-${{ github.run_number }}


### PR DESCRIPTION
This seems to fix the warning message:
```
 Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Hopefully this will also fix CI rebuilding the world all the time.