### PR TITLE
ci: only save compiler cache when the branch is main

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install mdbook and mdbook-linkcheck from binaries
       run: |
         mkdir mdbook
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
         curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/latest/download/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -o mdbook-linkcheck.zip
         unzip mdbook-linkcheck.zip -d mdbook-linkcheck/

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -113,9 +113,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}
     env:
-        # 5 GB limit / 6 conditions = 833 MB
+        # 10 GB limit / 6 conditions = 1666 MB
         # Leave some headroom for Rust tools caches which take ~10-15 MB per OS
-        SCCACHE_CACHE_SIZE: 800M
+        SCCACHE_CACHE_SIZE: 1500M
 
     steps:
     # On Windows, the D drive that the workspace is on by default runs out of space when

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -146,13 +146,12 @@ jobs:
       run: cargo install sccache mdbook mdbook-linkcheck
 
     - name: "Compiler cache"
-      uses: actions/cache@v3
+      # Only restore here, later we save for only the main branch
+      # and always use the same key as we start from the main branch cache
+      uses: actions/cache/restore@v3
       with:
         path: ${{ matrix.compiler_cache_path }}
-        key: ${{ matrix.name }}-${{ github.head_ref }}-${{ github.run_number }}
-        restore-keys: |
-          ${{ matrix.name }}-${{ github.head_ref }}
-          ${{ matrix.name }}
+        key: ${{ matrix.name }}_compiler_cache
 
     - name: "[Ubuntu] Install dependencies"
       if: runner.os == 'Linux'
@@ -238,3 +237,16 @@ jobs:
           ${{ matrix.workspace }}/build/vcpkg-manifest-install.log
           ${{ matrix.workspace }}/build/vcpkg_installed/vcpkg/issue_body.md
         if-no-files-found: ignore
+
+    - name: "Post compiler cache"
+      # Only save the cache when we are the main branch
+      #
+      # This should prevent the cache from increasing in size dramatically over time.
+      # Which then can cache the useful caches to be purged. Instead we always start
+      # with the main branch cache and build from here, this has the disadvantage of
+      # needing to rebuild any changes in the branch each time.
+      if: github.event.base_ref == 'refs/heads/main'
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ matrix.compiler_cache_path }}
+        key: ${{ matrix.name }}_compiler_cache

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -140,7 +140,7 @@ jobs:
           ${{ matrix.cargo_dir }}/bin/sccache${{ matrix.exe_suffix }}
           ${{ matrix.cargo_dir }}/bin/mdbook${{ matrix.exe_suffix }}
           ${{ matrix.cargo_dir }}/bin/mdbook-linkcheck${{ matrix.exe_suffix }}
-        key: ${{ matrix.os }}_sccache-0.3.0_mdbook-0.4.15_mdbook-linkcheck-0.2.8
+        key: ${{ matrix.os }}_sccache-0.4.1_mdbook-0.4.28_mdbook-linkcheck-0.7.7
     - name: "Build Rust tools"
       if: steps.rust-tools-cache.outputs.cache-hit != 'true'
       run: cargo install sccache mdbook mdbook-linkcheck


### PR DESCRIPTION
This should prevent the cache increasing in size due to a cache per branch, which can cause the main cache to be removed.