### PR TITLE
cxx-qt-build: enable parallel feature of cc crate

### DIFF
--- a/crates/cxx-qt-build/Cargo.toml
+++ b/crates/cxx-qt-build/Cargo.toml
@@ -13,7 +13,7 @@ description = "Helpers for integrating `cxx-qt` crate into a Cargo build"
 repository.workspace = true
 
 [dependencies]
-cc = "1.0.74"
+cc = { version = "1.0.74", features = ["parallel"] }
 convert_case.workspace = true
 cxx-gen.workspace = true
 cxx-qt-lib-headers.workspace = true


### PR DESCRIPTION
This allows for parallel compilation of C/C++ code.