### PR TITLE
cxx-qt-gen: use impl cxx_qt::Threading for T {} to make threading opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `QDateTime` API to use `current_date_time` rather than `current_date`
 - Always call `qt_build_utils::setup_linker()` in `CxxQtBuilder` and remove the proxy method
 - Moved to `syn` 2.0 internally and for any exported `syn` types
+- `impl cxx_qt::Threading for qobject::T` now needs to be specified for `qt_thread()` to be available
 
 ### Removed
 

--- a/book/src/qobject/cxxqtthread.md
+++ b/book/src/qobject/cxxqtthread.md
@@ -15,7 +15,13 @@ Therefore they may not be passed between threads nor accessed from multiple thre
 This object is `Send` and can therefore be moved into other threads.
 It allows you to queue events from a different thread to occur on the thread of the `qobject::T` by using the Qt Event Loop.
 
-To access the `CxxQtThread<T>` use the `qt_thread(&self)` method on a [`qobject::T`](./generated-qobject.md).
+First threading needs to be enabled for the [`qobject::T`](./generated-qobject.md) by using `impl cxx_qt::Threading for qobject::T {}`.
+
+```rust,ignore,noplayground
+{{#include ../../../examples/qml_features/rust/src/threading.rs:book_qt_thread}}
+```
+
+Then to access the `CxxQtThread<T>` use the `qt_thread(&self)` method on a [`qobject::T`](./generated-qobject.md).
 
 ```rust,ignore,noplayground
 {{#include ../../../examples/qml_features/rust/src/threading.rs:book_qt_thread}}

--- a/crates/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -9,6 +9,7 @@ pub mod invokable;
 pub mod property;
 pub mod qobject;
 pub mod signal;
+pub mod threading;
 pub mod types;
 
 use crate::parser::Parser;

--- a/crates/cxx-qt-gen/src/generator/cpp/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/threading.rs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::generator::{
+    cpp::{fragment::CppFragment, qobject::GeneratedCppQObjectBlocks},
+    naming::qobject::QObjectName,
+};
+use indoc::formatdoc;
+use syn::Result;
+
+pub fn generate(qobject_idents: &QObjectName) -> Result<GeneratedCppQObjectBlocks> {
+    let mut result = GeneratedCppQObjectBlocks::default();
+
+    let ident = &qobject_idents.cpp_class.cpp;
+    let cxx_qt_thread_ident = &qobject_idents.cxx_qt_thread_class;
+
+    result.forward_declares.push(format!(
+        "using {cxx_qt_thread_ident} = ::rust::cxxqtlib1::CxxQtThread<{ident}>;"
+    ));
+    result.members.push(CppFragment::Pair {
+        header: format!("::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<{ident}>> m_cxxQtThreadObj;"),
+        source: format!(", m_cxxQtThreadObj(::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<{ident}>>(this))"),
+    });
+    result.methods.push(CppFragment::Pair {
+        header: format!("::std::unique_ptr<{cxx_qt_thread_ident}> qtThread() const;"),
+        source: formatdoc! {
+            r#"
+            ::std::unique_ptr<{cxx_qt_thread_ident}>
+            {ident}::qtThread() const
+            {{
+            return ::std::make_unique<{cxx_qt_thread_ident}>(m_cxxQtThreadObj, m_rustObjMutex);
+            }}
+            "#
+        },
+    });
+    result.deconstructors.push(formatdoc! {
+        r#"
+        const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
+        m_cxxQtThreadObj->ptr = nullptr;
+        "#
+    });
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::generator::naming::qobject::tests::create_qobjectname;
+    use indoc::indoc;
+    use pretty_assertions::assert_str_eq;
+
+    #[test]
+    fn test_generate_cpp_threading() {
+        let qobject_idents = create_qobjectname();
+
+        let generated = generate(&qobject_idents).unwrap();
+
+        // forward declares
+        assert_eq!(generated.forward_declares.len(), 1);
+
+        assert_str_eq!(
+            generated.forward_declares[0],
+            "using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;"
+        );
+
+        // members
+        assert_eq!(generated.members.len(), 1);
+
+        let (header, source) = if let CppFragment::Pair { header, source } = &generated.members[0] {
+            (header, source)
+        } else {
+            panic!("Expected pair")
+        };
+        assert_str_eq!(
+            header,
+            "::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>> m_cxxQtThreadObj;"
+        );
+        assert_str_eq!(
+            source,
+            ", m_cxxQtThreadObj(::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(this))"
+        );
+
+        // methods
+        assert_eq!(generated.methods.len(), 1);
+
+        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[0] {
+            (header, source)
+        } else {
+            panic!("Expected pair")
+        };
+        assert_str_eq!(
+            header,
+            "::std::unique_ptr<MyObjectCxxQtThread> qtThread() const;"
+        );
+        assert_str_eq!(
+            source,
+            indoc! {r#"
+            ::std::unique_ptr<MyObjectCxxQtThread>
+            MyObject::qtThread() const
+            {
+            return ::std::make_unique<MyObjectCxxQtThread>(m_cxxQtThreadObj, m_rustObjMutex);
+            }
+            "#}
+        );
+
+        // deconstructors
+        assert_eq!(generated.deconstructors.len(), 1);
+        assert_str_eq!(
+            generated.deconstructors[0],
+            indoc! {r#"
+            const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
+            m_cxxQtThreadObj->ptr = nullptr;
+            "#}
+        );
+    }
+}

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -10,6 +10,7 @@ pub mod invokable;
 pub mod property;
 pub mod qobject;
 pub mod signals;
+pub mod threading;
 pub mod types;
 
 use crate::generator::rust::qobject::GeneratedRustQObject;

--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::generator::{
+    naming::{namespace::NamespaceName, qobject::QObjectName},
+    rust::qobject::GeneratedRustQObjectBlocks,
+};
+use quote::quote;
+use syn::Result;
+
+use super::fragment::RustFragmentPair;
+
+pub fn generate(
+    qobject_ident: &QObjectName,
+    namespace_ident: &NamespaceName,
+) -> Result<GeneratedRustQObjectBlocks> {
+    let mut blocks = GeneratedRustQObjectBlocks::default();
+
+    let cpp_struct_ident = &qobject_ident.cpp_class.rust;
+    let cxx_qt_thread_ident = &qobject_ident.cxx_qt_thread_class;
+    let cxx_qt_thread_queued_fn_ident = &qobject_ident.cxx_qt_thread_queued_fn_struct;
+    let namespace_internals = &namespace_ident.internal;
+
+    let fragment = RustFragmentPair {
+        cxx_bridge: vec![
+            quote! {
+                unsafe extern "C++" {
+                    /// Specialised version of CxxQtThread, which can be moved into other threads.
+                    ///
+                    /// CXX doesn't support having generic types in the function yet
+                    /// so we cannot have CxxQtThread<T> in cxx-qt-lib and then use that here
+                    /// For now we use a type alias in C++ then use it like a normal type here
+                    /// <https://github.com/dtolnay/cxx/issues/683>
+                    type #cxx_qt_thread_ident;
+                    include!("cxx-qt-lib/cxxqt_thread.h");
+
+                    /// Create an instance of a CxxQtThread
+                    ///
+                    /// This allows for queueing closures onto the Qt event loop from a background thread.
+                    #[cxx_name = "qtThread"]
+                    fn qt_thread(self: &#cpp_struct_ident) -> UniquePtr<#cxx_qt_thread_ident>;
+
+                    // SAFETY:
+                    // - Send + 'static: argument closure can be transferred to QObject thread.
+                    // - FnOnce: QMetaObject::invokeMethod() should call the function at most once.
+                    #[doc(hidden)]
+                    #[cxx_name = "queue"]
+                    fn queue_boxed_fn(
+                        self: &#cxx_qt_thread_ident,
+                        func: fn(Pin<&mut #cpp_struct_ident>, Box<#cxx_qt_thread_queued_fn_ident>),
+                        arg: Box<#cxx_qt_thread_queued_fn_ident>,
+                    ) -> Result<()>;
+                }
+            },
+            quote! {
+                extern "Rust" {
+                    #[namespace = #namespace_internals]
+                    type #cxx_qt_thread_queued_fn_ident;
+                }
+            },
+        ],
+        implementation: vec![
+            quote! {
+                unsafe impl Send for #cxx_qt_thread_ident {}
+            },
+            quote! {
+                impl #cxx_qt_thread_ident {
+                    /// Queue the given closure onto the Qt event loop for this QObject
+                    pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
+                    where
+                        F: FnOnce(std::pin::Pin<&mut #cpp_struct_ident>),
+                        F: Send + 'static,
+                    {
+                        // Wrap the given closure and pass in to C++ function as an opaque type
+                        // to work around the cxx limitation.
+                        // https://github.com/dtolnay/cxx/issues/114
+                        #[allow(clippy::boxed_local)]
+                        #[doc(hidden)]
+                        fn func(
+                            obj: std::pin::Pin<&mut #cpp_struct_ident>,
+                            arg: std::boxed::Box<#cxx_qt_thread_queued_fn_ident>,
+                        ) {
+                            (arg.inner)(obj)
+                        }
+                        let arg = #cxx_qt_thread_queued_fn_ident { inner: std::boxed::Box::new(f) };
+                        self.queue_boxed_fn(func, std::boxed::Box::new(arg))
+                    }
+                }
+            },
+            quote! {
+                #[doc(hidden)]
+                pub struct #cxx_qt_thread_queued_fn_ident {
+                    // An opaque Rust type is required to be Sized.
+                    // https://github.com/dtolnay/cxx/issues/665
+                    inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut #cpp_struct_ident>) + Send>,
+                }
+            },
+        ],
+    };
+
+    blocks
+        .cxx_mod_contents
+        .append(&mut fragment.cxx_bridge_as_items()?);
+    blocks
+        .cxx_qt_mod_contents
+        .append(&mut fragment.implementation_as_items()?);
+
+    Ok(blocks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::tests::assert_tokens_eq;
+
+    use crate::parser::qobject::tests::create_parsed_qobject;
+
+    #[test]
+    fn test_generate_rust_threading() {
+        let qobject = create_parsed_qobject();
+        let qobject_idents = QObjectName::from(&qobject);
+        let namespace_ident = NamespaceName::from(&qobject);
+
+        let generated = generate(&qobject_idents, &namespace_ident).unwrap();
+
+        assert_eq!(generated.cxx_mod_contents.len(), 2);
+        assert_eq!(generated.cxx_qt_mod_contents.len(), 3);
+
+        // CXX bridges
+
+        assert_tokens_eq(
+            &generated.cxx_mod_contents[0],
+            quote! {
+                unsafe extern "C++" {
+                    /// Specialised version of CxxQtThread, which can be moved into other threads.
+                    ///
+                    /// CXX doesn't support having generic types in the function yet
+                    /// so we cannot have CxxQtThread<T> in cxx-qt-lib and then use that here
+                    /// For now we use a type alias in C++ then use it like a normal type here
+                    /// <https://github.com/dtolnay/cxx/issues/683>
+                    type MyObjectCxxQtThread;
+                    include!("cxx-qt-lib/cxxqt_thread.h");
+
+                    /// Create an instance of a CxxQtThread
+                    ///
+                    /// This allows for queueing closures onto the Qt event loop from a background thread.
+                    #[cxx_name = "qtThread"]
+                    fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
+
+                    // SAFETY:
+                    // - Send + 'static: argument closure can be transferred to QObject thread.
+                    // - FnOnce: QMetaObject::invokeMethod() should call the function at most once.
+                    #[doc(hidden)]
+                    #[cxx_name = "queue"]
+                    fn queue_boxed_fn(
+                        self: &MyObjectCxxQtThread,
+                        func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
+                        arg: Box<MyObjectCxxQtThreadQueuedFn>,
+                    ) -> Result<()>;
+                }
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_mod_contents[1],
+            quote! {
+                extern "Rust" {
+                    #[namespace = "cxx_qt_my_object"]
+                    type MyObjectCxxQtThreadQueuedFn;
+                }
+            },
+        );
+
+        // CXX-Qt generated contents
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[0],
+            quote! {
+                unsafe impl Send for MyObjectCxxQtThread {}
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[1],
+            quote! {
+                impl MyObjectCxxQtThread {
+                    /// Queue the given closure onto the Qt event loop for this QObject
+                    pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
+                    where
+                        F: FnOnce(std::pin::Pin<&mut MyObjectQt>),
+                        F: Send + 'static,
+                    {
+                        // Wrap the given closure and pass in to C++ function as an opaque type
+                        // to work around the cxx limitation.
+                        // https://github.com/dtolnay/cxx/issues/114
+                        #[allow(clippy::boxed_local)]
+                        #[doc(hidden)]
+                        fn func(
+                            obj: std::pin::Pin<&mut MyObjectQt>,
+                            arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
+                        ) {
+                            (arg.inner)(obj)
+                        }
+                        let arg = MyObjectCxxQtThreadQueuedFn { inner: std::boxed::Box::new(f) };
+                        self.queue_boxed_fn(func, std::boxed::Box::new(arg))
+                    }
+                }
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[2],
+            quote! {
+                #[doc(hidden)]
+                pub struct MyObjectCxxQtThreadQueuedFn {
+                    // An opaque Rust type is required to be Sized.
+                    // https://github.com/dtolnay/cxx/issues/665
+                    inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
+                }
+            },
+        );
+    }
+}

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -57,10 +57,12 @@ mod tests {
                 GeneratedCppQObject {
                     ident: "MyObject".to_owned(),
                     rust_ident: "MyObjectRust".to_owned(),
-                    cxx_qt_thread_ident: "MyObjectCxxQtThread".to_owned(),
                     namespace_internals: "cxx_qt::my_object::cxx_qt_my_object".to_owned(),
                     base_class: "QStringListModel".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
+                        deconstructors: vec![],
+                        forward_declares: vec![],
+                        members: vec![],
                         metaobjects: vec![
                             "Q_PROPERTY(int count READ count WRITE setCount NOTIFY countChanged)".to_owned(),
                             "Q_PROPERTY(bool longPropertyNameThatWrapsInClangFormat READ getToggle WRITE setToggle NOTIFY toggleChanged)"
@@ -155,10 +157,12 @@ mod tests {
                 GeneratedCppQObject {
                     ident: "FirstObject".to_owned(),
                     rust_ident: "FirstObjectRust".to_owned(),
-                    cxx_qt_thread_ident: "FirstObjectCxxQtThread".to_owned(),
                     namespace_internals: "cxx_qt::cxx_qt_first_object".to_owned(),
                     base_class: "QStringListModel".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
+                        deconstructors: vec![],
+                        forward_declares: vec![],
+                        members: vec![],
                         metaobjects: vec![
                             "Q_PROPERTY(int longPropertyNameThatWrapsInClangFormat READ count WRITE setCount NOTIFY countChanged)"
                                 .to_owned(),
@@ -192,10 +196,12 @@ mod tests {
                 GeneratedCppQObject {
                     ident: "SecondObject".to_owned(),
                     rust_ident: "SecondObjectRust".to_owned(),
-                    cxx_qt_thread_ident: "SecondObjectCxxQtThread".to_owned(),
                     namespace_internals: "cxx_qt::cxx_qt_second_object".to_owned(),
                     base_class: "QStringListModel".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
+                        deconstructors: vec![],
+                        forward_declares: vec![],
+                        members: vec![],
                         metaobjects: vec![
                             "Q_PROPERTY(int count READ count WRITE setCount NOTIFY countChanged)"
                                 .to_owned(),
@@ -253,7 +259,7 @@ mod tests {
 
         namespace cxx_qt::my_object {
         class MyObject;
-        using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;
+
         } // namespace cxx_qt::my_object
 
         #include "cxx-qt-gen/cxx_file_stem.cxx.h"
@@ -270,7 +276,6 @@ mod tests {
           ~MyObject();
           MyObjectRust const& unsafeRust() const;
           MyObjectRust& unsafeRustMut();
-          ::std::unique_ptr<MyObjectCxxQtThread> qtThread() const;
 
         public:
           int count() const;
@@ -285,7 +290,6 @@ mod tests {
         private:
           ::rust::Box<MyObjectRust> m_rustObj;
           ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
-          ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>> m_cxxQtThreadObj;
         };
 
         static_assert(::std::is_base_of<QObject, MyObject>::value, "MyObject must inherit from QObject");
@@ -316,12 +320,12 @@ mod tests {
 
         namespace cxx_qt {
         class FirstObject;
-        using FirstObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<FirstObject>;
+
         } // namespace cxx_qt
 
         namespace cxx_qt {
         class SecondObject;
-        using SecondObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<SecondObject>;
+
         } // namespace cxx_qt
 
         #include "cxx-qt-gen/cxx_file_stem.cxx.h"
@@ -337,7 +341,6 @@ mod tests {
           ~FirstObject();
           FirstObjectRust const& unsafeRust() const;
           FirstObjectRust& unsafeRustMut();
-          ::std::unique_ptr<FirstObjectCxxQtThread> qtThread() const;
 
         public:
           int count() const;
@@ -347,7 +350,6 @@ mod tests {
         private:
           ::rust::Box<FirstObjectRust> m_rustObj;
           ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
-          ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<FirstObject>> m_cxxQtThreadObj;
         };
 
         static_assert(::std::is_base_of<QObject, FirstObject>::value, "FirstObject must inherit from QObject");
@@ -371,7 +373,6 @@ mod tests {
           ~SecondObject();
           SecondObjectRust const& unsafeRust() const;
           SecondObjectRust& unsafeRustMut();
-          ::std::unique_ptr<SecondObjectCxxQtThread> qtThread() const;
 
         public:
           int count() const;
@@ -381,7 +382,6 @@ mod tests {
         private:
           ::rust::Box<SecondObjectRust> m_rustObj;
           ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
-          ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<SecondObject>> m_cxxQtThreadObj;
         };
 
         static_assert(::std::is_base_of<QObject, SecondObject>::value, "SecondObject must inherit from QObject");
@@ -412,7 +412,7 @@ mod tests {
 
 
         class MyObject;
-        using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;
+
 
 
         #include "cxx-qt-gen/cxx_file_stem.cxx.h"
@@ -429,7 +429,6 @@ mod tests {
           ~MyObject();
           MyObjectRust const& unsafeRust() const;
           MyObjectRust& unsafeRustMut();
-          ::std::unique_ptr<MyObjectCxxQtThread> qtThread() const;
 
         public:
           int count() const;
@@ -444,7 +443,6 @@ mod tests {
         private:
           ::rust::Box<MyObjectRust> m_rustObj;
           ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
-          ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>> m_cxxQtThreadObj;
         };
 
         static_assert(::std::is_base_of<QObject, MyObject>::value, "MyObject must inherit from QObject");
@@ -471,14 +469,12 @@ mod tests {
           : QStringListModel(parent)
           , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
           , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
-          , m_cxxQtThreadObj(::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(this))
         {
         }
 
         MyObject::~MyObject()
         {
-          const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
-          m_cxxQtThreadObj->ptr = nullptr;
+
         }
 
         MyObjectRust const&
@@ -491,12 +487,6 @@ mod tests {
         MyObject::unsafeRustMut()
         {
           return *m_rustObj;
-        }
-
-        ::std::unique_ptr<MyObjectCxxQtThread>
-        MyObject::qtThread() const
-        {
-          return ::std::make_unique<MyObjectCxxQtThread>(m_cxxQtThreadObj, m_rustObjMutex);
         }
 
         int
@@ -559,14 +549,12 @@ mod tests {
           : QStringListModel(parent)
           , m_rustObj(cxx_qt::cxx_qt_first_object::createRs())
           , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
-          , m_cxxQtThreadObj(::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<FirstObject>>(this))
         {
         }
 
         FirstObject::~FirstObject()
         {
-          const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
-          m_cxxQtThreadObj->ptr = nullptr;
+
         }
 
         FirstObjectRust const&
@@ -579,12 +567,6 @@ mod tests {
         FirstObject::unsafeRustMut()
         {
           return *m_rustObj;
-        }
-
-        ::std::unique_ptr<FirstObjectCxxQtThread>
-        FirstObject::qtThread() const
-        {
-          return ::std::make_unique<FirstObjectCxxQtThread>(m_cxxQtThreadObj, m_rustObjMutex);
         }
 
         int
@@ -615,14 +597,12 @@ mod tests {
           : QStringListModel(parent)
           , m_rustObj(cxx_qt::cxx_qt_second_object::createRs())
           , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
-          , m_cxxQtThreadObj(::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<SecondObject>>(this))
         {
         }
 
         SecondObject::~SecondObject()
         {
-          const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
-          m_cxxQtThreadObj->ptr = nullptr;
+
         }
 
         SecondObjectRust const&
@@ -635,12 +615,6 @@ mod tests {
         SecondObject::unsafeRustMut()
         {
           return *m_rustObj;
-        }
-
-        ::std::unique_ptr<SecondObjectCxxQtThread>
-        SecondObject::qtThread() const
-        {
-          return ::std::make_unique<SecondObjectCxxQtThread>(m_cxxQtThreadObj, m_rustObjMutex);
         }
 
         int
@@ -679,14 +653,12 @@ mod tests {
           : QStringListModel(parent)
           , m_rustObj(cxx_qt_my_object::createRs())
           , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
-          , m_cxxQtThreadObj(::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(this))
         {
         }
 
         MyObject::~MyObject()
         {
-          const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
-          m_cxxQtThreadObj->ptr = nullptr;
+
         }
 
         MyObjectRust const&
@@ -699,12 +671,6 @@ mod tests {
         MyObject::unsafeRustMut()
         {
           return *m_rustObj;
-        }
-
-        ::std::unique_ptr<MyObjectCxxQtThread>
-        MyObject::qtThread() const
-        {
-          return ::std::make_unique<MyObjectCxxQtThread>(m_cxxQtThreadObj, m_rustObjMutex);
         }
 
         int

--- a/crates/cxx-qt-gen/test_inputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_inputs/invokables.rs
@@ -76,4 +76,6 @@ mod ffi {
             println!("QML or C++ can't call this :)");
         }
     }
+
+    impl cxx_qt::Threading for qobject::MyObject {}
 }

--- a/crates/cxx-qt-gen/test_outputs/inheritance.cpp
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.cpp
@@ -4,17 +4,10 @@ MyObject::MyObject(QObject* parent)
   : QAbstractItemModel(parent)
   , m_rustObj(cxx_qt_my_object::createRs())
   , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
-  , m_cxxQtThreadObj(
-      ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(
-        this))
 {
 }
 
-MyObject::~MyObject()
-{
-  const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
-  m_cxxQtThreadObj->ptr = nullptr;
-}
+MyObject::~MyObject() {}
 
 MyObjectRust const&
 MyObject::unsafeRust() const
@@ -26,13 +19,6 @@ MyObjectRust&
 MyObject::unsafeRustMut()
 {
   return *m_rustObj;
-}
-
-::std::unique_ptr<MyObjectCxxQtThread>
-MyObject::qtThread() const
-{
-  return ::std::make_unique<MyObjectCxxQtThread>(m_cxxQtThreadObj,
-                                                 m_rustObjMutex);
 }
 
 QVariant

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -9,7 +9,6 @@ class CxxQtThread;
 }
 
 class MyObject;
-using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;
 
 #include "cxx-qt-gen/inheritance.cxx.h"
 
@@ -22,7 +21,6 @@ public:
   ~MyObject();
   MyObjectRust const& unsafeRust() const;
   MyObjectRust& unsafeRustMut();
-  ::std::unique_ptr<MyObjectCxxQtThread> qtThread() const;
 
 public:
   Q_INVOKABLE QVariant data(QModelIndex const& _index,
@@ -42,8 +40,6 @@ public:
 private:
   ::rust::Box<MyObjectRust> m_rustObj;
   ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
-  ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
-    m_cxxQtThreadObj;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -8,7 +8,6 @@ mod inheritance {
     }
     unsafe extern "C++" {
         include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/cxxqt_thread.h");
         include!("cxx-qt-lib/qt.h");
         #[doc(hidden)]
         #[namespace = "Qt"]
@@ -65,28 +64,9 @@ mod inheritance {
         unsafe fn fetch_more(self: Pin<&mut MyObjectQt>, index: &QModelIndex);
     }
     unsafe extern "C++" {
-        #[doc = r" Specialised version of CxxQtThread, which can be moved into other threads."]
-        #[doc = r""]
-        #[doc = r" CXX doesn't support having generic types in the function yet"]
-        #[doc = r" so we cannot have CxxQtThread<T> in cxx-qt-lib and then use that here"]
-        #[doc = r" For now we use a type alias in C++ then use it like a normal type here"]
-        #[doc = r" <https://github.com/dtolnay/cxx/issues/683>"]
-        type MyObjectCxxQtThread;
         #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
-        #[doc = r" Create an instance of a CxxQtThread"]
-        #[doc = r""]
-        #[doc = r" This allows for queueing closures onto the Qt event loop from a background thread."]
-        #[cxx_name = "qtThread"]
-        fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
-        #[doc(hidden)]
-        #[cxx_name = "queue"]
-        fn queue_boxed_fn(
-            self: &MyObjectCxxQtThread,
-            func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
-            arg: Box<MyObjectCxxQtThreadQueuedFn>,
-        ) -> Result<()>;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -103,8 +83,6 @@ mod inheritance {
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
     extern "Rust" {
-        #[namespace = "cxx_qt_my_object"]
-        type MyObjectCxxQtThreadQueuedFn;
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
@@ -167,32 +145,6 @@ mod cxx_qt_inheritance {
         pub fn has_children(&self, _parent: &QModelIndex) -> bool {
             false
         }
-    }
-    unsafe impl Send for MyObjectCxxQtThread {}
-    impl MyObjectCxxQtThread {
-        #[doc = r" Queue the given closure onto the Qt event loop for this QObject"]
-        pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
-        where
-            F: FnOnce(std::pin::Pin<&mut MyObjectQt>),
-            F: Send + 'static,
-        {
-            #[allow(clippy::boxed_local)]
-            #[doc(hidden)]
-            fn func(
-                obj: std::pin::Pin<&mut MyObjectQt>,
-                arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
-            ) {
-                (arg.inner)(obj)
-            }
-            let arg = MyObjectCxxQtThreadQueuedFn {
-                inner: std::boxed::Box::new(f),
-            };
-            self.queue_boxed_fn(func, std::boxed::Box::new(arg))
-        }
-    }
-    #[doc(hidden)]
-    pub struct MyObjectCxxQtThreadQueuedFn {
-        inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
     }
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -30,13 +30,6 @@ MyObject::unsafeRustMut()
   return *m_rustObj;
 }
 
-::std::unique_ptr<MyObjectCxxQtThread>
-MyObject::qtThread() const
-{
-  return ::std::make_unique<MyObjectCxxQtThread>(m_cxxQtThreadObj,
-                                                 m_rustObjMutex);
-}
-
 void
 MyObject::invokable() const
 {
@@ -93,6 +86,13 @@ MyObject::invokableVirtual() const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
   m_rustObj->invokableVirtualWrapper(*this);
+}
+
+::std::unique_ptr<MyObjectCxxQtThread>
+MyObject::qtThread() const
+{
+  return ::std::make_unique<MyObjectCxxQtThread>(m_cxxQtThreadObj,
+                                                 m_rustObjMutex);
 }
 
 } // namespace cxx_qt::my_object

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -25,7 +25,6 @@ public:
   ~MyObject();
   MyObjectRust const& unsafeRust() const;
   MyObjectRust& unsafeRustMut();
-  ::std::unique_ptr<MyObjectCxxQtThread> qtThread() const;
 
 public:
   Q_INVOKABLE void invokable() const;
@@ -38,6 +37,7 @@ public:
   Q_INVOKABLE void invokableFinal() const final;
   Q_INVOKABLE void invokableOverride() const override;
   Q_INVOKABLE virtual void invokableVirtual() const;
+  ::std::unique_ptr<MyObjectCxxQtThread> qtThread() const;
 
 private:
   ::rust::Box<MyObjectRust> m_rustObj;

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -9,7 +9,6 @@ mod ffi {
     }
     unsafe extern "C++" {
         include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/cxxqt_thread.h");
         include!("cxx-qt-lib/qt.h");
         #[doc(hidden)]
         #[namespace = "Qt"]
@@ -90,9 +89,7 @@ mod ffi {
         #[doc = r" For now we use a type alias in C++ then use it like a normal type here"]
         #[doc = r" <https://github.com/dtolnay/cxx/issues/683>"]
         type MyObjectCxxQtThread;
-        #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
-        #[cxx_name = "unsafeRust"]
-        fn rust(self: &MyObjectQt) -> &MyObject;
+        include!("cxx-qt-lib/cxxqt_thread.h");
         #[doc = r" Create an instance of a CxxQtThread"]
         #[doc = r""]
         #[doc = r" This allows for queueing closures onto the Qt event loop from a background thread."]
@@ -105,6 +102,15 @@ mod ffi {
             func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
             arg: Box<MyObjectCxxQtThreadQueuedFn>,
         ) -> Result<()>;
+    }
+    extern "Rust" {
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        type MyObjectCxxQtThreadQueuedFn;
+    }
+    unsafe extern "C++" {
+        #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
+        #[cxx_name = "unsafeRust"]
+        fn rust(self: &MyObjectQt) -> &MyObject;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -121,8 +127,6 @@ mod ffi {
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
     extern "Rust" {
-        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        type MyObjectCxxQtThreadQueuedFn;
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -6,17 +6,10 @@ MyObject::MyObject(QObject* parent)
   : QStringListModel(parent)
   , m_rustObj(cxx_qt::multi_object::cxx_qt_my_object::createRs())
   , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
-  , m_cxxQtThreadObj(
-      ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(
-        this))
 {
 }
 
-MyObject::~MyObject()
-{
-  const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
-  m_cxxQtThreadObj->ptr = nullptr;
-}
+MyObject::~MyObject() {}
 
 MyObjectRust const&
 MyObject::unsafeRust() const
@@ -28,13 +21,6 @@ MyObjectRust&
 MyObject::unsafeRustMut()
 {
   return *m_rustObj;
-}
-
-::std::unique_ptr<MyObjectCxxQtThread>
-MyObject::qtThread() const
-{
-  return ::std::make_unique<MyObjectCxxQtThread>(m_cxxQtThreadObj,
-                                                 m_rustObjMutex);
 }
 
 ::std::int32_t const&
@@ -95,17 +81,10 @@ SecondObject::SecondObject(QObject* parent)
   : QObject(parent)
   , m_rustObj(cxx_qt::multi_object::cxx_qt_second_object::createRs())
   , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
-  , m_cxxQtThreadObj(
-      ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<SecondObject>>(
-        this))
 {
 }
 
-SecondObject::~SecondObject()
-{
-  const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
-  m_cxxQtThreadObj->ptr = nullptr;
-}
+SecondObject::~SecondObject() {}
 
 SecondObjectRust const&
 SecondObject::unsafeRust() const
@@ -117,13 +96,6 @@ SecondObjectRust&
 SecondObject::unsafeRustMut()
 {
   return *m_rustObj;
-}
-
-::std::unique_ptr<SecondObjectCxxQtThread>
-SecondObject::qtThread() const
-{
-  return ::std::make_unique<SecondObjectCxxQtThread>(m_cxxQtThreadObj,
-                                                     m_rustObjMutex);
 }
 
 ::std::int32_t const&

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -10,12 +10,12 @@ class CxxQtThread;
 
 namespace cxx_qt::multi_object {
 class MyObject;
-using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;
+
 } // namespace cxx_qt::multi_object
 
 namespace cxx_qt::multi_object {
 class SecondObject;
-using SecondObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<SecondObject>;
+
 } // namespace cxx_qt::multi_object
 
 #include "cxx-qt-gen/multi_object.cxx.h"
@@ -32,7 +32,6 @@ public:
   ~MyObject();
   MyObjectRust const& unsafeRust() const;
   MyObjectRust& unsafeRustMut();
-  ::std::unique_ptr<MyObjectCxxQtThread> qtThread() const;
 
 public:
   ::std::int32_t const& getPropertyName() const;
@@ -47,8 +46,6 @@ public:
 private:
   ::rust::Box<MyObjectRust> m_rustObj;
   ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
-  ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
-    m_cxxQtThreadObj;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,
@@ -74,7 +71,6 @@ public:
   ~SecondObject();
   SecondObjectRust const& unsafeRust() const;
   SecondObjectRust& unsafeRustMut();
-  ::std::unique_ptr<SecondObjectCxxQtThread> qtThread() const;
 
 public:
   ::std::int32_t const& getPropertyName() const;
@@ -89,8 +85,6 @@ public:
 private:
   ::rust::Box<SecondObjectRust> m_rustObj;
   ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
-  ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<SecondObject>>
-    m_cxxQtThreadObj;
 };
 
 static_assert(::std::is_base_of<QObject, SecondObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -46,7 +46,6 @@ pub mod ffi {
     }
     unsafe extern "C++" {
         include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/cxxqt_thread.h");
         include!("cxx-qt-lib/qt.h");
         #[doc(hidden)]
         #[namespace = "Qt"]
@@ -115,28 +114,9 @@ pub mod ffi {
         ) -> CxxQtQMetaObjectConnection;
     }
     unsafe extern "C++" {
-        #[doc = r" Specialised version of CxxQtThread, which can be moved into other threads."]
-        #[doc = r""]
-        #[doc = r" CXX doesn't support having generic types in the function yet"]
-        #[doc = r" so we cannot have CxxQtThread<T> in cxx-qt-lib and then use that here"]
-        #[doc = r" For now we use a type alias in C++ then use it like a normal type here"]
-        #[doc = r" <https://github.com/dtolnay/cxx/issues/683>"]
-        type MyObjectCxxQtThread;
         #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
-        #[doc = r" Create an instance of a CxxQtThread"]
-        #[doc = r""]
-        #[doc = r" This allows for queueing closures onto the Qt event loop from a background thread."]
-        #[cxx_name = "qtThread"]
-        fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
-        #[doc(hidden)]
-        #[cxx_name = "queue"]
-        fn queue_boxed_fn(
-            self: &MyObjectCxxQtThread,
-            func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
-            arg: Box<MyObjectCxxQtThreadQueuedFn>,
-        ) -> Result<()>;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -153,8 +133,6 @@ pub mod ffi {
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
     extern "Rust" {
-        #[namespace = "cxx_qt::multi_object::cxx_qt_my_object"]
-        type MyObjectCxxQtThreadQueuedFn;
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::multi_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
@@ -213,28 +191,9 @@ pub mod ffi {
         ) -> CxxQtQMetaObjectConnection;
     }
     unsafe extern "C++" {
-        #[doc = r" Specialised version of CxxQtThread, which can be moved into other threads."]
-        #[doc = r""]
-        #[doc = r" CXX doesn't support having generic types in the function yet"]
-        #[doc = r" so we cannot have CxxQtThread<T> in cxx-qt-lib and then use that here"]
-        #[doc = r" For now we use a type alias in C++ then use it like a normal type here"]
-        #[doc = r" <https://github.com/dtolnay/cxx/issues/683>"]
-        type SecondObjectCxxQtThread;
         #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
         fn rust(self: &SecondObjectQt) -> &SecondObject;
-        #[doc = r" Create an instance of a CxxQtThread"]
-        #[doc = r""]
-        #[doc = r" This allows for queueing closures onto the Qt event loop from a background thread."]
-        #[cxx_name = "qtThread"]
-        fn qt_thread(self: &SecondObjectQt) -> UniquePtr<SecondObjectCxxQtThread>;
-        #[doc(hidden)]
-        #[cxx_name = "queue"]
-        fn queue_boxed_fn(
-            self: &SecondObjectCxxQtThread,
-            func: fn(Pin<&mut SecondObjectQt>, Box<SecondObjectCxxQtThreadQueuedFn>),
-            arg: Box<SecondObjectCxxQtThreadQueuedFn>,
-        ) -> Result<()>;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "SecondObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -251,8 +210,6 @@ pub mod ffi {
         unsafe fn rust_mut(self: Pin<&mut SecondObjectQt>) -> Pin<&mut SecondObject>;
     }
     extern "Rust" {
-        #[namespace = "cxx_qt::multi_object::cxx_qt_second_object"]
-        type SecondObjectCxxQtThreadQueuedFn;
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::multi_object::cxx_qt_second_object"]
         fn create_rs_second_object() -> Box<SecondObject>;
@@ -379,32 +336,6 @@ mod cxx_qt_ffi {
             }
         }
     }
-    unsafe impl Send for MyObjectCxxQtThread {}
-    impl MyObjectCxxQtThread {
-        #[doc = r" Queue the given closure onto the Qt event loop for this QObject"]
-        pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
-        where
-            F: FnOnce(std::pin::Pin<&mut MyObjectQt>),
-            F: Send + 'static,
-        {
-            #[allow(clippy::boxed_local)]
-            #[doc(hidden)]
-            fn func(
-                obj: std::pin::Pin<&mut MyObjectQt>,
-                arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
-            ) {
-                (arg.inner)(obj)
-            }
-            let arg = MyObjectCxxQtThreadQueuedFn {
-                inner: std::boxed::Box::new(f),
-            };
-            self.queue_boxed_fn(func, std::boxed::Box::new(arg))
-        }
-    }
-    #[doc(hidden)]
-    pub struct MyObjectCxxQtThreadQueuedFn {
-        inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
-    }
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {
         std::default::Default::default()
@@ -500,32 +431,6 @@ mod cxx_qt_ffi {
                 SecondSignals::Ready {} => self.emit_ready(),
             }
         }
-    }
-    unsafe impl Send for SecondObjectCxxQtThread {}
-    impl SecondObjectCxxQtThread {
-        #[doc = r" Queue the given closure onto the Qt event loop for this QObject"]
-        pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
-        where
-            F: FnOnce(std::pin::Pin<&mut SecondObjectQt>),
-            F: Send + 'static,
-        {
-            #[allow(clippy::boxed_local)]
-            #[doc(hidden)]
-            fn func(
-                obj: std::pin::Pin<&mut SecondObjectQt>,
-                arg: std::boxed::Box<SecondObjectCxxQtThreadQueuedFn>,
-            ) {
-                (arg.inner)(obj)
-            }
-            let arg = SecondObjectCxxQtThreadQueuedFn {
-                inner: std::boxed::Box::new(f),
-            };
-            self.queue_boxed_fn(func, std::boxed::Box::new(arg))
-        }
-    }
-    #[doc(hidden)]
-    pub struct SecondObjectCxxQtThreadQueuedFn {
-        inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut SecondObjectQt>) + Send>,
     }
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_second_object() -> std::boxed::Box<SecondObject> {

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -6,17 +6,10 @@ MyObject::MyObject(QObject* parent)
   : QObject(parent)
   , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
   , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
-  , m_cxxQtThreadObj(
-      ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(
-        this))
 {
 }
 
-MyObject::~MyObject()
-{
-  const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
-  m_cxxQtThreadObj->ptr = nullptr;
-}
+MyObject::~MyObject() {}
 
 MyObjectRust const&
 MyObject::unsafeRust() const
@@ -28,13 +21,6 @@ MyObjectRust&
 MyObject::unsafeRustMut()
 {
   return *m_rustObj;
-}
-
-::std::unique_ptr<MyObjectCxxQtThread>
-MyObject::qtThread() const
-{
-  return ::std::make_unique<MyObjectCxxQtThread>(m_cxxQtThreadObj,
-                                                 m_rustObjMutex);
 }
 
 ::std::int32_t const&

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -10,7 +10,7 @@ class CxxQtThread;
 
 namespace cxx_qt::my_object {
 class MyObject;
-using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;
+
 } // namespace cxx_qt::my_object
 
 #include "cxx-qt-gen/ffi.cxx.h"
@@ -29,7 +29,6 @@ public:
   ~MyObject();
   MyObjectRust const& unsafeRust() const;
   MyObjectRust& unsafeRustMut();
-  ::std::unique_ptr<MyObjectCxxQtThread> qtThread() const;
 
 public:
   ::std::int32_t const& getPrimitive() const;
@@ -42,8 +41,6 @@ public:
 private:
   ::rust::Box<MyObjectRust> m_rustObj;
   ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
-  ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
-    m_cxxQtThreadObj;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -6,17 +6,10 @@ MyObject::MyObject(QObject* parent)
   : QObject(parent)
   , m_rustObj(cxx_qt::my_object::cxx_qt_my_object::createRs())
   , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
-  , m_cxxQtThreadObj(
-      ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(
-        this))
 {
 }
 
-MyObject::~MyObject()
-{
-  const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
-  m_cxxQtThreadObj->ptr = nullptr;
-}
+MyObject::~MyObject() {}
 
 MyObjectRust const&
 MyObject::unsafeRust() const
@@ -28,13 +21,6 @@ MyObjectRust&
 MyObject::unsafeRustMut()
 {
   return *m_rustObj;
-}
-
-::std::unique_ptr<MyObjectCxxQtThread>
-MyObject::qtThread() const
-{
-  return ::std::make_unique<MyObjectCxxQtThread>(m_cxxQtThreadObj,
-                                                 m_rustObjMutex);
 }
 
 void

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -10,7 +10,7 @@ class CxxQtThread;
 
 namespace cxx_qt::my_object {
 class MyObject;
-using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;
+
 } // namespace cxx_qt::my_object
 
 #include "cxx-qt-gen/ffi.cxx.h"
@@ -25,7 +25,6 @@ public:
   ~MyObject();
   MyObjectRust const& unsafeRust() const;
   MyObjectRust& unsafeRustMut();
-  ::std::unique_ptr<MyObjectCxxQtThread> qtThread() const;
 
 public:
   Q_INVOKABLE void invokable();
@@ -63,8 +62,6 @@ public:
 private:
   ::rust::Box<MyObjectRust> m_rustObj;
   ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
-  ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
-    m_cxxQtThreadObj;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -7,7 +7,6 @@ mod ffi {
     }
     unsafe extern "C++" {
         include ! (< QtCore / QObject >);
-        include!("cxx-qt-lib/cxxqt_thread.h");
         include!("cxx-qt-lib/qt.h");
         #[doc(hidden)]
         #[namespace = "Qt"]
@@ -116,28 +115,9 @@ mod ffi {
         ) -> CxxQtQMetaObjectConnection;
     }
     unsafe extern "C++" {
-        #[doc = r" Specialised version of CxxQtThread, which can be moved into other threads."]
-        #[doc = r""]
-        #[doc = r" CXX doesn't support having generic types in the function yet"]
-        #[doc = r" so we cannot have CxxQtThread<T> in cxx-qt-lib and then use that here"]
-        #[doc = r" For now we use a type alias in C++ then use it like a normal type here"]
-        #[doc = r" <https://github.com/dtolnay/cxx/issues/683>"]
-        type MyObjectCxxQtThread;
         #[doc = r" Retrieve an immutable reference to the Rust struct backing this C++ object"]
         #[cxx_name = "unsafeRust"]
         fn rust(self: &MyObjectQt) -> &MyObject;
-        #[doc = r" Create an instance of a CxxQtThread"]
-        #[doc = r""]
-        #[doc = r" This allows for queueing closures onto the Qt event loop from a background thread."]
-        #[cxx_name = "qtThread"]
-        fn qt_thread(self: &MyObjectQt) -> UniquePtr<MyObjectCxxQtThread>;
-        #[doc(hidden)]
-        #[cxx_name = "queue"]
-        fn queue_boxed_fn(
-            self: &MyObjectCxxQtThread,
-            func: fn(Pin<&mut MyObjectQt>, Box<MyObjectCxxQtThreadQueuedFn>),
-            arg: Box<MyObjectCxxQtThreadQueuedFn>,
-        ) -> Result<()>;
         #[doc = "Generated CXX-Qt method which creates a new"]
         #[doc = "MyObjectQt"]
         #[doc = "as a UniquePtr with no parent in Qt"]
@@ -154,8 +134,6 @@ mod ffi {
         unsafe fn rust_mut(self: Pin<&mut MyObjectQt>) -> Pin<&mut MyObject>;
     }
     extern "Rust" {
-        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        type MyObjectCxxQtThreadQueuedFn;
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs_my_object() -> Box<MyObject>;
@@ -282,32 +260,6 @@ mod cxx_qt_ffi {
                 } => self.emit_base_class_new_data(first, second, third, fourth),
             }
         }
-    }
-    unsafe impl Send for MyObjectCxxQtThread {}
-    impl MyObjectCxxQtThread {
-        #[doc = r" Queue the given closure onto the Qt event loop for this QObject"]
-        pub fn queue<F>(&self, f: F) -> std::result::Result<(), cxx::Exception>
-        where
-            F: FnOnce(std::pin::Pin<&mut MyObjectQt>),
-            F: Send + 'static,
-        {
-            #[allow(clippy::boxed_local)]
-            #[doc(hidden)]
-            fn func(
-                obj: std::pin::Pin<&mut MyObjectQt>,
-                arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
-            ) {
-                (arg.inner)(obj)
-            }
-            let arg = MyObjectCxxQtThreadQueuedFn {
-                inner: std::boxed::Box::new(f),
-            };
-            self.queue_boxed_fn(func, std::boxed::Box::new(arg))
-        }
-    }
-    #[doc(hidden)]
-    pub struct MyObjectCxxQtThreadQueuedFn {
-        inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObjectQt>) + Send>,
     }
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_my_object() -> std::boxed::Box<MyObject> {

--- a/examples/demo_threading/rust/src/lib.rs
+++ b/examples/demo_threading/rust/src/lib.rs
@@ -67,6 +67,9 @@ mod ffi {
         }
     }
 
+    // Enabling threading on the qobject
+    impl cxx_qt::Threading for qobject::EnergyUsage {}
+
     /// Define Q_SIGNALS that are created on the QObject
     #[cxx_qt::qsignals(EnergyUsage)]
     #[allow(clippy::enum_variant_names)]

--- a/examples/qml_features/rust/src/custom_base_class.rs
+++ b/examples/qml_features/rust/src/custom_base_class.rs
@@ -47,6 +47,9 @@ pub mod ffi {
     }
     // ANCHOR_END: book_inherit_qalm
 
+    // Enabling threading on the qobject
+    impl cxx_qt::Threading for qobject::CustomBaseClass {}
+
     /// The signals for our QAbstractListModel struct
     // ANCHOR: book_qsignals_inherit
     #[cxx_qt::qsignals(CustomBaseClass)]

--- a/examples/qml_features/rust/src/multiple_qobjects.rs
+++ b/examples/qml_features/rust/src/multiple_qobjects.rs
@@ -35,6 +35,9 @@ pub mod ffi {
         }
     }
 
+    // Enabling threading on the qobject
+    impl cxx_qt::Threading for qobject::FirstObject {}
+
     /// Signals for the first QObject
     #[cxx_qt::qsignals(FirstObject)]
     pub enum FirstSignals {
@@ -78,6 +81,9 @@ pub mod ffi {
             }
         }
     }
+
+    // Enabling threading on the qobject
+    impl cxx_qt::Threading for qobject::SecondObject {}
 
     /// Signals for the second QObject
     #[cxx_qt::qsignals(SecondObject)]

--- a/examples/qml_features/rust/src/threading.rs
+++ b/examples/qml_features/rust/src/threading.rs
@@ -45,6 +45,11 @@ pub mod ffi {
         }
     }
 
+    // ANCHOR: book_threading_trait
+    // Enabling threading on the qobject
+    impl cxx_qt::Threading for qobject::ThreadingWebsite {}
+    // ANCHOR_END: book_threading_trait
+
     impl qobject::ThreadingWebsite {
         /// Swap the URL between kdab.com and github.com
         #[qinvokable]

--- a/tests/basic_cxx_qt/rust/src/lib.rs
+++ b/tests/basic_cxx_qt/rust/src/lib.rs
@@ -36,6 +36,9 @@ mod ffi {
         }
     }
 
+    // Enabling threading on the qobject
+    impl cxx_qt::Threading for qobject::MyObject {}
+
     impl qobject::MyObject {
         #[qinvokable]
         pub fn double_number_self(self: Pin<&mut Self>) {


### PR DESCRIPTION
Instead of always generating threading opt in via a trait.

Closes #560