### PR TITLE
Cargo test workspace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,31 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     list(APPEND CARGO_ENV ${RUNTIME_ENV})
 endif()
 
+# Same logic as in Corrosion.cmake
+if(CMAKE_VS_PLATFORM_NAME)
+    set(BUILD_DIR "${CMAKE_VS_PLATFORM_NAME}/$<CONFIG>")
+elseif(CMAKE_CONFIGURATION_TYPES)
+    set(BUILD_DIR "$<CONFIG>")
+else()
+    set(BUILD_DIR .)
+endif()
+
+# Set the target dir to the same that Corrosion uses to reuse build artifacts
+# from the main build.
+set(CARGO_TARGET_DIR "${CMAKE_BINARY_DIR}/${BUILD_DIR}/cargo/build")
+
+# Add CMake tests for `cargo test/clippy/fmt`.
+add_test(NAME cargo_tests COMMAND cargo test --all-targets --target-dir
+                                  ${CARGO_TARGET_DIR})
+add_test(NAME cargo_doc_tests COMMAND cargo test --doc --target-dir
+                                      ${CARGO_TARGET_DIR})
+add_test(NAME cargo_clippy COMMAND cargo clippy --all-targets --target-dir
+                                   ${CARGO_TARGET_DIR} -- -D warnings)
+
+set_tests_properties(cargo_tests cargo_doc_tests cargo_clippy PROPERTIES
+    ENVIRONMENT_MODIFICATION "${CARGO_ENV}"
+)
+
 # Create helper method which adds relevent cargo tests for a given manifest
 function(add_test_cargo TEST_NAME_PREFIX MANIFEST_PATH ADD_DOCTESTS)
     # Add cargo as a test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,75 +206,11 @@ set_tests_properties(cargo_tests cargo_doc_tests cargo_clippy PROPERTIES
     ENVIRONMENT_MODIFICATION "${CARGO_ENV}"
 )
 
