### PR TITLE
github: push the cache from all branches

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -146,11 +146,12 @@ jobs:
       run: cargo install sccache mdbook mdbook-linkcheck
 
     - name: "Compiler cache"
-      # Only restore here, later we save for only the main branch
-      # and always use the same key as we start from the main branch cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache@v3
       with:
+        # Cache the sccache data
         path: ${{ matrix.compiler_cache_path }}
+        # Share the same cache key for branches
+        # this ensures that we don't create separate cache entries per branch
         key: ${{ matrix.name }}_compiler_cache
 
     - name: "[Ubuntu] Install dependencies"
@@ -237,16 +238,3 @@ jobs:
           ${{ matrix.workspace }}/build/vcpkg-manifest-install.log
           ${{ matrix.workspace }}/build/vcpkg_installed/vcpkg/issue_body.md
         if-no-files-found: ignore
-
-    - name: "Post compiler cache"
-      # Only save the cache when we are the main branch
-      #
-      # This should prevent the cache from increasing in size dramatically over time.
-      # Which then can cache the useful caches to be purged. Instead we always start
-      # with the main branch cache and build from here, this has the disadvantage of
-      # needing to rebuild any changes in the branch each time.
-      if: github.ref == 'refs/heads/main'
-      uses: actions/cache/save@v3
-      with:
-        path: ${{ matrix.compiler_cache_path }}
-        key: ${{ matrix.name }}_compiler_cache


### PR DESCRIPTION
GitHub expires caches if they aren't accessed after 7 days, this then means once the cache has expired a commit needs to reach main to generate a new cache entry.

Instead by pushing back the cache after each build we only have one slow commit, the downside is that the cache contains data not relevant to the current branch. But sccache should cycle less relevant data as the cache size is hit.