### PR TITLE
update_expected: ensure cwd is the cxx-qt-gen folder

### DIFF
--- a/crates/cxx-qt-gen/update_expected.sh
+++ b/crates/cxx-qt-gen/update_expected.sh
@@ -10,5 +10,7 @@ set -ex
 
 SCRIPT=$(realpath "$0")
 SCRIPT_DIR=$(dirname "$SCRIPT")
+
+cd "${SCRIPT_DIR}"
 CXXQT_UPDATE_EXPECTED="${SCRIPT_DIR}" cargo test tests::generates
 


### PR DESCRIPTION
Otherwise all cargo projects in the cwd are built when this isn't required to update the expected.