### PR TITLE
doc: add `--global` to `git config` when setting up symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ First, [enable Windows Developer Mode](https://learn.microsoft.com/en-us/gaming/
 to avoid needing administrator privileges to create symlinks. Then, enable symlinks in Git:
 
 ```shell
-git config core.symlinks true
+git config --global core.symlinks true
 ```
 
 Now clone the Git repository:


### PR DESCRIPTION
It is stated that symlink should be enabled before cloning, but copying the current command from readme doesn't work if we are not in a repo.

```
> git config core.symlinks true
fatal: not in a git directory
```

Adding the --global flag write it in the user config.