### PR TITLE
Pass the qobject uri's to the moc compiler with the -Muri option.

### DIFF
--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -496,7 +496,14 @@ impl CxxQtBuilder {
         let mut cc_builder_whole_archive_files_added = false;
         // Run moc on C++ headers with Q_OBJECT macro
         for qobject_header in self.qobject_headers {
-            let moc_products = qtbuild.moc(&qobject_header.path);
+            let moc_uri_opt = qobject_header
+                .qml_metadata
+                .iter()
+                .flat_map(|qml_metadata| ["-Muri=", &qml_metadata.uri, " "])
+                .flat_map(|s| s.chars())
+                .collect::<String>()
+                .trim_end();
+            let moc_products = qtbuild.moc(&qobject_header.path, &moc_uri_opt);
             self.cc_builder.file(moc_products.cpp);
             for qml_metadata in qobject_header.qml_metadata {
                 self.cc_builder.define("QT_STATICPLUGIN", None);

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -496,14 +496,11 @@ impl CxxQtBuilder {
         let mut cc_builder_whole_archive_files_added = false;
         // Run moc on C++ headers with Q_OBJECT macro
         for qobject_header in self.qobject_headers {
-            let moc_uri_opt = qobject_header
+            let uris = qobject_header
                 .qml_metadata
                 .iter()
-                .flat_map(|qml_metadata| ["-Muri=", &qml_metadata.uri, " "])
-                .flat_map(|s| s.chars())
-                .collect::<String>()
-                .trim_end();
-            let moc_products = qtbuild.moc(&qobject_header.path, &moc_uri_opt);
+                .map(|qml_metadata| qml_metadata.uri.as_str());
+            let moc_products = qtbuild.moc(&qobject_header.path, uris);
             self.cc_builder.file(moc_products.cpp);
             for qml_metadata in qobject_header.qml_metadata {
                 self.cc_builder.define("QT_STATICPLUGIN", None);

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -450,6 +450,8 @@ impl QtBuild {
     /// Run moc on a C++ header file and save the output into [cargo's OUT_DIR](https://doc.rust-lang.org/cargo/reference/environment-variables.html).
     /// The return value contains the path to the generated C++ file, which can then be passed to [cc::Build::files](https://docs.rs/cc/latest/cc/struct.Build.html#method.file),
     /// as well as the path to the generated metatypes.json file, which can be passed to [register_qml_types](Self::register_qml_types).
+    ///
+    /// * uris - An iterator of uri's that the moc compiler is working on. This is required because some moc compilers require this to be specified.
     pub fn moc<'a>(
         &mut self,
         input_file: impl AsRef<Path>,
@@ -478,6 +480,7 @@ impl QtBuild {
             uri_args += &format!("-Muri={} ", uri);
         }
 
+        // FIXME when uris is empty the moc compiler fails
         let cmd = Command::new(self.moc_executable.as_ref().unwrap())
             .args([
                 &include_args,

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -480,16 +480,16 @@ impl QtBuild {
             uri_args += &format!("-Muri={} ", uri);
         }
 
-        // FIXME when uris is empty the moc compiler fails
-        let cmd = Command::new(self.moc_executable.as_ref().unwrap())
-            .args([
-                &include_args,
-                uri_args.trim_end(),
-                input_path.to_str().unwrap(),
-                "-o",
-                output_path.to_str().unwrap(),
-                "--output-json",
-            ])
+        let mut cmd = Command::new(self.moc_executable.as_ref().unwrap());
+        cmd.args(include_args.trim_end().split(' '));
+        if !uri_args.is_empty() {
+            cmd.args(uri_args.trim_end().split(' '));
+        }
+        cmd.arg(input_path.to_str().unwrap())
+            .arg("-o")
+            .arg(output_path.to_str().unwrap())
+            .arg("--output-json");
+        let cmd = cmd
             .output()
             .unwrap_or_else(|_| panic!("moc failed for {}", input_path.display()));
 

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -450,7 +450,7 @@ impl QtBuild {
     /// Run moc on a C++ header file and save the output into [cargo's OUT_DIR](https://doc.rust-lang.org/cargo/reference/environment-variables.html).
     /// The return value contains the path to the generated C++ file, which can then be passed to [cc::Build::files](https://docs.rs/cc/latest/cc/struct.Build.html#method.file),
     /// as well as the path to the generated metatypes.json file, which can be passed to [register_qml_types](Self::register_qml_types).
-    pub fn moc(&mut self, input_file: impl AsRef<Path>) -> MocProducts {
+    pub fn moc(&mut self, input_file: impl AsRef<Path>, uri_opt: &str) -> MocProducts {
         if self.moc_executable.is_none() {
             self.moc_executable = Some(self.get_qt_tool("moc").expect("Could not find moc"));
         }
@@ -472,6 +472,7 @@ impl QtBuild {
         let cmd = Command::new(self.moc_executable.as_ref().unwrap())
             .args([
                 &include_args,
+                uri_opt,
                 input_path.to_str().unwrap(),
                 "-o",
                 output_path.to_str().unwrap(),
@@ -575,7 +576,7 @@ public:
 "#
         )
         .unwrap();
-        self.moc(&qml_plugin_cpp_path);
+        self.moc(&qml_plugin_cpp_path, &format!("-Muri={import_name}"));
 
         let qml_plugin_init_path = PathBuf::from(format!("{out_dir}/{plugin_class_name}_init.cpp"));
         let mut qml_plugin_init = File::create(&qml_plugin_init_path).unwrap();


### PR DESCRIPTION
For some targets the moc compiler requires that the -Muri option should be passed for all qobjects. If this is not done the resulting qml application would not be able to find the qobject and will fail to load.