-# Create helper method which adds relevent cargo tests for a given manifest
-function(add_test_cargo TEST_NAME_PREFIX MANIFEST_PATH ADD_DOCTESTS)
-    # Add cargo as a test
-    set(CARGO_TEST_NAME ${TEST_NAME_PREFIX}_cargo_tests)
-    add_test(NAME ${CARGO_TEST_NAME}
-             COMMAND cargo test --all-features --all-targets --manifest-path
-                     ${MANIFEST_PATH}
-    )
-    set_tests_properties(
-        ${CARGO_TEST_NAME} PROPERTIES ENVIRONMENT_MODIFICATION "${CARGO_ENV}"
-    )
-
-    # Check if we should enable doc tests
-    if(${ADD_DOCTESTS} STREQUAL "DOCTESTS_ON")
-        set(CARGO_DOC_TEST_NAME ${TEST_NAME_PREFIX}_cargo_doc_tests)
-        # Add cargo docs as a test
-        add_test(NAME ${CARGO_DOC_TEST_NAME}
-                 COMMAND cargo test --all-features --doc --manifest-path
-                         ${MANIFEST_PATH}
-        )
-        set_tests_properties(
-            ${CARGO_DOC_TEST_NAME} PROPERTIES ENVIRONMENT_MODIFICATION
-                                              "${CARGO_ENV}"
-        )
-    endif()
-
-    # Add clippy as a test
-    set(CARGO_CLIPPY_TEST_NAME ${TEST_NAME_PREFIX}_cargo_clippy)
-    add_test(NAME ${CARGO_CLIPPY_TEST_NAME}
-             COMMAND cargo clippy --all-features --all-targets --manifest-path
-                     ${MANIFEST_PATH} -- -D warnings
-    )
-    set_tests_properties(
-        ${CARGO_CLIPPY_TEST_NAME} PROPERTIES ENVIRONMENT_MODIFICATION
-                                             "${CARGO_ENV}"
-    )
-
-    # Add rustfmt as a test
-    set(CARGO_FMT_TEST_NAME ${TEST_NAME_PREFIX}_cargo_fmt)
-    add_test(NAME ${CARGO_FMT_TEST_NAME} COMMAND cargo fmt --manifest-path
-                                                 ${MANIFEST_PATH} -- --check
-    )
-    set_tests_properties(
-        ${CARGO_FMT_TEST_NAME} PROPERTIES ENVIRONMENT_MODIFICATION
-                                          "${CARGO_ENV}"
-    )
-endfunction()
-
-# Add cargo tests for all our manifests
-#
-# Note doctests are not supported on the staticlib in root
-add_test_cargo(cxx_qt "${CMAKE_CURRENT_SOURCE_DIR}/crates/cxx-qt/Cargo.toml" DOCTESTS_ON)
-add_test_cargo(cxx_qt_build "${CMAKE_CURRENT_SOURCE_DIR}/crates/cxx-qt-build/Cargo.toml" DOCTESTS_ON)
-add_test_cargo(cxx_qt_gen "${CMAKE_CURRENT_SOURCE_DIR}/crates/cxx-qt-gen/Cargo.toml" DOCTESTS_ON)
-add_test_cargo(cxx_qt_lib "${CMAKE_CURRENT_SOURCE_DIR}/crates/cxx-qt-lib/Cargo.toml" DOCTESTS_ON)
-add_test_cargo(cxx_qt_lib_headers "${CMAKE_CURRENT_SOURCE_DIR}/crates/cxx-qt-lib-headers/Cargo.toml" DOCTESTS_ON)
-
 # Ensure test inputs and outputs are formatted
 file(GLOB CXX_QT_GEN_TEST_INPUTS ${CMAKE_CURRENT_SOURCE_DIR}/crates/cxx-qt-gen/test_inputs/*.rs)
 file(GLOB CXX_QT_GEN_TEST_OUTPUTS ${CMAKE_CURRENT_SOURCE_DIR}/crates/cxx-qt-gen/test_outputs/*.rs)
 add_test(NAME cxx_qt_gen_test_inputs_gen COMMAND rustfmt --check ${CXX_QT_GEN_TEST_INPUTS})
 add_test(NAME cxx_qt_gen_test_outputs_gen COMMAND rustfmt --check ${CXX_QT_GEN_TEST_OUTPUTS})
-
-# QML example has add_test in it's CMakeLists, so just add the cargo tests here
-add_test_cargo(qt-build-utils "${CMAKE_CURRENT_SOURCE_DIR}/crates/qt-build-utils/Cargo.toml" DOCTESTS_ON)
-add_test_cargo(demo_threading "${CMAKE_CURRENT_SOURCE_DIR}/examples/demo_threading/rust/Cargo.toml" DOCTESTS_OFF)
-add_test_cargo(qml_features "${CMAKE_CURRENT_SOURCE_DIR}/examples/qml_features/rust/Cargo.toml" DOCTESTS_OFF)
-add_test_cargo(qml_extension_plugin "${CMAKE_CURRENT_SOURCE_DIR}/examples/qml_extension_plugin/plugin/rust/Cargo.toml" DOCTESTS_OFF)
-add_test_cargo(qml_minimal "${CMAKE_CURRENT_SOURCE_DIR}/examples/qml_minimal/rust/Cargo.toml" DOCTESTS_OFF)
 
 # Add test which scans for all .cpp and .h files in this project and runs clang-format
 add_test(NAME cpp_clang_format COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/clang_format_check.sh" "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,12 +12,6 @@ function(add_acceptance_tests TEST_NAME)
     set(NAME_WITH_PREFIX test_${TEST_NAME})
     set(TARGET_NAME tests_${TEST_NAME})
 
-    # Add all the normal tests used on the other modules
-    add_test_cargo(
-        ${NAME_WITH_PREFIX}
-        "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME}/rust/Cargo.toml" DOCTESTS_OFF
-    )
-
     set(CPP_TEST_NAME ${NAME_WITH_PREFIX}_cpp_tests)
     add_test(NAME ${CPP_TEST_NAME} COMMAND $<TARGET_FILE:${TARGET_NAME}>)
 


### PR DESCRIPTION
Continue effort from https://github.com/KDAB/cxx-qt/pull/243 now that CI work on windows.

- I've removed `WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}` since I'm not sure what it is for?
- I've fixed the `--target-dir` to work with multi config generator too.