### PR TITLE
cxx-qt-gen: remove qobject:: from impl a trait for a qobject in a bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `#[qproperty]` is now defined as an attribute on the qobject rather than the field
 - QObject struct is now split between the bridge and implementation outside via a type alias
 - `qobject` module is no longer generated
+- `impl cxx_qt::trait for qobject::T` inside the bridge is now `impl cxx_qt::trait for T`
 
 ### Fixed
 

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -333,7 +333,7 @@ pub mod tests {
     fn test_parse_trait_impl_valid() {
         let mut qobject = create_parsed_qobject();
         let item: ItemImpl = parse_quote! {
-            impl cxx_qt::Threading for qobject::MyObject {}
+            impl cxx_qt::Threading for MyObject {}
         };
         assert!(!qobject.threading);
         assert!(qobject.parse_trait_impl(item).is_ok());
@@ -346,27 +346,27 @@ pub mod tests {
 
         // must be a trait
         let item: ItemImpl = parse_quote! {
-            impl qobject::T {}
+            impl T {}
         };
         assert!(qobject.parse_trait_impl(item).is_err());
 
         // no attribute allowed
         let item: ItemImpl = parse_quote! {
             #[attr]
-            impl cxx_qt::Threading for qobject::T {}
+            impl cxx_qt::Threading for T {}
         };
         assert!(qobject.parse_trait_impl(item).is_err());
 
         // Threading cannot be negative
         let item: ItemImpl = parse_quote! {
-            impl !cxx_qt::Threading for qobject::T {}
+            impl !cxx_qt::Threading for T {}
         };
         assert!(qobject.parse_trait_impl(item).is_err());
 
         // must be a known trait
         let item: ItemImpl = parse_quote! {
             #[attr]
-            impl cxx_qt::ABC for qobject::T {}
+            impl cxx_qt::ABC for T {}
         };
         assert!(qobject.parse_trait_impl(item).is_err());
     }

--- a/crates/cxx-qt-gen/test_inputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_inputs/invokables.rs
@@ -42,14 +42,14 @@ mod ffi {
         fn invokable_virtual(self: &qobject::MyObject);
     }
 
-    impl cxx_qt::Threading for qobject::MyObject {}
+    impl cxx_qt::Threading for MyObject {}
 
     impl
         cxx_qt::Constructor<
             (i32, *mut QObject),
             BaseArguments = (*mut QObject,),
             NewArguments = (i32,),
-        > for qobject::MyObject
+        > for MyObject
     {
     }
 }

--- a/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
@@ -93,19 +93,13 @@ pub mod ffi {
         fn invokable_name(self: Pin<&mut qobject::MyObject>);
     }
 
-    impl MyTrait for MyObject {
-        fn my_func() -> String {
-            "Hello".to_owned()
-        }
-    }
-
     extern "RustQt" {
         #[cxx_qt::qobject]
         #[qproperty(i32, property_name)]
         type SecondObject = super::SecondObjectRust;
     }
 
-    unsafe impl !cxx_qt::Locking for qobject::SecondObject {}
+    unsafe impl !cxx_qt::Locking for SecondObject {}
 
     unsafe extern "RustQt" {
         #[my_attribute]

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -215,11 +215,6 @@ pub mod cxx_qt_ffi {
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     use super::MyTrait;
-    impl MyTrait for MyObject {
-        fn my_func() -> String {
-            "Hello".to_owned()
-        }
-    }
     type MyObjectRust = super::MyObjectRust;
     impl MyObjectRust {
         #[doc(hidden)]

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -38,7 +38,7 @@ pub trait CxxQtType {
 ///
 /// By default, CXX-Qt will guard all access to the generated QObject with a recursive mutex.
 /// For performance reasons it may be desirable to disable this behavior for certain QObjects.
-/// You can do so by negative implementing this trait `unsafe impl !cxx_qt::Locking for qobject::T {}`.
+/// You can do so by negative implementing this trait `unsafe impl !cxx_qt::Locking for T {}`.
 ///
 /// However, this is unsafe, as it may lead to concurrent mutable access to the QObject from C++.
 /// You are responsible for ensuring this does not happen!
@@ -52,7 +52,7 @@ pub trait Locking {
 /// Indicates that the object implements threading and has a method which returns a [CxxQtThread].
 ///
 /// This trait is implemented by CxxQt automatically.
-/// To enable this for a `qobject::T`, add `impl cxx_qt::Threading for qobject::T {}` to your [`#[cxx_qt::bridge]`](bridge).
+/// To enable this for a `T`, add `impl cxx_qt::Threading for T {}` to your [`#[cxx_qt::bridge]`](bridge).
 pub trait Threading: Locking + Sized {
     #[doc(hidden)]
     type BoxedQueuedFn;
@@ -101,7 +101,7 @@ pub trait Threading: Locking + Sized {
 ///     // Declare that we want to use a custom constructor
 ///     // Note that the arguments must be a tuple of CXX types.
 ///     // Any associated types that aren't included here are assumed to be `()`.
-///     impl cxx_qt::Constructor<(i32, String), NewArguments=(i32, String)> for qobject::MyStruct {}
+///     impl cxx_qt::Constructor<(i32, String), NewArguments=(i32, String)> for MyStruct {}
 /// }
 ///
 /// // Struct without `Default` implementation

--- a/examples/demo_threading/rust/src/lib.rs
+++ b/examples/demo_threading/rust/src/lib.rs
@@ -26,7 +26,7 @@ mod qobject {
     }
 
     // Enabling threading on the qobject
-    impl cxx_qt::Threading for qobject::EnergyUsage {}
+    impl cxx_qt::Threading for EnergyUsage {}
 
     unsafe extern "RustQt" {
         /// A new sensor has been detected
@@ -46,7 +46,7 @@ mod qobject {
         fn sensor_power(self: Pin<&mut qobject::EnergyUsage>, uuid: &QString) -> f64;
     }
 
-    impl cxx_qt::Constructor<()> for qobject::EnergyUsage {}
+    impl cxx_qt::Constructor<()> for EnergyUsage {}
 }
 
 use crate::{

--- a/examples/qml_features/rust/src/custom_base_class.rs
+++ b/examples/qml_features/rust/src/custom_base_class.rs
@@ -45,7 +45,7 @@ pub mod qobject {
     // ANCHOR_END: book_inherit_qalm
 
     // Enabling threading on the qobject
-    impl cxx_qt::Threading for qobject::CustomBaseClass {}
+    impl cxx_qt::Threading for CustomBaseClass {}
 
     // ANCHOR: book_qsignals_inherit
     unsafe extern "RustQt" {

--- a/examples/qml_features/rust/src/custom_parent_class.rs
+++ b/examples/qml_features/rust/src/custom_parent_class.rs
@@ -64,7 +64,7 @@ mod qobject {
         fn update(self: Pin<&mut qobject::CustomParentClass>);
     }
 
-    impl cxx_qt::Constructor<()> for qobject::CustomParentClass {}
+    impl cxx_qt::Constructor<()> for CustomParentClass {}
 }
 
 use core::pin::Pin;

--- a/examples/qml_features/rust/src/multiple_qobjects.rs
+++ b/examples/qml_features/rust/src/multiple_qobjects.rs
@@ -25,7 +25,7 @@ pub mod qobject {
     }
 
     // Enabling threading on the qobject
-    impl cxx_qt::Threading for qobject::FirstObject {}
+    impl cxx_qt::Threading for FirstObject {}
 
     unsafe extern "RustQt" {
         /// Accepted Q_SIGNAL
@@ -51,7 +51,7 @@ pub mod qobject {
     }
 
     // Enabling threading on the qobject
-    impl cxx_qt::Threading for qobject::SecondObject {}
+    impl cxx_qt::Threading for SecondObject {}
 
     unsafe extern "RustQt" {
         /// Accepted Q_SIGNAL

--- a/examples/qml_features/rust/src/nested_qobjects.rs
+++ b/examples/qml_features/rust/src/nested_qobjects.rs
@@ -46,7 +46,7 @@ pub mod qobject {
         fn reset(self: Pin<&mut qobject::OuterObject>);
     }
 
-    impl cxx_qt::Constructor<()> for qobject::OuterObject {}
+    impl cxx_qt::Constructor<()> for OuterObject {}
 }
 
 use core::pin::Pin;

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -53,7 +53,7 @@ pub mod qobject {
     }
     // ANCHOR_END: book_rust_obj_impl
 
-    impl cxx_qt::Constructor<()> for qobject::RustSignals {}
+    impl cxx_qt::Constructor<()> for RustSignals {}
 }
 
 use core::pin::Pin;

--- a/examples/qml_features/rust/src/threading.rs
+++ b/examples/qml_features/rust/src/threading.rs
@@ -30,7 +30,7 @@ pub mod qobject {
 
     // ANCHOR: book_threading_trait
     // Enabling threading on the qobject
-    impl cxx_qt::Threading for qobject::ThreadingWebsite {}
+    impl cxx_qt::Threading for ThreadingWebsite {}
     // ANCHOR_END: book_threading_trait
 
     unsafe extern "RustQt" {

--- a/tests/basic_cxx_qt/rust/src/lib.rs
+++ b/tests/basic_cxx_qt/rust/src/lib.rs
@@ -25,7 +25,7 @@ mod qobject {
     }
 
     // Enabling threading on the qobject
-    impl cxx_qt::Threading for qobject::MyObject {}
+    impl cxx_qt::Threading for MyObject {}
 
     unsafe extern "RustQt" {
         #[qinvokable]

--- a/tests/basic_cxx_qt/rust/src/locking.rs
+++ b/tests/basic_cxx_qt/rust/src/locking.rs
@@ -30,7 +30,7 @@ pub mod qobject {
         fn increment(self: Pin<&mut qobject::RustLockingDisabled>);
     }
 
-    unsafe impl !cxx_qt::Locking for qobject::RustLockingDisabled {}
+    unsafe impl !cxx_qt::Locking for RustLockingDisabled {}
 }
 
 use core::pin::Pin;


### PR DESCRIPTION
Related to #559