### PR TITLE
cxx-qt-gen: remove wrapper method for C++ -> Rust invokables

### DIFF
--- a/crates/cxx-qt-gen/test_outputs/inheritance.cpp
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.cpp
@@ -18,14 +18,14 @@ QVariant
 MyObject::data(QModelIndex const& _index, ::std::int32_t _role) const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  return m_rustObj->dataWrapper(*this, _index, _role);
+  return dataWrapper(_index, _role);
 }
 
 bool
 MyObject::hasChildren(QModelIndex const& _parent) const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  return m_rustObj->hasChildrenWrapper(*this, _parent);
+  return hasChildrenWrapper(_parent);
 }
 
 MyObject::MyObject(QObject* parent)

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -38,6 +38,11 @@ public:
   explicit MyObject(QObject* parent = nullptr);
 
 private:
+  QVariant dataWrapper(QModelIndex const& _index,
+                       ::std::int32_t _role) const noexcept;
+  bool hasChildrenWrapper(QModelIndex const& _parent) const noexcept;
+
+private:
   ::rust::Box<MyObjectRust> m_rustObj;
   ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
 };

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -35,18 +35,14 @@ mod inheritance {
         type MyObjectRust;
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "dataWrapper"]
-        fn data_wrapper(
-            self: &MyObjectRust,
-            cpp: &MyObject,
-            _index: &QModelIndex,
-            _role: i32,
-        ) -> QVariant;
+        fn data(self: &MyObject, _index: &QModelIndex, _role: i32) -> QVariant;
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "hasChildrenWrapper"]
-        fn has_children_wrapper(self: &MyObjectRust, cpp: &MyObject, _parent: &QModelIndex)
-            -> bool;
+        fn has_children(self: &MyObject, _parent: &QModelIndex) -> bool;
     }
     unsafe extern "C++" {
         #[doc = " Inherited hasChildren from the base class"]
@@ -83,27 +79,6 @@ pub mod cxx_qt_inheritance {
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn data_wrapper(
-            self: &MyObjectRust,
-            cpp: &MyObject,
-            _index: &QModelIndex,
-            _role: i32,
-        ) -> QVariant {
-            return cpp.data(_index, _role);
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn has_children_wrapper(
-            self: &MyObjectRust,
-            cpp: &MyObject,
-            _parent: &QModelIndex,
-        ) -> bool {
-            return cpp.has_children(_parent);
-        }
-    }
     impl cxx_qt::Locking for MyObject {}
     #[doc = r" Generated CXX-Qt method which creates a boxed rust struct of a QObject"]
     pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -24,14 +24,14 @@ void
 MyObject::invokable() const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->invokableWrapper(*this);
+  invokableWrapper();
 }
 
 void
 MyObject::invokableMutable()
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->invokableMutableWrapper(*this);
+  invokableMutableWrapper();
 }
 
 void
@@ -40,42 +40,42 @@ MyObject::invokableParameters(QColor const& opaque,
                               ::std::int32_t primitive) const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->invokableParametersWrapper(*this, opaque, trivial, primitive);
+  invokableParametersWrapper(opaque, trivial, primitive);
 }
 
 ::std::unique_ptr<Opaque>
 MyObject::invokableReturnOpaque()
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  return m_rustObj->invokableReturnOpaqueWrapper(*this);
+  return invokableReturnOpaqueWrapper();
 }
 
 QPoint
 MyObject::invokableReturnTrivial()
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  return m_rustObj->invokableReturnTrivialWrapper(*this);
+  return invokableReturnTrivialWrapper();
 }
 
 void
 MyObject::invokableFinal() const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->invokableFinalWrapper(*this);
+  invokableFinalWrapper();
 }
 
 void
 MyObject::invokableOverride() const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->invokableOverrideWrapper(*this);
+  invokableOverrideWrapper();
 }
 
 void
 MyObject::invokableVirtual() const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->invokableVirtualWrapper(*this);
