### PR TITLE
qt-build-utils: default to qmake, qmake6, qmake-qt5

### DIFF
--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -254,7 +254,7 @@ impl QtBuild {
         }
 
         // Fedora 36 renames Qt5's qmake to qmake-qt5
-        let candidate_executable_names = ["qmake6", "qmake-qt5", "qmake"];
+        let candidate_executable_names = ["qmake", "qmake6", "qmake-qt5"];
         for (index, executable_name) in candidate_executable_names.iter().enumerate() {
             match verify_candidate(executable_name) {
                 Ok((executable_name, version)) => {
@@ -267,10 +267,9 @@ impl QtBuild {
                         qt_modules,
                     });
                 }
-                // If QT_VERSION_MAJOR is specified, it is expected that one of the versioned
-                // executable names will not match, so the unversioned `qmake` needs to be
-                // attempted last and QtVersionMajorDoesNotMatch should only be returned if
-                // none of the candidate executable names match.
+                // If QT_VERSION_MAJOR is specified, it is expected that some of the versioned
+                // executable names will not match. QtVersionMajorDoesNotMatch should only be
+                // returned if none of the candidates match.
                 Err(QtBuildError::QtVersionMajorDoesNotMatch {
                     qmake_version,
                     qt_version_major,


### PR DESCRIPTION
When using Nix with Qt 6 the output of qmake6 -query is incorrect and ends up pointing to the incorrect locations. But qmake -query points to the correct ones.

This solves the issue for Nix but looks like Debian only has qmake for Qt 5 and qmake6 for Qt 6.

Related to #590