### PR TITLE
ctest: ensure that cargo fmt is run across the workspace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,8 +201,9 @@ add_test(NAME cargo_doc_tests COMMAND cargo test --doc --target-dir
                                       ${CARGO_TARGET_DIR})
 add_test(NAME cargo_clippy COMMAND cargo clippy --all-targets --target-dir
                                    ${CARGO_TARGET_DIR} -- -D warnings)
+add_test(NAME cargo_fmt COMMAND cargo fmt --all --check WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-set_tests_properties(cargo_tests cargo_doc_tests cargo_clippy PROPERTIES
+set_tests_properties(cargo_tests cargo_doc_tests cargo_clippy cargo_fmt PROPERTIES
     ENVIRONMENT_MODIFICATION "${CARGO_ENV}"
 )
 


### PR DESCRIPTION
This appears to have been missed in
https://github.com/KDAB/cxx-qt/commit/048c7e9ab3bde427ed321044b4abed9e37f404a5