+  invokableVirtualWrapper();
 }
 
 static_assert(alignof(MyObjectCxxQtThread) <= alignof(::std::size_t),

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -40,6 +40,16 @@ public:
   explicit MyObject(::std::int32_t arg0, QObject* arg1);
 
 private:
+  void invokableWrapper() const noexcept;
+  void invokableMutableWrapper() noexcept;
+  void invokableParametersWrapper(QColor const& opaque,
+                                  QPoint const& trivial,
+                                  ::std::int32_t primitive) const noexcept;
+  ::std::unique_ptr<Opaque> invokableReturnOpaqueWrapper() noexcept;
+  QPoint invokableReturnTrivialWrapper() noexcept;
+  void invokableFinalWrapper() const noexcept;
+  void invokableOverrideWrapper() const noexcept;
+  void invokableVirtualWrapper() const noexcept;
   explicit MyObject(
     cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments0&& args);
 

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -36,48 +36,44 @@ mod ffi {
         type MyObjectRust;
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableWrapper"]
-        fn invokable_wrapper(self: &MyObjectRust, cpp: &MyObject);
+        fn invokable(self: &MyObject);
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableMutableWrapper"]
-        fn invokable_mutable_wrapper(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>);
+        fn invokable_mutable(self: Pin<&mut MyObject>);
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableParametersWrapper"]
-        fn invokable_parameters_wrapper(
-            self: &MyObjectRust,
-            cpp: &MyObject,
-            opaque: &QColor,
-            trivial: &QPoint,
-            primitive: i32,
-        );
+        fn invokable_parameters(self: &MyObject, opaque: &QColor, trivial: &QPoint, primitive: i32);
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableReturnOpaqueWrapper"]
-        fn invokable_return_opaque_wrapper(
-            self: &mut MyObjectRust,
-            cpp: Pin<&mut MyObject>,
-        ) -> UniquePtr<Opaque>;
+        fn invokable_return_opaque(self: Pin<&mut MyObject>) -> UniquePtr<Opaque>;
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableReturnTrivialWrapper"]
-        fn invokable_return_trivial_wrapper(
-            self: &mut MyObjectRust,
-            cpp: Pin<&mut MyObject>,
-        ) -> QPoint;
+        fn invokable_return_trivial(self: Pin<&mut MyObject>) -> QPoint;
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableFinalWrapper"]
-        fn invokable_final_wrapper(self: &MyObjectRust, cpp: &MyObject);
+        fn invokable_final(self: &MyObject);
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableOverrideWrapper"]
-        fn invokable_override_wrapper(self: &MyObjectRust, cpp: &MyObject);
+        fn invokable_override(self: &MyObject);
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableVirtualWrapper"]
-        fn invokable_virtual_wrapper(self: &MyObjectRust, cpp: &MyObject);
+        fn invokable_virtual(self: &MyObject);
     }
     unsafe extern "C++" {
         #[doc(hidden)]
@@ -174,66 +170,6 @@ pub mod cxx_qt_ffi {
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_wrapper(self: &MyObjectRust, cpp: &MyObject) {
-            cpp.invokable();
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_mutable_wrapper(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>) {
-            cpp.invokable_mutable();
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_parameters_wrapper(
-            self: &MyObjectRust,
-            cpp: &MyObject,
-            opaque: &QColor,
-            trivial: &QPoint,
-            primitive: i32,
-        ) {
-            cpp.invokable_parameters(opaque, trivial, primitive);
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_return_opaque_wrapper(
-            self: &mut MyObjectRust,
-            cpp: Pin<&mut MyObject>,
-        ) -> UniquePtr<Opaque> {
-            return cpp.invokable_return_opaque();
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_return_trivial_wrapper(
-            self: &mut MyObjectRust,
-            cpp: Pin<&mut MyObject>,
-        ) -> QPoint {
-            return cpp.invokable_return_trivial();
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_final_wrapper(self: &MyObjectRust, cpp: &MyObject) {
-            cpp.invokable_final();
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_override_wrapper(self: &MyObjectRust, cpp: &MyObject) {
-            cpp.invokable_override();
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_virtual_wrapper(self: &MyObjectRust, cpp: &MyObject) {
-            cpp.invokable_virtual();
-        }
-    }
     impl cxx_qt::Threading for MyObject {
         type BoxedQueuedFn = MyObjectCxxQtThreadQueuedFn;
         type ThreadingTypeId = cxx::type_id!("cxx_qt::my_object::MyObjectCxxQtThread");

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -49,7 +49,7 @@ void
 MyObject::invokableName()
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->invokableNameWrapper(*this);
+  invokableNameWrapper();
 }
 
 ::QMetaObject::Connection
@@ -122,7 +122,7 @@ void
 SecondObject::invokableName()
 {
 
-  m_rustObj->invokableNameWrapper(*this);
+  invokableNameWrapper();
 }
 
 ::QMetaObject::Connection

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -46,6 +46,9 @@ public:
   explicit MyObject(QObject* parent = nullptr);
 
 private:
+  void invokableNameWrapper() noexcept;
+
+private:
   ::rust::Box<MyObjectRust> m_rustObj;
   ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
 };
@@ -80,6 +83,9 @@ public:
   ::QMetaObject::Connection readyConnect(::rust::Fn<void(SecondObject&)> func,
                                          ::Qt::ConnectionType type);
   explicit SecondObject(QObject* parent = nullptr);
+
+private:
+  void invokableNameWrapper() noexcept;
 
 private:
   ::rust::Box<SecondObjectRust> m_rustObj;

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -98,8 +98,9 @@ pub mod ffi {
         ) -> CxxQtQMetaObjectConnection;
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableNameWrapper"]
-        fn invokable_name_wrapper(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>);
+        fn invokable_name(self: Pin<&mut MyObject>);
     }
     unsafe extern "C++" {
         #[rust_name = "ready"]
@@ -170,8 +171,9 @@ pub mod ffi {
         ) -> CxxQtQMetaObjectConnection;
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableNameWrapper"]
-        fn invokable_name_wrapper(self: &mut SecondObjectRust, cpp: Pin<&mut SecondObject>);
+        fn invokable_name(self: Pin<&mut SecondObject>);
     }
     unsafe extern "C++" {
         #[my_attribute]
@@ -260,12 +262,6 @@ pub mod cxx_qt_ffi {
             self.connect_property_name_changed(func, CxxQtConnectionType::AutoConnection)
         }
     }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_name_wrapper(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>) {
-            cpp.invokable_name();
-        }
-    }
     impl MyObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "ready"]
@@ -343,12 +339,6 @@ pub mod cxx_qt_ffi {
             func: fn(Pin<&mut SecondObject>),
         ) -> CxxQtQMetaObjectConnection {
             self.connect_property_name_changed(func, CxxQtConnectionType::AutoConnection)
-        }
-    }
-    impl SecondObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_name_wrapper(self: &mut SecondObjectRust, cpp: Pin<&mut SecondObject>) {
-            cpp.invokable_name();
         }
     }
     impl SecondObject {

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -20,7 +20,7 @@ void
 MyObject::invokable()
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->invokableWrapper(*this);
+  invokableWrapper();
 }
 
 ::QMetaObject::Connection

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -51,6 +51,9 @@ public:
   explicit MyObject(QObject* parent = nullptr);
 
 private:
+  void invokableWrapper() noexcept;
+
+private:
   ::rust::Box<MyObjectRust> m_rustObj;
   ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
 };

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -34,8 +34,9 @@ mod ffi {
         type MyObjectRust;
     }
     extern "Rust" {
+        #[doc(hidden)]
         #[cxx_name = "invokableWrapper"]
-        fn invokable_wrapper(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>);
+        fn invokable(self: Pin<&mut MyObject>);
     }
     unsafe extern "C++" {
         #[rust_name = "ready"]
@@ -134,12 +135,6 @@ pub mod cxx_qt_ffi {
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn invokable_wrapper(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>) {
-            cpp.invokable();
-        }
-    }
     impl MyObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "ready"]


### PR DESCRIPTION
This then avoids us needing to generate Rust methods with fully qualified types on the Rust side and removes a load of generation.

Related to #404