### PR TITLE
cxx-qt-gen: don't import Pin in hidden module resolving IDE integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Do not use -bundle otherwise CMake builds are missing qt-static-initalizers (note this is broken in rustc 1.69)
+- Do not import `Pin` in hidden module as invokables are outside now, resolving IDE integration
 
 ### Removed
 

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -128,7 +128,7 @@ mod tests {
                 impl MyObject {
                     #[doc = "Setter for the Q_PROPERTY "]
                     #[doc = "trivial_property"]
-                    pub fn set_trivial_property(mut self: Pin<&mut Self>, value: i32) {
+                    pub fn set_trivial_property(mut self: core::pin::Pin<&mut Self>, value: i32) {
                         if self.trivial_property == value {
                             return;
                         }
@@ -180,7 +180,7 @@ mod tests {
                 impl MyObject {
                     #[doc = "Setter for the Q_PROPERTY "]
                     #[doc = "opaque_property"]
-                    pub fn set_opaque_property(mut self: Pin<&mut Self>, value: UniquePtr<QColor>) {
+                    pub fn set_opaque_property(mut self: core::pin::Pin<&mut Self>, value: UniquePtr<QColor>) {
                         if self.opaque_property == value {
                             return;
                         }
@@ -232,7 +232,7 @@ mod tests {
                 impl MyObject {
                     #[doc = "Setter for the Q_PROPERTY "]
                     #[doc = "unsafe_property"]
-                    pub fn set_unsafe_property(mut self: Pin<&mut Self>, value: *mut T) {
+                    pub fn set_unsafe_property(mut self: core::pin::Pin<&mut Self>, value: *mut T) {
                         if self.unsafe_property == value {
                             return;
                         }
@@ -278,7 +278,7 @@ mod tests {
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
                     #[must_use]
-                    pub fn on_trivial_property_changed(self: Pin<&mut MyObject>, func: fn(Pin<&mut MyObject>, )) -> CxxQtQMetaObjectConnection
+                    pub fn on_trivial_property_changed(self: core::pin::Pin<&mut MyObject>, func: fn(core::pin::Pin<&mut MyObject>, )) -> CxxQtQMetaObjectConnection
                     {
                         self.connect_trivial_property_changed(func, CxxQtConnectionType::AutoConnection)
                     }
@@ -319,7 +319,7 @@ mod tests {
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
                     #[must_use]
-                    pub fn on_opaque_property_changed(self: Pin<&mut MyObject>, func: fn(Pin<&mut MyObject>, )) -> CxxQtQMetaObjectConnection
+                    pub fn on_opaque_property_changed(self: core::pin::Pin<&mut MyObject>, func: fn(core::pin::Pin<&mut MyObject>, )) -> CxxQtQMetaObjectConnection
                     {
                         self.connect_opaque_property_changed(func, CxxQtConnectionType::AutoConnection)
                     }
@@ -360,7 +360,7 @@ mod tests {
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
                     #[must_use]
-                    pub fn on_unsafe_property_changed(self: Pin<&mut MyObject>, func: fn(Pin<&mut MyObject>, )) -> CxxQtQMetaObjectConnection
+                    pub fn on_unsafe_property_changed(self: core::pin::Pin<&mut MyObject>, func: fn(core::pin::Pin<&mut MyObject>, )) -> CxxQtQMetaObjectConnection
                     {
                         self.connect_unsafe_property_changed(func, CxxQtConnectionType::AutoConnection)
                     }

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -41,7 +41,7 @@ pub fn generate(
             impl #cpp_class_name_rust {
                 #[doc = "Setter for the Q_PROPERTY "]
                 #[doc = #ident_str]
-                pub fn #setter_rust(mut self: Pin<&mut Self>, value: #ty) {
+                pub fn #setter_rust(mut self: core::pin::Pin<&mut Self>, value: #ty) {
                     if self.#ident == value {
                         // don't want to set the value again and reemit the signal,
                         // as this can cause binding loops

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -43,10 +43,13 @@ pub fn generate_rust_signals(
             })
             .collect::<Vec<TokenStream>>();
 
-        let self_type = if signal.mutable {
-            quote! { Pin<&mut #qobject_name> }
+        let (self_type, self_type_cxx) = if signal.mutable {
+            (
+                quote! { core::pin::Pin<&mut #qobject_name> },
+                quote! { Pin<&mut #qobject_name> },
+            )
         } else {
-            quote! { &#qobject_name }
+            (quote! { &#qobject_name }, quote! { &#qobject_name })
         };
 
         let mut unsafe_block = None;
@@ -63,7 +66,7 @@ pub fn generate_rust_signals(
                     #unsafe_block extern "C++" {
                         #(#attrs)*
                         #[rust_name = #signal_name_rust_str]
-                        #unsafe_call fn #signal_name_cpp(self: #self_type, #(#parameters),*);
+                        #unsafe_call fn #signal_name_cpp(self: #self_type_cxx, #(#parameters),*);
                     }
                 },
                 quote! {
@@ -73,7 +76,7 @@ pub fn generate_rust_signals(
                         #[doc = ", so that when the signal is emitted the function pointer is executed."]
                         #[must_use]
                         #[rust_name = #connect_ident_rust_str]
-                        fn #connect_ident_cpp(self: #self_type, func: #unsafe_call fn(#self_type, #(#parameters),*), conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
+                        fn #connect_ident_cpp(self: #self_type_cxx, func: #unsafe_call fn(#self_type_cxx, #(#parameters),*), conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
                     }
                 },
             ],
@@ -169,7 +172,7 @@ mod tests {
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
                     #[must_use]
-                    pub fn on_ready(self: Pin<&mut MyObject>, func: fn(Pin<&mut MyObject>, )) -> CxxQtQMetaObjectConnection
+                    pub fn on_ready(self: core::pin::Pin<&mut MyObject>, func: fn(core::pin::Pin<&mut MyObject>, )) -> CxxQtQMetaObjectConnection
                     {
                         self.connect_ready(func, CxxQtConnectionType::AutoConnection)
                     }
@@ -244,7 +247,7 @@ mod tests {
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
                     #[must_use]
-                    pub fn on_data_changed(self: Pin<&mut MyObject>, func: fn(Pin<&mut MyObject>, trivial: i32, opaque: UniquePtr<QColor>)) -> CxxQtQMetaObjectConnection
+                    pub fn on_data_changed(self: core::pin::Pin<&mut MyObject>, func: fn(core::pin::Pin<&mut MyObject>, trivial: i32, opaque: UniquePtr<QColor>)) -> CxxQtQMetaObjectConnection
                     {
                         self.connect_data_changed(func, CxxQtConnectionType::AutoConnection)
                     }
@@ -311,7 +314,7 @@ mod tests {
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
                     #[must_use]
-                    pub fn on_unsafe_signal(self: Pin<&mut MyObject>, func: fn(Pin<&mut MyObject>, param: *mut T)) -> CxxQtQMetaObjectConnection
+                    pub fn on_unsafe_signal(self: core::pin::Pin<&mut MyObject>, func: fn(core::pin::Pin<&mut MyObject>, param: *mut T)) -> CxxQtQMetaObjectConnection
                     {
                         self.connect_unsafe_signal(func, CxxQtConnectionType::AutoConnection)
                     }
@@ -377,7 +380,7 @@ mod tests {
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
                     #[must_use]
-                    pub fn on_existing_signal(self: Pin<&mut MyObject>, func: fn(Pin<&mut MyObject>, )) -> CxxQtQMetaObjectConnection
+                    pub fn on_existing_signal(self: core::pin::Pin<&mut MyObject>, func: fn(core::pin::Pin<&mut MyObject>, )) -> CxxQtQMetaObjectConnection
                     {
                         self.connect_existing_signal(func, CxxQtConnectionType::AutoConnection)
                     }

--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -93,7 +93,7 @@ pub fn generate(
                     #[doc(hidden)]
                     fn queue<F>(cxx_qt_thread: &#cxx_qt_thread_ident, f: F) -> std::result::Result<(), cxx::Exception>
                     where
-                        F: FnOnce(std::pin::Pin<&mut #cpp_struct_ident>),
+                        F: FnOnce(core::pin::Pin<&mut #cpp_struct_ident>),
                         F: Send + 'static,
                     {
                         // Wrap the given closure and pass in to C++ function as an opaque type
@@ -102,7 +102,7 @@ pub fn generate(
                         #[allow(clippy::boxed_local)]
                         #[doc(hidden)]
                         fn func(
-                            obj: std::pin::Pin<&mut #cpp_struct_ident>,
+                            obj: core::pin::Pin<&mut #cpp_struct_ident>,
                             arg: std::boxed::Box<#cxx_qt_thread_queued_fn_ident>,
                         ) {
                             (arg.inner)(obj)
@@ -129,7 +129,7 @@ pub fn generate(
                 pub struct #cxx_qt_thread_queued_fn_ident {
                     // An opaque Rust type is required to be Sized.
                     // https://github.com/dtolnay/cxx/issues/665
-                    inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut #cpp_struct_ident>) + Send>,
+                    inner: std::boxed::Box<dyn FnOnce(core::pin::Pin<&mut #cpp_struct_ident>) + Send>,
                 }
             },
         ],
@@ -228,7 +228,7 @@ mod tests {
                     #[doc(hidden)]
                     fn queue<F>(cxx_qt_thread: &MyObjectCxxQtThread, f: F) -> std::result::Result<(), cxx::Exception>
                     where
-                        F: FnOnce(std::pin::Pin<&mut MyObject>),
+                        F: FnOnce(core::pin::Pin<&mut MyObject>),
                         F: Send + 'static,
                     {
                         // Wrap the given closure and pass in to C++ function as an opaque type
@@ -237,7 +237,7 @@ mod tests {
                         #[allow(clippy::boxed_local)]
                         #[doc(hidden)]
                         fn func(
-                            obj: std::pin::Pin<&mut MyObject>,
+                            obj: core::pin::Pin<&mut MyObject>,
                             arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
                         ) {
                             (arg.inner)(obj)
@@ -267,7 +267,7 @@ mod tests {
                 pub struct MyObjectCxxQtThreadQueuedFn {
                     // An opaque Rust type is required to be Sized.
                     // https://github.com/dtolnay/cxx/issues/665
-                    inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObject>) + Send>,
+                    inner: std::boxed::Box<dyn FnOnce(core::pin::Pin<&mut MyObject>) + Send>,
                 }
             },
         );

--- a/crates/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/rust/mod.rs
@@ -53,7 +53,7 @@ fn cxx_qt_common_blocks(qobject: &GeneratedRustQObject) -> Vec<TokenStream> {
                     self.cxx_qt_ffi_rust()
                 }
 
-                fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+                fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
                     self.cxx_qt_ffi_rust_mut()
                 }
             }
@@ -154,7 +154,6 @@ pub fn write_rust(generated: &GeneratedRustBlocks) -> TokenStream {
         /// Internal CXX-Qt module, made public temporarily between API changes
         pub mod #cxx_qt_mod_ident {
             use super::#cxx_mod_ident::*;
-            use std::pin::Pin;
             use cxx_qt::CxxQtType;
 
             #[doc(hidden)]
@@ -359,7 +358,6 @@ mod tests {
             #[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
             pub mod cxx_qt_ffi {
                 use super::ffi::*;
-                use std::pin::Pin;
                 use cxx_qt::CxxQtType;
 
                 #[doc(hidden)]
@@ -389,7 +387,7 @@ mod tests {
                     fn rust(&self) -> &Self::Rust {
                         self.cxx_qt_ffi_rust()
                     }
-                    fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+                    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
                         self.cxx_qt_ffi_rust_mut()
                     }
                 }
@@ -468,7 +466,6 @@ mod tests {
             #[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
             pub mod cxx_qt_ffi {
                 use super::ffi::*;
-                use std::pin::Pin;
                 use cxx_qt::CxxQtType;
 
                 #[doc(hidden)]
@@ -498,7 +495,7 @@ mod tests {
                     fn rust(&self) -> &Self::Rust {
                         self.cxx_qt_ffi_rust()
                     }
-                    fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+                    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
                         self.cxx_qt_ffi_rust_mut()
                     }
                 }
@@ -525,7 +522,7 @@ mod tests {
                     fn rust(&self) -> &Self::Rust {
                         self.cxx_qt_ffi_rust()
                     }
-                    fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+                    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
                         self.cxx_qt_ffi_rust_mut()
                     }
                 }

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -75,7 +75,6 @@ use self::cxx_qt_inheritance::*;
 pub mod cxx_qt_inheritance {
     use super::inheritance::*;
     use cxx_qt::CxxQtType;
-    use std::pin::Pin;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
@@ -95,7 +94,7 @@ pub mod cxx_qt_inheritance {
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()
         }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
             self.cxx_qt_ffi_rust_mut()
         }
     }

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -176,7 +176,6 @@ use self::cxx_qt_ffi::*;
 pub mod cxx_qt_ffi {
     use super::ffi::*;
     use cxx_qt::CxxQtType;
-    use std::pin::Pin;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
@@ -192,13 +191,13 @@ pub mod cxx_qt_ffi {
             f: F,
         ) -> std::result::Result<(), cxx::Exception>
         where
-            F: FnOnce(std::pin::Pin<&mut MyObject>),
+            F: FnOnce(core::pin::Pin<&mut MyObject>),
             F: Send + 'static,
         {
             #[allow(clippy::boxed_local)]
             #[doc(hidden)]
             fn func(
-                obj: std::pin::Pin<&mut MyObject>,
+                obj: core::pin::Pin<&mut MyObject>,
                 arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
             ) {
                 (arg.inner)(obj)
@@ -219,7 +218,7 @@ pub mod cxx_qt_ffi {
     }
     #[doc(hidden)]
     pub struct MyObjectCxxQtThreadQueuedFn {
-        inner: std::boxed::Box<dyn FnOnce(std::pin::Pin<&mut MyObject>) + Send>,
+        inner: std::boxed::Box<dyn FnOnce(core::pin::Pin<&mut MyObject>) + Send>,
     }
     impl cxx_qt::Locking for MyObject {}
     #[doc(hidden)]
@@ -276,7 +275,7 @@ pub mod cxx_qt_ffi {
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()
         }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
             self.cxx_qt_ffi_rust_mut()
         }
     }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -213,7 +213,6 @@ pub use self::cxx_qt_ffi::*;
 pub mod cxx_qt_ffi {
     use super::ffi::*;
     use cxx_qt::CxxQtType;
-    use std::pin::Pin;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     use super::MyTrait;
@@ -228,7 +227,7 @@ pub mod cxx_qt_ffi {
     impl MyObject {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "property_name"]
-        pub fn set_property_name(mut self: Pin<&mut Self>, value: i32) {
+        pub fn set_property_name(mut self: core::pin::Pin<&mut Self>, value: i32) {
             if self.property_name == value {
                 return;
             }
@@ -244,8 +243,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_property_name_changed(
-            self: Pin<&mut MyObject>,
-            func: fn(Pin<&mut MyObject>),
+            self: core::pin::Pin<&mut MyObject>,
+            func: fn(core::pin::Pin<&mut MyObject>),
         ) -> CxxQtQMetaObjectConnection {
             self.connect_property_name_changed(func, CxxQtConnectionType::AutoConnection)
         }
@@ -258,8 +257,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_ready(
-            self: Pin<&mut MyObject>,
-            func: fn(Pin<&mut MyObject>),
+            self: core::pin::Pin<&mut MyObject>,
+            func: fn(core::pin::Pin<&mut MyObject>),
         ) -> CxxQtQMetaObjectConnection {
             self.connect_ready(func, CxxQtConnectionType::AutoConnection)
         }
@@ -280,7 +279,7 @@ pub mod cxx_qt_ffi {
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()
         }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
             self.cxx_qt_ffi_rust_mut()
         }
     }
@@ -295,7 +294,7 @@ pub mod cxx_qt_ffi {
     impl SecondObject {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "property_name"]
-        pub fn set_property_name(mut self: Pin<&mut Self>, value: i32) {
+        pub fn set_property_name(mut self: core::pin::Pin<&mut Self>, value: i32) {
             if self.property_name == value {
                 return;
             }
@@ -311,8 +310,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_property_name_changed(
-            self: Pin<&mut SecondObject>,
-            func: fn(Pin<&mut SecondObject>),
+            self: core::pin::Pin<&mut SecondObject>,
+            func: fn(core::pin::Pin<&mut SecondObject>),
         ) -> CxxQtQMetaObjectConnection {
             self.connect_property_name_changed(func, CxxQtConnectionType::AutoConnection)
         }
@@ -325,8 +324,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_ready(
-            self: Pin<&mut SecondObject>,
-            func: fn(Pin<&mut SecondObject>),
+            self: core::pin::Pin<&mut SecondObject>,
+            func: fn(core::pin::Pin<&mut SecondObject>),
         ) -> CxxQtQMetaObjectConnection {
             self.connect_ready(func, CxxQtConnectionType::AutoConnection)
         }
@@ -346,7 +345,7 @@ pub mod cxx_qt_ffi {
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()
         }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
             self.cxx_qt_ffi_rust_mut()
         }
     }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -104,7 +104,6 @@ use self::cxx_qt_ffi::*;
 pub mod cxx_qt_ffi {
     use super::ffi::*;
     use cxx_qt::CxxQtType;
-    use std::pin::Pin;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
@@ -118,7 +117,7 @@ pub mod cxx_qt_ffi {
     impl MyObject {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "primitive"]
-        pub fn set_primitive(mut self: Pin<&mut Self>, value: i32) {
+        pub fn set_primitive(mut self: core::pin::Pin<&mut Self>, value: i32) {
             if self.primitive == value {
                 return;
             }
@@ -136,7 +135,7 @@ pub mod cxx_qt_ffi {
     impl MyObject {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "trivial"]
-        pub fn set_trivial(mut self: Pin<&mut Self>, value: QPoint) {
+        pub fn set_trivial(mut self: core::pin::Pin<&mut Self>, value: QPoint) {
             if self.trivial == value {
                 return;
             }
@@ -152,8 +151,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_primitive_changed(
-            self: Pin<&mut MyObject>,
-            func: fn(Pin<&mut MyObject>),
+            self: core::pin::Pin<&mut MyObject>,
+            func: fn(core::pin::Pin<&mut MyObject>),
         ) -> CxxQtQMetaObjectConnection {
             self.connect_primitive_changed(func, CxxQtConnectionType::AutoConnection)
         }
@@ -166,8 +165,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_trivial_changed(
-            self: Pin<&mut MyObject>,
-            func: fn(Pin<&mut MyObject>),
+            self: core::pin::Pin<&mut MyObject>,
+            func: fn(core::pin::Pin<&mut MyObject>),
         ) -> CxxQtQMetaObjectConnection {
             self.connect_trivial_changed(func, CxxQtConnectionType::AutoConnection)
         }
@@ -188,7 +187,7 @@ pub mod cxx_qt_ffi {
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()
         }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
             self.cxx_qt_ffi_rust_mut()
         }
     }

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -131,7 +131,6 @@ use self::cxx_qt_ffi::*;
 pub mod cxx_qt_ffi {
     use super::ffi::*;
     use cxx_qt::CxxQtType;
-    use std::pin::Pin;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
@@ -143,8 +142,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_ready(
-            self: Pin<&mut MyObject>,
-            func: fn(Pin<&mut MyObject>),
+            self: core::pin::Pin<&mut MyObject>,
+            func: fn(core::pin::Pin<&mut MyObject>),
         ) -> CxxQtQMetaObjectConnection {
             self.connect_ready(func, CxxQtConnectionType::AutoConnection)
         }
@@ -157,9 +156,9 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_data_changed(
-            self: Pin<&mut MyObject>,
+            self: core::pin::Pin<&mut MyObject>,
             func: fn(
-                Pin<&mut MyObject>,
+                core::pin::Pin<&mut MyObject>,
                 first: i32,
                 second: UniquePtr<Opaque>,
                 third: QPoint,
@@ -177,9 +176,9 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_base_class_new_data(
-            self: Pin<&mut MyObject>,
+            self: core::pin::Pin<&mut MyObject>,
             func: fn(
-                Pin<&mut MyObject>,
+                core::pin::Pin<&mut MyObject>,
                 first: i32,
                 second: UniquePtr<Opaque>,
                 third: QPoint,
@@ -205,7 +204,7 @@ pub mod cxx_qt_ffi {
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()
         }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
+        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
             self.cxx_qt_ffi_rust_mut()
         }
     }

--- a/crates/cxx-qt-lib/src/core/qcoreapplication.rs
+++ b/crates/cxx-qt-lib/src/core/qcoreapplication.rs
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{QByteArray, QString, QStringList, QVector};
-use std::pin::Pin;
+use core::pin::Pin;
 
 #[cxx::bridge]
 mod ffi {

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.rs
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.rs
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{QByteArray, QString, QStringList, QVector};
-use std::pin::Pin;
+use core::pin::Pin;
 
 #[cxx::bridge]
 mod ffi {

--- a/examples/demo_threading/rust/src/workers/sensors.rs
+++ b/examples/demo_threading/rust/src/workers/sensors.rs
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{constants::SENSOR_MAXIMUM_COUNT, network::NetworkChannel, qobject};
+use core::pin::Pin;
 use cxx_qt::CxxQtThread;
 use cxx_qt_lib::QString;
 use std::{
@@ -85,9 +86,7 @@ impl SensorsWorker {
                         // Queue a Signal that the sensor has been removed to Qt
                         qt_thread
                             .queue(
-                                move |qobject_energy_usage: std::pin::Pin<
-                                    &mut qobject::EnergyUsage,
-                                >| {
+                                move |qobject_energy_usage: Pin<&mut qobject::EnergyUsage>| {
                                     qobject_energy_usage
                                         .sensor_removed(QString::from(&uuid.to_string()));
                                 },
@@ -118,7 +117,7 @@ impl SensorsWorker {
                             if is_occupied {
                                 qt_thread
                                     .queue(
-                                        move |qobject_energy_usage: std::pin::Pin<
+                                        move |qobject_energy_usage: Pin<
                                             &mut qobject::EnergyUsage,
                                         >| {
                                             qobject_energy_usage
@@ -129,7 +128,7 @@ impl SensorsWorker {
                             } else {
                                 qt_thread
                                     .queue(
-                                        move |qobject_energy_usage: std::pin::Pin<
+                                        move |qobject_energy_usage: Pin<
                                             &mut qobject::EnergyUsage,
                                         >| {
                                             qobject_energy_usage

--- a/tests/qt_types_standalone/rust/src/qbytearray.rs
+++ b/tests/qt_types_standalone/rust/src/qbytearray.rs
@@ -38,7 +38,7 @@ fn read_qbytearray(s: &cxx_qt_lib::QByteArray) -> bool {
     rs == "String constructed by C++"
 }
 
-fn modify_qbytearray(mut s: std::pin::Pin<&mut cxx_qt_lib::QByteArray>) {
+fn modify_qbytearray(mut s: core::pin::Pin<&mut cxx_qt_lib::QByteArray>) {
     *s = QByteArray::from("Updated string value");
 }
 

--- a/tests/qt_types_standalone/rust/src/qstring.rs
+++ b/tests/qt_types_standalone/rust/src/qstring.rs
@@ -37,7 +37,7 @@ fn read_qstring(s: &cxx_qt_lib::QString) -> bool {
     rs == "String constructed by C++"
 }
 
-fn modify_qstring(mut s: std::pin::Pin<&mut cxx_qt_lib::QString>) {
+fn modify_qstring(mut s: core::pin::Pin<&mut cxx_qt_lib::QString>) {
     *s = QString::from("Updated string value");
 }
 


### PR DESCRIPTION
Now that impls are outside of the bridge the developer needs to import Pin anyway.

Closes #417

Requires #553