### PR TITLE
cxx-qt-build: always call qt_build_utils::setup_linker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `QDateTime` API to use `current_date_time` rather than `current_date`
+- Always call `qt_build_utils::setup_linker()` in `CxxQtBuilder` and remove the proxy method
 
 ## [0.5.1](https://github.com/KDAB/cxx-qt/compare/v0.5.0...v0.5.1) - 2023-03-27
 

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -348,12 +348,6 @@ impl CxxQtBuilder {
         self
     }
 
-    /// Convenience wrapper around [qt_build_utils::setup_linker].
-    pub fn setup_linker(self) -> Self {
-        qt_build_utils::setup_linker();
-        self
-    }
-
     /// Use a closure to run additional customization on [CxxQtBuilder]'s internal [cc::Build]
     /// before calling [CxxQtBuilder::build]. This allows to add extra include paths, compiler flags,
     /// or anything else available via [cc::Build]'s API. For example, to add an include path for
@@ -377,6 +371,9 @@ impl CxxQtBuilder {
     /// Generate and compile cxx-qt C++ code, as well as compile any additional files from
     /// [CxxQtBuilder::qobject_header] and [CxxQtBuilder::cc_builder].
     pub fn build(mut self) {
+        // Ensure that the linker is setup correctly for Cargo builds
+        qt_build_utils::setup_linker();
+
         let out_dir = env::var("OUT_DIR").unwrap();
         // The include directory needs to be namespaced by crate name when exporting for a C++ build system,
         // but for using cargo build without a C++ build system, OUT_DIR is already namespaced by crate name.

--- a/examples/cargo_without_cmake/build.rs
+++ b/examples/cargo_without_cmake/build.rs
@@ -19,7 +19,6 @@ fn main() {
         // Generate C++ code from the .qrc file with the rcc tool
         // https://doc.qt.io/qt-6/resources.html
         .qrc("qml/qml.qrc")
-        .setup_linker()
         .build();
 }
 // ANCHOR_END: book_cargo_executable_build_rs


### PR DESCRIPTION
As it has no side affect for CMake builds, always call it so that developers don't need to know about this detail for Cargo builds.

Closes #508