### PR TITLE
cxx-qt-gen: remove wrapper method for C++ -> Rust properties

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/getter.rs
@@ -27,13 +27,22 @@ pub fn generate(
             {qobject_ident}::{ident_getter}() const
             {{
                 {rust_obj_guard}
-                return m_rustObj->{ident_getter}(*this);
+                return {ident_getter_wrapper}();
             }}
             "#,
             return_cxx_ty = cxx_ty.as_cxx_ty(),
             ident_getter = idents.getter.cpp.to_string(),
+            ident_getter_wrapper = idents.getter_wrapper.cpp.to_string(),
             qobject_ident = qobject_ident,
             rust_obj_guard = lock_guard.unwrap_or_default(),
         ),
     }
+}
+
+pub fn generate_wrapper(idents: &QPropertyName, cxx_ty: &CppType) -> CppFragment {
+    CppFragment::Header(format!(
+        "{return_cxx_ty} const& {ident_getter_wrapper}() const noexcept;",
+        return_cxx_ty = cxx_ty.as_cxx_ty(),
+        ident_getter_wrapper = idents.getter_wrapper.cpp
+    ))
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -37,12 +37,18 @@ pub fn generate_cpp_properties(
             &cxx_ty,
             lock_guard,
         ));
+        generated
+            .private_methods
+            .push(getter::generate_wrapper(&idents, &cxx_ty));
         generated.methods.push(setter::generate(
             &idents,
             &qobject_ident,
             &cxx_ty,
             lock_guard,
         ));
+        generated
+            .private_methods
+            .push(setter::generate_wrapper(&idents, &cxx_ty));
         signals.push(signal::generate(&idents, qobject_idents));
     }
 
@@ -109,7 +115,7 @@ mod tests {
             MyObject::getTrivialProperty() const
             {
                 // ::std::lock_guard
-                return m_rustObj->getTrivialProperty(*this);
+                return getTrivialPropertyWrapper();
             }
             "#}
         );
@@ -130,7 +136,7 @@ mod tests {
                 MyObject::setTrivialProperty(::std::int32_t const& value)
                 {
                     // ::std::lock_guard
-                    m_rustObj->setTrivialProperty(*this, value);
+                    setTrivialPropertyWrapper(value);
                 }
                 "#}
         );
@@ -151,7 +157,7 @@ mod tests {
             MyObject::getOpaqueProperty() const
             {
                 // ::std::lock_guard
-                return m_rustObj->getOpaqueProperty(*this);
+                return getOpaquePropertyWrapper();
             }
             "#}
         );
@@ -172,7 +178,7 @@ mod tests {
             MyObject::setOpaqueProperty(::std::unique_ptr<QColor> const& value)
             {
                 // ::std::lock_guard
-                m_rustObj->setOpaqueProperty(*this, value);
+                setOpaquePropertyWrapper(value);
             }
             "#}
         );
@@ -242,6 +248,48 @@ mod tests {
             }
             "#}
         );
+
+        // private methods
+        assert_eq!(generated.private_methods.len(), 4);
+        let header = if let CppFragment::Header(header) = &generated.private_methods[0] {
+            header
+        } else {
+            panic!("Expected header")
+        };
+        assert_str_eq!(
+            header,
+            "::std::int32_t const& getTrivialPropertyWrapper() const noexcept;"
+        );
+
+        let header = if let CppFragment::Header(header) = &generated.private_methods[1] {
+            header
+        } else {
+            panic!("Expected header")
+        };
+        assert_str_eq!(
+            header,
+            "void setTrivialPropertyWrapper(::std::int32_t value) noexcept;"
+        );
+
+        let header = if let CppFragment::Header(header) = &generated.private_methods[2] {
+            header
+        } else {
+            panic!("Expected header")
+        };
+        assert_str_eq!(
+            header,
+            "::std::unique_ptr<QColor> const& getOpaquePropertyWrapper() const noexcept;"
+        );
+
+        let header = if let CppFragment::Header(header) = &generated.private_methods[3] {
+            header
+        } else {
+            panic!("Expected header")
+        };
+        assert_str_eq!(
+            header,
+            "void setOpaquePropertyWrapper(::std::unique_ptr<QColor> value) noexcept;"
+        );
     }
 
     #[test]
@@ -284,7 +332,7 @@ mod tests {
             MyObject::getMappedProperty() const
             {
                 // ::std::lock_guard
-                return m_rustObj->getMappedProperty(*this);
+                return getMappedPropertyWrapper();
             }
             "#}
         );
