### PR TITLE
cxx-qt-gen: remove generated qobject module and use bridge mod instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `rust_mut` is now safe to call
 - `#[qproperty]` is now defined as an attribute on the qobject rather than the field
 - QObject struct is now split between the bridge and implementation outside via a type alias
+- `qobject` module is no longer generated
 
 ### Fixed
 

--- a/book/src/concepts/nested_objects.md
+++ b/book/src/concepts/nested_objects.md
@@ -11,7 +11,7 @@ Rust Qt objects can be nested as properties or parameters of each other.
 
 A nested object is referred to by using a pointer to its QObject representation.
 
-First define a type with an extern block for your bridge, this should point to the `qobject::T` of the QObject and the `cxx_name` should match the QObject name.
+First define a type within an extern block for your bridge as normal.
 
 ```rust,ignore,noplayground
 {{#include ../../../examples/qml_features/rust/src/nested_qobjects.rs:book_extern_block}}

--- a/crates/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/rust/mod.rs
@@ -121,17 +121,6 @@ pub fn write_rust(generated: &GeneratedRustBlocks) -> TokenStream {
         })
     }
 
-    // Create the qobject block for the type alias
-    cxx_qt_mod_contents.push(
-        syn::parse2(quote! {
-            /// Generated CXX-Qt module containing type alias to the C++ types of the QObjects
-            pub mod qobject {
-                #(#qobject_types)*
-            }
-        })
-        .expect("Could not build qobject block"),
-    );
-
     // Inject the CXX blocks
     if let Some((_, items)) = &mut cxx_mod.content {
         items.extend(cxx_mod_contents.into_iter());
@@ -385,17 +374,6 @@ mod tests {
                         self.cxx_qt_ffi_rust_mut()
                     }
                 }
-
-                /// Generated CXX-Qt module containing type alias to the C++ types of the QObjects
-                pub mod qobject {
-                    #[doc = "The C++ type for the QObject "]
-                    #[doc = "MyObject"]
-                    #[doc = "\n"]
-                    #[doc = "Use this type when referring to the QObject as a pointer"]
-                    #[doc = "\n"]
-                    #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
-                    pub type MyObject = super::MyObject;
-                }
             }
         }
         .into_token_stream()
@@ -515,24 +493,6 @@ mod tests {
                     fn rust_mut(self: core::pin::Pin<&mut Self>) -> Pin<&mut Self::Rust> {
                         self.cxx_qt_ffi_rust_mut()
                     }
-                }
-
-                /// Generated CXX-Qt module containing type alias to the C++ types of the QObjects
-                pub mod qobject {
-                    #[doc = "The C++ type for the QObject "]
-                    #[doc = "FirstObject"]
-                    #[doc = "\n"]
-                    #[doc = "Use this type when referring to the QObject as a pointer"]
-                    #[doc = "\n"]
-                    #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
-                    pub type FirstObject = super::FirstObject;
-                    #[doc = "The C++ type for the QObject "]
-                    #[doc = "SecondObject"]
-                    #[doc = "\n"]
-                    #[doc = "Use this type when referring to the QObject as a pointer"]
-                    #[doc = "\n"]
-                    #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
-                    pub type SecondObject = super::SecondObject;
                 }
             }
         }

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -118,14 +118,4 @@ pub mod cxx_qt_inheritance {
             self.cxx_qt_ffi_rust_mut()
         }
     }
-    #[doc = r" Generated CXX-Qt module containing type alias to the C++ types of the QObjects"]
-    pub mod qobject {
-        #[doc = "The C++ type for the QObject "]
-        #[doc = "MyObject"]
-        #[doc = "\n"]
-        #[doc = "Use this type when referring to the QObject as a pointer"]
-        #[doc = "\n"]
-        #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
-        pub type MyObject = super::MyObject;
-    }
 }

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -328,14 +328,4 @@ pub mod cxx_qt_ffi {
             self.cxx_qt_ffi_rust_mut()
         }
     }
-    #[doc = r" Generated CXX-Qt module containing type alias to the C++ types of the QObjects"]
-    pub mod qobject {
-        #[doc = "The C++ type for the QObject "]
-        #[doc = "MyObject"]
-        #[doc = "\n"]
-        #[doc = "Use this type when referring to the QObject as a pointer"]
-        #[doc = "\n"]
-        #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
-        pub type MyObject = super::MyObject;
-    }
 }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -377,21 +377,4 @@ pub mod cxx_qt_ffi {
             self.cxx_qt_ffi_rust_mut()
         }
     }
-    #[doc = r" Generated CXX-Qt module containing type alias to the C++ types of the QObjects"]
-    pub mod qobject {
-        #[doc = "The C++ type for the QObject "]
-        #[doc = "MyObject"]
-        #[doc = "\n"]
-        #[doc = "Use this type when referring to the QObject as a pointer"]
-        #[doc = "\n"]
-        #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
-        pub type MyObject = super::MyObject;
-        #[doc = "The C++ type for the QObject "]
-        #[doc = "SecondObject"]
-        #[doc = "\n"]
-        #[doc = "Use this type when referring to the QObject as a pointer"]
-        #[doc = "\n"]
-        #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
-        pub type SecondObject = super::SecondObject;
-    }
 }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -210,14 +210,4 @@ pub mod cxx_qt_ffi {
             self.cxx_qt_ffi_rust_mut()
         }
     }
-    #[doc = r" Generated CXX-Qt module containing type alias to the C++ types of the QObjects"]
-    pub mod qobject {
-        #[doc = "The C++ type for the QObject "]
-        #[doc = "MyObject"]
-        #[doc = "\n"]
-        #[doc = "Use this type when referring to the QObject as a pointer"]
-        #[doc = "\n"]
-        #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
-        pub type MyObject = super::MyObject;
-    }
 }

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -208,14 +208,4 @@ pub mod cxx_qt_ffi {
             self.cxx_qt_ffi_rust_mut()
         }
     }
-    #[doc = r" Generated CXX-Qt module containing type alias to the C++ types of the QObjects"]
-    pub mod qobject {
-        #[doc = "The C++ type for the QObject "]
-        #[doc = "MyObject"]
-        #[doc = "\n"]
-        #[doc = "Use this type when referring to the QObject as a pointer"]
-        #[doc = "\n"]
-        #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
-        pub type MyObject = super::MyObject;
-    }
 }

--- a/crates/cxx-qt-macro/src/lib.rs
+++ b/crates/cxx-qt-macro/src/lib.rs
@@ -18,7 +18,7 @@ use cxx_qt_gen::{write_rust, GeneratedRustBlocks, Parser};
 ///
 /// ```rust
 /// #[cxx_qt::bridge(namespace = "cxx_qt::my_object")]
