### PR TITLE
Remove newCppObject method for now.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed support for `cxx_type` and `cxx_return_type` and related conversion methods.
+- Removed `newCppObject` function that allowed creation of default-constructed QObject from Rust.
 
 ## [0.5.3](https://github.com/KDAB/cxx-qt/compare/v0.5.2...v0.5.3) - 2023-05-19
 

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -86,17 +86,11 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
             static_assert(::std::is_base_of<QObject, {ident}>::value, "{ident} must inherit from QObject");
             {namespace_end}
 
-            namespace {namespace_internals} {{
-            ::std::unique_ptr<{ident}>
-            newCppObject();
-            }} // namespace {namespace_internals}
-
             Q_DECLARE_METATYPE({metatype}*)
         "#,
         ident = qobject.ident,
         namespace_start = namespace_start,
         namespace_end = namespace_end,
-        namespace_internals = qobject.namespace_internals,
         rust_ident = qobject.rust_ident,
         base_class = qobject.base_class,
         metaobjects = qobject.blocks.metaobjects.join("\n  "),

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -298,11 +298,6 @@ mod tests {
         static_assert(::std::is_base_of<QObject, MyObject>::value, "MyObject must inherit from QObject");
         } // namespace cxx_qt::my_object
 
-        namespace cxx_qt::my_object::cxx_qt_my_object {
-        ::std::unique_ptr<MyObject>
-        newCppObject();
-        } // namespace cxx_qt::my_object::cxx_qt_my_object
-
         Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)
 
         "#}
@@ -358,11 +353,6 @@ mod tests {
         static_assert(::std::is_base_of<QObject, FirstObject>::value, "FirstObject must inherit from QObject");
         } // namespace cxx_qt
 
-        namespace cxx_qt::cxx_qt_first_object {
-        ::std::unique_ptr<FirstObject>
-        newCppObject();
-        } // namespace cxx_qt::cxx_qt_first_object
-
         Q_DECLARE_METATYPE(cxx_qt::FirstObject*)
 
         namespace cxx_qt {
@@ -388,11 +378,6 @@ mod tests {
 
         static_assert(::std::is_base_of<QObject, SecondObject>::value, "SecondObject must inherit from QObject");
         } // namespace cxx_qt
-
-        namespace cxx_qt::cxx_qt_second_object {
-        ::std::unique_ptr<SecondObject>
-        newCppObject();
-        } // namespace cxx_qt::cxx_qt_second_object
 
         Q_DECLARE_METATYPE(cxx_qt::SecondObject*)
 
@@ -449,11 +434,6 @@ mod tests {
 
         static_assert(::std::is_base_of<QObject, MyObject>::value, "MyObject must inherit from QObject");
 
-
-        namespace cxx_qt_my_object {
-        ::std::unique_ptr<MyObject>
-        newCppObject();
-        } // namespace cxx_qt_my_object
 
         Q_DECLARE_METATYPE(MyObject*)
 
@@ -529,14 +509,6 @@ mod tests {
 
         } // namespace cxx_qt::my_object
 
-        namespace cxx_qt::my_object::cxx_qt_my_object {
-        ::std::unique_ptr<MyObject>
-        newCppObject()
-        {
-          return ::std::make_unique<MyObject>();
-        }
-        } // namespace cxx_qt::my_object::cxx_qt_my_object
-
         "#}
     }
 
@@ -585,14 +557,6 @@ mod tests {
 
         } // namespace cxx_qt
 
-        namespace cxx_qt::cxx_qt_first_object {
-        ::std::unique_ptr<FirstObject>
-        newCppObject()
-        {
-          return ::std::make_unique<FirstObject>();
-        }
-        } // namespace cxx_qt::cxx_qt_first_object
-
         namespace cxx_qt {
 
         SecondObject::SecondObject(QObject* parent)
@@ -631,14 +595,6 @@ mod tests {
         }
 
         } // namespace cxx_qt
-
-        namespace cxx_qt::cxx_qt_second_object {
-        ::std::unique_ptr<SecondObject>
-        newCppObject()
-        {
-          return ::std::make_unique<SecondObject>();
-        }
-        } // namespace cxx_qt::cxx_qt_second_object
 
         "#}
     }
@@ -711,14 +667,6 @@ mod tests {
         }
 
 
