### PR TITLE
cxx-qt-gen: remove tokens_to_syn and use parse_quote instead

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
@@ -52,20 +52,16 @@ pub fn generate(
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_str_eq;
-    use syn::ForeignItemFn;
+    use syn::{parse_quote, ForeignItemFn};
 
-    use crate::{
-        parser::inherit::ParsedInheritedMethod, syntax::safety::Safety, tests::tokens_to_syn,
-    };
+    use crate::{parser::inherit::ParsedInheritedMethod, syntax::safety::Safety};
 
     use super::*;
-    use quote::quote;
 
     fn generate_from_foreign(
-        tokens: proc_macro2::TokenStream,
+        method: ForeignItemFn,
         base_class: Option<&str>,
     ) -> Result<GeneratedCppQObjectBlocks> {
-        let method: ForeignItemFn = tokens_to_syn(tokens);
         let inherited_methods = vec![ParsedInheritedMethod::parse(method, Safety::Safe).unwrap()];
         let base_class = base_class.map(|s| s.to_owned());
         generate(
@@ -87,7 +83,7 @@ mod tests {
     #[test]
     fn test_immutable() {
         let generated = generate_from_foreign(
-            quote! {
+            parse_quote! {
                 fn test(self: &qobject::T, a: B, b: C);
             },
             Some("TestBaseClass"),
@@ -109,7 +105,7 @@ mod tests {
     #[test]
     fn test_mutable() {
         let generated = generate_from_foreign(
-            quote! {
+            parse_quote! {
                 fn test(self: Pin<&mut qobject::T>);
             },
             Some("TestBaseClass"),
@@ -131,7 +127,7 @@ mod tests {
     #[test]
     fn test_default_base_class() {
         let generated = generate_from_foreign(
-            quote! {
+            parse_quote! {
                 fn test(self: &qobject::T);
             },
             None,

--- a/crates/cxx-qt-gen/src/generator/cpp/invokable.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/invokable.rs
@@ -156,54 +156,50 @@ mod tests {
 
     use crate::generator::naming::qobject::tests::create_qobjectname;
     use crate::parser::parameter::ParsedFunctionParameter;
-    use crate::tests::tokens_to_syn;
     use indoc::indoc;
     use pretty_assertions::assert_str_eq;
-    use quote::{format_ident, quote};
+    use quote::format_ident;
     use std::collections::HashSet;
+    use syn::parse_quote;
 
     #[test]
     fn test_generate_cpp_invokables() {
         let invokables = vec![
             ParsedQInvokable {
-                method: tokens_to_syn(quote! { fn void_invokable(&self) {} }),
+                method: parse_quote! { fn void_invokable(&self) {} },
                 mutable: false,
                 parameters: vec![],
                 return_cxx_type: None,
                 specifiers: HashSet::new(),
             },
             ParsedQInvokable {
-                method: tokens_to_syn(quote! { fn trivial_invokable(&self, param: i32) -> i32 {} }),
+                method: parse_quote! { fn trivial_invokable(&self, param: i32) -> i32 {} },
                 mutable: false,
                 parameters: vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
-                    ty: tokens_to_syn::<syn::Type>(quote! { i32 }),
+                    ty: parse_quote! { i32 },
                     cxx_type: None,
                 }],
                 return_cxx_type: None,
                 specifiers: HashSet::new(),
             },
             ParsedQInvokable {
-                method: tokens_to_syn(
-                    quote! { fn opaque_invokable(self: Pin<&mut Self>, param: &QColor) -> UniquePtr<QColor> {} },
-                ),
+                method: parse_quote! { fn opaque_invokable(self: Pin<&mut Self>, param: &QColor) -> UniquePtr<QColor> {} },
                 mutable: true,
                 parameters: vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
-                    ty: tokens_to_syn::<syn::Type>(quote! { &QColor }),
+                    ty: parse_quote! { &QColor },
                     cxx_type: None,
                 }],
                 return_cxx_type: Some("QColor".to_owned()),
                 specifiers: HashSet::new(),
             },
             ParsedQInvokable {
-                method: tokens_to_syn(
-                    quote! { fn specifiers_invokable(&self, param: i32) -> i32 {} },
-                ),
+                method: parse_quote! { fn specifiers_invokable(&self, param: i32) -> i32 {} },
                 mutable: false,
                 parameters: vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
-                    ty: tokens_to_syn::<syn::Type>(quote! { i32 }),
+                    ty: parse_quote! { i32 },
                     cxx_type: None,
                 }],
                 return_cxx_type: None,
@@ -310,11 +306,11 @@ mod tests {
     #[test]
     fn test_generate_cpp_invokables_mapped_cxx_name() {
         let invokables = vec![ParsedQInvokable {
-            method: tokens_to_syn(quote! { fn trivial_invokable(&self, param: A) -> B {} }),
+            method: parse_quote! { fn trivial_invokable(&self, param: A) -> B {} },
             mutable: false,
             parameters: vec![ParsedFunctionParameter {
                 ident: format_ident!("param"),
-                ty: tokens_to_syn::<syn::Type>(quote! { i32 }),
+                ty: parse_quote! { i32 },
                 cxx_type: None,
             }],
             return_cxx_type: None,

--- a/crates/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -49,19 +49,17 @@ mod tests {
     use super::*;
 
     use crate::parser::Parser;
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
-    use syn::ItemMod;
+    use syn::{parse_quote, ItemMod};
 
     #[test]
     fn test_generated_cpp_blocks() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let cpp = GeneratedCppBlocks::from(&parser).unwrap();
@@ -72,13 +70,13 @@ mod tests {
 
     #[test]
     fn test_generated_cpp_blocks_cxx_file_stem() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(cxx_file_stem = "my_object")]
             mod ffi {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let cpp = GeneratedCppBlocks::from(&parser).unwrap();
@@ -89,13 +87,13 @@ mod tests {
 
     #[test]
     fn test_generated_cpp_blocks_namespace() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let cpp = GeneratedCppBlocks::from(&parser).unwrap();

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -45,24 +45,24 @@ mod tests {
     use super::*;
 
     use crate::generator::naming::qobject::tests::create_qobjectname;
-    use crate::tests::tokens_to_syn;
     use crate::CppFragment;
     use indoc::indoc;
     use pretty_assertions::assert_str_eq;
-    use quote::{format_ident, quote};
+    use quote::format_ident;
+    use syn::parse_quote;
 
     #[test]
     fn test_generate_cpp_properties() {
         let properties = vec![
             ParsedQProperty {
                 ident: format_ident!("trivial_property"),
-                ty: tokens_to_syn(quote! { i32 }),
+                ty: parse_quote! { i32 },
                 vis: syn::Visibility::Inherited,
                 cxx_type: None,
             },
             ParsedQProperty {
                 ident: format_ident!("opaque_property"),
-                ty: tokens_to_syn(quote! { UniquePtr<QColor> }),
+                ty: parse_quote! { UniquePtr<QColor> },
                 vis: syn::Visibility::Inherited,
                 cxx_type: Some("QColor".to_owned()),
             },
@@ -175,7 +175,7 @@ mod tests {
     fn test_generate_cpp_properties_mapped_cxx_name() {
         let properties = vec![ParsedQProperty {
             ident: format_ident!("mapped_property"),
-            ty: tokens_to_syn(quote! { A1 }),
+            ty: parse_quote! { A1 },
             vis: syn::Visibility::Inherited,
             cxx_type: None,
         }];

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -122,19 +122,17 @@ mod tests {
     use super::*;
 
     use crate::parser::Parser;
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
-    use syn::ItemMod;
+    use syn::{parse_quote, ItemMod};
 
     #[test]
     fn test_generated_cpp_qobject_blocks() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let cpp = GeneratedCppQObject::from(
@@ -152,13 +150,13 @@ mod tests {
 
     #[test]
     fn test_generated_cpp_qobject_blocks_base_and_namespace() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject(base = "QStringListModel")]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let cpp = GeneratedCppQObject::from(
@@ -173,13 +171,13 @@ mod tests {
 
     #[test]
     fn test_generated_cpp_qobject_named() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_name = "MyQmlElement")]
                 pub struct MyNamedObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let cpp = GeneratedCppQObject::from(
@@ -197,13 +195,13 @@ mod tests {
 
     #[test]
     fn test_generated_cpp_qobject_singleton() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_singleton)]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let cpp = GeneratedCppQObject::from(
@@ -222,13 +220,13 @@ mod tests {
 
     #[test]
     fn test_generated_cpp_qobject_uncreatable() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_uncreatable)]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let cpp = GeneratedCppQObject::from(

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -99,10 +99,10 @@ mod tests {
 
     use crate::generator::naming::qobject::tests::create_qobjectname;
     use crate::parser::parameter::ParsedFunctionParameter;
-    use crate::tests::tokens_to_syn;
     use indoc::indoc;
     use pretty_assertions::assert_str_eq;
-    use quote::{format_ident, quote};
+    use quote::format_ident;
+    use syn::parse_quote;
 
     #[test]
     fn test_generate_cpp_signals() {
@@ -113,12 +113,12 @@ mod tests {
             parameters: vec![
                 ParsedFunctionParameter {
                     ident: format_ident!("trivial"),
-                    ty: tokens_to_syn(quote! { i32 }),
+                    ty: parse_quote! { i32 },
                     cxx_type: None,
                 },
                 ParsedFunctionParameter {
                     ident: format_ident!("opaque"),
-                    ty: tokens_to_syn(quote! { UniquePtr<QColor> }),
+                    ty: parse_quote! { UniquePtr<QColor> },
                     cxx_type: Some("QColor".to_owned()),
                 },
             ],
@@ -168,7 +168,7 @@ mod tests {
             inherit: false,
             parameters: vec![ParsedFunctionParameter {
                 ident: format_ident!("mapped"),
-                ty: tokens_to_syn(quote! { A1 }),
+                ty: parse_quote! { A1 },
                 cxx_type: None,
             }],
         }];

--- a/crates/cxx-qt-gen/src/generator/cpp/types.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/types.rs
@@ -274,14 +274,13 @@ fn possible_built_in_template_base(ty: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use syn::parse_quote;
 
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
+    use super::*;
 
     #[test]
     fn test_cxx_type_with_attribute() {
-        let ty = tokens_to_syn(quote! { UniquePtr<QColor> });
+        let ty = parse_quote! { UniquePtr<QColor> };
         let cxx_ty = CppType::from(
             &ty,
             &Some("QColor".to_owned()),
@@ -294,7 +293,7 @@ mod tests {
 
     #[test]
     fn test_cxx_type_without_attribute() {
-        let ty = tokens_to_syn(quote! { UniquePtr<QColor> });
+        let ty = parse_quote! { UniquePtr<QColor> };
         let cxx_ty = CppType::from(&ty, &None, &ParsedCxxMappings::default()).unwrap();
         assert_eq!(cxx_ty.as_cxx_ty(), "::std::unique_ptr<QColor>");
         assert_eq!(cxx_ty.as_rust_ty(), "::std::unique_ptr<QColor>");
@@ -302,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_cxx_type_mapped() {
-        let ty = tokens_to_syn(quote! { A });
+        let ty = parse_quote! { A };
         let mut cxx_mappings = ParsedCxxMappings::default();
         cxx_mappings
             .cxx_names
@@ -314,7 +313,7 @@ mod tests {
 
     #[test]
     fn test_cxx_type_mapped_with_attribute() {
-        let ty = tokens_to_syn(quote! { A });
+        let ty = parse_quote! { A };
         let mut cxx_mappings = ParsedCxxMappings::default();
         cxx_mappings
             .cxx_names
@@ -326,7 +325,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_built_in_one_part() {
-        let ty = tokens_to_syn(quote! { i32 });
+        let ty = parse_quote! { i32 };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::std::int32_t"
@@ -335,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_unknown_one_part() {
-        let ty = tokens_to_syn(quote! { QPoint });
+        let ty = parse_quote! { QPoint };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "QPoint"
@@ -344,7 +343,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_ref_const_one_part() {
-        let ty = tokens_to_syn(quote! { &QPoint });
+        let ty = parse_quote! { &QPoint };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "QPoint const&"
@@ -353,7 +352,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_ref_mut_one_part() {
-        let ty = tokens_to_syn(quote! { &mut QPoint });
+        let ty = parse_quote! { &mut QPoint };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "QPoint&"
@@ -362,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_ref_const_ptr_mut_one_part() {
-        let ty = tokens_to_syn(quote! { &*mut T });
+        let ty = parse_quote! { &*mut T };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "T* const&"
@@ -371,7 +370,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_ref_const_ptr_const_one_part() {
-        let ty = tokens_to_syn(quote! { &*const T });
+        let ty = parse_quote! { &*const T };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "const T* const&"
@@ -380,7 +379,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_ref_mut_ptr_mut_one_part() {
-        let ty = tokens_to_syn(quote! { &mut *mut T });
+        let ty = parse_quote! { &mut *mut T };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "T*&"
@@ -389,7 +388,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_ref_mut_ptr_const_one_part() {
-        let ty = tokens_to_syn(quote! { &mut *const T });
+        let ty = parse_quote! { &mut *const T };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "const T*&"
@@ -398,7 +397,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_ptr_mut_one_part() {
-        let ty = tokens_to_syn(quote! { *mut T });
+        let ty = parse_quote! { *mut T };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "T*"
@@ -407,7 +406,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_ptr_const_one_part() {
-        let ty = tokens_to_syn(quote! { *const T });
+        let ty = parse_quote! { *const T };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "const T*"
@@ -416,7 +415,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_templated_built_in() {
-        let ty = tokens_to_syn(quote! { Vec<f64> });
+        let ty = parse_quote! { Vec<f64> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::rust::Vec<double>"
@@ -425,7 +424,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_templated_unknown() {
-        let ty = tokens_to_syn(quote! { UniquePtr<QColor> });
+        let ty = parse_quote! { UniquePtr<QColor> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::std::unique_ptr<QColor>"
@@ -434,7 +433,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_templated_built_in_ref_const() {
-        let ty = tokens_to_syn(quote! { &Vec<f64> });
+        let ty = parse_quote! { &Vec<f64> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::rust::Vec<double> const&"
@@ -443,7 +442,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_templated_built_in_ptr_mut() {
-        let ty = tokens_to_syn(quote! { &Vec<*mut T> });
+        let ty = parse_quote! { &Vec<*mut T> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::rust::Vec<T*> const&"
@@ -452,7 +451,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_templated_built_in_ptr_const() {
-        let ty = tokens_to_syn(quote! { &Vec<*const T> });
+        let ty = parse_quote! { &Vec<*const T> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::rust::Vec<const T*> const&"
@@ -461,7 +460,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_templated_unknown_ref_mut() {
-        let ty = tokens_to_syn(quote! { &mut UniquePtr<QColor> });
+        let ty = parse_quote! { &mut UniquePtr<QColor> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::std::unique_ptr<QColor>&"
@@ -470,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_templated_unknown_ptr_mut() {
-        let ty = tokens_to_syn(quote! { &mut UniquePtr<*mut T> });
+        let ty = parse_quote! { &mut UniquePtr<*mut T> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::std::unique_ptr<T*>&"
@@ -479,7 +478,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_templated_unknown_ptr_const() {
-        let ty = tokens_to_syn(quote! { &mut UniquePtr<*const T> });
+        let ty = parse_quote! { &mut UniquePtr<*const T> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::std::unique_ptr<const T*>&"
@@ -488,7 +487,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_mapped() {
-        let ty = tokens_to_syn(quote! { A });
+        let ty = parse_quote! { A };
         let mut cxx_mappings = ParsedCxxMappings::default();
         cxx_mappings
             .cxx_names
@@ -498,7 +497,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_mapped_with_namespace() {
-        let ty = tokens_to_syn(quote! { A });
+        let ty = parse_quote! { A };
         let mut cxx_mappings = ParsedCxxMappings::default();
         cxx_mappings
             .cxx_names
@@ -511,7 +510,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_pin() {
-        let ty = tokens_to_syn(quote! { Pin<T> });
+        let ty = parse_quote! { Pin<T> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "T"
@@ -520,7 +519,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_pin_ref() {
-        let ty = tokens_to_syn(quote! { Pin<&T> });
+        let ty = parse_quote! { Pin<&T> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "T const&"
@@ -529,7 +528,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_pin_ref_mut() {
-        let ty = tokens_to_syn(quote! { Pin<&mut T> });
+        let ty = parse_quote! { Pin<&mut T> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "T&"
@@ -538,7 +537,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_pin_template() {
-        let ty = tokens_to_syn(quote! { Pin<UniquePtr<T>> });
+        let ty = parse_quote! { Pin<UniquePtr<T>> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::std::unique_ptr<T>"
@@ -547,7 +546,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_pin_template_ref() {
-        let ty = tokens_to_syn(quote! { Pin<&UniquePtr<T>> });
+        let ty = parse_quote! { Pin<&UniquePtr<T>> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::std::unique_ptr<T> const&"
@@ -556,7 +555,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_pin_template_ref_mut() {
-        let ty = tokens_to_syn(quote! { Pin<&mut UniquePtr<T>> });
+        let ty = parse_quote! { Pin<&mut UniquePtr<T>> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::std::unique_ptr<T>&"
@@ -565,7 +564,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_slice() {
-        let ty = tokens_to_syn(quote! { &[i32] });
+        let ty = parse_quote! { &[i32] };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::rust::Slice<::std::int32_t const>"
@@ -574,7 +573,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_slice_mut() {
-        let ty = tokens_to_syn(quote! { &mut [i32] });
+        let ty = parse_quote! { &mut [i32] };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::rust::Slice<::std::int32_t>"
@@ -583,7 +582,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_str() {
-        let ty = tokens_to_syn(quote! { &str });
+        let ty = parse_quote! { &str };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::rust::Str"
@@ -592,7 +591,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_str_template() {
-        let ty = tokens_to_syn(quote! { Vec<&str> });
+        let ty = parse_quote! { Vec<&str> };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::rust::Vec<::rust::Str>"
@@ -601,7 +600,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_array() {
-        let ty = tokens_to_syn(quote! { [i32; 10] });
+        let ty = parse_quote! { [i32; 10] };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::std::array<::std::int32_t, 10>"
@@ -610,19 +609,19 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_array_length_zero() {
-        let ty = tokens_to_syn(quote! { [i32; 0] });
+        let ty = parse_quote! { [i32; 0] };
         assert!(to_cpp_string(&ty, &ParsedCxxMappings::default()).is_err());
     }
 
     #[test]
     fn test_to_cpp_string_array_length_invalid() {
-        let ty = tokens_to_syn(quote! { [i32; String] });
+        let ty = parse_quote! { [i32; String] };
         assert!(to_cpp_string(&ty, &ParsedCxxMappings::default()).is_err());
     }
 
     #[test]
     fn test_to_cpp_string_fn() {
-        let ty = tokens_to_syn(quote! { fn(i32, i32) -> bool });
+        let ty = parse_quote! { fn(i32, i32) -> bool };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::rust::Fn<bool, (::std::int32_t, ::std::int32_t)>"
@@ -631,7 +630,7 @@ mod tests {
 
     #[test]
     fn test_to_cpp_string_fn_void() {
-        let ty = tokens_to_syn(quote! { fn() });
+        let ty = parse_quote! { fn() };
         assert_eq!(
             to_cpp_string(&ty, &ParsedCxxMappings::default()).unwrap(),
             "::rust::Fn<void, ()>"

--- a/crates/cxx-qt-gen/src/generator/naming/invokable.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/invokable.rs
@@ -42,19 +42,19 @@ impl CombinedIdent {
 
 #[cfg(test)]
 mod tests {
+    use syn::parse_quote;
+
     use super::*;
 
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
     use std::collections::HashSet;
 
     #[test]
     fn test_from_impl_method() {
-        let item: ImplItemFn = tokens_to_syn(quote! {
+        let item: ImplItemFn = parse_quote! {
             fn my_invokable() {
 
             }
-        });
+        };
         let parsed = ParsedQInvokable {
             method: item,
             mutable: false,

--- a/crates/cxx-qt-gen/src/generator/naming/property.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/property.rs
@@ -81,13 +81,12 @@ impl CombinedIdent {
 
 #[cfg(test)]
 pub mod tests {
+    use syn::parse_quote;
+
     use super::*;
 
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
-
     pub fn create_i32_qpropertyname() -> QPropertyName {
-        let ty: syn::Type = tokens_to_syn(quote! { i32 });
+        let ty: syn::Type = parse_quote! { i32 };
         let property = ParsedQProperty {
             ident: format_ident!("my_property"),
             ty,

--- a/crates/cxx-qt-gen/src/generator/rust/field.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/field.rs
@@ -70,24 +70,22 @@ pub fn generate_rust_fields(
 mod tests {
     use super::*;
 
-    use crate::{
-        generator::naming::qobject::tests::create_qobjectname,
-        tests::{assert_tokens_eq, tokens_to_syn},
-    };
+    use crate::{generator::naming::qobject::tests::create_qobjectname, tests::assert_tokens_eq};
     use quote::{format_ident, quote};
+    use syn::parse_quote;
 
     #[test]
     fn test_generate_rust_properties() {
         let properties = vec![
             ParsedRustField {
                 ident: format_ident!("private_field"),
-                ty: tokens_to_syn::<syn::Type>(quote! { i32 }),
+                ty: parse_quote! { i32 },
                 vis: syn::Visibility::Inherited,
             },
             ParsedRustField {
                 ident: format_ident!("public_field"),
-                ty: tokens_to_syn::<syn::Type>(quote! { f64 }),
-                vis: tokens_to_syn::<syn::Visibility>(quote! { pub }),
+                ty: parse_quote! { f64 },
+                vis: parse_quote! { pub },
             },
         ];
         let qobject_idents = create_qobjectname();

--- a/crates/cxx-qt-gen/src/generator/rust/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/inherit.rs
@@ -61,17 +61,15 @@ pub fn generate(
 mod tests {
     use super::*;
     use crate::{
-        generator::naming::qobject::tests::create_qobjectname,
-        syntax::safety::Safety,
-        tests::{assert_tokens_eq, tokens_to_syn},
+        generator::naming::qobject::tests::create_qobjectname, syntax::safety::Safety,
+        tests::assert_tokens_eq,
     };
-    use syn::ForeignItemFn;
+    use syn::{parse_quote, ForeignItemFn};
 
     fn generate_from_foreign(
-        tokens: proc_macro2::TokenStream,
+        method: ForeignItemFn,
         safety: Safety,
     ) -> Result<GeneratedRustQObjectBlocks> {
-        let method: ForeignItemFn = tokens_to_syn(tokens);
         let inherited_methods = vec![ParsedInheritedMethod::parse(method, safety).unwrap()];
         generate(&create_qobjectname(), &inherited_methods)
     }
@@ -79,7 +77,7 @@ mod tests {
     #[test]
     fn test_mutable() {
         let generated = generate_from_foreign(
-            quote! {
+            parse_quote! {
                     fn test(self: Pin<&mut qobject::MyObject>, a: B, b: C);
             },
             Safety::Safe,
@@ -103,7 +101,7 @@ mod tests {
     #[test]
     fn test_immutable() {
         let generated = generate_from_foreign(
-            quote! {
+            parse_quote! {
                 fn test(self: &qobject::MyObject, a: B, b: C);
             },
             Safety::Safe,
@@ -127,7 +125,7 @@ mod tests {
     #[test]
     fn test_unsafe() {
         let generated = generate_from_foreign(
-            quote! {
+            parse_quote! {
                 unsafe fn test(self: &qobject::MyObject);
             },
             Safety::Unsafe,

--- a/crates/cxx-qt-gen/src/generator/rust/invokable.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/invokable.rs
@@ -124,52 +124,49 @@ mod tests {
 
     use crate::generator::naming::qobject::tests::create_qobjectname;
     use crate::parser::parameter::ParsedFunctionParameter;
-    use crate::tests::{assert_tokens_eq, tokens_to_syn};
+    use crate::tests::assert_tokens_eq;
     use quote::format_ident;
     use std::collections::HashSet;
+    use syn::parse_quote;
 
     #[test]
     fn test_generate_rust_invokables() {
         let invokables = vec![
             ParsedQInvokable {
-                method: tokens_to_syn(quote! { fn void_invokable(&self) {} }),
+                method: parse_quote! { fn void_invokable(&self) {} },
                 mutable: false,
                 parameters: vec![],
                 return_cxx_type: None,
                 specifiers: HashSet::new(),
             },
             ParsedQInvokable {
-                method: tokens_to_syn(quote! { fn trivial_invokable(&self, param: i32) -> i32 {} }),
+                method: parse_quote! { fn trivial_invokable(&self, param: i32) -> i32 {} },
                 mutable: false,
                 parameters: vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
-                    ty: tokens_to_syn::<syn::Type>(quote! { i32 }),
+                    ty: parse_quote! { i32 },
                     cxx_type: None,
                 }],
                 return_cxx_type: None,
                 specifiers: HashSet::new(),
             },
             ParsedQInvokable {
-                method: tokens_to_syn(
-                    quote! { fn opaque_invokable(self: Pin<&mut Self>, param: &QColor) -> UniquePtr<QColor> {} },
-                ),
+                method: parse_quote! { fn opaque_invokable(self: Pin<&mut Self>, param: &QColor) -> UniquePtr<QColor> {} },
                 mutable: true,
                 parameters: vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
-                    ty: tokens_to_syn::<syn::Type>(quote! { &QColor }),
+                    ty: parse_quote! { &QColor },
                     cxx_type: None,
                 }],
                 return_cxx_type: Some("QColor".to_owned()),
                 specifiers: HashSet::new(),
             },
             ParsedQInvokable {
-                method: tokens_to_syn(
-                    quote! { fn unsafe_invokable(&self, param: *mut T) -> *mut T {} },
-                ),
+                method: parse_quote! { fn unsafe_invokable(&self, param: *mut T) -> *mut T {} },
                 mutable: false,
                 parameters: vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
-                    ty: tokens_to_syn::<syn::Type>(quote! { *mut T }),
+                    ty: parse_quote! { *mut T },
                     cxx_type: None,
                 }],
                 return_cxx_type: None,

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -61,19 +61,21 @@ fn generate_include(parser: &Parser) -> Result<Item> {
 
 #[cfg(test)]
 mod tests {
+    use syn::parse_quote;
+
     use super::*;
 
-    use crate::tests::{assert_tokens_eq, tokens_to_syn};
+    use crate::tests::assert_tokens_eq;
 
     #[test]
     fn test_generated_rust_blocks() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let rust = GeneratedRustBlocks::from(&parser).unwrap();
@@ -94,13 +96,13 @@ mod tests {
 
     #[test]
     fn test_generated_rust_blocks_namespace() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let rust = GeneratedRustBlocks::from(&parser).unwrap();
@@ -113,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_generated_rust_blocks_uses() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 use std::collections::HashMap;
@@ -121,7 +123,7 @@ mod tests {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let rust = GeneratedRustBlocks::from(&parser).unwrap();
@@ -134,13 +136,13 @@ mod tests {
 
     #[test]
     fn test_generated_rust_blocks_cxx_file_stem() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(cxx_file_stem = "my_object")]
             mod ffi {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let rust = GeneratedRustBlocks::from(&parser).unwrap();

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -60,27 +60,28 @@ pub fn generate_rust_properties(
 mod tests {
     use super::*;
 
-    use crate::{generator::naming::qobject::tests::create_qobjectname, tests::tokens_to_syn};
-    use quote::{format_ident, quote};
+    use crate::generator::naming::qobject::tests::create_qobjectname;
+    use quote::format_ident;
+    use syn::parse_quote;
 
     #[test]
     fn test_generate_rust_properties() {
         let properties = vec![
             ParsedQProperty {
                 ident: format_ident!("trivial_property"),
-                ty: tokens_to_syn::<syn::Type>(quote! { i32 }),
+                ty: parse_quote! { i32 },
                 vis: syn::Visibility::Inherited,
                 cxx_type: None,
             },
             ParsedQProperty {
                 ident: format_ident!("opaque_property"),
-                ty: tokens_to_syn::<syn::Type>(quote! { UniquePtr<QColor> }),
-                vis: tokens_to_syn::<syn::Visibility>(quote! { pub }),
+                ty: parse_quote! { UniquePtr<QColor> },
+                vis: parse_quote! { pub },
                 cxx_type: Some("QColor".to_owned()),
             },
             ParsedQProperty {
                 ident: format_ident!("unsafe_property"),
-                ty: tokens_to_syn::<syn::Type>(quote! { *mut T }),
+                ty: parse_quote! { *mut T },
                 vis: syn::Visibility::Inherited,
                 cxx_type: None,
             },
@@ -98,67 +99,67 @@ mod tests {
         // Getter
         assert_eq!(
             generated.cxx_mod_contents[0],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 extern "Rust" {
                     #[cxx_name = "getTrivialProperty"]
                     unsafe fn trivial_property<'a>(self: &'a MyObject, cpp: &'a MyObjectQt) -> &'a i32;
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[0],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObject {
                     pub fn trivial_property<'a>(&'a self, cpp: &'a MyObjectQt) -> &'a i32 {
                         cpp.trivial_property()
                     }
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[1],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObjectQt {
                     pub fn trivial_property(&self) -> &i32 {
                         &self.rust().trivial_property
                     }
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[2],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObjectQt {
                     pub unsafe fn trivial_property_mut<'a>(mut self: Pin<&'a mut Self>) -> &'a mut i32 {
                         &mut self.rust_mut().get_unchecked_mut().trivial_property
                     }
                 }
-            })
+            }
         );
 
         // Setters
         assert_eq!(
             generated.cxx_mod_contents[1],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 extern "Rust" {
                     #[cxx_name = "setTrivialProperty"]
                     fn set_trivial_property(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: i32);
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[3],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObject {
                     pub fn set_trivial_property(&mut self, cpp: Pin<&mut MyObjectQt>, value: i32) {
                         cpp.set_trivial_property(value);
                     }
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[4],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObjectQt {
                     pub fn set_trivial_property(mut self: Pin<&mut Self>, value: i32) {
                         if self.rust().trivial_property == value {
@@ -170,18 +171,18 @@ mod tests {
                         self.as_mut().trivial_property_changed();
                     }
                 }
-            })
+            }
         );
 
         // Notify
         assert_eq!(
             generated.cxx_mod_contents[2],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 unsafe extern "C++" {
                     #[rust_name = "trivial_property_changed"]
                     fn trivialPropertyChanged(self: Pin<&mut MyObjectQt>);
                 }
-            })
+            }
         );
 
         // Opaque Property
@@ -189,67 +190,67 @@ mod tests {
         // Getter
         assert_eq!(
             generated.cxx_mod_contents[3],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 extern "Rust" {
                     #[cxx_name = "getOpaqueProperty"]
                     unsafe fn opaque_property<'a>(self: &'a MyObject, cpp: &'a MyObjectQt) -> &'a UniquePtr<QColor>;
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[5],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObject {
                     pub fn opaque_property<'a>(&'a self, cpp: &'a MyObjectQt) -> &'a UniquePtr<QColor> {
                         cpp.opaque_property()
                     }
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[6],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObjectQt {
                     pub fn opaque_property(&self) -> &UniquePtr<QColor> {
                         &self.rust().opaque_property
                     }
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[7],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObjectQt {
                     pub unsafe fn opaque_property_mut<'a>(mut self: Pin<&'a mut Self>) -> &'a mut UniquePtr<QColor> {
                         &mut self.rust_mut().get_unchecked_mut().opaque_property
                     }
                 }
-            })
+            }
         );
 
         // Setters
         assert_eq!(
             generated.cxx_mod_contents[4],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 extern "Rust" {
                     #[cxx_name = "setOpaqueProperty"]
                     fn set_opaque_property(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: UniquePtr<QColor>);
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[8],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObject {
                     pub fn set_opaque_property(&mut self, cpp: Pin<&mut MyObjectQt>, value: UniquePtr<QColor>) {
                         cpp.set_opaque_property(value);
                     }
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[9],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObjectQt {
                     pub fn set_opaque_property(mut self: Pin<&mut Self>, value: UniquePtr<QColor>) {
                         if self.rust().opaque_property == value {
@@ -261,18 +262,18 @@ mod tests {
                         self.as_mut().opaque_property_changed();
                     }
                 }
-            })
+            }
         );
 
         // Notify
         assert_eq!(
             generated.cxx_mod_contents[5],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 unsafe extern "C++" {
                     #[rust_name = "opaque_property_changed"]
                     fn opaquePropertyChanged(self: Pin<&mut MyObjectQt>);
                 }
-            })
+            }
         );
 
         // Unsafe Property
@@ -280,67 +281,67 @@ mod tests {
         // Getter
         assert_eq!(
             generated.cxx_mod_contents[6],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 extern "Rust" {
                     #[cxx_name = "getUnsafeProperty"]
                     unsafe fn unsafe_property<'a>(self: &'a MyObject, cpp: &'a MyObjectQt) -> &'a *mut T;
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[10],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObject {
                     pub fn unsafe_property<'a>(&'a self, cpp: &'a MyObjectQt) -> &'a *mut T {
                         cpp.unsafe_property()
                     }
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[11],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObjectQt {
                     pub fn unsafe_property(&self) -> &*mut T {
                         &self.rust().unsafe_property
                     }
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[12],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObjectQt {
                     pub unsafe fn unsafe_property_mut<'a>(mut self: Pin<&'a mut Self>) -> &'a mut *mut T {
                         &mut self.rust_mut().get_unchecked_mut().unsafe_property
                     }
                 }
-            })
+            }
         );
 
         // Setters
         assert_eq!(
             generated.cxx_mod_contents[7],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 extern "Rust" {
                     #[cxx_name = "setUnsafeProperty"]
                     unsafe fn set_unsafe_property(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: *mut T);
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[13],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObject {
                     pub fn set_unsafe_property(&mut self, cpp: Pin<&mut MyObjectQt>, value: *mut T) {
                         cpp.set_unsafe_property(value);
                     }
                 }
-            })
+            }
         );
         assert_eq!(
             generated.cxx_qt_mod_contents[14],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 impl MyObjectQt {
                     pub fn set_unsafe_property(mut self: Pin<&mut Self>, value: *mut T) {
                         if self.rust().unsafe_property == value {
@@ -352,18 +353,18 @@ mod tests {
                         self.as_mut().unsafe_property_changed();
                     }
                 }
-            })
+            }
         );
 
         // Notify
         assert_eq!(
             generated.cxx_mod_contents[8],
-            tokens_to_syn::<syn::Item>(quote! {
+            parse_quote! {
                 unsafe extern "C++" {
                     #[rust_name = "unsafe_property_changed"]
                     fn unsafePropertyChanged(self: Pin<&mut MyObjectQt>);
                 }
-            })
+            }
         );
     }
 }

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -187,18 +187,18 @@ mod tests {
     use super::*;
 
     use crate::parser::Parser;
-    use crate::tests::{assert_tokens_eq, tokens_to_syn};
-    use syn::ItemMod;
+    use crate::tests::assert_tokens_eq;
+    use syn::{parse_quote, ItemMod};
 
     #[test]
     fn test_generated_rust_qobject_blocks() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let rust = GeneratedRustQObject::from(parser.cxx_qt_data.qobjects.values().next().unwrap())
@@ -215,13 +215,13 @@ mod tests {
 
     #[test]
     fn test_generated_rust_qobject_blocks_namespace() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let rust = GeneratedRustQObject::from(parser.cxx_qt_data.qobjects.values().next().unwrap())
@@ -238,13 +238,13 @@ mod tests {
 
     #[test]
     fn test_generated_rust_qobject_blocks_singleton() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_singleton)]
                 pub struct MyObject;
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
 
         let rust = GeneratedRustQObject::from(parser.cxx_qt_data.qobjects.values().next().unwrap())

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -115,16 +115,16 @@ pub fn generate_rust_signals(
 mod tests {
     use super::*;
 
-    use crate::tests::{assert_tokens_eq, tokens_to_syn};
+    use crate::tests::assert_tokens_eq;
     use crate::{
         generator::naming::qobject::tests::create_qobjectname, parser::signals::ParsedSignalsEnum,
     };
     use quote::quote;
-    use syn::ItemEnum;
+    use syn::{parse_quote, ItemEnum};
 
     #[test]
     fn test_generate_rust_signals() {
-        let e: ItemEnum = tokens_to_syn(quote! {
+        let e: ItemEnum = parse_quote! {
             #[cxx_qt::qsignals(MyObject)]
             enum MySignals {
                 Ready,
@@ -140,7 +140,7 @@ mod tests {
                 #[inherit]
                 ExistingSignal,
             }
-        });
+        };
         let signals_enum = ParsedSignalsEnum::from(&e, 0).unwrap();
         let qobject_idents = create_qobjectname();
 

--- a/crates/cxx-qt-gen/src/generator/rust/types.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/types.rs
@@ -33,34 +33,29 @@ pub fn is_unsafe_cxx_type(ty: &Type) -> bool {
 mod tests {
     use super::*;
 
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
+    use syn::parse_quote;
 
     #[test]
     fn test_is_unsafe_cxx_type_path() {
-        assert!(!is_unsafe_cxx_type(&tokens_to_syn(quote! { i32 })));
+        assert!(!is_unsafe_cxx_type(&parse_quote! { i32 }));
     }
 
     #[test]
     fn test_is_unsafe_cxx_type_path_template() {
-        assert!(!is_unsafe_cxx_type(&tokens_to_syn(quote! { Vector<i32> })));
-        assert!(is_unsafe_cxx_type(&tokens_to_syn(
-            quote! { Vector<*mut T> }
-        )));
+        assert!(!is_unsafe_cxx_type(&parse_quote! { Vector<i32> }));
+        assert!(is_unsafe_cxx_type(&parse_quote! { Vector<*mut T> }));
     }
 
     #[test]
     fn test_is_unsafe_cxx_type_ptr() {
-        assert!(is_unsafe_cxx_type(&tokens_to_syn(quote! { *mut T })));
+        assert!(is_unsafe_cxx_type(&parse_quote! { *mut T }));
     }
 
     #[test]
     fn test_is_unsafe_cxx_type_reference() {
-        assert!(!is_unsafe_cxx_type(&tokens_to_syn(quote! { &i32 })));
-        assert!(is_unsafe_cxx_type(&tokens_to_syn(quote! { &*mut T })));
-        assert!(!is_unsafe_cxx_type(&tokens_to_syn(quote! { &Vector<i32> })));
-        assert!(is_unsafe_cxx_type(&tokens_to_syn(
-            quote! { &Vector<*mut T> }
-        )));
+        assert!(!is_unsafe_cxx_type(&parse_quote! { &i32 }));
+        assert!(is_unsafe_cxx_type(&parse_quote! { &*mut T }));
+        assert!(!is_unsafe_cxx_type(&parse_quote! { &Vector<i32> }));
+        assert!(is_unsafe_cxx_type(&parse_quote! { &Vector<*mut T> }));
     }
 }

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -68,11 +68,6 @@ mod tests {
         output.replace("\n\n", "\n")
     }
 
-    /// Helper to parse a quote TokenStream into a given syn item
-    pub fn tokens_to_syn<T: syn::parse::Parse>(tokens: proc_macro2::TokenStream) -> T {
-        syn::parse2(tokens.into_token_stream()).unwrap()
-    }
-
     fn sanitize_code(mut code: String) -> String {
         code.retain(|c| c != '\r');
         code

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -109,26 +109,23 @@ impl Parser {
 mod tests {
     use super::*;
 
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
-    use syn::ItemMod;
-    use syn::Type;
+    use syn::{parse_quote, ItemMod, Type};
 
     /// Helper which returns a f64 as a [syn::Type]
     pub fn f64_type() -> Type {
-        tokens_to_syn(quote! { f64 })
+        parse_quote! { f64 }
     }
 
     #[test]
     fn test_parser_from_empty_module() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge]
             mod ffi {}
-        });
+        };
         let parser = Parser::from(module).unwrap();
-        let expected_module: ItemMod = tokens_to_syn(quote! {
+        let expected_module: ItemMod = parse_quote! {
             mod ffi {}
-        });
+        };
         assert_eq!(parser.passthrough_module, expected_module);
         assert_eq!(parser.cxx_qt_data.namespace, "");
         assert_eq!(parser.cxx_qt_data.qobjects.len(), 0);
@@ -136,22 +133,22 @@ mod tests {
 
     #[test]
     fn test_parser_from_cxx_items() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge]
             mod ffi {
                 extern "Rust" {
                     fn test();
                 }
             }
-        });
+        };
         let parser = Parser::from(module).unwrap();
-        let expected_module: ItemMod = tokens_to_syn(quote! {
+        let expected_module: ItemMod = parse_quote! {
             mod ffi {
                 extern "Rust" {
                     fn test();
                 }
             }
-        });
+        };
         assert_eq!(parser.passthrough_module, expected_module);
         assert_eq!(parser.cxx_qt_data.namespace, "");
         assert_eq!(parser.cxx_qt_data.qobjects.len(), 0);
@@ -159,7 +156,7 @@ mod tests {
 
     #[test]
     fn test_parser_from_cxx_qt_items() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 #[cxx_qt::qobject]
@@ -170,7 +167,7 @@ mod tests {
                     Ready,
                 }
             }
-        });
+        };
         let parser = Parser::from(module.clone()).unwrap();
 
         assert_ne!(parser.passthrough_module, module);
@@ -184,7 +181,7 @@ mod tests {
 
     #[test]
     fn test_parser_from_cxx_and_cxx_qt_items() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
@@ -199,7 +196,7 @@ mod tests {
                     fn test();
                 }
             }
-        });
+        };
         let parser = Parser::from(module.clone()).unwrap();
 
         assert_ne!(parser.passthrough_module, module);
@@ -213,7 +210,7 @@ mod tests {
 
     #[test]
     fn test_parser_from_error() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge]
             mod ffi {
                 #[cxx_qt::qobject]
@@ -224,20 +221,20 @@ mod tests {
                     Ready,
                 }
             }
-        });
+        };
         let parser = Parser::from(module);
         assert!(parser.is_err());
     }
 
     #[test]
     fn test_parser_from_error_no_attribute() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             mod ffi {
                 extern "Rust" {
                     fn test();
                 }
             }
-        });
+        };
         let parser = Parser::from(module);
         assert!(parser.is_err());
     }

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -108,19 +108,19 @@ impl ParsedSignalsEnum {
 
 #[cfg(test)]
 mod tests {
+    use syn::parse_quote;
+
     use super::*;
 
     use crate::parser::tests::f64_type;
     use crate::syntax::path::path_compare_str;
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
 
     #[test]
     fn test_parsed_signals_from_empty() {
-        let e: ItemEnum = tokens_to_syn(quote! {
+        let e: ItemEnum = parse_quote! {
             #[cxx_qt::qsignals(MyObject)]
             enum MySignals {}
-        });
+        };
         let signals = ParsedSignalsEnum::from(&e, 0).unwrap();
         assert_eq!(signals.ident, "MySignals");
         assert_eq!(signals.item.attrs.len(), 0);
@@ -129,12 +129,12 @@ mod tests {
 
     #[test]
     fn test_parsed_signals_from_empty_attrs() {
-        let e: ItemEnum = tokens_to_syn(quote! {
+        let e: ItemEnum = parse_quote! {
             #[before]
             #[cxx_qt::qsignals(MyObject)]
             #[after]
             enum MySignals {}
-        });
+        };
         let signals = ParsedSignalsEnum::from(&e, 1).unwrap();
         assert_eq!(signals.ident, "MySignals");
         assert_eq!(signals.item.attrs.len(), 2);
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_parsed_signals_from_named() {
-        let e: ItemEnum = tokens_to_syn(quote! {
+        let e: ItemEnum = parse_quote! {
             #[cxx_qt::qsignals(MyObject)]
             enum MySignals {
                 Ready,
@@ -164,7 +164,7 @@ mod tests {
                 #[inherit]
                 ExistingSignal,
             }
-        });
+        };
         let signals = ParsedSignalsEnum::from(&e, 0).unwrap();
         assert_eq!(signals.ident, "MySignals");
         assert_eq!(signals.item.attrs.len(), 0);
@@ -195,13 +195,13 @@ mod tests {
 
     #[test]
     fn test_parsed_signals_from_unnamed() {
-        let e: ItemEnum = tokens_to_syn(quote! {
+        let e: ItemEnum = parse_quote! {
             #[cxx_qt::qsignals(MyObject)]
             enum MySignals {
                 Ready,
                 PointChanged(f64, f64),
             }
-        });
+        };
         let signals = ParsedSignalsEnum::from(&e, 0);
         assert!(signals.is_err());
     }

--- a/crates/cxx-qt-gen/src/syntax/attribute.rs
+++ b/crates/cxx-qt-gen/src/syntax/attribute.rs
@@ -111,19 +111,18 @@ pub fn attribute_tokens_to_map<K: std::cmp::Eq + std::hash::Hash + Parse, V: Par
 mod tests {
     use super::*;
 
-    use crate::tests::tokens_to_syn;
-    use quote::{format_ident, quote};
-    use syn::{Ident, ItemMod, LitStr};
+    use quote::format_ident;
+    use syn::{parse_quote, Ident, ItemMod, LitStr};
 
     #[test]
     fn test_attribute_find_path() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[qinvokable]
             #[cxx_qt::bridge]
             #[cxx_qt::qsignals(MyObject)]
             #[cxx_qt::bridge(namespace = "my::namespace")]
             mod module;
-        });
+        };
 
         assert!(attribute_find_path(&module.attrs, &["qinvokable"]).is_some());
         assert!(attribute_find_path(&module.attrs, &["cxx_qt", "bridge"]).is_some());
@@ -133,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_attribute_tokens_to_ident() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[qinvokable]
             #[cxx_qt::bridge]
             #[cxx_qt::qsignals(MyObject)]
@@ -141,7 +140,7 @@ mod tests {
             #[cxx_qt::list(A, B, C)]
             #[cxx_qt::empty()]
             mod module;
-        });
+        };
 
         assert!(attribute_tokens_to_ident(&module.attrs[0]).is_err());
         assert!(attribute_tokens_to_ident(&module.attrs[1]).is_err());
@@ -157,7 +156,7 @@ mod tests {
 
     #[test]
     fn test_attribute_tokens_to_list() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[qinvokable]
             #[cxx_qt::bridge]
             #[cxx_qt::qsignals(MyObject)]
@@ -165,7 +164,7 @@ mod tests {
             #[cxx_qt::list(A, B, C)]
             #[cxx_qt::list()]
             mod module;
-        });
+        };
 
         assert!(attribute_tokens_to_list(&module.attrs[0]).is_err());
         assert!(attribute_tokens_to_list(&module.attrs[1]).is_err());
@@ -187,7 +186,7 @@ mod tests {
 
     #[test]
     fn test_attribute_tokens_to_map() {
-        let module: ItemMod = tokens_to_syn(quote! {
+        let module: ItemMod = parse_quote! {
             #[qinvokable]
             #[cxx_qt::bridge]
             #[cxx_qt::qsignals(MyObject)]
@@ -198,7 +197,7 @@ mod tests {
             #[cxx_qt::bridge()]
             #[qinvokable(cxx_override, return_cxx_type = "T")]
             mod module;
-        });
+        };
 
         assert_eq!(
             attribute_tokens_to_map::<Ident, LitStr>(&module.attrs[0], AttributeDefault::None)

--- a/crates/cxx-qt-gen/src/syntax/fields.rs
+++ b/crates/cxx-qt-gen/src/syntax/fields.rs
@@ -21,20 +21,18 @@ pub fn fields_to_named_fields_mut(fields: &mut Fields) -> Result<Vec<&mut Field>
 mod tests {
     use super::*;
 
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
-    use syn::{ItemStruct, Type, Variant};
+    use syn::{parse_quote, ItemStruct, Type, Variant};
 
     /// Helper which returns a f64 as a [syn::Type]
     fn f64_type() -> Type {
-        tokens_to_syn(quote! { f64 })
+        parse_quote! { f64 }
     }
 
     #[test]
     fn test_fields_to_named_fields_enum_variant_named() {
-        let mut v: Variant = tokens_to_syn(quote! {
+        let mut v: Variant = parse_quote! {
             PointChanged { x: f64, y: f64 }
-        });
+        };
         let result = fields_to_named_fields_mut(&mut v.fields).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].ident.as_ref().unwrap(), "x");
@@ -45,30 +43,30 @@ mod tests {
 
     #[test]
     fn test_fields_to_named_fields_enum_variant_unamed() {
-        let mut v: Variant = tokens_to_syn(quote! {
+        let mut v: Variant = parse_quote! {
             PointChanged(f64, f64)
-        });
+        };
         let result = fields_to_named_fields_mut(&mut v.fields);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_fields_to_named_fields_enum_variant_empty() {
-        let mut v: Variant = tokens_to_syn(quote! {
+        let mut v: Variant = parse_quote! {
             PointChanged
-        });
+        };
         let result = fields_to_named_fields_mut(&mut v.fields).unwrap();
         assert_eq!(result.len(), 0);
     }
 
     #[test]
     fn test_fields_to_named_fields_struct_named() {
-        let mut s: ItemStruct = tokens_to_syn(quote! {
+        let mut s: ItemStruct = parse_quote! {
             struct Point {
                 x: f64,
                 y: f64
             }
-        });
+        };
         let result = fields_to_named_fields_mut(&mut s.fields).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].ident.as_ref().unwrap(), "x");
@@ -79,41 +77,41 @@ mod tests {
 
     #[test]
     fn test_fields_to_named_fields_struct_unamed() {
-        let mut s: ItemStruct = tokens_to_syn(quote! {
+        let mut s: ItemStruct = parse_quote! {
             struct Point(f64, f64);
-        });
+        };
         let result = fields_to_named_fields_mut(&mut s.fields);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_fields_to_named_fields_struct_empty() {
-        let mut s: ItemStruct = tokens_to_syn(quote! {
+        let mut s: ItemStruct = parse_quote! {
             struct Point;
-        });
+        };
         let result = fields_to_named_fields_mut(&mut s.fields).unwrap();
         assert_eq!(result.len(), 0);
     }
 
     #[test]
     fn test_fields_to_named_fields_mutatable() {
-        let mut s: ItemStruct = tokens_to_syn(quote! {
+        let mut s: ItemStruct = parse_quote! {
             struct Point {
                 #[attribute]
                 x: f64,
                 y: f64
             }
-        });
+        };
         let mut result = fields_to_named_fields_mut(&mut s.fields).unwrap();
         assert_eq!(result.len(), 2);
         result[0].attrs.clear();
 
-        let expected: ItemStruct = tokens_to_syn(quote! {
+        let expected: ItemStruct = parse_quote! {
             struct Point {
                 x: f64,
                 y: f64
             }
-        });
+        };
         assert_eq!(s, expected);
     }
 }

--- a/crates/cxx-qt-gen/src/syntax/foreignmod.rs
+++ b/crates/cxx-qt-gen/src/syntax/foreignmod.rs
@@ -154,15 +154,13 @@ pub fn self_type_from_foreign_fn(signature: &Signature) -> Result<Receiver> {
 
 #[cfg(test)]
 mod tests {
-    use syn::ForeignItemFn;
+    use syn::{parse_quote, ForeignItemFn};
 
     use super::*;
 
-    use crate::tests::tokens_to_syn;
-
     #[test]
     fn test_foreign_mod_to_foreign_item_types() {
-        let item: ItemForeignMod = tokens_to_syn(quote! {
+        let item: ItemForeignMod = parse_quote! {
             extern "C++" {
                 #[namespace = "a"]
                 type A;
@@ -170,7 +168,7 @@ mod tests {
                 #[cxx_name = "D"]
                 type B = C;
             }
-        });
+        };
         let result = foreign_mod_to_foreign_item_types(&item).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].attrs.len(), 1);
@@ -196,9 +194,9 @@ mod tests {
 
     #[test]
     fn test_foreign_fn_self() {
-        let foreign_fn: ForeignItemFn = tokens_to_syn(quote! {
+        let foreign_fn: ForeignItemFn = parse_quote! {
             fn foo(self: &qobject::T, a: A) -> B;
-        });
+        };
         let result = self_type_from_foreign_fn(&foreign_fn.sig).unwrap();
         assert_eq!(result.ty.to_token_stream().to_string(), "& qobject :: T");
     }
@@ -207,9 +205,9 @@ mod tests {
     fn test_foreign_fn_invalid_self() {
         macro_rules! test {
             ($($tt:tt)*) => {
-                let foreign_fn: ForeignItemFn = tokens_to_syn(quote! {
+                let foreign_fn: ForeignItemFn = parse_quote! {
                     $($tt)*
-                });
+                };
                 assert!(self_type_from_foreign_fn(&foreign_fn.sig).is_err());
             }
         }

--- a/crates/cxx-qt-gen/src/syntax/implitemfn.rs
+++ b/crates/cxx-qt-gen/src/syntax/implitemfn.rs
@@ -22,69 +22,51 @@ pub fn is_method_mutable_pin_of_self(signature: &Signature) -> bool {
 mod tests {
     use super::*;
 
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
-    use syn::ImplItemFn;
+    use syn::{parse_quote, ImplItemFn};
 
     #[test]
     fn test_is_method_mutable_self() {
-        assert!(!is_method_mutable_pin_of_self(
-            &tokens_to_syn::<ImplItemFn>(quote! {
-                fn invokable(&self) {}
-            })
-            .sig
-        ));
+        let item: ImplItemFn = parse_quote! {
+            fn invokable(&self) {}
+        };
+        assert!(!is_method_mutable_pin_of_self(&item.sig));
 
-        assert!(!is_method_mutable_pin_of_self(
-            &tokens_to_syn::<ImplItemFn>(quote! {
-                fn invokable(&mut self) {}
-            })
-            .sig
-        ));
+        let item: ImplItemFn = parse_quote! {
+            fn invokable(&mut self) {}
+        };
+        assert!(!is_method_mutable_pin_of_self(&item.sig));
 
-        assert!(is_method_mutable_pin_of_self(
-            &tokens_to_syn::<ImplItemFn>(quote! {
-                fn invokable_with_return_cxx_type(self: Pin<&mut Self>) -> f64 {}
-            })
-            .sig
-        ));
+        let item: ImplItemFn = parse_quote! {
+            fn invokable_with_return_cxx_type(self: Pin<&mut Self>) -> f64 {}
+        };
+        assert!(is_method_mutable_pin_of_self(&item.sig));
 
-        assert!(is_method_mutable_pin_of_self(
-            &tokens_to_syn::<ImplItemFn>(quote! {
-                fn invokable_with_return_cxx_type(mut self: Pin<&mut Self>) -> f64 {}
-            })
-            .sig
-        ));
+        let item: ImplItemFn = parse_quote! {
+            fn invokable_with_return_cxx_type(mut self: Pin<&mut Self>) -> f64 {}
+        };
+        assert!(is_method_mutable_pin_of_self(&item.sig));
     }
 
     #[test]
     fn test_is_method_mutable_value() {
-        assert!(!is_method_mutable_pin_of_self(
-            &tokens_to_syn::<ImplItemFn>(quote! {
-                fn invokable(value: T) {}
-            })
-            .sig
-        ));
+        let item: ImplItemFn = parse_quote! {
+            fn invokable(value: T) {}
+        };
+        assert!(!is_method_mutable_pin_of_self(&item.sig));
 
-        assert!(!is_method_mutable_pin_of_self(
-            &tokens_to_syn::<ImplItemFn>(quote! {
-                fn invokable_with_return_cxx_type(value: Pin<&mut T>) -> f64 {}
-            })
-            .sig
-        ));
+        let item: ImplItemFn = parse_quote! {
+            fn invokable_with_return_cxx_type(value: Pin<&mut T>) -> f64 {}
+        };
+        assert!(!is_method_mutable_pin_of_self(&item.sig));
 
-        assert!(!is_method_mutable_pin_of_self(
-            &tokens_to_syn::<ImplItemFn>(quote! {
-                fn invokable_with_return_cxx_type(mut value: Pin<&mut T>) -> f64 {}
-            })
-            .sig
-        ));
+        let item: ImplItemFn = parse_quote! {
+            fn invokable_with_return_cxx_type(mut value: Pin<&mut T>) -> f64 {}
+        };
+        assert!(!is_method_mutable_pin_of_self(&item.sig));
 
-        assert!(!is_method_mutable_pin_of_self(
-            &tokens_to_syn::<ImplItemFn>(quote! {
-                fn invokable_with_return_cxx_type(mut value: T) -> f64 {}
-            })
-            .sig
-        ));
+        let item: ImplItemFn = parse_quote! {
+            fn invokable_with_return_cxx_type(mut value: T) -> f64 {}
+        };
+        assert!(!is_method_mutable_pin_of_self(&item.sig));
     }
 }

--- a/crates/cxx-qt-gen/src/syntax/path.rs
+++ b/crates/cxx-qt-gen/src/syntax/path.rs
@@ -34,14 +34,13 @@ pub fn path_to_single_ident(path: &Path) -> Result<Ident> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use syn::parse_quote;
 
-    use crate::tests::tokens_to_syn;
-    use quote::quote;
+    use super::*;
 
     #[test]
     fn test_path_compare_str() {
-        let path: Path = tokens_to_syn(quote! { a::b::c });
+        let path: Path = parse_quote! { a::b::c };
         assert!(!path_compare_str(&path, &["a", "b"]));
         assert!(path_compare_str(&path, &["a", "b", "c"]));
         assert!(!path_compare_str(&path, &["a", "c", "b"]));
@@ -50,10 +49,10 @@ mod tests {
 
     #[test]
     fn test_path_to_single_ident() {
-        let path: Path = tokens_to_syn(quote! { a::b::c });
+        let path: Path = parse_quote! { a::b::c };
         assert!(path_to_single_ident(&path).is_err());
 
-        let path: Path = tokens_to_syn(quote! { a });
+        let path: Path = parse_quote! { a };
         let ident = path_to_single_ident(&path).unwrap();
         assert_eq!(ident, "a");
     }

--- a/crates/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/rust/mod.rs
@@ -219,27 +219,25 @@ pub fn write_rust(generated: &GeneratedRustBlocks) -> TokenStream {
 mod tests {
     use super::*;
 
-    use crate::{
-        generator::rust::qobject::{GeneratedRustQObject, GeneratedRustQObjectBlocks},
-        tests::tokens_to_syn,
-    };
+    use crate::generator::rust::qobject::{GeneratedRustQObject, GeneratedRustQObjectBlocks};
     use pretty_assertions::assert_str_eq;
     use quote::format_ident;
+    use syn::parse_quote;
 
     /// Helper to create a GeneratedRustBlocks for testing
     pub fn create_generated_rust() -> GeneratedRustBlocks {
         GeneratedRustBlocks {
-            cxx_mod: tokens_to_syn(quote! {
+            cxx_mod: parse_quote! {
                 mod ffi {}
-            }),
-            cxx_mod_contents: vec![tokens_to_syn(quote! {
+            },
+            cxx_mod_contents: vec![parse_quote! {
                 unsafe extern "C++" {
                     include!("myobject.cxxqt.h");
                 }
-            })],
-            cxx_qt_mod_contents: vec![tokens_to_syn(quote! {
+            }],
+            cxx_qt_mod_contents: vec![parse_quote! {
                 use module::Struct;
-            })],
+            }],
             namespace: "cxx_qt::my_object".to_owned(),
             qobjects: vec![GeneratedRustQObject {
                 cpp_struct_ident: format_ident!("MyObjectQt"),
@@ -249,31 +247,31 @@ mod tests {
                 rust_struct_ident: format_ident!("MyObject"),
                 blocks: GeneratedRustQObjectBlocks {
                     cxx_mod_contents: vec![
-                        tokens_to_syn(quote! {
+                        parse_quote! {
                             unsafe extern "C++" {
                                 #[cxx_name = "MyObject"]
                                 type MyObjectQt;
                             }
-                        }),
-                        tokens_to_syn(quote! {
+                        },
+                        parse_quote! {
                             extern "Rust" {
                                 #[cxx_name = "MyObjectRust"]
                                 type MyObject;
                             }
-                        }),
+                        },
                     ],
                     cxx_qt_mod_contents: vec![
-                        tokens_to_syn(quote! {
+                        parse_quote! {
                             #[derive(Default)]
                             pub struct MyObject;
-                        }),
-                        tokens_to_syn(quote! {
+                        },
+                        parse_quote! {
                             impl MyObject {
                                 fn rust_method(&self) {
 
                                 }
                             }
-                        }),
+                        },
                     ],
                 },
             }],
@@ -283,17 +281,17 @@ mod tests {
     /// Helper to create a GeneratedRustBlocks for testing with multiple qobjects
     pub fn create_generated_rust_multi_qobjects() -> GeneratedRustBlocks {
         GeneratedRustBlocks {
-            cxx_mod: tokens_to_syn(quote! {
+            cxx_mod: parse_quote! {
                 mod ffi {}
-            }),
-            cxx_mod_contents: vec![tokens_to_syn(quote! {
+            },
+            cxx_mod_contents: vec![parse_quote! {
                 unsafe extern "C++" {
                     include!("multiobject.cxxqt.h");
                 }
-            })],
-            cxx_qt_mod_contents: vec![tokens_to_syn(quote! {
+            }],
+            cxx_qt_mod_contents: vec![parse_quote! {
                 use module::Struct;
-            })],
+            }],
             namespace: "cxx_qt".to_owned(),
             qobjects: vec![
                 GeneratedRustQObject {
@@ -304,31 +302,31 @@ mod tests {
                     rust_struct_ident: format_ident!("FirstObject"),
                     blocks: GeneratedRustQObjectBlocks {
                         cxx_mod_contents: vec![
-                            tokens_to_syn(quote! {
+                            parse_quote! {
                                 unsafe extern "C++" {
                                     #[cxx_name = "FirstObject"]
                                     type FirstObjectQt;
                                 }
-                            }),
-                            tokens_to_syn(quote! {
+                            },
+                            parse_quote! {
                                 extern "Rust" {
                                     #[cxx_name = "FirstObjectRust"]
                                     type FirstObject;
                                 }
-                            }),
+                            },
                         ],
                         cxx_qt_mod_contents: vec![
-                            tokens_to_syn(quote! {
+                            parse_quote! {
                                 #[derive(Default)]
                                 pub struct FirstObject;
-                            }),
-                            tokens_to_syn(quote! {
+                            },
+                            parse_quote! {
                                 impl FirstObject {
                                     fn rust_method(&self) {
 
                                     }
                                 }
-                            }),
+                            },
                         ],
                     },
                 },
@@ -340,31 +338,31 @@ mod tests {
                     rust_struct_ident: format_ident!("SecondObject"),
                     blocks: GeneratedRustQObjectBlocks {
                         cxx_mod_contents: vec![
-                            tokens_to_syn(quote! {
+                            parse_quote! {
                                 unsafe extern "C++" {
                                     #[cxx_name = "SecondObject"]
                                     type SecondObjectQt;
                                 }
-                            }),
-                            tokens_to_syn(quote! {
+                            },
+                            parse_quote! {
                                 extern "Rust" {
                                     #[cxx_name = "SecondObjectRust"]
                                     type SecondObject;
                                 }
-                            }),
+                            },
                         ],
                         cxx_qt_mod_contents: vec![
-                            tokens_to_syn(quote! {
+                            parse_quote! {
                                 #[derive(Default)]
                                 pub struct SecondObject;
-                            }),
-                            tokens_to_syn(quote! {
+                            },
+                            parse_quote! {
                                 impl SecondObject {
                                     fn rust_method(&self) {
 
                                     }
                                 }
-                            }),
+                            },
                         ],
                     },
                 },


### PR DESCRIPTION
Requires #502