### PR TITLE
bump: release to 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.5.1...HEAD)
+## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.5.2...HEAD)
 
 ### Changed
 
 - `QDateTime` API to use `current_date_time` rather than `current_date`
 - Always call `qt_build_utils::setup_linker()` in `CxxQtBuilder` and remove the proxy method
+
+## [0.5.2](https://github.com/KDAB/cxx-qt/compare/v0.5.1...v0.5.2) - 2023-04-27
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,17 +27,17 @@ members = [
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/KDAB/cxx-qt/"
-version = "0.5.1"
+version = "0.5.2"
 
 # Note a version needs to be specified on dependencies of packages
 # we publish, otherwise crates.io complains as it doesn't know the version.
 [workspace.dependencies]
 cxx-qt = { path = "crates/cxx-qt" }
 cxx-qt-build = { path = "crates/cxx-qt-build" }
-cxx-qt-gen = { path = "crates/cxx-qt-gen", version = "0.5.1" }
+cxx-qt-gen = { path = "crates/cxx-qt-gen", version = "0.5.2" }
 cxx-qt-lib = { path = "crates/cxx-qt-lib" }
-cxx-qt-lib-headers = { path = "crates/cxx-qt-lib-headers", version = "0.5.1" }
-qt-build-utils = { path = "crates/qt-build-utils", version = "0.5.1" }
+cxx-qt-lib-headers = { path = "crates/cxx-qt-lib-headers", version = "0.5.2" }
+qt-build-utils = { path = "crates/qt-build-utils", version = "0.5.2" }
 
 # Ensure that the example comments are kept in sync
 # examples/cargo_without_cmake/Cargo.toml


### PR DESCRIPTION
This cherry-picks back the CHANGELOG and version updates for 0.5.2 into main