-
-        namespace cxx_qt_my_object {
-        ::std::unique_ptr<MyObject>
-        newCppObject()
-        {
-          return ::std::make_unique<MyObject>();
-        }
-        } // namespace cxx_qt_my_object
 
         "#}
     }

--- a/crates/cxx-qt-gen/src/writer/cpp/source.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/source.rs
@@ -49,19 +49,10 @@ fn qobjects_source(generated: &GeneratedCppBlocks) -> Vec<String> {
 
             {methods}
             {namespace_end}
-
-            namespace {namespace_internals} {{
-            ::std::unique_ptr<{ident}>
-            newCppObject()
-            {{
-              return ::std::make_unique<{ident}>();
-            }}
-            }} // namespace {namespace_internals}
         "#,
         ident = qobject.ident,
         namespace_start = namespace_start,
         namespace_end = namespace_end,
-        namespace_internals = qobject.namespace_internals,
         base_class = qobject.base_class,
         rust_ident = qobject.rust_ident,
         methods = qobject.blocks.methods.iter().filter_map(pair_as_source).collect::<Vec<String>>().join("\n"),

--- a/crates/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/rust/mod.rs
@@ -21,11 +21,9 @@ fn mangle(name: &str, object: &Ident) -> Ident {
 /// Return common blocks for CXX bridge which the C++ writer adds as well
 fn cxx_bridge_common_blocks(qobject: &GeneratedRustQObject) -> Vec<TokenStream> {
     let cpp_struct_ident = &qobject.cpp_struct_ident;
-    let cpp_struct_ident_str = cpp_struct_ident.to_string();
     let rust_struct_ident = &qobject.rust_struct_ident;
     let namespace_internals = &qobject.namespace_internals;
 
-    let new_cpp_obj_str = mangle("new_cpp_object", cpp_struct_ident).to_string();
     let create_rs_ident = mangle("create_rs", rust_struct_ident);
 
     vec![
@@ -34,13 +32,6 @@ fn cxx_bridge_common_blocks(qobject: &GeneratedRustQObject) -> Vec<TokenStream> 
                 #[cxx_name = "unsafeRust"]
                 #[doc(hidden)]
                 fn cxx_qt_ffi_rust(self: &#cpp_struct_ident) -> &#rust_struct_ident;
-
-                #[doc = "Generated CXX-Qt method which creates a new"]
-                #[doc = #cpp_struct_ident_str]
-                #[doc = "as a UniquePtr with no parent in Qt"]
-                #[rust_name = #new_cpp_obj_str]
-                #[namespace = #namespace_internals]
-                fn newCppObject() -> UniquePtr<#cpp_struct_ident>;
             }
         },
         quote! {
@@ -389,13 +380,6 @@ mod tests {
                     #[cxx_name = "unsafeRust"]
                     #[doc(hidden)]
                     fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
-
-                    #[doc = "Generated CXX-Qt method which creates a new"]
-                    #[doc = "MyObjectQt"]
-                    #[doc = "as a UniquePtr with no parent in Qt"]
-                    #[rust_name = "new_cpp_object_my_object_qt"]
-                    #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-                    fn newCppObject() -> UniquePtr<MyObjectQt>;
                 }
 
                 extern "C++" {
@@ -501,13 +485,6 @@ mod tests {
                     #[cxx_name = "unsafeRust"]
                     #[doc(hidden)]
                     fn cxx_qt_ffi_rust(self: &FirstObjectQt) -> &FirstObject;
-
-                    #[doc = "Generated CXX-Qt method which creates a new"]
-                    #[doc = "FirstObjectQt"]
-                    #[doc = "as a UniquePtr with no parent in Qt"]
-                    #[rust_name = "new_cpp_object_first_object_qt"]
-                    #[namespace = "cxx_qt::cxx_qt_first_object"]
-                    fn newCppObject() -> UniquePtr<FirstObjectQt>;
                 }
 
                 extern "C++" {
@@ -535,13 +512,6 @@ mod tests {
                     #[cxx_name = "unsafeRust"]
                     #[doc(hidden)]
                     fn cxx_qt_ffi_rust(self: &SecondObjectQt) -> &SecondObject;
-
-                    #[doc = "Generated CXX-Qt method which creates a new"]
-                    #[doc = "SecondObjectQt"]
-                    #[doc = "as a UniquePtr with no parent in Qt"]
-                    #[rust_name = "new_cpp_object_second_object_qt"]
-                    #[namespace = "cxx_qt::cxx_qt_second_object"]
-                    fn newCppObject() -> UniquePtr<SecondObjectQt>;
                 }
 
                 extern "C++" {

--- a/crates/cxx-qt-gen/test_outputs/inheritance.cpp
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.cpp
@@ -34,11 +34,3 @@ MyObject::hasChildren(QModelIndex const& _parent) const
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
   return m_rustObj->hasChildrenWrapper(*this, _parent);
 }
-
-namespace cxx_qt_my_object {
-::std::unique_ptr<MyObject>
-newCppObject()
-{
-  return ::std::make_unique<MyObject>();
-}
-} // namespace cxx_qt_my_object

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -45,9 +45,4 @@ private:
 static_assert(::std::is_base_of<QObject, MyObject>::value,
               "MyObject must inherit from QObject");
 
-namespace cxx_qt_my_object {
-::std::unique_ptr<MyObject>
-newCppObject();
-} // namespace cxx_qt_my_object
-
 Q_DECLARE_METATYPE(MyObject*)

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -67,12 +67,6 @@ mod inheritance {
         #[cxx_name = "unsafeRust"]
         #[doc(hidden)]
         fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
-        #[doc = "Generated CXX-Qt method which creates a new"]
-        #[doc = "MyObjectQt"]
-        #[doc = "as a UniquePtr with no parent in Qt"]
-        #[rust_name = "new_cpp_object_my_object_qt"]
-        #[namespace = "cxx_qt_my_object"]
-        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
     extern "C++" {
         #[cxx_name = "unsafeRustMut"]

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -96,11 +96,3 @@ MyObject::qtThread() const
 }
 
 } // namespace cxx_qt::my_object
-
-namespace cxx_qt::my_object::cxx_qt_my_object {
-::std::unique_ptr<MyObject>
-newCppObject()
-{
-  return ::std::make_unique<MyObject>();
-}
-} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -50,9 +50,4 @@ static_assert(::std::is_base_of<QObject, MyObject>::value,
               "MyObject must inherit from QObject");
 } // namespace cxx_qt::my_object
 
-namespace cxx_qt::my_object::cxx_qt_my_object {
-::std::unique_ptr<MyObject>
-newCppObject();
-} // namespace cxx_qt::my_object::cxx_qt_my_object
-
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -111,12 +111,6 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         #[doc(hidden)]
         fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
-        #[doc = "Generated CXX-Qt method which creates a new"]
-        #[doc = "MyObjectQt"]
-        #[doc = "as a UniquePtr with no parent in Qt"]
-        #[rust_name = "new_cpp_object_my_object_qt"]
-        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
     extern "C++" {
         #[cxx_name = "unsafeRustMut"]

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -67,14 +67,6 @@ MyObject::readyConnect(::rust::Fn<void(MyObject&)> func,
 
 } // namespace cxx_qt::multi_object
 
-namespace cxx_qt::multi_object::cxx_qt_my_object {
-::std::unique_ptr<MyObject>
-newCppObject()
-{
-  return ::std::make_unique<MyObject>();
-}
-} // namespace cxx_qt::multi_object::cxx_qt_my_object
-
 namespace cxx_qt::multi_object {
 
 SecondObject::SecondObject(QObject* parent)
@@ -137,11 +129,3 @@ SecondObject::readyConnect(::rust::Fn<void(SecondObject&)> func,
 }
 
 } // namespace cxx_qt::multi_object
-
-namespace cxx_qt::multi_object::cxx_qt_second_object {
-::std::unique_ptr<SecondObject>
-newCppObject()
-{
-  return ::std::make_unique<SecondObject>();
-}
-} // namespace cxx_qt::multi_object::cxx_qt_second_object

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -52,11 +52,6 @@ static_assert(::std::is_base_of<QObject, MyObject>::value,
               "MyObject must inherit from QObject");
 } // namespace cxx_qt::multi_object
 
-namespace cxx_qt::multi_object::cxx_qt_my_object {
-::std::unique_ptr<MyObject>
-newCppObject();
-} // namespace cxx_qt::multi_object::cxx_qt_my_object
-
 Q_DECLARE_METATYPE(cxx_qt::multi_object::MyObject*)
 
 namespace cxx_qt::multi_object {
@@ -89,10 +84,5 @@ private:
 static_assert(::std::is_base_of<QObject, SecondObject>::value,
               "SecondObject must inherit from QObject");
 } // namespace cxx_qt::multi_object
-
-namespace cxx_qt::multi_object::cxx_qt_second_object {
-::std::unique_ptr<SecondObject>
-newCppObject();
-} // namespace cxx_qt::multi_object::cxx_qt_second_object
 
 Q_DECLARE_METATYPE(cxx_qt::multi_object::SecondObject*)

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -117,12 +117,6 @@ pub mod ffi {
         #[cxx_name = "unsafeRust"]
         #[doc(hidden)]
         fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
-        #[doc = "Generated CXX-Qt method which creates a new"]
-        #[doc = "MyObjectQt"]
-        #[doc = "as a UniquePtr with no parent in Qt"]
-        #[rust_name = "new_cpp_object_my_object_qt"]
-        #[namespace = "cxx_qt::multi_object::cxx_qt_my_object"]
-        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
     extern "C++" {
         #[cxx_name = "unsafeRustMut"]
@@ -191,12 +185,6 @@ pub mod ffi {
         #[cxx_name = "unsafeRust"]
         #[doc(hidden)]
         fn cxx_qt_ffi_rust(self: &SecondObjectQt) -> &SecondObject;
-        #[doc = "Generated CXX-Qt method which creates a new"]
-        #[doc = "SecondObjectQt"]
-        #[doc = "as a UniquePtr with no parent in Qt"]
-        #[rust_name = "new_cpp_object_second_object_qt"]
-        #[namespace = "cxx_qt::multi_object::cxx_qt_second_object"]
-        fn newCppObject() -> UniquePtr<SecondObjectQt>;
     }
     extern "C++" {
         #[cxx_name = "unsafeRustMut"]

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -52,11 +52,3 @@ MyObject::setTrivial(QPoint const& value)
 }
 
 } // namespace cxx_qt::my_object
-
-namespace cxx_qt::my_object::cxx_qt_my_object {
-::std::unique_ptr<MyObject>
-newCppObject()
-{
-  return ::std::make_unique<MyObject>();
-}
-} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -47,9 +47,4 @@ static_assert(::std::is_base_of<QObject, MyObject>::value,
               "MyObject must inherit from QObject");
 } // namespace cxx_qt::my_object
 
-namespace cxx_qt::my_object::cxx_qt_my_object {
-::std::unique_ptr<MyObject>
-newCppObject();
-} // namespace cxx_qt::my_object::cxx_qt_my_object
-
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -75,12 +75,6 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         #[doc(hidden)]
         fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
-        #[doc = "Generated CXX-Qt method which creates a new"]
-        #[doc = "MyObjectQt"]
-        #[doc = "as a UniquePtr with no parent in Qt"]
-        #[rust_name = "new_cpp_object_my_object_qt"]
-        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
     extern "C++" {
         #[cxx_name = "unsafeRustMut"]

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -128,11 +128,3 @@ MyObject::newDataConnect(::rust::Fn<void(MyObject&,
 }
 
 } // namespace cxx_qt::my_object
-
-namespace cxx_qt::my_object::cxx_qt_my_object {
-::std::unique_ptr<MyObject>
-newCppObject()
-{
-  return ::std::make_unique<MyObject>();
-}
-} // namespace cxx_qt::my_object::cxx_qt_my_object

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -68,9 +68,4 @@ static_assert(::std::is_base_of<QObject, MyObject>::value,
               "MyObject must inherit from QObject");
 } // namespace cxx_qt::my_object
 
-namespace cxx_qt::my_object::cxx_qt_my_object {
-::std::unique_ptr<MyObject>
-newCppObject();
-} // namespace cxx_qt::my_object::cxx_qt_my_object
-
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -118,12 +118,6 @@ mod ffi {
         #[cxx_name = "unsafeRust"]
         #[doc(hidden)]
         fn cxx_qt_ffi_rust(self: &MyObjectQt) -> &MyObject;
-        #[doc = "Generated CXX-Qt method which creates a new"]
-        #[doc = "MyObjectQt"]
-        #[doc = "as a UniquePtr with no parent in Qt"]
-        #[rust_name = "new_cpp_object_my_object_qt"]
-        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
-        fn newCppObject() -> UniquePtr<MyObjectQt>;
     }
     extern "C++" {
         #[cxx_name = "unsafeRustMut"]


### PR DESCRIPTION
Will probably be readded as part of the Constructor trait later.

This wasn't documented anywhere and isn't used by anything at the moment.