### PR TITLE
Prl file parsing fixes

### DIFF
--- a/crates/cxx-qt-build/Cargo.toml
+++ b/crates/cxx-qt-build/Cargo.toml
@@ -27,3 +27,4 @@ codespan-reporting = "0.11"
 default = ["qt_gui", "qt_qml"]
 qt_gui = ["cxx-qt-lib-headers/qt_gui"]
 qt_qml = ["cxx-qt-lib-headers/qt_qml"]
+link_qt_external = []

--- a/crates/cxx-qt-build/Cargo.toml
+++ b/crates/cxx-qt-build/Cargo.toml
@@ -27,3 +27,4 @@ codespan-reporting = "0.11"
 default = ["qt_gui", "qt_qml"]
 qt_gui = ["cxx-qt-lib-headers/qt_gui"]
 qt_qml = ["cxx-qt-lib-headers/qt_qml"]
+include_qt_objects = ["qt-build-utils/include_qt_objects"]

--- a/crates/cxx-qt-build/Cargo.toml
+++ b/crates/cxx-qt-build/Cargo.toml
@@ -27,4 +27,3 @@ codespan-reporting = "0.11"
 default = ["qt_gui", "qt_qml"]
 qt_gui = ["cxx-qt-lib-headers/qt_gui"]
 qt_qml = ["cxx-qt-lib-headers/qt_qml"]
