### PR TITLE
cxx-qt-gen: fix test on windows (remove '\r')

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -91,7 +91,7 @@ jobs:
             # FIXME: many tests fail to link
             # https://github.com/KDAB/cxx-qt/issues/111
             # cxx_qt_lib_cargo_tests fails to run with a missing DLL error.
-            ctest_args: --exclude-regex '^(cxx_qt_gen_cargo_tests|demo_threading_cargo_tests|example_qml.*|qml.*tests|test.*|reuse_lint|cpp_clang_format|.*valgrind|cxx_qt_lib_cargo_tests)$'
+            ctest_args: --exclude-regex '^(demo_threading_cargo_tests|example_qml.*|qml.*tests|test.*|reuse_lint|cpp_clang_format|.*valgrind|cxx_qt_lib_cargo_tests)$'
             exe_suffix: .exe
             qt_qpa_platform: windows
             compiler_cache_path: C:\Users\runneradmin\AppData\Local\Mozilla\sccache\cache
@@ -106,7 +106,7 @@ jobs:
             # FIXME: many tests fail to link
             # https://github.com/KDAB/cxx-qt/issues/111
             # cxx_qt_lib_cargo_tests fails to run with a missing DLL error.
-            ctest_args: --exclude-regex '^(cxx_qt_gen_cargo_tests|demo_threading_cargo_tests|example_qml.*|qml.*tests|test.*|reuse_lint|cpp_clang_format|.*valgrind|cxx_qt_lib_cargo_tests)$'
+            ctest_args: --exclude-regex '^(demo_threading_cargo_tests|example_qml.*|qml.*tests|test.*|reuse_lint|cpp_clang_format|.*valgrind|cxx_qt_lib_cargo_tests)$'
             exe_suffix: .exe
             qt_qpa_platform: windows
             compiler_cache_path: C:\Users\runneradmin\AppData\Local\Mozilla\sccache\cache


### PR DESCRIPTION
On windows sometime the generated file, or the value returned from the clang-format call get \r in them.

It is sane to remove all of them, to get consistency between unix and windows system for tests.