### PR TITLE
cxx-qt-build: unset bundle for link modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `QDateTime` API to use `current_date_time` rather than `current_date`
 - Always call `qt_build_utils::setup_linker()` in `CxxQtBuilder` and remove the proxy method
 
+### Fixed
+
+- Builds failing due to `link modifiers combination +bundle,+whole-archive is unstable when generating rlibs`
+
 ## [0.5.1](https://github.com/KDAB/cxx-qt/compare/v0.5.0...v0.5.1) - 2023-03-27
 
 ### Fixed

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -408,6 +408,10 @@ impl CxxQtBuilder {
         // to avoid bloating the binary.
         let mut cc_builder_whole_archive = cc::Build::new();
         cc_builder_whole_archive.link_lib_modifier("+whole-archive");
+        // We need to set -bundle otherwise the compiler fails with
+        // link modifiers combination `+bundle,+whole-archive` is unstable when generating rlibs
+        // https://github.com/rust-lang/rust/issues/108081
+        cc_builder_whole_archive.link_lib_modifier("-bundle");
         for builder in [&mut self.cc_builder, &mut cc_builder_whole_archive] {
             builder.cpp(true);
             // MSVC


### PR DESCRIPTION
Otherwise the build fails with

link modifiers combination `+bundle,+whole-archive` is unstable when generating rlibs

Closes #519