@@ -302,7 +350,7 @@ mod tests {
                 MyObject::setMappedProperty(A1 const& value)
                 {
                     // ::std::lock_guard
-                    m_rustObj->setMappedProperty(*this, value);
+                    setMappedPropertyWrapper(value);
                 }
                 "#}
         );
@@ -338,5 +386,24 @@ mod tests {
             }
             "#}
         );
+
+        // private methods
+        assert_eq!(generated.private_methods.len(), 2);
+        let header = if let CppFragment::Header(header) = &generated.private_methods[0] {
+            header
+        } else {
+            panic!("Expected header")
+        };
+        assert_str_eq!(
+            header,
+            "A1 const& getMappedPropertyWrapper() const noexcept;"
+        );
+
+        let header = if let CppFragment::Header(header) = &generated.private_methods[1] {
+            header
+        } else {
+            panic!("Expected header")
+        };
+        assert_str_eq!(header, "void setMappedPropertyWrapper(A1 value) noexcept;");
     }
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/setter.rs
@@ -27,13 +27,24 @@ pub fn generate(
             {qobject_ident}::{ident_setter}({cxx_ty} const& value)
             {{
                 {rust_obj_guard}
-                m_rustObj->{ident_setter}(*this, value);
+                {ident_setter_wrapper}(value);
             }}
             "#,
             cxx_ty = cxx_ty.as_cxx_ty(),
             ident_setter = idents.setter.cpp,
+            ident_setter_wrapper = idents.setter_wrapper.cpp.to_string(),
             qobject_ident = qobject_ident,
             rust_obj_guard = lock_guard.unwrap_or_default(),
         },
     }
+}
+
+pub fn generate_wrapper(idents: &QPropertyName, cxx_ty: &CppType) -> CppFragment {
+    CppFragment::Header(format!(
+        // Note that we pass T not const T& to Rust so that it is by-value
+        // https://github.com/KDAB/cxx-qt/issues/463
+        "void {ident_setter_wrapper}({cxx_ty} value) noexcept;",
+        cxx_ty = cxx_ty.as_cxx_ty(),
+        ident_setter_wrapper = idents.setter_wrapper.cpp
+    ))
 }

