### PR TITLE
cxx-qt-gen: use extern "RustQt" block for inherit and signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Always call `qt_build_utils::setup_linker()` in `CxxQtBuilder` and remove the proxy method
 - Moved to `syn` 2.0 internally and for any exported `syn` types
 - `impl cxx_qt::Threading for qobject::T` now needs to be specified for `qt_thread()` to be available
+- `#[cxx_qt::qsignals]` and `#[cxx_qt::inherit]` are now used in an `extern "RustQt"` block as `#[qsignal]` and `#[inherit]`
 
 ### Removed
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,7 +20,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 - [QObject](./qobject/index.md)
     - [`#[cxx_qt::bridge]` - Bridge Macro](./qobject/bridge-macro.md)
     - [`#[cxx_qt::qobject]` - Defining QObjects](./qobject/qobject_struct.md)
-    - [`#[cxx_qt::qsignals]` - Signals macro](./qobject/signals.md)
+    - [`#[qsignal]` - Signal macro](./qobject/signals.md)
     - [`qobject::T` - The generated QObject](./qobject/generated-qobject.md)
     - [CxxQtThread](./qobject/cxxqtthread.md)
 - [Concepts](./concepts/index.md)

--- a/book/src/concepts/inheritance.md
+++ b/book/src/concepts/inheritance.md
@@ -12,8 +12,8 @@ Some Qt APIs require you to override certain methods from an abstract base class
 To support creating such subclasses directly from within Rust, CXX-Qt provides you with multiple helpers.
 
 ## Accessing base class methods