-include_qt_objects = ["qt-build-utils/include_qt_objects"]

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -400,7 +400,7 @@ impl CxxQtBuilder {
 
         let mut qtbuild = qt_build_utils::QtBuild::new(self.qt_modules.into_iter().collect())
             .expect("Could not find Qt installation");
-        qtbuild.cargo_link_libraries(&mut self.cc_builder);
+        qtbuild.cargo_link_libraries(Some(&mut self.cc_builder));
 
         // Write cxx-qt-lib and cxx headers
         cxx_qt_lib_headers::write_headers(format!("{header_root}/cxx-qt-lib"));

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -400,7 +400,7 @@ impl CxxQtBuilder {
 
         let mut qtbuild = qt_build_utils::QtBuild::new(self.qt_modules.into_iter().collect())
             .expect("Could not find Qt installation");
-        qtbuild.cargo_link_libraries();
+        qtbuild.cargo_link_libraries(&mut self.cc_builder);
 
         // Write cxx-qt-lib and cxx headers
         cxx_qt_lib_headers::write_headers(format!("{header_root}/cxx-qt-lib"));

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -400,7 +400,13 @@ impl CxxQtBuilder {
 
         let mut qtbuild = qt_build_utils::QtBuild::new(self.qt_modules.into_iter().collect())
             .expect("Could not find Qt installation");
-        qtbuild.cargo_link_libraries(Some(&mut self.cc_builder));
+        // some external build systems will include object files found by cargo_link_libraries and
+        // are hard to remove. instead instruct this function to not include these object files.
+        if cfg!(feature = "link_qt_external") {
+            qtbuild.cargo_link_libraries(None);
+        } else {
+            qtbuild.cargo_link_libraries(Some(&mut self.cc_builder));
+        }
 
         // Write cxx-qt-lib and cxx headers
         cxx_qt_lib_headers::write_headers(format!("{header_root}/cxx-qt-lib"));

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -172,7 +172,7 @@ fn main() {
     let mut builder =
         cxx_build::bridges(rust_bridges.iter().map(|bridge| format!("src/{bridge}.rs")));
 
-    qtbuild.cargo_link_libraries(&mut builder);
+    qtbuild.cargo_link_libraries(None);
     // Required for tests
     qt_build_utils::setup_linker();
 

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -15,18 +15,6 @@ fn main() {
         qt_modules.push("Qml".to_owned());
     }
 
-    let qtbuild = qt_build_utils::QtBuild::new(qt_modules).expect("Could not find Qt installation");
-    qtbuild.cargo_link_libraries();
-    // Required for tests
-    qt_build_utils::setup_linker();
-
-    // Find the Qt version and tell the Rust compiler
-    // this allows us to have conditional Rust code
-    println!(
-        "cargo:rustc-cfg=qt_version_major=\"{}\"",
-        qtbuild.version().major
-    );
-
     let mut rust_bridges = vec![
         "core/qbytearray",
         "core/qcoreapplication",
@@ -173,6 +161,8 @@ fn main() {
         println!("cargo:rerun-if-changed=src/{bridge}.rs");
     }
 
+    let qtbuild = qt_build_utils::QtBuild::new(qt_modules).expect("Could not find Qt installation");
+
     for include_path in qtbuild.include_paths() {
         cxx_build::CFG
             .exported_header_dirs
@@ -181,6 +171,17 @@ fn main() {
 
     let mut builder =
         cxx_build::bridges(rust_bridges.iter().map(|bridge| format!("src/{bridge}.rs")));
+
+    qtbuild.cargo_link_libraries(&mut builder);
+    // Required for tests
+    qt_build_utils::setup_linker();
+
+    // Find the Qt version and tell the Rust compiler
+    // this allows us to have conditional Rust code
+    println!(
+        "cargo:rustc-cfg=qt_version_major=\"{}\"",
+        qtbuild.version().major
+    );
 
     let mut cpp_files = vec![
         "core/qbytearray",

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -15,6 +15,18 @@ fn main() {
         qt_modules.push("Qml".to_owned());
     }
 
+    let qtbuild = qt_build_utils::QtBuild::new(qt_modules).expect("Could not find Qt installation");
+    qtbuild.cargo_link_libraries(None);
+    // Required for tests
+    qt_build_utils::setup_linker();
+
+    // Find the Qt version and tell the Rust compiler
+    // this allows us to have conditional Rust code
+    println!(
+        "cargo:rustc-cfg=qt_version_major=\"{}\"",
+        qtbuild.version().major
+    );
+
     let mut rust_bridges = vec![
         "core/qbytearray",
         "core/qcoreapplication",
@@ -161,8 +173,6 @@ fn main() {
         println!("cargo:rerun-if-changed=src/{bridge}.rs");
     }
 
-    let qtbuild = qt_build_utils::QtBuild::new(qt_modules).expect("Could not find Qt installation");
-
     for include_path in qtbuild.include_paths() {
         cxx_build::CFG
             .exported_header_dirs
@@ -171,17 +181,6 @@ fn main() {
 
     let mut builder =
         cxx_build::bridges(rust_bridges.iter().map(|bridge| format!("src/{bridge}.rs")));
-
-    qtbuild.cargo_link_libraries(None);
-    // Required for tests
-    qt_build_utils::setup_linker();
-
-    // Find the Qt version and tell the Rust compiler
-    // this allows us to have conditional Rust code
-    println!(
-        "cargo:rustc-cfg=qt_version_major=\"{}\"",
-        qtbuild.version().major
-    );
 
     let mut cpp_files = vec![
         "core/qbytearray",

--- a/crates/qt-build-utils/Cargo.toml
+++ b/crates/qt-build-utils/Cargo.toml
@@ -16,6 +16,3 @@ repository.workspace = true
 cc = "1.0.74"
 versions = "4.1.0"
 thiserror = "1.0"
-
-[features]
-include_qt_objects = []

--- a/crates/qt-build-utils/Cargo.toml
+++ b/crates/qt-build-utils/Cargo.toml
@@ -13,5 +13,9 @@ description = "Build script helper for linking Qt libraries and using moc code g
 repository.workspace = true
 
 [dependencies]
+cc = "1.0.74"
 versions = "4.1.0"
 thiserror = "1.0"
+
+[features]
+include_qt_objects = []

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -421,6 +421,23 @@ impl QtBuild {
                 &prl_path,
             );
         }
+
+        let emscripten_targeted = match env::var("CARGO_CFG_TARGET_OS") {
+            Ok(val) => val == "emscripten",
+            Err(_) => false,
+        };
+        if emscripten_targeted {
+            let platforms_path = format!("{}/platforms", self.qmake_query("QT_INSTALL_PLUGINS"));
+            println!("cargo:rustc-link-search={platforms_path}");
+            self.cargo_link_qt_library(
+                builder,
+                "qwasm",
+                &prefix_path,
+                &lib_path,
+                "qwasm",
+                &format!("{platforms_path}/libqwasm.prl"),
+            );
+        }
     }
 
     /// Get the include paths for Qt, including Qt module subdirectories. This is intended

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -317,15 +317,15 @@ impl QtBuild {
     ) {
         println!("cargo:rustc-link-lib={link_lib}");
 
-        match std::fs::read_to_string(&prl_path) {
+        match std::fs::read_to_string(prl_path) {
             Ok(prl) => {
                 for line in prl.lines() {
                     if let Some(line) = line.strip_prefix("QMAKE_PRL_LIBS = ") {
                         parse_cflags::parse_libs_cflags(
                             builder,
                             name,
-                            line.replace(r"$$[QT_INSTALL_LIBS]", &lib_path)
-                                .replace(r"$$[QT_INSTALL_PREFIX]", &prefix_path)
+                            line.replace(r"$$[QT_INSTALL_LIBS]", lib_path)
+                                .replace(r"$$[QT_INSTALL_PREFIX]", prefix_path)
                                 .as_bytes(),
                         );
                     }
@@ -341,7 +341,13 @@ impl QtBuild {
     }
 
     /// Some prl files don't follow a consistent naming scheme. Try to find it by looking at all files in lib_path.
-    fn find_qt_module_prl(&self, lib_path: &str, prefix: &str, version_major: u32, qt_module: &str) -> String {
+    fn find_qt_module_prl(
+        &self,
+        lib_path: &str,
+        prefix: &str,
+        version_major: u32,
+        qt_module: &str,
+    ) -> String {
         match Path::new(lib_path).read_dir() {
             Ok(lib_dir) => {
                 for entry in lib_dir {
@@ -367,7 +373,10 @@ impl QtBuild {
             }
         }
 
-        format!("{}/{}Qt{}{}.prl",lib_path, prefix, version_major, qt_module)
+        format!(
+            "{}/{}Qt{}{}.prl",
+            lib_path, prefix, version_major, qt_module
+        )
     }
 
     /// Tell Cargo to link each Qt module.

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -341,6 +341,8 @@ impl QtBuild {
     }
 
     /// Some prl files don't follow a consistent naming scheme. Try to find it by looking at all files in lib_path.
+    /// The android libraries adds its architecture at the end of it prl files eg liQt6Core_{arch}.prl.
+    /// The arch placeholder is somewhat different for each architecture preventing the use of a simple format.
     fn find_qt_module_prl(
         &self,
         lib_path: &str,

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -308,12 +308,12 @@ impl QtBuild {
 
     fn cargo_link_qt_library(
         &self,
-        builder: &mut cc::Build,
         name: &str,
         prefix_path: &str,
         lib_path: &str,
         link_lib: &str,
         prl_path: &str,
+        builder: &mut cc::Build,
     ) {
         println!("cargo:rustc-link-lib={link_lib}");
 
@@ -322,11 +322,11 @@ impl QtBuild {
                 for line in prl.lines() {
                     if let Some(line) = line.strip_prefix("QMAKE_PRL_LIBS = ") {
                         parse_cflags::parse_libs_cflags(
-                            builder,
                             name,
                             line.replace(r"$$[QT_INSTALL_LIBS]", lib_path)
                                 .replace(r"$$[QT_INSTALL_PREFIX]", prefix_path)
                                 .as_bytes(),
+                            builder,
                         );
                     }
                 }
@@ -422,12 +422,12 @@ impl QtBuild {
             };
 
             self.cargo_link_qt_library(
-                builder,
                 &format!("Qt{}{qt_module}", self.version.major),
                 &prefix_path,
                 &lib_path,
                 &link_lib,
                 &prl_path,
+                builder,
             );
         }
 
@@ -439,12 +439,12 @@ impl QtBuild {
             let platforms_path = format!("{}/platforms", self.qmake_query("QT_INSTALL_PLUGINS"));
             println!("cargo:rustc-link-search={platforms_path}");
             self.cargo_link_qt_library(
-                builder,
                 "qwasm",
                 &prefix_path,
                 &lib_path,
                 "qwasm",
                 &format!("{platforms_path}/libqwasm.prl"),
+                builder,
             );
         }
     }

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -313,7 +313,7 @@ impl QtBuild {
         lib_path: &str,
         link_lib: &str,
         prl_path: &str,
-        builder: &mut cc::Build,
+        builder: &mut Option<&mut cc::Build>,
     ) {
         println!("cargo:rustc-link-lib={link_lib}");
 
@@ -382,7 +382,7 @@ impl QtBuild {
     }
 
     /// Tell Cargo to link each Qt module.
-    pub fn cargo_link_libraries(&self, builder: &mut cc::Build) {
+    pub fn cargo_link_libraries(&self, mut builder: Option<&mut cc::Build>) {
         let prefix_path = self.qmake_query("QT_INSTALL_PREFIX");
         let lib_path = self.qmake_query("QT_INSTALL_LIBS");
         println!("cargo:rustc-link-search={lib_path}");
@@ -429,7 +429,7 @@ impl QtBuild {
                 &lib_path,
                 &link_lib,
                 &prl_path,
-                builder,
+                &mut builder,
             );
         }
 
@@ -446,7 +446,7 @@ impl QtBuild {
                 &lib_path,
                 "qwasm",
                 &format!("{platforms_path}/libqwasm.prl"),
-                builder,
+                &mut builder,
             );
         }
     }

--- a/crates/qt-build-utils/src/parse_cflags.rs
+++ b/crates/qt-build-utils/src/parse_cflags.rs
@@ -103,7 +103,7 @@ fn split_flags(link_args: &[u8]) -> Vec<String> {
     words
 }
 
-pub(crate) fn parse_libs_cflags(_builder: &mut cc::Build, name: &str, link_args: &[u8]) {
+pub(crate) fn parse_libs_cflags(name: &str, link_args: &[u8], _builder: &mut cc::Build) {
     let mut is_msvc = false;
     let target = env::var("TARGET");
     if let Ok(target) = &target {
@@ -168,6 +168,12 @@ pub(crate) fn parse_libs_cflags(_builder: &mut cc::Build, name: &str, link_args:
                         (path.parent(), path.file_name(), &target)
                     {
                         if file_name.to_string_lossy().ends_with(".o") {
+                            // Cargo doesn't have a means to directly specify an object to link,
+                            // so use the cc crate to specify it instead.
+                            // TODO: pass file path directly when link-arg library type is stabilized
+                            // https://github.com/rust-lang/rust/issues/99427#issuecomment-1562092085
+                            // TODO: remove builder argument when it's not used anymore to link object files.
+                            // also remove the dependency on cc when this is done
                             #[cfg(feature = "include_qt_objects")]
                             _builder.object(path);
                         } else {

--- a/crates/qt-build-utils/src/parse_cflags.rs
+++ b/crates/qt-build-utils/src/parse_cflags.rs
@@ -8,7 +8,9 @@
 //! It has been decoupled from the pkg-config crate because qt-build-utils reads Qt's .prl files instead, which
 //! does not require a pkg-config executable to be available.
 
-use std::env;
+use std::{collections::HashSet, env, sync::OnceLock};
+
+static mut LINKED_OBJECT_FILES: OnceLock<HashSet<String>> = OnceLock::new();
 
 /// Extract the &str to pass to cargo:rustc-link-lib from a filename (just the file name, not including directories)
 /// using target-specific logic.
@@ -103,7 +105,7 @@ fn split_flags(link_args: &[u8]) -> Vec<String> {
     words
 }
 
-pub(crate) fn parse_libs_cflags(name: &str, link_args: &[u8], _builder: &mut cc::Build) {
+pub(crate) fn parse_libs_cflags(name: &str, link_args: &[u8], builder: &mut cc::Build) {
     let mut is_msvc = false;
     let target = env::var("TARGET");
     if let Ok(target) = &target {
@@ -162,20 +164,27 @@ pub(crate) fn parse_libs_cflags(name: &str, link_args: &[u8], _builder: &mut cc:
                 if path.is_file() {
                     // Cargo doesn't have a means to directly specify a file path to link,
                     // so split up the path into the parent directory and library name.
-                    // TODO: pass file path directly when link-arg library type is stabilized
-                    // https://github.com/rust-lang/rust/issues/99427
                     if let (Some(dir), Some(file_name), Ok(target)) =
                         (path.parent(), path.file_name(), &target)
                     {
                         if file_name.to_string_lossy().ends_with(".o") {
-                            // Cargo doesn't have a means to directly specify an object to link,
-                            // so use the cc crate to specify it instead.
-                            // TODO: pass file path directly when link-arg library type is stabilized
-                            // https://github.com/rust-lang/rust/issues/99427#issuecomment-1562092085
-                            // TODO: remove builder argument when it's not used anymore to link object files.
-                            // also remove the dependency on cc when this is done
-                            #[cfg(feature = "include_qt_objects")]
-                            _builder.object(path);
+                            let path_string = path.to_string_lossy().to_string();
+                            unsafe {
+                                // Linking will fail with duplicate symbol errors if the same .o file is linked twice.
+                                // Many of Qt's .prl files repeat listing .o files that other .prl files also list.
+                                let already_linked_object_files =
+                                    LINKED_OBJECT_FILES.get_or_init(|| HashSet::new());
+                                if !already_linked_object_files.contains(&path_string) {
+                                    // Cargo doesn't have a means to directly specify an object to link,
+                                    // so use the cc crate to specify it instead.
+                                    // TODO: pass file path directly when link-arg library type is stabilized
+                                    // https://github.com/rust-lang/rust/issues/99427#issuecomment-1562092085
+                                    // TODO: remove builder argument when it's not used anymore to link object files.
+                                    // also remove the dependency on cc when this is done
+                                    builder.object(path);
+                                }
+                                LINKED_OBJECT_FILES.get_mut().unwrap().insert(path_string);
+                            }
                         } else {
                             match extract_lib_from_filename(target, &file_name.to_string_lossy()) {
                                 Some(lib_basename) => {


### PR DESCRIPTION
The following three issues with prl file parsing have been fixed:
- previously QT_INSTALL_PREFIX would be treated the same as QT_INSTALL_LIBS which is not correct.
- some prl files names(mainly from android) would not follow the assumed patern.
- building for wasm requires that the libqwasm.prl must be included.