### PR TITLE
Add ability to auto-update test_outputs/ directory

### DIFF
--- a/crates/cxx-qt-gen/Cargo.toml
+++ b/crates/cxx-qt-gen/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 license.workspace = true
 description = "Code generation for integrating `cxx-qt` into higher level tools"
 repository.workspace = true
+exclude = ["update_expected.sh"]
 
 [dependencies]
 proc-macro2.workspace = true

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -22,13 +22,18 @@ pub use syn::{Error, Result};
 mod tests {
     use super::*;
 
-    use clang_format::{clang_format, ClangFormatStyle, CLANG_FORMAT_STYLE};
+    use clang_format::{ClangFormatStyle, CLANG_FORMAT_STYLE};
     use generator::{cpp::GeneratedCppBlocks, rust::GeneratedRustBlocks};
     use parser::Parser;
     use pretty_assertions::assert_str_eq;
     use proc_macro2::TokenStream;
     use quote::ToTokens;
-    use std::io::Write;
+    use std::{
+        env,
+        fs::OpenOptions,
+        io::Write,
+        path::{Path, PathBuf},
+    };
     use writer::{cpp::write_cpp, rust::write_rust};
 
     #[ctor::ctor]
@@ -73,45 +78,84 @@ mod tests {
         code
     }
 
+    fn update_expected_file(path: PathBuf, source: &str) {
+        println!("Updating expected file: {:?}", path);
+
+        let mut file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .unwrap();
+        file.write_all(source.as_bytes()).unwrap();
+    }
+
+    fn update_expected(test_name: &str, rust: &str, header: &str, source: &str) -> bool {
+        // Ideally we'd be able to get the path from `file!()`, but that unfortunately only
+        // gives us a relative path, which isn't really all that useful.
+        // So require the path of the crate to be set via an environment variable.
+        //
+        // In the simplest case this can be achieved by running:
+        //
+        //      CXXQT_UPDATE_EXPECTED=$(pwd) cargo test
+        //
+        if let Ok(path) = env::var("CXXQT_UPDATE_EXPECTED") {
+            let output_folder = Path::new(&path);
+            let output_folder = output_folder.join("test_outputs");
+
+            let update = |file_ending, contents| {
+                update_expected_file(
+                    output_folder.join(format!("{test_name}.{file_ending}")),
+                    contents,
+                );
+            };
+            update("rs", rust);
+            update("h", header);
+            update("cpp", source);
+
+            true
+        } else {
+            false
+        }
+    }
+
+    fn test_code_generation_internal(
+        test_name: &str,
+        input: &str,
+        expected_rust_output: &str,
+        expected_cpp_header: &str,
+        expected_cpp_source: &str,
+    ) {
+        let parser = Parser::from(syn::parse_str(input).unwrap()).unwrap();
+
+        let generated_cpp = GeneratedCppBlocks::from(&parser).unwrap();
+        let (header, source) =
+            if let CppFragment::Pair { header, source } = write_cpp(&generated_cpp) {
+                (sanitize_code(header), sanitize_code(source))
+            } else {
+                panic!("Expected CppFragment::Pair")
+            };
+
+        let generated_rust = GeneratedRustBlocks::from(&parser).unwrap();
+        let rust = sanitize_code(format_rs_source(&write_rust(&generated_rust).to_string()));
+
+        if !update_expected(test_name, &rust, &header, &source) {
+            assert_str_eq!(header, sanitize_code(expected_cpp_header.to_owned()));
+            assert_str_eq!(source, sanitize_code(expected_cpp_source.to_owned()));
+            assert_str_eq!(rust, sanitize_code(expected_rust_output.to_owned()));
+        }
+    }
+
     /// Helper for testing if a given input Rust file generates the expected C++ & Rust code
     /// This needs to be a macro rather than a function because include_str needs the file path at compile time.
     macro_rules! test_code_generation {
         ( $file_stem:literal ) => {
-            let parser = Parser::from(
-                syn::parse_str(include_str!(concat!("../test_inputs/", $file_stem, ".rs")))
-                    .unwrap(),
-            )
-            .unwrap();
-
-            let generated_cpp = GeneratedCppBlocks::from(&parser).unwrap();
-            let (header, source) =
-                if let CppFragment::Pair { header, source } = write_cpp(&generated_cpp) {
-                    (sanitize_code(header), sanitize_code(source))
-                } else {
-                    panic!("Expected CppFragment::Pair")
-                };
-            let expected_cpp_header =
-                clang_format(include_str!(concat!("../test_outputs/", $file_stem, ".h")))
-                    .map(sanitize_code)
-                    .unwrap();
-            let expected_cpp_source = clang_format(include_str!(concat!(
-                "../test_outputs/",
+            test_code_generation_internal(
                 $file_stem,
-                ".cpp"
-            )))
-            .map(sanitize_code)
-            .unwrap();
-            assert_str_eq!(header, expected_cpp_header);
-            assert_str_eq!(source, expected_cpp_source);
-
-            let generated_rust = GeneratedRustBlocks::from(&parser).unwrap();
-            let rust = sanitize_code(format_rs_source(&write_rust(&generated_rust).to_string()));
-            let expected_rust_output = sanitize_code(format_rs_source(include_str!(concat!(
-                "../test_outputs/",
-                $file_stem,
-                ".rs"
-            ))));
-            assert_str_eq!(rust, expected_rust_output);
+                include_str!(concat!("../test_inputs/", $file_stem, ".rs")),
+                include_str!(concat!("../test_outputs/", $file_stem, ".rs")),
+                include_str!(concat!("../test_outputs/", $file_stem, ".h")),
+                include_str!(concat!("../test_outputs/", $file_stem, ".cpp")),
+            );
         };
     }
 

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -23,7 +23,6 @@ mod inheritance {
         #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
         #[cxx_name = "MyObject"]
         type MyObjectQt;
-
     }
     extern "Rust" {
         #[cxx_name = "MyObjectRust"]

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -7,17 +7,14 @@ mod ffi {
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = cxx_qt_lib::QPoint;
     }
-
     unsafe extern "C++" {
         include ! (< QtCore / QObject >);
         include!("cxx-qt-lib/convert.h");
         include!("cxx-qt-lib/cxxqt_thread.h");
     }
-
     unsafe extern "C++" {
         include!("cxx-qt-gen/ffi.cxxqt.h");
     }
-
     unsafe extern "C++" {
         #[doc = "The C++ type for the QObject "]
         #[doc = "MyObject"]
@@ -28,22 +25,18 @@ mod ffi {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
     }
-
     extern "Rust" {
         #[cxx_name = "MyObjectRust"]
         type MyObject;
     }
-
     extern "Rust" {
         #[cxx_name = "invokableWrapper"]
         fn invokable_wrapper(self: &MyObject, cpp: &MyObjectQt);
     }
-
     extern "Rust" {
         #[cxx_name = "invokableMutableWrapper"]
         fn invokable_mutable_wrapper(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>);
     }
-
     extern "Rust" {
         #[cxx_name = "invokableParametersWrapper"]
         fn invokable_parameters_wrapper(
@@ -54,7 +47,6 @@ mod ffi {
             primitive: i32,
         );
     }
-
     extern "Rust" {
         #[cxx_name = "invokableReturnOpaqueWrapper"]
         fn invokable_return_opaque_wrapper(
@@ -62,7 +54,6 @@ mod ffi {
             cpp: Pin<&mut MyObjectQt>,
         ) -> UniquePtr<Opaque>;
     }
-
     extern "Rust" {
         #[cxx_name = "invokableReturnTrivialWrapper"]
         fn invokable_return_trivial_wrapper(
@@ -70,22 +61,18 @@ mod ffi {
             cpp: Pin<&mut MyObjectQt>,
         ) -> QPoint;
     }
-
     extern "Rust" {
         #[cxx_name = "invokableFinalWrapper"]
         fn invokable_final_wrapper(self: &MyObject, cpp: &MyObjectQt);
     }
-
     extern "Rust" {
         #[cxx_name = "invokableOverrideWrapper"]
         fn invokable_override_wrapper(self: &MyObject, cpp: &MyObjectQt);
     }
-
     extern "Rust" {
         #[cxx_name = "invokableVirtualWrapper"]
         fn invokable_virtual_wrapper(self: &MyObject, cpp: &MyObjectQt);
     }
-
     unsafe extern "C++" {
         #[doc = r" Specialised version of CxxQtThread, which can be moved into other threads."]
         #[doc = r""]
@@ -94,17 +81,14 @@ mod ffi {
         #[doc = r" For now we use a type alias in C++ then use it like a normal type here"]
         #[doc = r" <https://github.com/dtolnay/cxx/issues/683>"]
         type MyObjectCxxQtThread;
-
         #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
-
         #[doc = r" Create an instance of a CxxQtThread"]
         #[doc = r""]
         #[doc = r" This allows for queueing closures onto the Qt event loop from a background thread."]
         #[cxx_name = "qtThread"]
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
-
         #[doc(hidden)]
         #[cxx_name = "queue"]
         fn queue_boxed_fn(
@@ -112,7 +96,6 @@ mod ffi {
             func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
             arg: Box<MyObjectCxxQtThreadQueuedFn>,
         ) -> Result<()>;
-
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -120,7 +103,6 @@ mod ffi {
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
-
     extern "C++" {
         #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
         #[doc = r""]
@@ -129,60 +111,49 @@ mod ffi {
         #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
-
     extern "Rust" {
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         type MyObjectCxxQtThreadQueuedFn;
-
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
     }
 }
-
 use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
     use std::pin::Pin;
-
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
     impl MyObject {
         pub fn rust_only_method(&self) {
             println!("QML or C++ can't call this :)");
         }
     }
-
     #[derive(Default)]
     pub struct MyObject;
-
     impl MyObject {
         #[doc(hidden)]
         pub fn invokable_wrapper(self: &MyObject, cpp: &MyObjectQt) {
             cpp.invokable();
         }
     }
-
     impl MyObjectQt {
         pub fn invokable(&self) {
             println!("invokable");
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn invokable_mutable_wrapper(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>) {
             cpp.invokable_mutable();
         }
     }
-
     impl MyObjectQt {
         pub fn invokable_mutable(self: Pin<&mut Self>) {
             println!("This method is mutable!");
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn invokable_parameters_wrapper(
@@ -195,7 +166,6 @@ mod cxx_qt_ffi {
             cpp.invokable_parameters(opaque, trivial, primitive);
         }
     }
-
     impl MyObjectQt {
         pub fn invokable_parameters(&self, opaque: &QColor, trivial: &QPoint, primitive: i32) {
             println!(
@@ -206,7 +176,6 @@ mod cxx_qt_ffi {
             );
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn invokable_return_opaque_wrapper(
@@ -216,13 +185,11 @@ mod cxx_qt_ffi {
             return cpp.invokable_return_opaque();
         }
     }
-
     impl MyObjectQt {
         pub fn invokable_return_opaque(self: Pin<&mut Self>) -> UniquePtr<Opaque> {
             Opaque::new()
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn invokable_return_trivial_wrapper(
@@ -232,72 +199,60 @@ mod cxx_qt_ffi {
             return cpp.invokable_return_trivial();
         }
     }
-
     impl MyObjectQt {
         pub fn invokable_return_trivial(self: Pin<&mut Self>) -> QPoint {
             QPoint::new(1, 2)
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn invokable_final_wrapper(self: &MyObject, cpp: &MyObjectQt) {
             cpp.invokable_final();
         }
     }
-
     impl MyObjectQt {
         pub fn invokable_final(&self) {
             println!("Final");
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn invokable_override_wrapper(self: &MyObject, cpp: &MyObjectQt) {
             cpp.invokable_override();
         }
     }
-
     impl MyObjectQt {
         pub fn invokable_override(&self) {
             println!("Override");
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn invokable_virtual_wrapper(self: &MyObject, cpp: &MyObjectQt) {
             cpp.invokable_virtual();
         }
     }
-
     impl MyObjectQt {
         pub fn invokable_virtual(&self) {
             println!("Virtual");
         }
     }
-
     impl MyObjectQt {
         pub fn cpp_context_method(&self) {
             println!("C++ context method");
         }
     }
-
     impl MyObjectQt {
         pub fn cpp_context_method_mutable(self: Pin<&mut Self>) {
             println!("mutable method");
         }
     }
-
     impl MyObjectQt {
         pub fn cpp_context_method_return_opaque(&self) -> UniquePtr<Opaque> {
             Opaque::new()
         }
     }
-
     unsafe impl Send for MyObjectCxxQtThread {}
-
     impl MyObjectCxxQtThread {
         #[doc = r" Queue the given closure onto the Qt event loop for this QObject"]
         pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
@@ -319,17 +274,14 @@ mod cxx_qt_ffi {
             self.queue_boxed_fn(func, std::boxed::Box::new(arg))
         }
     }
-
     #[doc(hidden)]
     pub struct MyObjectCxxQtThreadQueuedFn {
         inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
     }
-
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
-
     #[doc = r" Generated CXX-Qt module containing type alias to the C++ types of the QObjects"]
     pub mod qobject {
         #[doc = "The C++ type for the QObject "]

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -3,76 +3,55 @@
 #[attrB]
 pub mod ffi {
     const MAX: u16 = 65535;
-
     enum Event {
         MyEvent,
     }
-
     extern crate serde;
-
     fn do_something() {
         println!("I am a free function");
     }
-
     extern "C" {}
-
     #[namespace = "namespace"]
     extern "C" {}
-
     #[namespace = "namespace"]
     #[custom_attr = "test"]
     extern "C" {}
-
     unsafe extern "C++" {}
-
     #[namespace = "namespace"]
     unsafe extern "C++" {}
-
     #[namespace = "namespace"]
     #[custom_attr = "test"]
     unsafe extern "C++" {}
-
     macro_rules! macro1 {
         () => {
             0
         };
     }
-
     macro macro2() {
         0
     }
-
     mod m {}
-
     static BIKE: Event = Event::MyEvent;
-
     pub trait CustomTrait {
         fn method();
     }
-
     pub trait SharableIterator = CustomTrait + Sync;
-
     type Result<T> = std::result::Result<T, Event>;
-
     union Foo<A, B> {
         x: A,
         y: B,
     }
-
     unsafe extern "C++" {
         include ! (< QtCore / QStringListModel >);
     }
-
     unsafe extern "C++" {
         include ! (< QtCore / QObject >);
         include!("cxx-qt-lib/convert.h");
         include!("cxx-qt-lib/cxxqt_thread.h");
     }
-
     unsafe extern "C++" {
         include!("cxx-qt-gen/multi_object.cxxqt.h");
     }
-
     unsafe extern "C++" {
         #[doc = "The C++ type for the QObject "]
         #[doc = "MyObject"]
@@ -83,22 +62,18 @@ pub mod ffi {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
     }
-
     extern "Rust" {
         #[cxx_name = "MyObjectRust"]
         type MyObject;
     }
-
     extern "Rust" {
         #[cxx_name = "getPropertyName"]
         unsafe fn property_name<'a>(self: &'a MyObject, cpp: &'a MyObjectQt) -> &'a i32;
     }
-
     extern "Rust" {
         #[cxx_name = "setPropertyName"]
         fn set_property_name(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: i32);
     }
-
     unsafe extern "C++" {
         #[doc = "Notify signal for the Q_PROPERTY"]
         #[doc = "property_name"]
@@ -109,18 +84,15 @@ pub mod ffi {
         #[rust_name = "property_name_changed"]
         fn propertyNameChanged(self: Pin<&mut MyObjectQt>);
     }
-
     extern "Rust" {
         #[cxx_name = "invokableNameWrapper"]
         fn invokable_name_wrapper(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>);
     }
-
     unsafe extern "C++" {
         #[doc(hidden)]
         #[rust_name = "emit_ready"]
         fn emitReady(self: Pin<&mut MyObjectQt>);
     }
-
     unsafe extern "C++" {
         #[doc = r" Specialised version of CxxQtThread, which can be moved into other threads."]
         #[doc = r""]
@@ -129,17 +101,14 @@ pub mod ffi {
         #[doc = r" For now we use a type alias in C++ then use it like a normal type here"]
         #[doc = r" <https://github.com/dtolnay/cxx/issues/683>"]
         type MyObjectCxxQtThread;
-
         #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
-
         #[doc = r" Create an instance of a CxxQtThread"]
         #[doc = r""]
         #[doc = r" This allows for queueing closures onto the Qt event loop from a background thread."]
         #[cxx_name = "qtThread"]
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
-
         #[doc(hidden)]
         #[cxx_name = "queue"]
         fn queue_boxed_fn(
@@ -147,7 +116,6 @@ pub mod ffi {
             func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
             arg: Box<MyObjectCxxQtThreadQueuedFn>,
         ) -> Result<()>;
-
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -155,7 +123,6 @@ pub mod ffi {
         #[namespace = "cxx_qt::multi_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
-
     extern "C++" {
         #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
         #[doc = r""]
@@ -164,16 +131,13 @@ pub mod ffi {
         #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
-
     extern "Rust" {
         #[namespace = "cxx_qt::multi_object::cxx_qt_my_object"]
         type MyObjectCxxQtThreadQueuedFn;
-
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::multi_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
     }
-
     unsafe extern "C++" {
         #[doc = "The C++ type for the QObject "]
         #[doc = "SecondObject"]
@@ -184,22 +148,18 @@ pub mod ffi {
         #[cxx_name = "SecondObject"]
         type SecondObjectQt;
     }
-
     extern "Rust" {
         #[cxx_name = "SecondObjectRust"]
         type SecondObject;
     }
-
     extern "Rust" {
         #[cxx_name = "getPropertyName"]
         unsafe fn property_name<'a>(self: &'a SecondObject, cpp: &'a SecondObjectQt) -> &'a i32;
     }
-
     extern "Rust" {
         #[cxx_name = "setPropertyName"]
         fn set_property_name(self: &mut SecondObject, cpp: Pin<&mut SecondObjectQt>, value: i32);
     }
-
     unsafe extern "C++" {
         #[doc = "Notify signal for the Q_PROPERTY"]
         #[doc = "property_name"]
@@ -210,18 +170,15 @@ pub mod ffi {
         #[rust_name = "property_name_changed"]
         fn propertyNameChanged(self: Pin<&mut SecondObjectQt>);
     }
-
     extern "Rust" {
         #[cxx_name = "invokableNameWrapper"]
         fn invokable_name_wrapper(self: &mut SecondObject, cpp: Pin<&mut SecondObjectQt>);
     }
-
     unsafe extern "C++" {
         #[doc(hidden)]
         #[rust_name = "emit_ready"]
         fn emitReady(self: Pin<&mut SecondObjectQt>);
     }
-
     unsafe extern "C++" {
         #[doc = r" Specialised version of CxxQtThread, which can be moved into other threads."]
         #[doc = r""]
@@ -252,7 +209,6 @@ pub mod ffi {
         #[namespace = "cxx_qt::multi_object::cxx_qt_second_object"]
         fn newCppObject() -> UniquePtr<SecondObjectQt>;
     }
-
     extern "C++" {
         #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
         #[doc = r""]
@@ -261,7 +217,6 @@ pub mod ffi {
         #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut SecondObjectQt>) -> Pin<&mut SecondObject>;
     }
-
     extern "Rust" {
         #[namespace = "cxx_qt::multi_object::cxx_qt_second_object"]
         type SecondObjectCxxQtThreadQueuedFn;
@@ -270,50 +225,40 @@ pub mod ffi {
         fn create_rs_second_object() -> Box<SecondObject>;
     }
 }
-
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
     use std::pin::Pin;
-
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
     use super::MyTrait;
-
     impl Default for MyObject {
         fn default() -> Self {
             Self { property_name: 32 }
         }
     }
-
     impl MyObject {
         fn test_angled(&self, optional: Option<bool>) -> Option<bool> {
             optional
         }
-
         fn test_unknown(&self, unknown: MyType) -> MyType {
             unknown
         }
     }
-
     impl MyTrait for MyObject {
         fn my_func() -> String {
             "Hello".to_owned()
         }
     }
-
     pub struct MyObject {
         property_name: i32,
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn property_name<'a>(&'a self, cpp: &'a MyObjectQt) -> &'a i32 {
             cpp.property_name()
         }
     }
-
     impl MyObjectQt {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "property_name"]
@@ -321,7 +266,6 @@ mod cxx_qt_ffi {
             &self.rust().property_name
         }
     }
-
     impl MyObjectQt {
         #[doc = "unsafe getter for the Q_PROPERTY "]
         #[doc = "property_name"]
@@ -334,14 +278,12 @@ mod cxx_qt_ffi {
             &mut self.rust_mut().get_unchecked_mut().property_name
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn set_property_name(&mut self, cpp: Pin<&mut MyObjectQt>, value: i32) {
             cpp.set_property_name(value);
         }
     }
-
     impl MyObjectQt {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "property_name"]
@@ -355,37 +297,30 @@ mod cxx_qt_ffi {
             self.as_mut().property_name_changed();
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn invokable_name_wrapper(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>) {
             cpp.invokable_name();
         }
     }
-
     impl MyObjectQt {
         pub fn invokable_name(self: Pin<&mut Self>) {
             println!("Bye from Rust!");
             self.as_mut().set_property_name(5);
         }
     }
-
     impl MyObjectQt {
         pub const MY_CONSTANT: i32 = 42;
     }
-
     impl MyObjectQt {
         type MyType = i32;
     }
-
     impl MyObjectQt {
         my_macro!();
     }
-
     pub enum MySignals {
         Ready,
     }
-
     impl MyObjectQt {
         #[doc = "Emit the signal from the enum "]
         #[doc = "MySignals"]
@@ -397,9 +332,7 @@ mod cxx_qt_ffi {
             }
         }
     }
-
     unsafe impl Send for MyObjectCxxQtThread {}
-
     impl MyObjectCxxQtThread {
         #[doc = r" Queue the given closure onto the Qt event loop for this QObject"]
         pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
@@ -421,34 +354,28 @@ mod cxx_qt_ffi {
             self.queue_boxed_fn(func, std::boxed::Box::new(arg))
         }
     }
-
     #[doc(hidden)]
     pub struct MyObjectCxxQtThreadQueuedFn {
         inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
     }
-
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
-
     impl Default for SecondObject {
         fn default() -> Self {
             Self { property_name: 32 }
         }
     }
-
     pub struct SecondObject {
         property_name: i32,
     }
-
     impl SecondObject {
         #[doc(hidden)]
         pub fn property_name<'a>(&'a self, cpp: &'a SecondObjectQt) -> &'a i32 {
             cpp.property_name()
         }
     }
-
     impl SecondObjectQt {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "property_name"]
@@ -468,14 +395,12 @@ mod cxx_qt_ffi {
             &mut self.rust_mut().get_unchecked_mut().property_name
         }
     }
-
     impl SecondObject {
         #[doc(hidden)]
         pub fn set_property_name(&mut self, cpp: Pin<&mut SecondObjectQt>, value: i32) {
             cpp.set_property_name(value);
         }
     }
-
     impl SecondObjectQt {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "property_name"]
@@ -489,25 +414,21 @@ mod cxx_qt_ffi {
             self.as_mut().property_name_changed();
         }
     }
-
     impl SecondObject {
         #[doc(hidden)]
         pub fn invokable_name_wrapper(self: &mut SecondObject, cpp: Pin<&mut SecondObjectQt>) {
             cpp.invokable_name();
         }
     }
-
     impl SecondObjectQt {
         pub fn invokable_name(self: Pin<&mut Self>) {
             println!("Bye from second Rust!");
             self.as_mut().set_property_name(5);
         }
     }
-
     pub enum SecondSignals {
         Ready,
     }
-
     impl SecondObjectQt {
         #[doc = "Emit the signal from the enum "]
         #[doc = "SecondSignals"]
@@ -519,9 +440,7 @@ mod cxx_qt_ffi {
             }
         }
     }
-
     unsafe impl Send for SecondObjectCxxQtThread {}
-
     impl SecondObjectCxxQtThread {
         #[doc = r" Queue the given closure onto the Qt event loop for this QObject"]
         pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
@@ -543,17 +462,14 @@ mod cxx_qt_ffi {
             self.queue_boxed_fn(func, std::boxed::Box::new(arg))
         }
     }
-
     #[doc(hidden)]
     pub struct SecondObjectCxxQtThreadQueuedFn {
         inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut SecondObjectQt>) + Send>,
     }
-
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_second_object() -> std::boxed::Box<SecondObject> {
         std::default::Default::default()
     }
-
     #[doc = r" Generated CXX-Qt module containing type alias to the C++ types of the QObjects"]
     pub mod qobject {
         #[doc = "The C++ type for the QObject "]

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -5,17 +5,14 @@ mod ffi {
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = cxx_qt_lib::QPoint;
     }
-
     unsafe extern "C++" {
         include ! (< QtCore / QObject >);
         include!("cxx-qt-lib/convert.h");
         include!("cxx-qt-lib/cxxqt_thread.h");
     }
-
     unsafe extern "C++" {
         include!("cxx-qt-gen/ffi.cxxqt.h");
     }
-
     unsafe extern "C++" {
         #[doc = "The C++ type for the QObject "]
         #[doc = "MyObject"]
@@ -26,22 +23,18 @@ mod ffi {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
     }
-
     extern "Rust" {
         #[cxx_name = "MyObjectRust"]
         type MyObject;
     }
-
     extern "Rust" {
         #[cxx_name = "getPrimitive"]
         unsafe fn primitive<'a>(self: &'a MyObject, cpp: &'a MyObjectQt) -> &'a i32;
     }
-
     extern "Rust" {
         #[cxx_name = "setPrimitive"]
         fn set_primitive(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: i32);
     }
-
     unsafe extern "C++" {
         #[doc = "Notify signal for the Q_PROPERTY"]
         #[doc = "primitive"]
@@ -52,17 +45,14 @@ mod ffi {
         #[rust_name = "primitive_changed"]
         fn primitiveChanged(self: Pin<&mut MyObjectQt>);
     }
-
     extern "Rust" {
         #[cxx_name = "getTrivial"]
         unsafe fn trivial<'a>(self: &'a MyObject, cpp: &'a MyObjectQt) -> &'a QPoint;
     }
-
     extern "Rust" {
         #[cxx_name = "setTrivial"]
         fn set_trivial(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: QPoint);
     }
-
     unsafe extern "C++" {
         #[doc = "Notify signal for the Q_PROPERTY"]
         #[doc = "trivial"]
@@ -73,17 +63,14 @@ mod ffi {
         #[rust_name = "trivial_changed"]
         fn trivialChanged(self: Pin<&mut MyObjectQt>);
     }
-
     extern "Rust" {
         #[cxx_name = "getOpaque"]
         unsafe fn opaque<'a>(self: &'a MyObject, cpp: &'a MyObjectQt) -> &'a UniquePtr<Opaque>;
     }
-
     extern "Rust" {
         #[cxx_name = "setOpaque"]
         fn set_opaque(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>, value: UniquePtr<Opaque>);
     }
-
     unsafe extern "C++" {
         #[doc = "Notify signal for the Q_PROPERTY"]
         #[doc = "opaque"]
@@ -94,7 +81,6 @@ mod ffi {
         #[rust_name = "opaque_changed"]
         fn opaqueChanged(self: Pin<&mut MyObjectQt>);
     }
-
     unsafe extern "C++" {
         #[doc = r" Specialised version of CxxQtThread, which can be moved into other threads."]
         #[doc = r""]
@@ -103,17 +89,14 @@ mod ffi {
         #[doc = r" For now we use a type alias in C++ then use it like a normal type here"]
         #[doc = r" <https://github.com/dtolnay/cxx/issues/683>"]
         type MyObjectCxxQtThread;
-
         #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
-
         #[doc = r" Create an instance of a CxxQtThread"]
         #[doc = r""]
         #[doc = r" This allows for queueing closures onto the Qt event loop from a background thread."]
         #[cxx_name = "qtThread"]
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
-
         #[doc(hidden)]
         #[cxx_name = "queue"]
         fn queue_boxed_fn(
@@ -121,7 +104,6 @@ mod ffi {
             func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
             arg: Box<MyObjectCxxQtThreadQueuedFn>,
         ) -> Result<()>;
-
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -129,7 +111,6 @@ mod ffi {
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
-
     extern "C++" {
         #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
         #[doc = r""]
@@ -138,25 +119,20 @@ mod ffi {
         #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
-
     extern "Rust" {
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         type MyObjectCxxQtThreadQueuedFn;
-
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
     }
 }
-
 use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
     use std::pin::Pin;
-
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
     #[derive(Default)]
     pub struct MyObject {
         primitive: i32,
@@ -165,14 +141,12 @@ mod cxx_qt_ffi {
         private_rust_field: i32,
         pub public_rust_field: f64,
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn primitive<'a>(&'a self, cpp: &'a MyObjectQt) -> &'a i32 {
             cpp.primitive()
         }
     }
-
     impl MyObjectQt {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "primitive"]
@@ -180,7 +154,6 @@ mod cxx_qt_ffi {
             &self.rust().primitive
         }
     }
-
     impl MyObjectQt {
         #[doc = "unsafe getter for the Q_PROPERTY "]
         #[doc = "primitive"]
@@ -193,14 +166,12 @@ mod cxx_qt_ffi {
             &mut self.rust_mut().get_unchecked_mut().primitive
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn set_primitive(&mut self, cpp: Pin<&mut MyObjectQt>, value: i32) {
             cpp.set_primitive(value);
         }
     }
-
     impl MyObjectQt {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "primitive"]
@@ -214,14 +185,12 @@ mod cxx_qt_ffi {
             self.as_mut().primitive_changed();
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn trivial<'a>(&'a self, cpp: &'a MyObjectQt) -> &'a QPoint {
             cpp.trivial()
         }
     }
-
     impl MyObjectQt {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "trivial"]
@@ -229,7 +198,6 @@ mod cxx_qt_ffi {
             &self.rust().trivial
         }
     }
-
     impl MyObjectQt {
         #[doc = "unsafe getter for the Q_PROPERTY "]
         #[doc = "trivial"]
@@ -242,14 +210,12 @@ mod cxx_qt_ffi {
             &mut self.rust_mut().get_unchecked_mut().trivial
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn set_trivial(&mut self, cpp: Pin<&mut MyObjectQt>, value: QPoint) {
             cpp.set_trivial(value);
         }
     }
-
     impl MyObjectQt {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "trivial"]
@@ -263,14 +229,12 @@ mod cxx_qt_ffi {
             self.as_mut().trivial_changed();
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn opaque<'a>(&'a self, cpp: &'a MyObjectQt) -> &'a UniquePtr<Opaque> {
             cpp.opaque()
         }
     }
-
     impl MyObjectQt {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "opaque"]
@@ -278,7 +242,6 @@ mod cxx_qt_ffi {
             &self.rust().opaque
         }
     }
-
     impl MyObjectQt {
         #[doc = "unsafe getter for the Q_PROPERTY "]
         #[doc = "opaque"]
@@ -291,14 +254,12 @@ mod cxx_qt_ffi {
             &mut self.rust_mut().get_unchecked_mut().opaque
         }
     }
-
     impl MyObject {
         #[doc(hidden)]
         pub fn set_opaque(&mut self, cpp: Pin<&mut MyObjectQt>, value: UniquePtr<Opaque>) {
             cpp.set_opaque(value);
         }
     }
-
     impl MyObjectQt {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "opaque"]
@@ -312,19 +273,16 @@ mod cxx_qt_ffi {
             self.as_mut().opaque_changed();
         }
     }
-
     impl MyObjectQt {
         fn private_rust_field(&self) -> &i32 {
             &self.rust().private_rust_field
         }
     }
-
     impl MyObjectQt {
         fn private_rust_field_mut<'a>(self: Pin<&'a mut Self>) -> &'a mut i32 {
             unsafe { &mut self.rust_mut().get_unchecked_mut().private_rust_field }
         }
     }
-
     impl MyObjectQt {
         fn set_private_rust_field(self: Pin<&mut Self>, value: i32) {
             unsafe {
@@ -332,19 +290,16 @@ mod cxx_qt_ffi {
             }
         }
     }
-
     impl MyObjectQt {
         pub fn public_rust_field(&self) -> &f64 {
             &self.rust().public_rust_field
         }
     }
-
     impl MyObjectQt {
         pub fn public_rust_field_mut<'a>(self: Pin<&'a mut Self>) -> &'a mut f64 {
             unsafe { &mut self.rust_mut().get_unchecked_mut().public_rust_field }
         }
     }
-
     impl MyObjectQt {
         pub fn set_public_rust_field(self: Pin<&mut Self>, value: f64) {
             unsafe {
@@ -352,9 +307,7 @@ mod cxx_qt_ffi {
             }
         }
     }
-
     unsafe impl Send for MyObjectCxxQtThread {}
-
     impl MyObjectCxxQtThread {
         #[doc = r" Queue the given closure onto the Qt event loop for this QObject"]
         pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
@@ -376,17 +329,14 @@ mod cxx_qt_ffi {
             self.queue_boxed_fn(func, std::boxed::Box::new(arg))
         }
     }
-
     #[doc(hidden)]
     pub struct MyObjectCxxQtThreadQueuedFn {
         inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
     }
-
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
-
     #[doc = r" Generated CXX-Qt module containing type alias to the C++ types of the QObjects"]
     pub mod qobject {
         #[doc = "The C++ type for the QObject "]

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -5,17 +5,14 @@ mod ffi {
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = cxx_qt_lib::QPoint;
     }
-
     unsafe extern "C++" {
         include ! (< QtCore / QObject >);
         include!("cxx-qt-lib/convert.h");
         include!("cxx-qt-lib/cxxqt_thread.h");
     }
-
     unsafe extern "C++" {
         include!("cxx-qt-gen/ffi.cxxqt.h");
     }
-
     unsafe extern "C++" {
         #[doc = "The C++ type for the QObject "]
         #[doc = "MyObject"]
@@ -26,23 +23,19 @@ mod ffi {
         #[cxx_name = "MyObject"]
         type MyObjectQt;
     }
-
     extern "Rust" {
         #[cxx_name = "MyObjectRust"]
         type MyObject;
     }
-
     extern "Rust" {
         #[cxx_name = "invokableWrapper"]
         fn invokable_wrapper(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>);
     }
-
     unsafe extern "C++" {
         #[doc(hidden)]
         #[rust_name = "emit_ready"]
         fn emitReady(self: Pin<&mut MyObjectQt>);
     }
-
     unsafe extern "C++" {
         #[doc(hidden)]
         #[rust_name = "emit_data_changed"]
@@ -54,7 +47,6 @@ mod ffi {
             fourth: &QPoint,
         );
     }
-
     unsafe extern "C++" {
         #[doc(hidden)]
         #[rust_name = "emit_new_data"]
@@ -66,7 +58,6 @@ mod ffi {
             fourth: &QPoint,
         );
     }
-
     unsafe extern "C++" {
         #[doc = r" Specialised version of CxxQtThread, which can be moved into other threads."]
         #[doc = r""]
@@ -75,17 +66,14 @@ mod ffi {
         #[doc = r" For now we use a type alias in C++ then use it like a normal type here"]
         #[doc = r" <https://github.com/dtolnay/cxx/issues/683>"]
         type MyObjectCxxQtThread;
-
         #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
-
         #[doc = r" Create an instance of a CxxQtThread"]
         #[doc = r""]
         #[doc = r" This allows for queueing closures onto the Qt event loop from a background thread."]
         #[cxx_name = "qtThread"]
         fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
-
         #[doc(hidden)]
         #[cxx_name = "queue"]
         fn queue_boxed_fn(
@@ -93,7 +81,6 @@ mod ffi {
             func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
             arg: Box<MyObjectCxxQtThreadQueuedFn>,
         ) -> Result<()>;
-
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -101,7 +88,6 @@ mod ffi {
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
-
     extern "C++" {
         #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
         #[doc = r""]
@@ -110,35 +96,28 @@ mod ffi {
         #[cxx_name = "unsafeRustMut"]
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
-
     extern "Rust" {
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         type MyObjectCxxQtThreadQueuedFn;
-
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
     }
 }
-
 use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
     use std::pin::Pin;
-
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
-
     #[derive(Default)]
     pub struct MyObject;
-
     impl MyObject {
         #[doc(hidden)]
         pub fn invokable_wrapper(self: &mut MyObject, cpp: Pin<&mut MyObjectQt>) {
             cpp.invokable();
         }
     }
-
     impl MyObjectQt {
         pub fn invokable(self: Pin<&mut Self>) {
             self.as_mut().emit(MySignals::DataChanged {
@@ -149,7 +128,6 @@ mod cxx_qt_ffi {
             });
         }
     }
-
     enum MySignals<'a> {
         Ready,
         DataChanged {
@@ -165,7 +143,6 @@ mod cxx_qt_ffi {
             fourth: &'a QPoint,
         },
     }
-
     impl MyObjectQt {
         #[doc = "Emit the signal from the enum "]
         #[doc = "MySignals"]
@@ -189,9 +166,7 @@ mod cxx_qt_ffi {
             }
         }
     }
-
     unsafe impl Send for MyObjectCxxQtThread {}
-
     impl MyObjectCxxQtThread {
         #[doc = r" Queue the given closure onto the Qt event loop for this QObject"]
         pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
@@ -213,17 +188,14 @@ mod cxx_qt_ffi {
             self.queue_boxed_fn(func, std::boxed::Box::new(arg))
         }
     }
-
     #[doc(hidden)]
     pub struct MyObjectCxxQtThreadQueuedFn {
         inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
     }
-
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
     }
-
     #[doc = r" Generated CXX-Qt module containing type alias to the C++ types of the QObjects"]
     pub mod qobject {
         #[doc = "The C++ type for the QObject "]

--- a/crates/cxx-qt-gen/update_expected.sh
+++ b/crates/cxx-qt-gen/update_expected.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+
+set -ex
+
+SCRIPT=$(realpath "$0")
+SCRIPT_DIR=$(dirname "$SCRIPT")
+CXXQT_UPDATE_EXPECTED="${SCRIPT_DIR}" cargo test tests::generates
+

--- a/crates/cxx-qt-lib/Cargo.toml
+++ b/crates/cxx-qt-lib/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 # Fake linking so that we expose cargo data as env vars for downstream crates
 # https://github.com/rust-lang/cargo/issues/3544
 links = "cxx-qt-lib"
+exclude = [ "**/generate.sh" ]
 
 [dependencies]
 cxx.workspace = true


### PR DESCRIPTION
Use CXXQT_UPDATE_EXPECTED=/path/to/crates/cxx-qt-gen/ to update the test_outputs/ directory.
This is very useful for bulk updates when making changes to small cross-cutting concerns.