### PR TITLE
cxx-qt: Add CxxQtType trait

### DIFF
--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -64,9 +64,9 @@ mod inheritance {
         unsafe fn fetch_more(self: Pin<&mut MyObjectQt>, index: &QModelIndex);
     }
     unsafe extern "C++" {
-        #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
-        fn rust(self: &MyObjectQt) -> &MyObject;
+        #[doc(hidden)]
+        fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -75,12 +75,9 @@ mod inheritance {
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
     extern "C++" {
-        #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
-        #[doc = r""]
-        #[doc = r" This method is unsafe because it allows a Q_PROPERTY to be modified without emitting its changed signal."]
-        #[doc = r" The property changed signal must be emitted manually."]
         #[cxx_name = "unsafeRustMut"]
-        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
+        #[doc(hidden)]
+        unsafe fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
     extern "Rust" {
         #[cxx_name = "createRs"]
@@ -91,6 +88,7 @@ mod inheritance {
 use self::cxx_qt_inheritance::*;
 mod cxx_qt_inheritance {
     use super::inheritance::*;
+    use cxx_qt::CxxQtType;
     use std::pin::Pin;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
@@ -144,6 +142,15 @@ mod cxx_qt_inheritance {
     impl MyObjectQt {
         pub fn has_children(&self, _parent: &QModelIndex) -> bool {
             false
+        }
+    }
+    impl cxx_qt::CxxQtType for MyObjectQt {
+        type Rust = MyObject;
+        fn rust(&self) -> &Self::Rust {
+            self.cxx_qt_ffi_rust()
+        }
+        unsafe fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+            self.cxx_qt_ffi_rust_mut()
         }
     }
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -108,9 +108,9 @@ mod ffi {
         type MyObjectCxxQtThreadQueuedFn;
     }
     unsafe extern "C++" {
-        #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
-        fn rust(self: &MyObjectQt) -> &MyObject;
+        #[doc(hidden)]
+        fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -119,12 +119,9 @@ mod ffi {
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
     extern "C++" {
-        #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
-        #[doc = r""]
-        #[doc = r" This method is unsafe because it allows a Q_PROPERTY to be modified without emitting its changed signal."]
-        #[doc = r" The property changed signal must be emitted manually."]
         #[cxx_name = "unsafeRustMut"]
-        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
+        #[doc(hidden)]
+        unsafe fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
     extern "Rust" {
         #[cxx_name = "createRs"]
@@ -135,6 +132,7 @@ mod ffi {
 use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use cxx_qt::CxxQtType;
     use std::pin::Pin;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
@@ -290,6 +288,15 @@ mod cxx_qt_ffi {
     #[doc(hidden)]
     pub struct MyObjectCxxQtThreadQueuedFn {
         inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
+    }
+    impl cxx_qt::CxxQtType for MyObjectQt {
+        type Rust = MyObject;
+        fn rust(&self) -> &Self::Rust {
+            self.cxx_qt_ffi_rust()
+        }
+        unsafe fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+            self.cxx_qt_ffi_rust_mut()
+        }
     }
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -114,9 +114,9 @@ pub mod ffi {
         ) -> CxxQtQMetaObjectConnection;
     }
     unsafe extern "C++" {
-        #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
-        fn rust(self: &MyObjectQt) -> &MyObject;
+        #[doc(hidden)]
+        fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -125,12 +125,9 @@ pub mod ffi {
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
     extern "C++" {
-        #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
-        #[doc = r""]
-        #[doc = r" This method is unsafe because it allows a Q_PROPERTY to be modified without emitting its changed signal."]
-        #[doc = r" The property changed signal must be emitted manually."]
         #[cxx_name = "unsafeRustMut"]
-        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
+        #[doc(hidden)]
+        unsafe fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
     extern "Rust" {
         #[cxx_name = "createRs"]
@@ -191,9 +188,9 @@ pub mod ffi {
         ) -> CxxQtQMetaObjectConnection;
     }
     unsafe extern "C++" {
-        #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
-        fn rust(self: &SecondObjectQt) -> &SecondObject;
+        #[doc(hidden)]
+        fn cxx_qt_ffi_rust(self: &SecondObjectQt) -> &SecondObject;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "SecondObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -202,12 +199,9 @@ pub mod ffi {
         fn newCppObject() -> UniquePtr<SecondObjectQt>;
     }
     extern "C++" {
-        #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
-        #[doc = r""]
-        #[doc = r" This method is unsafe because it allows a Q_PROPERTY to be modified without emitting its changed signal."]
-        #[doc = r" The property changed signal must be emitted manually."]
         #[cxx_name = "unsafeRustMut"]
-        unsafe fn rust_mut(self: Pin<&mut SecondObjectQt>) -> Pin<&mut SecondObject>;
+        #[doc(hidden)]
+        unsafe fn cxx_qt_ffi_rust_mut(self: Pin<&mut SecondObjectQt>) -> Pin<&mut SecondObject>;
     }
     extern "Rust" {
         #[cxx_name = "createRs"]
@@ -218,6 +212,7 @@ pub mod ffi {
 pub use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use cxx_qt::CxxQtType;
     use std::pin::Pin;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
@@ -336,6 +331,15 @@ mod cxx_qt_ffi {
             }
         }
     }
+    impl cxx_qt::CxxQtType for MyObjectQt {
+        type Rust = MyObject;
+        fn rust(&self) -> &Self::Rust {
+            self.cxx_qt_ffi_rust()
+        }
+        unsafe fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+            self.cxx_qt_ffi_rust_mut()
+        }
+    }
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
@@ -430,6 +434,15 @@ mod cxx_qt_ffi {
             match signal {
                 SecondSignals::Ready {} => self.emit_ready(),
             }
+        }
+    }
+    impl cxx_qt::CxxQtType for SecondObjectQt {
+        type Rust = SecondObject;
+        fn rust(&self) -> &Self::Rust {
+            self.cxx_qt_ffi_rust()
+        }
+        unsafe fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+            self.cxx_qt_ffi_rust_mut()
         }
     }
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -72,9 +72,9 @@ mod ffi {
         fn trivialChanged(self: Pin<&mut MyObjectQt>);
     }
     unsafe extern "C++" {
-        #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
-        fn rust(self: &MyObjectQt) -> &MyObject;
+        #[doc(hidden)]
+        fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -83,12 +83,9 @@ mod ffi {
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
     extern "C++" {
-        #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
-        #[doc = r""]
-        #[doc = r" This method is unsafe because it allows a Q_PROPERTY to be modified without emitting its changed signal."]
-        #[doc = r" The property changed signal must be emitted manually."]
         #[cxx_name = "unsafeRustMut"]
-        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
+        #[doc(hidden)]
+        unsafe fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
     extern "Rust" {
         #[cxx_name = "createRs"]
@@ -99,6 +96,7 @@ mod ffi {
 use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use cxx_qt::CxxQtType;
     use std::pin::Pin;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
@@ -247,6 +245,15 @@ mod cxx_qt_ffi {
             unsafe {
                 self.rust_mut().public_rust_field = value;
             }
+        }
+    }
+    impl cxx_qt::CxxQtType for MyObjectQt {
+        type Rust = MyObject;
+        fn rust(&self) -> &Self::Rust {
+            self.cxx_qt_ffi_rust()
+        }
+        unsafe fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+            self.cxx_qt_ffi_rust_mut()
         }
     }
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -115,9 +115,9 @@ mod ffi {
         ) -> CxxQtQMetaObjectConnection;
     }
     unsafe extern "C++" {
-        #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
-        fn rust(self: &MyObjectQt) -> &MyObject;
+        #[doc(hidden)]
+        fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -126,12 +126,9 @@ mod ffi {
         fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
     extern "C++" {
-        #[doc = r" Retrieve a mutable reference to the Rust struct backing this C++ object"]
-        #[doc = r""]
-        #[doc = r" This method is unsafe because it allows a Q_PROPERTY to be modified without emitting its changed signal."]
-        #[doc = r" The property changed signal must be emitted manually."]
         #[cxx_name = "unsafeRustMut"]
-        unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
+        #[doc(hidden)]
+        unsafe fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
     extern "Rust" {
         #[cxx_name = "createRs"]
@@ -142,6 +139,7 @@ mod ffi {
 use self::cxx_qt_ffi::*;
 mod cxx_qt_ffi {
     use super::ffi::*;
+    use cxx_qt::CxxQtType;
     use std::pin::Pin;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
@@ -259,6 +257,15 @@ mod cxx_qt_ffi {
                     fourth,
                 } => self.emit_base_class_new_data(first, second, third, fourth),
             }
+        }
+    }
+    impl cxx_qt::CxxQtType for MyObjectQt {
+        type Rust = MyObject;
+        fn rust(&self) -> &Self::Rust {
+            self.cxx_qt_ffi_rust()
+        }
+        unsafe fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+            self.cxx_qt_ffi_rust_mut()
         }
     }
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -13,3 +13,21 @@ pub use cxx_qt_macro::bridge;
 pub use cxx_qt_macro::inherit;
 pub use cxx_qt_macro::qobject;
 pub use cxx_qt_macro::qsignals;
+
+/// This trait is automatically implemented for all types which are marked as `#[cxx_qt::qobject]`.
+/// It provides information about the type that is wrapped by the QObject, as well as the methods
+/// that Cxx-Qt will generate for the QObject.
+pub trait CxxQtType {
+    /// The Rust type that this QObject is wrapping.
+    type Rust;
+
+    /// Retrieve an immutable reference to the Rust struct backing this C++ object
+    fn rust(&self) -> &Self::Rust;
+
+    /// Retrieve a mutable reference to the Rust struct backing this C++ object
+    ///
+    /// # Safety
+    /// This method is unsafe because it allows a Q_PROPERTY to be modified without emitting its changed signal.
+    /// The property changed signal must be emitted manually.
+    unsafe fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust>;
+}


### PR DESCRIPTION
This trait is automatically implemented on any `qobject::T`. It currently exposes the inner Rust type for a given QObject.

First step of implementing #550

This also requires us to split our macros into a cxx-qt-macro crate, as otherwise only exporting proc-macros is allowed.
We could now potentially move CxxQtThread into the cxx-qt crate now to remove the dependency on cxx-qt-lib.