-To access the methods of a base class in Rust, use the `#[cxx_qt::inherit]` macro.
-It can be placed in front of an `extern "C++"` block in a `#[cxx_qt::bridge]`.
+To access the methods of a base class in Rust, use the `#[inherit]` macro.
+It can be placed in front of a function in a `extern "RustQt"` block in a `#[cxx_qt::bridge]`.
 
 ```rust,ignore
 {{#include ../../../examples/qml_features/rust/src/custom_base_class.rs:book_inherit_qalm}}
@@ -27,10 +27,10 @@ It can be placed in front of an `extern "C++"` block in a `#[cxx_qt::bridge]`.
 [Full example](https://github.com/KDAB/cxx-qt/blob/main/examples/qml_features/rust/src/custom_base_class.rs)
 
 This code implements a QAbstractListModel subclass.
-For this, the `clear` method implemented in Rust needs to call `beginResetModel` and related methods from the base class, which are made accessible by using `#[cxx_qt::inherit]`.
+For this, the `clear` method implemented in Rust needs to call `beginResetModel` and related methods from the base class, which are made accessible by using `#[inherit]`.
 See [the Qt docs](https://doc.qt.io/qt-6/qabstractlistmodel.html) for more details on the specific subclassing requirements.
 
-Methods can be declared inside `#[cxx_qt::inherit]` in `extern "C++"` blocks similar to CXX, with the same restrictions regarding which types can be used.
+Methods in a `extern "RustQt"` block similar to CXX can be tagged with an `#[inherit]` attribute, with the same restrictions regarding which types can be used.
 Additionally, the `self` type must be either `self: Pin<&mut qobject::T>` or `self: &qobject::T`, where `qobject::T` must refer to a QObject marked with `#[cxx_qt::qobject]` in the `#[cxx_qt::bridge]`
 
 The declared methods will be case-converted as in other CXX-Qt APIs.
@@ -58,7 +58,7 @@ The below example overrides the [`data`](https://doc.qt.io/qt-6/qabstractitemmod
 ```
 [Full example](https://github.com/KDAB/cxx-qt/blob/main/examples/qml_features/rust/src/custom_base_class.rs)
 
-When a method is overridden using `cxx_override`, the base class version of the method can be accessed by using `#[cxx_qt::inherit]` in combination with the `#[cxx_name]` attribute.
+When a method is overridden using `cxx_override`, the base class version of the method can be accessed by using `#[inherit]` in combination with the `#[cxx_name]` attribute.
 In this case the base class version of the function must get a different name because Rust can't have two functions with the same name on one type.
 
 Example:

--- a/book/src/getting-started/1-qobjects-in-rust.md
+++ b/book/src/getting-started/1-qobjects-in-rust.md
@@ -47,7 +47,7 @@ Then you can use the afformentioned features with the help of more macros.
 - `#[cxx_qt::qobject]` - Expose a Rust struct to Qt as a QObject subclass.
     - `#[qproperty]` - Expose a field of the Rust struct to QML/C++ as a [`Q_PROPERTY`](https://doc.qt.io/qt-6/qtqml-cppintegration-exposecppattributes.html#exposing-properties).
     - `#[qinvokable]` - Expose a function on the QObject to QML and C++ as a [`Q_INVOKABLE`](https://doc.qt.io/qt-6/qtqml-cppintegration-exposecppattributes.html#exposing-methods-including-qt-slots).
-- `#[cxx_qt::qsignals]` - Define the [Signals](https://doc.qt.io/qt-6/signalsandslots.html#signals) of a QObject T.
+    - `#[qsignal]` - Define the [Signals](https://doc.qt.io/qt-6/signalsandslots.html#signals) of a QObject T.
 
 CXX-Qt will then expand this Rust module into two separate parts:
 - C++ files that define a QObject subclass for each `#[cxx_qt::qobject]` marked struct.

--- a/book/src/qobject/index.md
+++ b/book/src/qobject/index.md
@@ -15,7 +15,7 @@ For a simpler introduction, take a look at our [Getting Started guide](../gettin
 QObject Features and Parts:
   * [`#[cxx_qt::bridge]` - The macro around the module](./bridge-macro.md)
   * [`#[cxx_qt::qobject]` - Marking a Rust struct as a QObject](./qobject_struct.md)
-  * [`#[cxx_qt::qsignals]` - A macro for defining signals](./signals.md)
+  * [`#[qsignal]` - A macro for defining signals](./signals.md)
   * [`qobject:T` - The generated QObject](./generated-qobject.md)
   * [`CxxQtThread` - Queueing closures onto the Qt event loop](./cxxqtthread.md)
 

--- a/book/src/qobject/qobject_struct.md
+++ b/book/src/qobject/qobject_struct.md
@@ -27,7 +27,7 @@ The macro does multiple other things for you though:
 - Expose the generated QObject subclass to Rust as [`qobject::MyObject`](./generated-qobject.md)
 - Generate getters/setters for all fields.
 - Generate `Q_PROPERTY`s for all fields that are marked as `#[qproperty]`.
-- Generate signals if paired with a [`#[cxx_qt::qsignals]` macro](./signals.md).
+- Generate signals if paired with a [`#[qsignal]` macro](./signals.md).
 
 ## Exposing to QML
 `#[cxx_qt::qobject]` supports registering the Qt object as a QML type directly at build time.

--- a/book/src/qobject/signals.md
+++ b/book/src/qobject/signals.md
@@ -5,9 +5,9 @@ SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 SPDX-License-Identifier: MIT OR Apache-2.0
 -->
 
-# Signals enum
+# Signals
 
-The `cxx_qt::qsignals` attribute is used on an `extern "C++"` block to define [signals](https://doc.qt.io/qt-6/signalsandslots.html) for the a QObject.
+The `qsignal` attribute is used in an `extern "RustQt"` block to define [signals](https://doc.qt.io/qt-6/signalsandslots.html) for the a QObject.
 
 ```rust,ignore,noplayground
 {{#include ../../../examples/qml_features/rust/src/signals.rs:book_signals_block}}
@@ -57,7 +57,7 @@ In this case, it is no longer possible to disconnect later.
 
 ## Emitting a signal
 
-Call the function signature defined in the `extern "C++` block to emit the signal.
+Call the function signature defined in the `extern "RustQt"` block to emit the signal.
 
 Note that these are defined on the generated QObject [`qobject::T`](./generated-qobject.md), so can be called from any mutable `#[qinvokable]`.
 

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -162,8 +162,8 @@ mod tests {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
 
-                #[cxx_qt::qsignals]
-                unsafe extern "C++" {
+                unsafe extern "RustQt" {
+                    #[qsignal]
                     fn ready(self: Pin<&mut qobject::MyObject>);
                 }
             }
@@ -187,8 +187,8 @@ mod tests {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
 
-                #[cxx_qt::qsignals]
-                unsafe extern "C++" {
+                unsafe extern "RustQt" {
+                    #[qsignal]
                     fn ready(self: Pin<&mut qobject::MyObject>);
                 }
 
@@ -216,8 +216,8 @@ mod tests {
                 #[cxx_qt::qobject]
                 pub struct MyObject;
 
-                #[cxx_qt::qsignals]
-                unsafe extern "C++" {
+                unsafe extern "RustQt" {
+                    #[qsignal]
                     fn ready(self: Pin<&mut qobject::UnknownObject>);
                 }
             }

--- a/crates/cxx-qt-gen/src/syntax/attribute.rs
+++ b/crates/cxx-qt-gen/src/syntax/attribute.rs
@@ -97,14 +97,14 @@ mod tests {
         let module: ItemMod = parse_quote! {
             #[qinvokable]
             #[cxx_qt::bridge]
-            #[cxx_qt::qsignals(MyObject)]
+            #[cxx_qt::object(MyObject)]
             #[cxx_qt::bridge(namespace = "my::namespace")]
             mod module;
         };
 
         assert!(attribute_find_path(&module.attrs, &["qinvokable"]).is_some());
         assert!(attribute_find_path(&module.attrs, &["cxx_qt", "bridge"]).is_some());
-        assert!(attribute_find_path(&module.attrs, &["cxx_qt", "qsignals"]).is_some());
+        assert!(attribute_find_path(&module.attrs, &["cxx_qt", "object"]).is_some());
         assert!(attribute_find_path(&module.attrs, &["cxx_qt", "missing"]).is_none());
     }
 
@@ -113,7 +113,7 @@ mod tests {
         let module: ItemMod = parse_quote! {
             #[qinvokable]
             #[cxx_qt::bridge]
-            #[cxx_qt::qsignals(MyObject)]
+            #[cxx_qt::object(MyObject)]
             #[cxx_qt::bridge(namespace = "my::namespace")]
             #[cxx_qt::list(A, B, C)]
             #[cxx_qt::bridge(a = "b", namespace = "my::namespace")]

--- a/crates/cxx-qt-gen/test_inputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_inputs/inheritance.rs
@@ -13,16 +13,16 @@ mod inheritance {
         data: Vec<i32>,
     }
 
-    #[cxx_qt::inherit]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
         /// Inherited hasChildren from the base class
         #[cxx_name = "hasChildren"]
+        #[inherit]
         fn has_children_super(self: &qobject::MyObject, parent: &QModelIndex) -> bool;
     }
 
-    #[cxx_qt::inherit]
-    extern "C++" {
+    extern "RustQt" {
         /// Inherited fetchMore from the base class
+        #[inherit]
         unsafe fn fetch_more(self: Pin<&mut qobject::MyObject>, index: &QModelIndex);
     }
 

--- a/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
@@ -91,8 +91,8 @@ pub mod ffi {
         }
     }
 
-    #[cxx_qt::qsignals]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
+        #[qsignal]
         fn ready(self: Pin<&mut qobject::MyObject>);
     }
 
@@ -140,9 +140,9 @@ pub mod ffi {
         }
     }
 
-    #[cxx_qt::qsignals]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
         #[my_attribute]
+        #[qsignal]
         fn ready(self: Pin<&mut qobject::SecondObject>);
     }
 

--- a/crates/cxx-qt-gen/test_inputs/signals.rs
+++ b/crates/cxx-qt-gen/test_inputs/signals.rs
@@ -6,10 +6,11 @@ mod ffi {
         type QPoint = cxx_qt_lib::QPoint;
     }
 
-    #[cxx_qt::qsignals]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
+        #[qsignal]
         fn ready(self: Pin<&mut qobject::MyObject>);
 
+        #[qsignal]
         fn data_changed(
             self: Pin<&mut qobject::MyObject>,
             first: i32,
@@ -20,6 +21,7 @@ mod ffi {
 
         #[cxx_name = "newData"]
         #[inherit]
+        #[qsignal]
         fn base_class_new_data(
             self: Pin<&mut qobject::MyObject>,
             first: i32,

--- a/crates/cxx-qt-macro/src/lib.rs
+++ b/crates/cxx-qt-macro/src/lib.rs
@@ -57,34 +57,6 @@ pub fn bridge(args: TokenStream, input: TokenStream) -> TokenStream {
     extract_and_generate(module)
 }
 
-/// A macro which describes that an enum defines the signals for a QObject.
-///
-/// It should not be used by itself and instead should be used inside a cxx_qt::bridge definition.
-///
-/// # Example
-///
-/// ```rust
-/// #[cxx_qt::bridge]
-/// mod my_object {
-///     #[cxx_qt::qobject]
-///     #[derive(Default)]
-///     # // Note that we can't use properties as this confuses the linker on Windows
-///     pub struct MyObject;
-///
-///     #[cxx_qt::qsignals]
-///     unsafe extern "C++" {
-///         fn ready(self: Pin<&mut qobject::MyObject>);
-///     }
-/// }
-///
-/// # // Note that we need a fake main for doc tests to build
-/// # fn main() {}
-/// ```
-#[proc_macro_attribute]
-pub fn qsignals(_args: TokenStream, _input: TokenStream) -> TokenStream {
-    unreachable!("cxx_qt::qsignals should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")
-}
-
 /// A macro which describes that a struct should be made into a QObject.
 ///
 /// It should not be used by itself and instead should be used inside a cxx_qt::bridge definition.
@@ -127,48 +99,6 @@ pub fn qsignals(_args: TokenStream, _input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn qobject(_args: TokenStream, _input: TokenStream) -> TokenStream {
     unreachable!("cxx_qt::qobject should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")
-}
-
-/// A macro which allows you to access base class methods from within Rust.
-///
-/// It should not be used by itself and instead should be used inside a cxx_qt::bridge definition.
-/// Furthermore, the macro must be placed within the `impl` block of a `qobject::T`.
-/// See [the book page](https://kdab.github.io/cxx-qt/book/concepts/inheritance.html) for more
-/// details.
-///
-/// # Example
-/// ``` rust
-/// #[cxx_qt::bridge]
-/// mod my_object {
-///     extern "C++" {
-///         include!("cxx-qt-lib/qmodelindex.h");
-///         type QModelIndex = cxx_qt_lib::QModelIndex;
-///     }
-///
-///     #[cxx_qt::qobject(base="QAbstractListModel")]
-///     #[derive(Default)]
-///     # // Note that we can't use properties as this confuses the linker on Windows
-///     pub struct MyObject;
-///
-///     #[cxx_qt::inherit]
-///     extern "C++" {
-///         // Unsafe to call
-///         unsafe fn begin_insert_rows(self: Pin<&mut qobject::MyObject>, parent: &QModelIndex, first: i32, last: i32);
-///     }
-///
-///     #[cxx_qt::inherit]
-///     unsafe extern "C++" {
-///         // Safe to call - you are responsible to ensure this is true!
-///         fn end_insert_rows(self: Pin<&mut qobject::MyObject>);
-///     }
-/// }
-///
-/// # // Note that we need a fake main for doc tests to build
-/// # fn main() {}
-/// ```
-#[proc_macro_attribute]
-pub fn inherit(_args: TokenStream, _input: TokenStream) -> TokenStream {
-    unreachable!("cxx_qt::inherit should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")
 }
 
 // Take the module and C++ namespace and generate the rust code

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -10,9 +10,7 @@
 //! See the [book](https://kdab.github.io/cxx-qt/book/) for more information.
 
 pub use cxx_qt_macro::bridge;
-pub use cxx_qt_macro::inherit;
 pub use cxx_qt_macro::qobject;
-pub use cxx_qt_macro::qsignals;
 
 /// This trait is automatically implemented for all types which are marked as `#[cxx_qt::qobject]`.
 /// It provides information about the type that is wrapped by the QObject, as well as the methods

--- a/examples/demo_threading/rust/src/lib.rs
+++ b/examples/demo_threading/rust/src/lib.rs
@@ -70,13 +70,15 @@ mod ffi {
     // Enabling threading on the qobject
     impl cxx_qt::Threading for qobject::EnergyUsage {}
 
-    #[cxx_qt::qsignals]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
         /// A new sensor has been detected
+        #[qsignal]
         fn sensor_added(self: Pin<&mut qobject::EnergyUsage>, uuid: QString);
         /// A value on an existing sensor has changed
+        #[qsignal]
         fn sensor_changed(self: Pin<&mut qobject::EnergyUsage>, uuid: QString);
         /// An existing sensor has been removed
+        #[qsignal]
         fn sensor_removed(self: Pin<&mut qobject::EnergyUsage>, uuid: QString);
     }
 

--- a/examples/qml_features/rust/src/custom_base_class.rs
+++ b/examples/qml_features/rust/src/custom_base_class.rs
@@ -51,10 +51,10 @@ pub mod ffi {
     impl cxx_qt::Threading for qobject::CustomBaseClass {}
 
     // ANCHOR: book_qsignals_inherit
-    #[cxx_qt::qsignals]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
         /// Inherit the DataChanged signal from the QAbstractListModel base class
         #[inherit]
+        #[qsignal]
         fn data_changed(
             self: Pin<&mut qobject::CustomBaseClass>,
             top_left: &QModelIndex,
@@ -153,9 +153,9 @@ pub mod ffi {
 
     // ANCHOR: book_inherit_qalm_impl_unsafe
     // Create Rust bindings for C++ functions of the base class (QAbstractItemModel)
-    #[cxx_qt::inherit]
-    extern "C++" {
+    extern "RustQt" {
         /// Inherited beginInsertRows from the base class
+        #[inherit]
         unsafe fn begin_insert_rows(
             self: Pin<&mut qobject::CustomBaseClass>,
             parent: &QModelIndex,
@@ -163,9 +163,11 @@ pub mod ffi {
             last: i32,
         );
         /// Inherited endInsertRows from the base class
+        #[inherit]
         unsafe fn end_insert_rows(self: Pin<&mut qobject::CustomBaseClass>);
 
         /// Inherited beginRemoveRows from the base class
+        #[inherit]
         unsafe fn begin_remove_rows(
             self: Pin<&mut qobject::CustomBaseClass>,
             parent: &QModelIndex,
@@ -173,23 +175,27 @@ pub mod ffi {
             last: i32,
         );
         /// Inherited endRemoveRows from the base class
+        #[inherit]
         unsafe fn end_remove_rows(self: Pin<&mut qobject::CustomBaseClass>);
 
         /// Inherited beginResetModel from the base class
+        #[inherit]
         unsafe fn begin_reset_model(self: Pin<&mut qobject::CustomBaseClass>);
         /// Inherited endResetModel from the base class
+        #[inherit]
         unsafe fn end_reset_model(self: Pin<&mut qobject::CustomBaseClass>);
     }
     // ANCHOR_END: book_inherit_qalm_impl_unsafe
 
     // ANCHOR: book_inherit_qalm_impl_safe
-    #[cxx_qt::inherit]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
         /// Inherited canFetchMore from the base class
         #[cxx_name = "canFetchMore"]
+        #[inherit]
         fn base_can_fetch_more(self: &qobject::CustomBaseClass, parent: &QModelIndex) -> bool;
 
         /// Inherited index from the base class
+        #[inherit]
         fn index(
             self: &qobject::CustomBaseClass,
             row: i32,

--- a/examples/qml_features/rust/src/multiple_qobjects.rs
+++ b/examples/qml_features/rust/src/multiple_qobjects.rs
@@ -38,12 +38,13 @@ pub mod ffi {
     // Enabling threading on the qobject
     impl cxx_qt::Threading for qobject::FirstObject {}
 
-    #[cxx_qt::qsignals]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
         /// Accepted Q_SIGNAL
+        #[qsignal]
         fn accepted(self: Pin<&mut qobject::FirstObject>);
 
         /// Rejected Q_SIGNAL
+        #[qsignal]
         fn rejected(self: Pin<&mut qobject::FirstObject>);
     }
 
@@ -85,12 +86,13 @@ pub mod ffi {
     // Enabling threading on the qobject
     impl cxx_qt::Threading for qobject::SecondObject {}
 
-    #[cxx_qt::qsignals]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
         /// Accepted Q_SIGNAL
+        #[qsignal]
         fn accepted(self: Pin<&mut qobject::SecondObject>);
 
         /// Rejected Q_SIGNAL
+        #[qsignal]
         fn rejected(self: Pin<&mut qobject::SecondObject>);
     }
 

--- a/examples/qml_features/rust/src/nested_qobjects.rs
+++ b/examples/qml_features/rust/src/nested_qobjects.rs
@@ -25,9 +25,9 @@ pub mod ffi {
         counter: i32,
     }
 
-    #[cxx_qt::qsignals]
-    extern "C++" {
+    extern "RustQt" {
         /// A signal showing how to refer to another QObject as an argument
+        #[qsignal]
         unsafe fn called(self: Pin<&mut qobject::InnerObject>, inner: *mut CxxInnerObject);
     }
 
@@ -46,9 +46,9 @@ pub mod ffi {
         }
     }
 
-    #[cxx_qt::qsignals]
-    extern "C++" {
+    extern "RustQt" {
         /// A signal showing how to refer to another QObject as an argument
+        #[qsignal]
         unsafe fn called(self: Pin<&mut qobject::OuterObject>, inner: *mut CxxInnerObject);
     }
 

--- a/examples/qml_features/rust/src/serialisation.rs
+++ b/examples/qml_features/rust/src/serialisation.rs
@@ -48,9 +48,9 @@ pub mod ffi {
         pub string: QString,
     }
 
-    #[cxx_qt::qsignals]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
         /// An error signal
+        #[qsignal]
         fn error(self: Pin<&mut qobject::Serialisation>, message: QString);
     }
 

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -21,15 +21,17 @@ pub mod ffi {
     }
 
     // ANCHOR: book_signals_block
-    #[cxx_qt::qsignals]
-    unsafe extern "C++" {
+    unsafe extern "RustQt" {
         /// A Q_SIGNAL emitted when a connection occurs
+        #[qsignal]
         fn connected(self: Pin<&mut qobject::RustSignals>, url: &QUrl);
 
         /// A Q_SIGNAL emitted when a disconnect occurs
+        #[qsignal]
         fn disconnected(self: Pin<&mut qobject::RustSignals>);
 
         /// A Q_SIGNAL emitted when an error occurs
+        #[qsignal]
         fn error(self: Pin<&mut qobject::RustSignals>, message: QString);
     }
     // ANCHOR_END: book_signals_block


### PR DESCRIPTION
Requires #579 

Closes #557