--- a/crates/cxx-qt-gen/src/generator/naming/property.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/property.rs
@@ -12,16 +12,22 @@ use syn::Ident;
 pub struct QPropertyName {
     pub name: CombinedIdent,
     pub getter: CombinedIdent,
+    pub getter_wrapper: CombinedIdent,
     pub setter: CombinedIdent,
+    pub setter_wrapper: CombinedIdent,
     pub notify: CombinedIdent,
 }
 
 impl From<&Ident> for QPropertyName {
     fn from(ident: &Ident) -> Self {
+        let getter = CombinedIdent::getter_from_property(ident.clone());
+        let setter = CombinedIdent::setter_from_property(ident);
         Self {
             name: CombinedIdent::from_property(ident.clone()),
-            getter: CombinedIdent::getter_from_property(ident.clone()),
-            setter: CombinedIdent::setter_from_property(ident),
+            getter_wrapper: CombinedIdent::wrapper_from_combined_property(&getter),
+            getter,
+            setter_wrapper: CombinedIdent::wrapper_from_combined_property(&setter),
+            setter,
             notify: CombinedIdent::notify_from_property(ident),
         }
     }
@@ -65,6 +71,14 @@ impl CombinedIdent {
         Self {
             cpp: format_ident!("{}", ident.to_string().to_case(Case::Camel)),
             rust: ident,
+        }
+    }
+
+    /// For a given ident generate the Rust and C++ wrapper names
+    fn wrapper_from_combined_property(ident: &CombinedIdent) -> Self {
+        Self {
+            cpp: format_ident!("{}Wrapper", ident.cpp),
+            rust: format_ident!("{}_wrapper", ident.rust),
         }
     }
 }

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -16,8 +16,7 @@ pub fn generate(
     ty: &Type,
 ) -> RustFragmentPair {
     let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
-    let rust_struct_name_rust = &qobject_idents.rust_struct.rust;
-    let getter_cpp = idents.getter.cpp.to_string();
+    let getter_wrapper_cpp = idents.getter_wrapper.cpp.to_string();
     let getter_rust = &idents.getter.rust;
     let ident = &idents.name.rust;
     let ident_str = ident.to_string();
@@ -25,28 +24,18 @@ pub fn generate(
     RustFragmentPair {
         cxx_bridge: vec![quote! {
             extern "Rust" {
-                #[cxx_name = #getter_cpp]
-                unsafe fn #getter_rust<'a>(self: &'a #rust_struct_name_rust, cpp: &'a #cpp_class_name_rust) -> &'a #ty;
+                #[cxx_name = #getter_wrapper_cpp]
+                unsafe fn #getter_rust<'a>(self: &'a #cpp_class_name_rust) -> &'a #ty;
             }
         }],
-        implementation: vec![
-            quote! {
-                impl #rust_struct_name_rust {
-                    #[doc(hidden)]
-                    pub fn #getter_rust<'a>(&'a self, cpp: &'a #cpp_class_name_rust) -> &'a #ty {
-                        cpp.#getter_rust()
-                    }
+        implementation: vec![quote! {
+            impl #cpp_class_name_rust {
+                #[doc = "Getter for the Q_PROPERTY "]
+                #[doc = #ident_str]
+                pub fn #getter_rust(&self) -> &#ty {
+                    &self.#ident
                 }
-            },
-            quote! {
-                impl #cpp_class_name_rust {
-                    #[doc = "Getter for the Q_PROPERTY "]
-                    #[doc = #ident_str]
-                    pub fn #getter_rust(&self) -> &#ty {
-                        &self.#ident
-                    }
-                }
-            },
-        ],
+            }
+        }],
     }
 }

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -85,7 +85,7 @@ mod tests {
 
         // Check that we have the expected number of blocks
         assert_eq!(generated.cxx_mod_contents.len(), 12);
-        assert_eq!(generated.cxx_qt_mod_contents.len(), 15);
+        assert_eq!(generated.cxx_qt_mod_contents.len(), 9);
 
         // Trivial Property
 
@@ -94,24 +94,13 @@ mod tests {
             &generated.cxx_mod_contents[0],
             parse_quote! {
                 extern "Rust" {
-                    #[cxx_name = "getTrivialProperty"]
-                    unsafe fn trivial_property<'a>(self: &'a MyObjectRust, cpp: &'a MyObject) -> &'a i32;
+                    #[cxx_name = "getTrivialPropertyWrapper"]
+                    unsafe fn trivial_property<'a>(self: &'a MyObject) -> &'a i32;
                 }
             },
         );
         assert_tokens_eq(
             &generated.cxx_qt_mod_contents[0],
-            parse_quote! {
-                impl MyObjectRust {
-                    #[doc(hidden)]
-                    pub fn trivial_property<'a>(&'a self, cpp: &'a MyObject) -> &'a i32 {
-                        cpp.trivial_property()
-                    }
-                }
-            },
-        );
-        assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[1],
             parse_quote! {
                 impl MyObject {
                     #[doc = "Getter for the Q_PROPERTY "]
@@ -128,24 +117,13 @@ mod tests {
             &generated.cxx_mod_contents[1],
             parse_quote! {
                 extern "Rust" {
-                    #[cxx_name = "setTrivialProperty"]
-                    fn set_trivial_property(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>, value: i32);
+                    #[cxx_name = "setTrivialPropertyWrapper"]
+                    fn set_trivial_property(self: Pin<&mut MyObject>, value: i32);
                 }
             },
         );
         assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[2],
-            parse_quote! {
-                impl MyObjectRust {
-                    #[doc(hidden)]
-                    pub fn set_trivial_property(&mut self, cpp: Pin<&mut MyObject>, value: i32) {
-                        cpp.set_trivial_property(value);
-                    }
-                }
-            },
-        );
-        assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[3],
+            &generated.cxx_qt_mod_contents[1],
             parse_quote! {
                 impl MyObject {
                     #[doc = "Setter for the Q_PROPERTY "]
@@ -168,24 +146,13 @@ mod tests {
             &generated.cxx_mod_contents[2],
             parse_quote! {
                 extern "Rust" {
-                    #[cxx_name = "getOpaqueProperty"]
-                    unsafe fn opaque_property<'a>(self: &'a MyObjectRust, cpp: &'a MyObject) -> &'a UniquePtr<QColor>;
+                    #[cxx_name = "getOpaquePropertyWrapper"]
+                    unsafe fn opaque_property<'a>(self: &'a MyObject) -> &'a UniquePtr<QColor>;
                 }
             },
         );
         assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[4],
-            parse_quote! {
-                impl MyObjectRust {
-                    #[doc(hidden)]
-                    pub fn opaque_property<'a>(&'a self, cpp: &'a MyObject) -> &'a UniquePtr<QColor> {
-                        cpp.opaque_property()
-                    }
-                }
-            },
-        );
-        assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[5],
+            &generated.cxx_qt_mod_contents[2],
             parse_quote! {
                 impl MyObject {
                     #[doc = "Getter for the Q_PROPERTY "]
@@ -202,24 +169,13 @@ mod tests {
             &generated.cxx_mod_contents[3],
             parse_quote! {
                 extern "Rust" {
-                    #[cxx_name = "setOpaqueProperty"]
-                    fn set_opaque_property(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>, value: UniquePtr<QColor>);
+                    #[cxx_name = "setOpaquePropertyWrapper"]
+                    fn set_opaque_property(self: Pin<&mut MyObject>, value: UniquePtr<QColor>);
                 }
             },
         );
         assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[6],
-            parse_quote! {
-                impl MyObjectRust {
-                    #[doc(hidden)]
-                    pub fn set_opaque_property(&mut self, cpp: Pin<&mut MyObject>, value: UniquePtr<QColor>) {
-                        cpp.set_opaque_property(value);
-                    }
-                }
-            },
-        );
-        assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[7],
+            &generated.cxx_qt_mod_contents[3],
             parse_quote! {
                 impl MyObject {
                     #[doc = "Setter for the Q_PROPERTY "]
@@ -242,24 +198,13 @@ mod tests {
             &generated.cxx_mod_contents[4],
             parse_quote! {
                 extern "Rust" {
-                    #[cxx_name = "getUnsafeProperty"]
-                    unsafe fn unsafe_property<'a>(self: &'a MyObjectRust, cpp: &'a MyObject) -> &'a *mut T;
+                    #[cxx_name = "getUnsafePropertyWrapper"]
+                    unsafe fn unsafe_property<'a>(self: &'a MyObject) -> &'a *mut T;
                 }
             },
         );
         assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[8],
-            parse_quote! {
-                impl MyObjectRust {
-                    #[doc(hidden)]
-                    pub fn unsafe_property<'a>(&'a self, cpp: &'a MyObject) -> &'a *mut T {
-                        cpp.unsafe_property()
-                    }
-                }
-            },
-        );
-        assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[9],
+            &generated.cxx_qt_mod_contents[4],
             parse_quote! {
                 impl MyObject {
                     #[doc = "Getter for the Q_PROPERTY "]
@@ -276,24 +221,13 @@ mod tests {
             &generated.cxx_mod_contents[5],
             parse_quote! {
                 extern "Rust" {
-                    #[cxx_name = "setUnsafeProperty"]
-                    unsafe fn set_unsafe_property(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>, value: *mut T);
+                    #[cxx_name = "setUnsafePropertyWrapper"]
+                    unsafe fn set_unsafe_property(self: Pin<&mut MyObject>, value: *mut T);
                 }
             },
         );
         assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[10],
-            parse_quote! {
-                impl MyObjectRust {
-                    #[doc(hidden)]
-                    pub fn set_unsafe_property(&mut self, cpp: Pin<&mut MyObject>, value: *mut T) {
-                        cpp.set_unsafe_property(value);
-                    }
-                }
-            },
-        );
-        assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[11],
+            &generated.cxx_qt_mod_contents[5],
             parse_quote! {
                 impl MyObject {
                     #[doc = "Setter for the Q_PROPERTY "]
@@ -335,7 +269,7 @@ mod tests {
             },
         );
         assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[12],
+            &generated.cxx_qt_mod_contents[6],
             parse_quote! {
                 impl MyObject {
                     #[doc = "Connect the given function pointer to the signal "]
@@ -376,7 +310,7 @@ mod tests {
             },
         );
         assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[13],
+            &generated.cxx_qt_mod_contents[7],
             parse_quote! {
                 impl MyObject {
                     #[doc = "Connect the given function pointer to the signal "]
@@ -417,7 +351,7 @@ mod tests {
             },
         );
         assert_tokens_eq(
-            &generated.cxx_qt_mod_contents[14],
+            &generated.cxx_qt_mod_contents[8],
             parse_quote! {
                 impl MyObject {
                     #[doc = "Connect the given function pointer to the signal "]

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -20,14 +20,14 @@ MyObject::unsafeRustMut()
 MyObject::getPropertyName() const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  return m_rustObj->getPropertyName(*this);
+  return getPropertyNameWrapper();
 }
 
 void
 MyObject::setPropertyName(::std::int32_t const& value)
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->setPropertyName(*this, value);
+  setPropertyNameWrapper(value);
 }
 
 ::QMetaObject::Connection
@@ -96,14 +96,14 @@ SecondObject::unsafeRustMut()
 SecondObject::getPropertyName() const
 {
 
-  return m_rustObj->getPropertyName(*this);
+  return getPropertyNameWrapper();
 }
 
 void
 SecondObject::setPropertyName(::std::int32_t const& value)
 {
 
-  m_rustObj->setPropertyName(*this, value);
+  setPropertyNameWrapper(value);
 }
 
 ::QMetaObject::Connection

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -46,6 +46,8 @@ public:
   explicit MyObject(QObject* parent = nullptr);
 
 private:
+  ::std::int32_t const& getPropertyNameWrapper() const noexcept;
+  void setPropertyNameWrapper(::std::int32_t value) noexcept;
   void invokableNameWrapper() noexcept;
 
 private:
@@ -85,6 +87,8 @@ public:
   explicit SecondObject(QObject* parent = nullptr);
 
 private:
+  ::std::int32_t const& getPropertyNameWrapper() const noexcept;
+  void setPropertyNameWrapper(::std::int32_t value) noexcept;
   void invokableNameWrapper() noexcept;
 
 private:

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -73,12 +73,12 @@ pub mod ffi {
         type MyObjectRust;
     }
     extern "Rust" {
-        #[cxx_name = "getPropertyName"]
-        unsafe fn property_name<'a>(self: &'a MyObjectRust, cpp: &'a MyObject) -> &'a i32;
+        #[cxx_name = "getPropertyNameWrapper"]
+        unsafe fn property_name<'a>(self: &'a MyObject) -> &'a i32;
     }
     extern "Rust" {
-        #[cxx_name = "setPropertyName"]
-        fn set_property_name(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>, value: i32);
+        #[cxx_name = "setPropertyNameWrapper"]
+        fn set_property_name(self: Pin<&mut MyObject>, value: i32);
     }
     unsafe extern "C++" {
         #[doc = "Notify for the Q_PROPERTY"]
@@ -146,12 +146,12 @@ pub mod ffi {
         type SecondObjectRust;
     }
     extern "Rust" {
-        #[cxx_name = "getPropertyName"]
-        unsafe fn property_name<'a>(self: &'a SecondObjectRust, cpp: &'a SecondObject) -> &'a i32;
+        #[cxx_name = "getPropertyNameWrapper"]
+        unsafe fn property_name<'a>(self: &'a SecondObject) -> &'a i32;
     }
     extern "Rust" {
-        #[cxx_name = "setPropertyName"]
-        fn set_property_name(self: &mut SecondObjectRust, cpp: Pin<&mut SecondObject>, value: i32);
+        #[cxx_name = "setPropertyNameWrapper"]
+        fn set_property_name(self: Pin<&mut SecondObject>, value: i32);
     }
     unsafe extern "C++" {
         #[doc = "Notify for the Q_PROPERTY"]
@@ -218,23 +218,11 @@ pub mod cxx_qt_ffi {
     type UniquePtr<T> = cxx::UniquePtr<T>;
     use super::MyTrait;
     type MyObjectRust = super::MyObjectRust;
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn property_name<'a>(&'a self, cpp: &'a MyObject) -> &'a i32 {
-            cpp.property_name()
-        }
-    }
     impl MyObject {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "property_name"]
         pub fn property_name(&self) -> &i32 {
             &self.property_name
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn set_property_name(&mut self, cpp: Pin<&mut MyObject>, value: i32) {
-            cpp.set_property_name(value);
         }
     }
     impl MyObject {
@@ -297,23 +285,11 @@ pub mod cxx_qt_ffi {
         }
     }
     type SecondObjectRust = super::SecondObjectRust;
-    impl SecondObjectRust {
-        #[doc(hidden)]
-        pub fn property_name<'a>(&'a self, cpp: &'a SecondObject) -> &'a i32 {
-            cpp.property_name()
-        }
-    }
     impl SecondObject {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "property_name"]
         pub fn property_name(&self) -> &i32 {
             &self.property_name
-        }
-    }
-    impl SecondObjectRust {
-        #[doc(hidden)]
-        pub fn set_property_name(&mut self, cpp: Pin<&mut SecondObject>, value: i32) {
-            cpp.set_property_name(value);
         }
     }
     impl SecondObject {

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -20,28 +20,28 @@ MyObject::unsafeRustMut()
 MyObject::getPrimitive() const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  return m_rustObj->getPrimitive(*this);
+  return getPrimitiveWrapper();
 }
 
 void
 MyObject::setPrimitive(::std::int32_t const& value)
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->setPrimitive(*this, value);
+  setPrimitiveWrapper(value);
 }
 
 QPoint const&
 MyObject::getTrivial() const
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  return m_rustObj->getTrivial(*this);
+  return getTrivialWrapper();
 }
 
 void
 MyObject::setTrivial(QPoint const& value)
 {
   const ::std::lock_guard<::std::recursive_mutex> guard(*m_rustObjMutex);
-  m_rustObj->setTrivial(*this, value);
+  setTrivialWrapper(value);
 }
 
 ::QMetaObject::Connection

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -45,6 +45,12 @@ public:
   explicit MyObject(QObject* parent = nullptr);
 
 private:
+  ::std::int32_t const& getPrimitiveWrapper() const noexcept;
+  void setPrimitiveWrapper(::std::int32_t value) noexcept;
+  QPoint const& getTrivialWrapper() const noexcept;
+  void setTrivialWrapper(QPoint value) noexcept;
+
+private:
   ::rust::Box<MyObjectRust> m_rustObj;
   ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
 };

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -34,20 +34,20 @@ mod ffi {
         type MyObjectRust;
     }
     extern "Rust" {
-        #[cxx_name = "getPrimitive"]
-        unsafe fn primitive<'a>(self: &'a MyObjectRust, cpp: &'a MyObject) -> &'a i32;
+        #[cxx_name = "getPrimitiveWrapper"]
+        unsafe fn primitive<'a>(self: &'a MyObject) -> &'a i32;
     }
     extern "Rust" {
-        #[cxx_name = "setPrimitive"]
-        fn set_primitive(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>, value: i32);
+        #[cxx_name = "setPrimitiveWrapper"]
+        fn set_primitive(self: Pin<&mut MyObject>, value: i32);
     }
     extern "Rust" {
-        #[cxx_name = "getTrivial"]
-        unsafe fn trivial<'a>(self: &'a MyObjectRust, cpp: &'a MyObject) -> &'a QPoint;
+        #[cxx_name = "getTrivialWrapper"]
+        unsafe fn trivial<'a>(self: &'a MyObject) -> &'a QPoint;
     }
     extern "Rust" {
-        #[cxx_name = "setTrivial"]
-        fn set_trivial(self: &mut MyObjectRust, cpp: Pin<&mut MyObject>, value: QPoint);
+        #[cxx_name = "setTrivialWrapper"]
+        fn set_trivial(self: Pin<&mut MyObject>, value: QPoint);
     }
     unsafe extern "C++" {
         #[doc = "Notify for the Q_PROPERTY"]
@@ -108,23 +108,11 @@ pub mod cxx_qt_ffi {
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn primitive<'a>(&'a self, cpp: &'a MyObject) -> &'a i32 {
-            cpp.primitive()
-        }
-    }
     impl MyObject {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "primitive"]
         pub fn primitive(&self) -> &i32 {
             &self.primitive
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn set_primitive(&mut self, cpp: Pin<&mut MyObject>, value: i32) {
-            cpp.set_primitive(value);
         }
     }
     impl MyObject {
@@ -138,23 +126,11 @@ pub mod cxx_qt_ffi {
             self.as_mut().primitive_changed();
         }
     }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn trivial<'a>(&'a self, cpp: &'a MyObject) -> &'a QPoint {
-            cpp.trivial()
-        }
-    }
     impl MyObject {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "trivial"]
         pub fn trivial(&self) -> &QPoint {
             &self.trivial
-        }
-    }
-    impl MyObjectRust {
-        #[doc(hidden)]
-        pub fn set_trivial(&mut self, cpp: Pin<&mut MyObject>, value: QPoint) {
-            cpp.set_trivial(value);
         }
     }
     impl MyObject {


### PR DESCRIPTION
This then avoids us needing to generate Rust methods with
fully qualified types on the Rust side and removes a load of
generation.
    
Related to #404

Requires #589