### PR TITLE
cxx-qt-gen: remove generation of wrapper for emitting signals

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -97,7 +97,7 @@ mod tests {
         assert_str_eq!(generated.metaobjects[1], "Q_PROPERTY(::std::unique_ptr<QColor> opaqueProperty READ getOpaqueProperty WRITE setOpaqueProperty NOTIFY opaquePropertyChanged)");
 
         // methods
-        assert_eq!(generated.methods.len(), 10);
+        assert_eq!(generated.methods.len(), 8);
         let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[0] {
             (header, source)
         } else {
@@ -191,23 +191,6 @@ mod tests {
         } else {
             panic!("Expected Pair")
         };
-        assert_str_eq!(header, "void emitTrivialPropertyChanged();");
-        assert_str_eq!(
-            source,
-            indoc! {r#"
-            void
-            MyObject::emitTrivialPropertyChanged()
-            {
-                Q_EMIT trivialPropertyChanged();
-            }
-            "#}
-        );
-
-        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[6] {
-            (header, source)
-        } else {
-            panic!("Expected Pair")
-        };
         assert_str_eq!(
             header,
             "::QMetaObject::Connection trivialPropertyChangedConnect(::rust::Fn<void(MyObject&)> func, ::Qt::ConnectionType type);"
@@ -229,31 +212,14 @@ mod tests {
             "#}
         );
 
-        let header = if let CppFragment::Header(header) = &generated.methods[7] {
+        let header = if let CppFragment::Header(header) = &generated.methods[6] {
             header
         } else {
             panic!("Expected header!")
         };
         assert_str_eq!(header, "Q_SIGNAL void opaquePropertyChanged();");
 
-        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[8] {
-            (header, source)
-        } else {
-            panic!("Expected Pair")
-        };
-        assert_str_eq!(header, "void emitOpaquePropertyChanged();");
-        assert_str_eq!(
-            source,
-            indoc! {r#"
-            void
-            MyObject::emitOpaquePropertyChanged()
-            {
-                Q_EMIT opaquePropertyChanged();
-            }
-            "#}
-        );
-
-        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[9] {
+        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[7] {
             (header, source)
         } else {
             panic!("Expected Pair")
@@ -307,7 +273,7 @@ mod tests {
         assert_str_eq!(generated.metaobjects[0], "Q_PROPERTY(A1 mappedProperty READ getMappedProperty WRITE setMappedProperty NOTIFY mappedPropertyChanged)");
 
         // methods
-        assert_eq!(generated.methods.len(), 5);
+        assert_eq!(generated.methods.len(), 4);
         let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[0] {
             (header, source)
         } else {
@@ -351,23 +317,6 @@ mod tests {
         assert_str_eq!(header, "Q_SIGNAL void mappedPropertyChanged();");
 
         let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[3] {
-            (header, source)
-        } else {
-            panic!("Expected Pair")
-        };
-        assert_str_eq!(header, "void emitMappedPropertyChanged();");
-        assert_str_eq!(
-            source,
-            indoc! {r#"
-            void
-            MyObject::emitMappedPropertyChanged()
-            {
-                Q_EMIT mappedPropertyChanged();
-            }
-            "#}
-        );
-
-        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[4] {
             (header, source)
         } else {
             panic!("Expected Pair")

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -40,7 +40,6 @@ pub fn generate_cpp_signals(
 
         // Prepare the idents
         let idents = QSignalName::from(signal);
-        let emit_ident = idents.emit_name.cpp.to_string();
         let signal_ident = idents.name.cpp.to_string();
         let connect_ident = idents.connect_name.cpp.to_string();
 
@@ -52,29 +51,6 @@ pub fn generate_cpp_signals(
                 parameters = parameter_types_cpp.join(", "),
             )));
         }
-
-        // Generate the emitters
-        generated.methods.push(CppFragment::Pair {
-            header: format!(
-                "void {ident}({parameters});",
-                ident = emit_ident,
-                parameters = parameter_types_cpp.join(", "),
-            ),
-            source: formatdoc! {
-                r#"
-                void
-                {qobject_ident}::{emit_ident}({parameters})
-                {{
-                    Q_EMIT {ident}({parameter_values});
-                }}
-                "#,
-                ident = signal_ident,
-                parameters = parameter_types_cpp.join(", "),
-                parameter_values = parameter_values_emitter.join(", "),
-                emit_ident = emit_ident,
-                qobject_ident = qobject_ident,
-            },
-        });
 
         // Generate connection
         let mut parameter_types_rust = parameter_types_cpp.clone();
@@ -159,7 +135,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(generated.methods.len(), 3);
+        assert_eq!(generated.methods.len(), 2);
         let header = if let CppFragment::Header(header) = &generated.methods[0] {
             header
         } else {
@@ -171,26 +147,6 @@ mod tests {
         );
 
         let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[1] {
-            (header, source)
-        } else {
-            panic!("Expected Pair")
-        };
-        assert_str_eq!(
-            header,
-            "void emitDataChanged(::std::int32_t trivial, ::std::unique_ptr<QColor> opaque);"
-        );
-        assert_str_eq!(
-            source,
-            indoc! {r#"
-            void
-            MyObject::emitDataChanged(::std::int32_t trivial, ::std::unique_ptr<QColor> opaque)
-            {
-                Q_EMIT dataChanged(::std::move(trivial), ::std::move(opaque));
-            }
-            "#}
-        );
-
-        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[2] {
             (header, source)
         } else {
             panic!("Expected Pair")
@@ -251,7 +207,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(generated.methods.len(), 3);
+        assert_eq!(generated.methods.len(), 2);
         let header = if let CppFragment::Header(header) = &generated.methods[0] {
             header
         } else {
@@ -260,23 +216,6 @@ mod tests {
         assert_str_eq!(header, "Q_SIGNAL void dataChanged(A1 mapped);");
 
         let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[1] {
-            (header, source)
-        } else {
-            panic!("Expected Pair")
-        };
-        assert_str_eq!(header, "void emitDataChanged(A1 mapped);");
-        assert_str_eq!(
-            source,
-            indoc! {r#"
-            void
-            MyObject::emitDataChanged(A1 mapped)
-            {
-                Q_EMIT dataChanged(::std::move(mapped));
-            }
-            "#}
-        );
-
-        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[2] {
             (header, source)
         } else {
             panic!("Expected Pair")
@@ -330,25 +269,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(generated.methods.len(), 2);
-        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[0] {
-            (header, source)
-        } else {
-            panic!("Expected Pair")
-        };
-        assert_str_eq!(header, "void emitBaseName();");
-        assert_str_eq!(
-            source,
-            indoc! {r#"
-            void
-            MyObject::emitBaseName()
-            {
-                Q_EMIT baseName();
-            }
-            "#}
-        );
+        assert_eq!(generated.methods.len(), 1);
 
-        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[1] {
+        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[0] {
             (header, source)
         } else {
             panic!("Expected Pair")

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -377,7 +377,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc = "Notify for the Q_PROPERTY"]
                     #[rust_name = "trivial_property_changed"]
-                    fn emitTrivialPropertyChanged(self: Pin<&mut MyObjectQt>, );
+                    fn trivialPropertyChanged(self: Pin<&mut MyObjectQt>, );
                 }
             },
         );
@@ -418,7 +418,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc = "Notify for the Q_PROPERTY"]
                     #[rust_name = "opaque_property_changed"]
-                    fn emitOpaquePropertyChanged(self: Pin<&mut MyObjectQt>, );
+                    fn opaquePropertyChanged(self: Pin<&mut MyObjectQt>, );
                 }
             },
         );
@@ -459,7 +459,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc = "Notify for the Q_PROPERTY"]
                     #[rust_name = "unsafe_property_changed"]
-                    fn emitUnsafePropertyChanged(self: Pin<&mut MyObjectQt>, );
+                    fn unsafePropertyChanged(self: Pin<&mut MyObjectQt>, );
                 }
             },
         );

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -24,9 +24,10 @@ pub fn generate_rust_signals(
     // Create the methods for the other signals
     for signal in signals {
         let idents = QSignalName::from(signal);
-        let signal_ident_cpp_str = idents.name.cpp.to_string();
-        let emit_ident_cpp = &idents.emit_name.cpp;
-        let emit_ident_rust_str = idents.emit_name.rust.to_string();
+        let signal_name_rust = idents.name.rust;
+        let signal_name_rust_str = signal_name_rust.to_string();
+        let signal_name_cpp = idents.name.cpp;
+        let signal_name_cpp_str = signal_name_cpp.to_string();
         let connect_ident_cpp = idents.connect_name.cpp;
         let connect_ident_rust = idents.connect_name.rust;
         let connect_ident_rust_str = connect_ident_rust.to_string();
@@ -58,18 +59,17 @@ pub fn generate_rust_signals(
 
         let fragment = RustFragmentPair {
             cxx_bridge: vec![
-                // TODO: this will not call our wrapper in the future
                 quote! {
                     #unsafe_block extern "C++" {
                         #(#attrs)*
-                        #[rust_name = #emit_ident_rust_str]
-                        #unsafe_call fn #emit_ident_cpp(self: #self_type, #(#parameters),*);
+                        #[rust_name = #signal_name_rust_str]
+                        #unsafe_call fn #signal_name_cpp(self: #self_type, #(#parameters),*);
                     }
                 },
                 quote! {
                     unsafe extern "C++" {
                         #[doc = "Connect the given function pointer to the signal "]
-                        #[doc = #signal_ident_cpp_str]
+                        #[doc = #signal_name_cpp_str]
                         #[doc = ", so that when the signal is emitted the function pointer is executed."]
                         #[must_use]
                         #[rust_name = #connect_ident_rust_str]
@@ -80,7 +80,7 @@ pub fn generate_rust_signals(
             implementation: vec![quote! {
                 impl #qobject_name {
                     #[doc = "Connect the given function pointer to the signal "]
-                    #[doc = #signal_ident_cpp_str]
+                    #[doc = #signal_name_cpp_str]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
@@ -142,7 +142,7 @@ mod tests {
             quote! {
                 unsafe extern "C++" {
                     #[rust_name = "ready"]
-                    fn emitReady(self: Pin<&mut MyObjectQt>, );
+                    fn ready(self: Pin<&mut MyObjectQt>, );
                 }
             },
         );
@@ -217,7 +217,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[attribute]
                     #[rust_name = "data_changed"]
-                    fn emitDataChanged(self: Pin<&mut MyObjectQt>, trivial: i32, opaque: UniquePtr<QColor>);
+                    fn dataChanged(self: Pin<&mut MyObjectQt>, trivial: i32, opaque: UniquePtr<QColor>);
                 }
             },
         );
@@ -284,7 +284,7 @@ mod tests {
             quote! {
                 extern "C++" {
                     #[rust_name = "unsafe_signal"]
-                    unsafe fn emitUnsafeSignal(self: Pin<&mut MyObjectQt>, param: *mut T);
+                    unsafe fn unsafeSignal(self: Pin<&mut MyObjectQt>, param: *mut T);
                 }
             },
         );
@@ -350,7 +350,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[inherit]
                     #[rust_name = "existing_signal"]
-                    fn emitBaseName(self: Pin<&mut MyObjectQt>, );
+                    fn baseName(self: Pin<&mut MyObjectQt>, );
                 }
             },
         );

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -37,12 +37,6 @@ MyObject::setPropertyName(::std::int32_t const& value)
   m_rustObj->setPropertyName(*this, value);
 }
 
-void
-MyObject::emitPropertyNameChanged()
-{
-  Q_EMIT propertyNameChanged();
-}
-
 ::QMetaObject::Connection
 MyObject::propertyNameChangedConnect(::rust::Fn<void(MyObject&)> func,
                                      ::Qt::ConnectionType type)
@@ -63,12 +57,6 @@ MyObject::invokableName()
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->invokableNameWrapper(*this);
-}
-
-void
-MyObject::emitReady()
-{
-  Q_EMIT ready();
 }
 
 ::QMetaObject::Connection
@@ -124,12 +112,6 @@ SecondObject::setPropertyName(::std::int32_t const& value)
   m_rustObj->setPropertyName(*this, value);
 }
 
-void
-SecondObject::emitPropertyNameChanged()
-{
-  Q_EMIT propertyNameChanged();
-}
-
 ::QMetaObject::Connection
 SecondObject::propertyNameChangedConnect(::rust::Fn<void(SecondObject&)> func,
                                          ::Qt::ConnectionType type)
@@ -147,12 +129,6 @@ SecondObject::invokableName()
 {
 
   m_rustObj->invokableNameWrapper(*this);
-}
-
-void
-SecondObject::emitReady()
-{
-  Q_EMIT ready();
 }
 
 ::QMetaObject::Connection

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -37,13 +37,11 @@ public:
   ::std::int32_t const& getPropertyName() const;
   Q_SLOT void setPropertyName(::std::int32_t const& value);
   Q_SIGNAL void propertyNameChanged();
-  void emitPropertyNameChanged();
   ::QMetaObject::Connection propertyNameChangedConnect(
     ::rust::Fn<void(MyObject&)> func,
     ::Qt::ConnectionType type);
   Q_INVOKABLE void invokableName();
   Q_SIGNAL void ready();
-  void emitReady();
   ::QMetaObject::Connection readyConnect(::rust::Fn<void(MyObject&)> func,
                                          ::Qt::ConnectionType type);
 
@@ -75,13 +73,11 @@ public:
   ::std::int32_t const& getPropertyName() const;
   Q_SLOT void setPropertyName(::std::int32_t const& value);
   Q_SIGNAL void propertyNameChanged();
-  void emitPropertyNameChanged();
   ::QMetaObject::Connection propertyNameChangedConnect(
     ::rust::Fn<void(SecondObject&)> func,
     ::Qt::ConnectionType type);
   Q_INVOKABLE void invokableName();
   Q_SIGNAL void ready();
-  void emitReady();
   ::QMetaObject::Connection readyConnect(::rust::Fn<void(SecondObject&)> func,
                                          ::Qt::ConnectionType type);
 

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -85,7 +85,7 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc = "Notify for the Q_PROPERTY"]
         #[rust_name = "property_name_changed"]
-        fn emitPropertyNameChanged(self: Pin<&mut MyObjectQt>);
+        fn propertyNameChanged(self: Pin<&mut MyObjectQt>);
     }
     unsafe extern "C++" {
         #[doc = "Connect the given function pointer to the signal "]
@@ -105,7 +105,7 @@ pub mod ffi {
     }
     unsafe extern "C++" {
         #[rust_name = "ready"]
-        fn emitReady(self: Pin<&mut MyObjectQt>);
+        fn ready(self: Pin<&mut MyObjectQt>);
     }
     unsafe extern "C++" {
         #[doc = "Connect the given function pointer to the signal "]
@@ -159,7 +159,7 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc = "Notify for the Q_PROPERTY"]
         #[rust_name = "property_name_changed"]
-        fn emitPropertyNameChanged(self: Pin<&mut SecondObjectQt>);
+        fn propertyNameChanged(self: Pin<&mut SecondObjectQt>);
     }
     unsafe extern "C++" {
         #[doc = "Connect the given function pointer to the signal "]
@@ -180,7 +180,7 @@ pub mod ffi {
     unsafe extern "C++" {
         #[my_attribute]
         #[rust_name = "ready"]
-        fn emitReady(self: Pin<&mut SecondObjectQt>);
+        fn ready(self: Pin<&mut SecondObjectQt>);
     }
     unsafe extern "C++" {
         #[doc = "Connect the given function pointer to the signal "]

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -51,12 +51,6 @@ MyObject::setTrivial(QPoint const& value)
   m_rustObj->setTrivial(*this, value);
 }
 
-void
-MyObject::emitPrimitiveChanged()
-{
-  Q_EMIT primitiveChanged();
-}
-
 ::QMetaObject::Connection
 MyObject::primitiveChangedConnect(::rust::Fn<void(MyObject&)> func,
                                   ::Qt::ConnectionType type)
@@ -70,12 +64,6 @@ MyObject::primitiveChangedConnect(::rust::Fn<void(MyObject&)> func,
       func(*this);
     },
     type);
-}
-
-void
-MyObject::emitTrivialChanged()
-{
-  Q_EMIT trivialChanged();
 }
 
 ::QMetaObject::Connection

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -36,12 +36,10 @@ public:
   QPoint const& getTrivial() const;
   Q_SLOT void setTrivial(QPoint const& value);
   Q_SIGNAL void primitiveChanged();
-  void emitPrimitiveChanged();
   ::QMetaObject::Connection primitiveChangedConnect(
     ::rust::Fn<void(MyObject&)> func,
     ::Qt::ConnectionType type);
   Q_SIGNAL void trivialChanged();
-  void emitTrivialChanged();
   ::QMetaObject::Connection trivialChangedConnect(
     ::rust::Fn<void(MyObject&)> func,
     ::Qt::ConnectionType type);

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -54,7 +54,7 @@ mod ffi {
     unsafe extern "C++" {
         #[doc = "Notify for the Q_PROPERTY"]
         #[rust_name = "primitive_changed"]
-        fn emitPrimitiveChanged(self: Pin<&mut MyObjectQt>);
+        fn primitiveChanged(self: Pin<&mut MyObjectQt>);
     }
     unsafe extern "C++" {
         #[doc = "Connect the given function pointer to the signal "]
@@ -71,7 +71,7 @@ mod ffi {
     unsafe extern "C++" {
         #[doc = "Notify for the Q_PROPERTY"]
         #[rust_name = "trivial_changed"]
-        fn emitTrivialChanged(self: Pin<&mut MyObjectQt>);
+        fn trivialChanged(self: Pin<&mut MyObjectQt>);
     }
     unsafe extern "C++" {
         #[doc = "Connect the given function pointer to the signal "]

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -30,12 +30,6 @@ MyObject::invokable()
   m_rustObj->invokableWrapper(*this);
 }
 
-void
-MyObject::emitReady()
-{
-  Q_EMIT ready();
-}
-
 ::QMetaObject::Connection
 MyObject::readyConnect(::rust::Fn<void(MyObject&)> func,
                        ::Qt::ConnectionType type)
@@ -49,18 +43,6 @@ MyObject::readyConnect(::rust::Fn<void(MyObject&)> func,
       func(*this);
     },
     type);
-}
-
-void
-MyObject::emitDataChanged(::std::int32_t first,
-                          ::std::unique_ptr<Opaque> second,
-                          QPoint third,
-                          QPoint const& fourth)
-{
-  Q_EMIT dataChanged(::std::move(first),
-                     ::std::move(second),
-                     ::std::move(third),
-                     ::std::move(fourth));
 }
 
 ::QMetaObject::Connection
@@ -87,18 +69,6 @@ MyObject::dataChangedConnect(::rust::Fn<void(MyObject&,
            ::std::move(fourth));
     },
     type);
-}
-
-void
-MyObject::emitNewData(::std::int32_t first,
-                      ::std::unique_ptr<Opaque> second,
-                      QPoint third,
-                      QPoint const& fourth)
-{
-  Q_EMIT newData(::std::move(first),
-                 ::std::move(second),
-                 ::std::move(third),
-                 ::std::move(fourth));
 }
 
 ::QMetaObject::Connection

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -29,17 +29,12 @@ public:
 public:
   Q_INVOKABLE void invokable();
   Q_SIGNAL void ready();
-  void emitReady();
   ::QMetaObject::Connection readyConnect(::rust::Fn<void(MyObject&)> func,
                                          ::Qt::ConnectionType type);
   Q_SIGNAL void dataChanged(::std::int32_t first,
                             ::std::unique_ptr<Opaque> second,
                             QPoint third,
                             QPoint const& fourth);
-  void emitDataChanged(::std::int32_t first,
-                       ::std::unique_ptr<Opaque> second,
-                       QPoint third,
-                       QPoint const& fourth);
   ::QMetaObject::Connection dataChangedConnect(
     ::rust::Fn<void(MyObject&,
                     ::std::int32_t first,
@@ -47,10 +42,6 @@ public:
                     QPoint third,
                     QPoint const& fourth)> func,
     ::Qt::ConnectionType type);
-  void emitNewData(::std::int32_t first,
-                   ::std::unique_ptr<Opaque> second,
-                   QPoint third,
-                   QPoint const& fourth);
   ::QMetaObject::Connection newDataConnect(
     ::rust::Fn<void(MyObject&,
                     ::std::int32_t first,

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -41,7 +41,7 @@ mod ffi {
     }
     unsafe extern "C++" {
         #[rust_name = "ready"]
-        fn emitReady(self: Pin<&mut MyObjectQt>);
+        fn ready(self: Pin<&mut MyObjectQt>);
     }
     unsafe extern "C++" {
         #[doc = "Connect the given function pointer to the signal "]
@@ -57,7 +57,7 @@ mod ffi {
     }
     unsafe extern "C++" {
         #[rust_name = "data_changed"]
-        fn emitDataChanged(
+        fn dataChanged(
             self: Pin<&mut MyObjectQt>,
             first: i32,
             second: UniquePtr<Opaque>,
@@ -85,7 +85,7 @@ mod ffi {
     }
     unsafe extern "C++" {
         #[rust_name = "base_class_new_data"]
-        fn emitNewData(
+        fn newData(
             self: Pin<&mut MyObjectQt>,
             first: i32,
             second: UniquePtr<Opaque>,


### PR DESCRIPTION
This is now unused as the type conversion has been removed.

Requires #554 
Requires #571 