### PR TITLE
bump: release to 0.5.1 (sync back from `0.5.x` branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.5.0...HEAD)
+## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.5.1...HEAD)
 
 ### Changed
 
 - `QDateTime` API to use `current_date_time` rather than `current_date`
+
+## [0.5.1](https://github.com/KDAB/cxx-qt/compare/v0.5.0...v0.5.1) - 2023-03-27
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,17 +27,17 @@ members = [
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/KDAB/cxx-qt/"
-version = "0.5.0"
+version = "0.5.1"
 
 # Note a version needs to be specified on dependencies of packages
 # we publish, otherwise crates.io complains as it doesn't know the version.
 [workspace.dependencies]
 cxx-qt = { path = "crates/cxx-qt" }
 cxx-qt-build = { path = "crates/cxx-qt-build" }
-cxx-qt-gen = { path = "crates/cxx-qt-gen", version = "0.5" }
+cxx-qt-gen = { path = "crates/cxx-qt-gen", version = "0.5.1" }
 cxx-qt-lib = { path = "crates/cxx-qt-lib" }
-cxx-qt-lib-headers = { path = "crates/cxx-qt-lib-headers", version = "0.5" }
-qt-build-utils = { path = "crates/qt-build-utils", version = "0.5" }
+cxx-qt-lib-headers = { path = "crates/cxx-qt-lib-headers", version = "0.5.1" }
+qt-build-utils = { path = "crates/qt-build-utils", version = "0.5.1" }
 
 # Ensure that the example comments are kept in sync
 # examples/cargo_without_cmake/Cargo.toml


### PR DESCRIPTION
This syncs back the changes from the `0.5.x` branch