### PR TITLE
cxx-qt-gen: Fix the format of the error when a file is not found

### DIFF
--- a/crates/cxx-qt-gen/src/syntax/qtfile.rs
+++ b/crates/cxx-qt-gen/src/syntax/qtfile.rs
@@ -41,7 +41,10 @@ impl ToTokens for CxxQtFile {
 }
 
 pub fn parse_qt_file(path: impl AsRef<std::path::Path>) -> Result<CxxQtFile> {
-    let source = std::fs::read_to_string(path.as_ref()).expect("Could not read path {} to string");
+    let source = std::fs::read_to_string(path.as_ref()).unwrap_or_else(|err| {
+        // todo: fixme with a proper error propagation
+        panic!("Failed to read file {:?}: {}", path.as_ref(), err);
+    });
 
     // We drop the shebang from the generated Rust code
     if source.starts_with("#!") && !source.starts_with("#![") {


### PR DESCRIPTION
Before, the missing file was not logged in the panic message, making it hard to debug.

I encountered this error while following the qml-minimal example, I did a typo in my build.rs. Being not familiar with build.rs, it was quite frustrating for me to find the source of the problem.

```
ompiling qml-minimal v0.1.0 (C:\Users\olivi\dev\cxx-qt-tutorial\rust)
error: failed to run custom build command for `qml-minimal v0.1.0 (C:\Users\olivi\dev\cxx-qt-tutorial\rust)`

Caused by:
  process didn't exit successfully: `C:\Users\olivi\dev\cxx-qt-tutorial\rust\target\debug\build\qml-minimal-b0eab65f7e8191c2\build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-changed=src/cxxqt_object_doesntexist.rs
  cargo:rerun-if-env-changed=QMAKE
  cargo:rerun-if-env-changed=QT_VERSION_MAJOR
  cargo:rustc-link-search=C:/Qt/5.15.2/msvc2019_64/lib
  cargo:rustc-link-lib=Qt5Qml
  cargo:rustc-link-lib=Qt5Gui
  cargo:rustc-link-lib=Qt5Core
  cargo:rerun-if-changed=C:\Users\olivi\dev\cxx-qt-tutorial\rust/src/cxxqt_object_doesntexist.rs

  --- stderr
  thread 'main' panicked at 'Could not read path {} to string: Os { code: 2, kind: NotFound, message: "The system cannot find the file specified." }', C:\Users\olivi\scoop\persist\rustup\.cargo\registry\src\github.com-1ecc6299db9ec823\cxx-qt-gen-0.5.1\src\syntax\qtfile.rs:44:57
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ```

Now with this fix (I hacked examples/cargo_without_cmake/build.rs) to show a failing case.

```
cargo build -p qml-minimal-no-cmake
   Compiling qml-minimal-no-cmake v0.1.0 (C:\Users\olivi\dev\cxx-qt\examples\cargo_without_cmake)
error: failed to run custom build command for `qml-minimal-no-cmake v0.1.0 (C:\Users\olivi\dev\cxx-qt\examples\cargo_without_cmake)`

Caused by:
  process didn't exit successfully: `C:\Users\olivi\dev\cxx-qt\target\debug\build\qml-minimal-no-cmake-48641d8fda518a0e\build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-changed=src/cxxqt_object_doesntexist.rs
  cargo:rerun-if-changed=qml/qml.qrc
  cargo:rerun-if-env-changed=QMAKE
  cargo:rerun-if-env-changed=QT_VERSION_MAJOR
  cargo:rustc-link-search=C:/Qt/5.15.2/msvc2019_64/lib
  cargo:rustc-link-lib=Qt5Network
  cargo:rustc-link-lib=Qt5Core
  cargo:rustc-link-lib=Qt5Qml
  cargo:rustc-link-lib=Qt5Gui
  cargo:rerun-if-changed=C:\Users\olivi\dev\cxx-qt\examples\cargo_without_cmake/src/cxxqt_object_doesntexist.rs

  --- stderr
  thread 'main' panicked at 'Failed to read file "C:\\Users\\olivi\\dev\\cxx-qt\\examples\\cargo_without_cmake/src/cxxqt_object_doesntexist.rs": The system cannot find the file specified. (os error 2)', C:\Users\olivi\dev\cxx-qt\crates\cxx-qt-gen\src\syntax\qtfile.rs:47:13
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  
```