-/// mod ffi {
+/// mod qobject {
 ///     unsafe extern "RustQt" {
 ///         #[cxx_qt::qobject]
 ///         # // Note that we can't use properties as this confuses the linker on Windows
@@ -32,9 +32,7 @@ use cxx_qt_gen::{write_rust, GeneratedRustBlocks, Parser};
 /// #[derive(Default)]
 /// pub struct MyObjectRust;
 ///
-/// # // TODO: this will change to qobject::MyObject once
-/// # // https://github.com/KDAB/cxx-qt/issues/559 is done
-/// impl ffi::MyObject {
+/// impl qobject::MyObject {
 ///     fn invokable(&self, a: i32, b: i32) -> i32 {
 ///         a + b
 ///     }

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -92,7 +92,7 @@ pub trait Threading: Locking + Sized {
 /// # Minimal Example
 /// ```
 /// #[cxx_qt::bridge]
-/// mod ffi {
+/// mod qobject {
 ///     extern "RustQt" {
 ///         #[cxx_qt::qobject]
 ///         type MyStruct = super::MyStructRust;

--- a/examples/demo_threading/rust/src/lib.rs
+++ b/examples/demo_threading/rust/src/lib.rs
@@ -10,7 +10,7 @@ mod workers;
 
 // This mod defines our QObject called EnergyUsage
 #[cxx_qt::bridge(cxx_file_stem = "energy_usage", namespace = "cxx_qt::energy_usage")]
-mod ffi {
+mod qobject {
     #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");
@@ -99,9 +99,7 @@ impl Default for EnergyUsageRust {
     }
 }
 
-// TODO: this will change to qobject::EnergyUsage once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::EnergyUsage {
+impl qobject::EnergyUsage {
     /// A Q_INVOKABLE that returns the current power usage for a given uuid
     fn sensor_power(self: Pin<&mut Self>, uuid: &QString) -> f64 {
         let sensors = SensorsWorker::read_sensors(&self.rust_mut().sensors_map);

--- a/examples/qml_extension_plugin/plugin/rust/src/lib.rs
+++ b/examples/qml_extension_plugin/plugin/rust/src/lib.rs
@@ -27,7 +27,7 @@ impl From<&MyObjectRust> for DataSerde {
 const DEFAULT_STR: &str = r#"{"number": 1, "string": "Hello World!"}"#;
 
 #[cxx_qt::bridge(cxx_file_stem = "my_object", namespace = "core")]
-mod ffi {
+mod qobject {
     #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");
@@ -79,9 +79,7 @@ impl From<DataSerde> for MyObjectRust {
     }
 }
 
-// TODO: this will change to qobject::MyObject once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::MyObject {
+impl qobject::MyObject {
     pub fn increment(self: Pin<&mut Self>) {
         let new_number = self.number() + 1;
         self.set_number(new_number);

--- a/examples/qml_features/rust/src/containers.rs
+++ b/examples/qml_features/rust/src/containers.rs
@@ -7,7 +7,7 @@
 
 /// A CXX-Qt bridge which shows how to use Qt container types
 #[cxx_qt::bridge(cxx_file_stem = "rust_containers")]
-pub mod ffi {
+pub mod qobject {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qhash.h");
         /// QHash<QString, QVariant> from cxx_qt_lib
@@ -94,9 +94,7 @@ pub struct RustContainersRust {
     pub(crate) vector: QVector<i32>,
 }
 
-// TODO: this will change to qobject::RustContainers once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::RustContainers {
+impl qobject::RustContainers {
     /// Reset all the containers
     fn reset(mut self: Pin<&mut Self>) {
         // Update the private rust fields via the rust_mut

--- a/examples/qml_features/rust/src/custom_base_class.rs
+++ b/examples/qml_features/rust/src/custom_base_class.rs
@@ -8,7 +8,7 @@
 /// A CXX-Qt bridge which shows a custom base class and inheritance can be used
 // ANCHOR: book_macro_code
 #[cxx_qt::bridge(cxx_file_stem = "custom_base_class")]
-pub mod ffi {
+pub mod qobject {
     // ANCHOR: book_base_include
     unsafe extern "C++" {
         include!(< QAbstractListModel >);
@@ -182,9 +182,7 @@ pub struct CustomBaseClassRust {
     pub(crate) vector: Vec<(u32, f64)>,
 }
 
-// TODO: this will change to qobject::RustContainers once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::CustomBaseClass {
+impl qobject::CustomBaseClass {
     /// Add a new row to the QAbstractListModel on the current thread
     pub fn add(self: Pin<&mut Self>) {
         self.add_cpp_context();
@@ -227,7 +225,7 @@ impl ffi::CustomBaseClass {
 }
 
 // ANCHOR: book_inherit_clear
-impl ffi::CustomBaseClass {
+impl qobject::CustomBaseClass {
     /// Clear the rows in the QAbstractListModel
     pub fn clear(mut self: Pin<&mut Self>) {
         unsafe {
@@ -240,7 +238,7 @@ impl ffi::CustomBaseClass {
 }
 // ANCHOR_END: book_inherit_clear
 
-impl ffi::CustomBaseClass {
+impl qobject::CustomBaseClass {
     /// Multiply the number in the row with the given index by the given factor
     pub fn multiply(mut self: Pin<&mut Self>, index: i32, factor: f64) {
         if let Some((_, value)) = self.as_mut().rust_mut().vector.get_mut(index as usize) {
@@ -270,13 +268,10 @@ impl ffi::CustomBaseClass {
     }
 }
 
-// TODO: this will change to qobject::RustContainers once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-//
 // QAbstractListModel implementation
 //
 // ANCHOR: book_inherit_data
-impl ffi::CustomBaseClass {
+impl qobject::CustomBaseClass {
     /// i32 representing the id role
     pub const ID_ROLE: i32 = 0;
     /// i32 representing the value role
@@ -297,7 +292,7 @@ impl ffi::CustomBaseClass {
 // ANCHOR_END: book_inherit_data
 
 // ANCHOR: book_inherit_can_fetch_more
-impl ffi::CustomBaseClass {
+impl qobject::CustomBaseClass {
     /// Return whether the base class can fetch more
     // Example of overriding a C++ virtual method and calling the base class implementation.
     pub fn can_fetch_more(&self, parent: &QModelIndex) -> bool {
@@ -306,7 +301,7 @@ impl ffi::CustomBaseClass {
 }
 // ANCHOR_END: book_inherit_can_fetch_more
 
-impl ffi::CustomBaseClass {
+impl qobject::CustomBaseClass {
     /// Return the role names for the QAbstractListModel
     pub fn role_names(&self) -> QHash<QHashPair_i32_QByteArray> {
         let mut roles = QHash::<QHashPair_i32_QByteArray>::default();

--- a/examples/qml_features/rust/src/custom_parent_class.rs
+++ b/examples/qml_features/rust/src/custom_parent_class.rs
@@ -7,7 +7,7 @@
 
 /// A CXX-Qt bridge which shows a custom parent class can be used
 #[cxx_qt::bridge(cxx_file_stem = "custom_parent_class")]
-mod ffi {
+mod qobject {
     unsafe extern "C++" {
         /// QColor from cxx_qt_lib
         type QColor = cxx_qt_lib::QColor;
@@ -78,11 +78,9 @@ pub struct CustomParentClassRust {
     color: QColor,
 }
 
-// TODO: this will change to qobject::RustInvokables once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::CustomParentClass {
+impl qobject::CustomParentClass {
     /// Override QQuickPaintedItem::paint to draw two rectangles in Rust using QPainter
-    fn paint(self: Pin<&mut Self>, painter: *mut ffi::QPainter) {
+    fn paint(self: Pin<&mut Self>, painter: *mut qobject::QPainter) {
         // We need to convert the *mut QPainter to a Pin<&mut QPainter> so that we can reach the methods
         if let Some(painter) = unsafe { painter.as_mut() } {
             let mut pinned_painter = unsafe { Pin::new_unchecked(painter) };
@@ -103,9 +101,9 @@ impl ffi::CustomParentClass {
     }
 }
 
-impl cxx_qt::Constructor<()> for ffi::CustomParentClass {
+impl cxx_qt::Constructor<()> for qobject::CustomParentClass {
     type NewArguments = ();
-    type BaseArguments = (*mut ffi::QQuickItem,);
+    type BaseArguments = (*mut qobject::QQuickItem,);
     type InitializeArguments = ();
 
     fn route_arguments(

--- a/examples/qml_features/rust/src/invokables.rs
+++ b/examples/qml_features/rust/src/invokables.rs
@@ -8,7 +8,7 @@
 /// A CXX-Qt bridge which shows how a Q_INVOKABLE can be used
 // ANCHOR: book_macro_code
 #[cxx_qt::bridge(cxx_file_stem = "rust_invokables")]
-pub mod ffi {
+pub mod qobject {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qcolor.h");
         /// QColor from cxx_qt_lib
@@ -58,11 +58,8 @@ impl Default for RustInvokablesRust {
     }
 }
 
-// TODO: this will change to qobject::RustInvokables once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-//
 // ANCHOR: book_invokable_impl
-impl ffi::RustInvokables {
+impl qobject::RustInvokables {
     /// Immutable invokable method that returns the QColor
     fn load_color(&self) -> QColor {
         self.rust().as_qcolor()

--- a/examples/qml_features/rust/src/multiple_qobjects.rs
+++ b/examples/qml_features/rust/src/multiple_qobjects.rs
@@ -7,7 +7,7 @@
 
 /// A CXX-Qt bridge which shows multiple QObjects can be defined in one module
 #[cxx_qt::bridge(cxx_file_stem = "multiple_qobjects")]
-pub mod ffi {
+pub mod qobject {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qcolor.h");
         /// QColor from cxx_qt_lib
@@ -88,9 +88,7 @@ impl Default for FirstObjectRust {
     }
 }
 
-// TODO: this will change to qobject::FirstObject once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::FirstObject {
+impl qobject::FirstObject {
     /// A Q_INVOKABLE on the first QObject which increments a counter
     fn increment(mut self: Pin<&mut Self>) {
         let new_value = self.as_ref().counter() + 1;
@@ -121,9 +119,7 @@ impl Default for SecondObjectRust {
     }
 }
 
-// TODO: this will change to qobject::SecondObject once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::SecondObject {
+impl qobject::SecondObject {
     /// A Q_INVOKABLE on the second QObject which increments a counter
     fn increment(mut self: Pin<&mut Self>) {
         let new_value = self.as_ref().counter() + 1;

--- a/examples/qml_features/rust/src/properties.rs
+++ b/examples/qml_features/rust/src/properties.rs
@@ -7,7 +7,7 @@
 
 /// A CXX-Qt bridge which shows how a Q_PROPERTY can be used
 #[cxx_qt::bridge(cxx_file_stem = "rust_properties")]
-pub mod ffi {
+pub mod qobject {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         /// QString from cxx_qt_lib
@@ -69,9 +69,7 @@ impl Default for RustPropertiesRust {
 }
 // ANCHOR_END: book_properties_default
 
-// TODO: this will change to qobject::RustProperties once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::RustProperties {
+impl qobject::RustProperties {
     /// Connect to the given url
     fn connect(mut self: Pin<&mut Self>, mut url: QUrl) {
         // Check that the url starts with kdab

--- a/examples/qml_features/rust/src/serialisation.rs
+++ b/examples/qml_features/rust/src/serialisation.rs
@@ -28,7 +28,7 @@ impl From<&SerialisationRust> for DataSerde {
 
 /// A CXX-Qt bridge which shows how use serde for (de)serialization of the data in a QObjects' QPROPERTY's
 #[cxx_qt::bridge(cxx_file_stem = "serialisation")]
-pub mod ffi {
+pub mod qobject {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         /// QString from cxx_qt_lib
@@ -86,9 +86,7 @@ impl From<DataSerde> for SerialisationRust {
     }
 }
 
-// TODO: this will change to qobject::Serialisation once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::Serialisation {
+impl qobject::Serialisation {
     /// Retrieve the JSON form of this QObject
     fn as_json_str(self: Pin<&mut Self>) -> QString {
         let data_serde = DataSerde::from(self.rust());

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -8,7 +8,7 @@
 /// A CXX-Qt bridge which shows how a Q_SIGNAL can be used
 // ANCHOR: book_macro_code
 #[cxx_qt::bridge(cxx_file_stem = "rust_signals")]
-pub mod ffi {
+pub mod qobject {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         /// QString from cxx_qt_lib
@@ -68,9 +68,7 @@ pub struct RustSignalsRust {
     logging_enabled: bool,
 }
 
-// TODO: this will change to qobject::RustSignals once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::RustSignals {
+impl qobject::RustSignals {
     /// Connect to the given url
     fn connect(self: Pin<&mut Self>, url: &QUrl) {
         // Check that the url starts with kdab

--- a/examples/qml_features/rust/src/singleton.rs
+++ b/examples/qml_features/rust/src/singleton.rs
@@ -8,7 +8,7 @@
 /// A CXX-Qt bridge which shows how a QML_SINGLETON can be used
 // ANCHOR: book_macro_code
 #[cxx_qt::bridge(cxx_file_stem = "rust_singleton")]
-pub mod ffi {
+pub mod qobject {
     unsafe extern "RustQt" {
         #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0", qml_singleton)]
         #[qproperty(i32, persistent_value)]
@@ -29,9 +29,7 @@ pub struct RustSingletonRust {
     persistent_value: i32,
 }
 
-// TODO: this will change to qobject::RustSingleton once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::RustSingleton {
+impl qobject::RustSingleton {
     /// Increment the persistent value Q_PROPERTY of the QML_SINGLETON
     fn increment(self: Pin<&mut Self>) {
         let new_value = self.persistent_value() + 1;

--- a/examples/qml_features/rust/src/threading.rs
+++ b/examples/qml_features/rust/src/threading.rs
@@ -9,7 +9,7 @@
 // ANCHOR: book_macro_code
 // ANCHOR: book_namespace_macro
 #[cxx_qt::bridge(cxx_file_stem = "threading_website", namespace = "cxx_qt::website")]
-pub mod ffi {
+pub mod qobject {
     // ANCHOR_END: book_namespace_macro
     #[namespace = ""]
     unsafe extern "C++" {
@@ -69,9 +69,7 @@ impl Default for ThreadingWebsiteRust {
     }
 }
 
-// TODO: this will change to qobject::ThreadingWebsite once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::ThreadingWebsite {
+impl qobject::ThreadingWebsite {
     /// Swap the URL between kdab.com and github.com
     fn change_url(self: Pin<&mut Self>) {
         let new_url = if self.url().to_string() == "https://kdab.com" {

--- a/examples/qml_features/rust/src/types.rs
+++ b/examples/qml_features/rust/src/types.rs
@@ -113,8 +113,6 @@ impl Default for TypesRust {
     }
 }
 
-// TODO: this will change to qobject::Types once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
 impl ffi::Types {
     /// Load the value from a QVariant
     fn load_from_variant(self: Pin<&mut Self>, variant: &QVariant) {

--- a/examples/qml_minimal/rust/src/cxxqt_object.rs
+++ b/examples/qml_minimal/rust/src/cxxqt_object.rs
@@ -10,7 +10,7 @@
 
 /// The bridge definition for our QObject
 #[cxx_qt::bridge]
-pub mod ffi {
+pub mod qobject {
     // ANCHOR_END: book_bridge_macro
 
     // ANCHOR: book_qstring_import
@@ -63,11 +63,8 @@ impl Default for MyObjectRust {
 }
 // ANCHOR_END: book_rustobj_default
 
-// TODO: this will change to qobject::MyObject once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-//
 // ANCHOR: book_rustobj_invokable_impl
-impl ffi::MyObject {
+impl qobject::MyObject {
     /// Increment the number Q_PROPERTY
     pub fn increment_number(self: Pin<&mut Self>) {
         let previous = *self.as_ref().number();

--- a/tests/basic_cxx_qt/rust/src/data.rs
+++ b/tests/basic_cxx_qt/rust/src/data.rs
@@ -23,7 +23,7 @@ impl From<&MyDataRust> for DataSerde {
 }
 
 #[cxx_qt::bridge(cxx_file_stem = "my_data", namespace = "cxx_qt::my_data")]
-mod ffi {
+mod qobject {
     #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");
@@ -70,9 +70,7 @@ impl From<DataSerde> for MyDataRust {
     }
 }
 
-// TODO: this will change to qobject::MyData once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::MyData {
+impl qobject::MyData {
     pub fn as_json_str(&self) -> QString {
         let data_serde = DataSerde::from(self.rust());
         let data_string = serde_json::to_string(&data_serde).unwrap();

--- a/tests/basic_cxx_qt/rust/src/lib.rs
+++ b/tests/basic_cxx_qt/rust/src/lib.rs
@@ -10,7 +10,7 @@ mod locking;
 mod types;
 
 #[cxx_qt::bridge(cxx_file_stem = "my_object", namespace = "cxx_qt::my_object")]
-mod ffi {
+mod qobject {
     #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");
@@ -69,9 +69,7 @@ impl Default for MyObjectRust {
     }
 }
 
-// TODO: this will change to qobject::MyObject once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::MyObject {
+impl qobject::MyObject {
     fn double_number_self(self: Pin<&mut Self>) {
         let value = self.number() * 2;
         self.set_number(value);

--- a/tests/basic_cxx_qt/rust/src/locking.rs
+++ b/tests/basic_cxx_qt/rust/src/locking.rs
@@ -5,7 +5,7 @@
 
 /// Two QObject that allow for testing that locking works
 #[cxx_qt::bridge(cxx_file_stem = "locking")]
-pub mod ffi {
+pub mod qobject {
     unsafe extern "RustQt" {
         /// A QObject which has cxx_qt::Locking
         #[cxx_qt::qobject]
@@ -46,9 +46,7 @@ pub struct RustLockingEnabledRust {
     pub(crate) counter: AtomicU32,
 }
 
-// TODO: this will change to qobject::RustLockingEnabled once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::RustLockingEnabled {
+impl qobject::RustLockingEnabled {
     fn get_counter(&self) -> u32 {
         self.rust().counter.load(Ordering::Acquire)
     }
@@ -65,9 +63,7 @@ pub struct RustLockingDisabledRust {
     pub(crate) counter: AtomicU32,
 }
 
-// TODO: this will change to qobject::RustLockingDisabled once
-// https://github.com/KDAB/cxx-qt/issues/559 is done
-impl ffi::RustLockingDisabled {
+impl qobject::RustLockingDisabled {
     fn get_counter(&self) -> u32 {
         self.rust().counter.load(Ordering::Acquire)
     }


### PR DESCRIPTION
Related to #559

Requires #611 