### PR TITLE
cxxqtthread: add Sync marker so that it can be used by reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for further types: `QLine`, `QLineF`, `QImage`, `QPainter`, `QFont`, `QPen`
 - `internal_pointer_mut()` function on `QModelIndex`
 - `c_void` in CXX-Qt-lib for easy access to `void *`
+- `CxxQtThread` is now marked as `Sync` so that it can be used by reference
 
 ### Changed
 

--- a/crates/cxx-qt/src/threading.rs
+++ b/crates/cxx-qt/src/threading.rs
@@ -57,7 +57,13 @@ where
     }
 }
 
+// CxxQtThread is safe to be sent across threads and handles
+// locking and checks with the original QObject to prevent issues
 unsafe impl<T> Send for CxxQtThread<T> where T: Threading {}
+
+// CxxQtThread is safe to use as a reference in parallel from multiple
+// places as it protects the queue call and the closure with mutexes
+unsafe impl<T> Sync for CxxQtThread<T> where T: Threading {}
 
 impl<T> CxxQtThread<T>
 where


### PR DESCRIPTION
This then means it can be used in async blocks too.

Closes #481