### PR TITLE
cxx-qt-gen: remove hidden module

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 
 use crate::generator::{
-    naming::qobject::QObjectName, rust::qobject::GeneratedRustQObjectBlocks,
+    naming::qobject::QObjectName, rust::qobject::GeneratedRustQObject,
     utils::rust::syn_ident_cxx_bridge_to_qualified_impl,
 };
 use quote::quote;
@@ -17,8 +17,8 @@ use super::fragment::RustFragmentPair;
 pub fn generate(
     qobject_ident: &QObjectName,
     qualified_mappings: &BTreeMap<Ident, Path>,
-) -> Result<GeneratedRustQObjectBlocks> {
-    let mut blocks = GeneratedRustQObjectBlocks::default();
+) -> Result<GeneratedRustQObject> {
+    let mut blocks = GeneratedRustQObject::default();
 
     let cpp_struct_ident = &qobject_ident.cpp_class.rust;
     let rust_struct_ident = &qobject_ident.rust_struct.rust;

--- a/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::generator::{naming::qobject::QObjectName, rust::qobject::GeneratedRustQObjectBlocks};
+use quote::quote;
+use syn::Result;
+
+use super::fragment::RustFragmentPair;
+
+pub fn generate(qobject_ident: &QObjectName) -> Result<GeneratedRustQObjectBlocks> {
+    let mut blocks = GeneratedRustQObjectBlocks::default();
+
+    let cpp_struct_ident = &qobject_ident.cpp_class.rust;
+    let rust_struct_ident = &qobject_ident.rust_struct.rust;
+
+    let fragment = RustFragmentPair {
+        cxx_bridge: vec![
+            quote! {
+                unsafe extern "C++" {
+                    #[cxx_name = "unsafeRust"]
+                    #[doc(hidden)]
+                    fn cxx_qt_ffi_rust(self: &#cpp_struct_ident) -> &#rust_struct_ident;
+                }
+            },
+            quote! {
+                unsafe extern "C++" {
+                    #[cxx_name = "unsafeRustMut"]
+                    #[doc(hidden)]
+                    fn cxx_qt_ffi_rust_mut(self: Pin<&mut #cpp_struct_ident>) -> Pin<&mut #rust_struct_ident>;
+                }
+            },
+        ],
+        implementation: vec![
+            quote! {
+                impl core::ops::Deref for #cpp_struct_ident {
+                    type Target = #rust_struct_ident;
+
+                    fn deref(&self) -> &Self::Target {
+                        self.cxx_qt_ffi_rust()
+                    }
+                }
+            },
+            quote! {
+                impl cxx_qt::CxxQtType for #cpp_struct_ident {
+                    type Rust = #rust_struct_ident;
+
+                    fn rust(&self) -> &Self::Rust {
+                        self.cxx_qt_ffi_rust()
+                    }
+
+                    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+                        self.cxx_qt_ffi_rust_mut()
+                    }
+                }
+            },
+        ],
+    };
+
+    blocks
+        .cxx_mod_contents
+        .append(&mut fragment.cxx_bridge_as_items()?);
+    blocks
+        .cxx_qt_mod_contents
+        .append(&mut fragment.implementation_as_items()?);
+
+    Ok(blocks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::tests::assert_tokens_eq;
+
+    use crate::parser::qobject::tests::create_parsed_qobject;
+
+    #[test]
+    fn test_generate_rust_cxxqttype() {
+        let qobject = create_parsed_qobject();
+        let qobject_idents = QObjectName::from(&qobject);
+
+        let generated = generate(&qobject_idents).unwrap();
+
+        assert_eq!(generated.cxx_mod_contents.len(), 2);
+        assert_eq!(generated.cxx_qt_mod_contents.len(), 2);
+
+        // CXX bridges
+
+        assert_tokens_eq(
+            &generated.cxx_mod_contents[0],
+            quote! {
+                unsafe extern "C++" {
+                    #[cxx_name = "unsafeRust"]
+                    #[doc(hidden)]
+                    fn cxx_qt_ffi_rust(self: &MyObject) -> &MyObjectRust;
+                }
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_mod_contents[1],
+            quote! {
+                unsafe extern "C++" {
+                    #[cxx_name = "unsafeRustMut"]
+                    #[doc(hidden)]
+                    fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObject>) -> Pin<&mut MyObjectRust>;
+                }
+            },
+        );
+
+        // CXX-Qt generated contents
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[0],
+            quote! {
+                impl core::ops::Deref for MyObject {
+                    type Target = MyObjectRust;
+
+                    fn deref(&self) -> &Self::Target {
+                        self.cxx_qt_ffi_rust()
+                    }
+                }
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_qt_mod_contents[1],
+            quote! {
+                impl cxx_qt::CxxQtType for MyObject {
+                    type Rust = MyObjectRust;
+
+                    fn rust(&self) -> &Self::Rust {
+                        self.cxx_qt_ffi_rust()
+                    }
+
+                    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+                        self.cxx_qt_ffi_rust_mut()
+                    }
+                }
+            },
+        );
+    }
+}

--- a/crates/cxx-qt-gen/src/generator/rust/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/inherit.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
-    generator::{naming::qobject::QObjectName, rust::qobject::GeneratedRustQObjectBlocks},
+    generator::{naming::qobject::QObjectName, rust::qobject::GeneratedRustQObject},
     parser::inherit::ParsedInheritedMethod,
 };
 use proc_macro2::TokenStream;
@@ -14,8 +14,8 @@ use syn::{Item, Result};
 pub fn generate(
     qobject_ident: &QObjectName,
     methods: &[ParsedInheritedMethod],
-) -> Result<GeneratedRustQObjectBlocks> {
-    let mut blocks = GeneratedRustQObjectBlocks::default();
+) -> Result<GeneratedRustQObject> {
+    let mut blocks = GeneratedRustQObject::default();
     let qobject_name = &qobject_ident.cpp_class.rust;
 
     let mut bridges = methods
@@ -71,7 +71,7 @@ mod tests {
     fn generate_from_foreign(
         method: ForeignItemFn,
         safety: Safety,
-    ) -> Result<GeneratedRustQObjectBlocks> {
+    ) -> Result<GeneratedRustQObject> {
         let inherited_methods = vec![ParsedInheritedMethod::parse(method, safety).unwrap()];
         generate(&create_qobjectname(), &inherited_methods)
     }

--- a/crates/cxx-qt-gen/src/generator/rust/invokable.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/invokable.rs
@@ -6,7 +6,7 @@
 use crate::{
     generator::{
         naming::{invokable::QInvokableName, qobject::QObjectName},
-        rust::{fragment::RustFragmentPair, qobject::GeneratedRustQObjectBlocks},
+        rust::{fragment::RustFragmentPair, qobject::GeneratedRustQObject},
     },
     parser::invokable::ParsedQInvokable,
 };
@@ -17,8 +17,8 @@ use syn::Result;
 pub fn generate_rust_invokables(
     invokables: &Vec<ParsedQInvokable>,
     qobject_idents: &QObjectName,
-) -> Result<GeneratedRustQObjectBlocks> {
-    let mut generated = GeneratedRustQObjectBlocks::default();
+) -> Result<GeneratedRustQObject> {
+    let mut generated = GeneratedRustQObject::default();
     let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
 
     for invokable in invokables {

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -44,7 +44,11 @@ impl GeneratedRustBlocks {
                 .qobjects
                 .values()
                 .map(|qobject| {
-                    GeneratedRustQObject::from(qobject, &parser.cxx_qt_data.qualified_mappings)
+                    GeneratedRustQObject::from(
+                        qobject,
+                        &parser.cxx_qt_data.qualified_mappings,
+                        &parser.passthrough_module.ident,
+                    )
                 })
                 .collect::<Result<Vec<GeneratedRustQObject>>>()?,
         })

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 pub mod constructor;
+pub mod cxxqttype;
 pub mod fragment;
 pub mod inherit;
 pub mod invokable;

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -43,7 +43,9 @@ impl GeneratedRustBlocks {
                 .cxx_qt_data
                 .qobjects
                 .values()
-                .map(GeneratedRustQObject::from)
+                .map(|qobject| {
+                    GeneratedRustQObject::from(qobject, &parser.cxx_qt_data.qualified_mappings)
+                })
                 .collect::<Result<Vec<GeneratedRustQObject>>>()?,
         })
     }

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -37,7 +37,7 @@ impl GeneratedRustBlocks {
         Ok(GeneratedRustBlocks {
             cxx_mod: parser.passthrough_module.clone(),
             cxx_mod_contents: vec![generate_include(parser)?],
-            cxx_qt_mod_contents: parser.cxx_qt_data.uses.clone(),
+            cxx_qt_mod_contents: vec![],
             namespace: parser.cxx_qt_data.namespace.clone(),
             qobjects: parser
                 .cxx_qt_data
@@ -120,29 +120,6 @@ mod tests {
         assert_eq!(rust.cxx_mod.content.unwrap().1.len(), 0);
         assert_eq!(rust.cxx_mod_contents.len(), 1);
         assert_eq!(rust.cxx_qt_mod_contents.len(), 0);
-        assert_eq!(rust.namespace, "cxx_qt");
-        assert_eq!(rust.qobjects.len(), 1);
-    }
-
-    #[test]
-    fn test_generated_rust_blocks_uses() {
-        let module: ItemMod = parse_quote! {
-            #[cxx_qt::bridge(namespace = "cxx_qt")]
-            mod ffi {
-                use std::collections::HashMap;
-
-                extern "RustQt" {
-                    #[cxx_qt::qobject]
-                    type MyObject = super::MyObjectRust;
-                }
-            }
-        };
-        let parser = Parser::from(module).unwrap();
-
-        let rust = GeneratedRustBlocks::from(&parser).unwrap();
-        assert_eq!(rust.cxx_mod.content.unwrap().1.len(), 0);
-        assert_eq!(rust.cxx_mod_contents.len(), 1);
-        assert_eq!(rust.cxx_qt_mod_contents.len(), 1);
         assert_eq!(rust.namespace, "cxx_qt");
         assert_eq!(rust.qobjects.len(), 1);
     }

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -9,19 +9,21 @@ use crate::generator::{
     utils::rust::syn_type_cxx_bridge_to_qualified,
 };
 use quote::quote;
-use syn::Type;
+use std::collections::BTreeMap;
+use syn::{Ident, Path, Type};
 
 pub fn generate(
     idents: &QPropertyName,
     qobject_idents: &QObjectName,
     cxx_ty: &Type,
+    qualified_mappings: &BTreeMap<Ident, Path>,
 ) -> RustFragmentPair {
     let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
     let getter_wrapper_cpp = idents.getter_wrapper.cpp.to_string();
     let getter_rust = &idents.getter.rust;
     let ident = &idents.name.rust;
     let ident_str = ident.to_string();
-    let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty);
+    let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, qualified_mappings);
 
     RustFragmentPair {
         cxx_bridge: vec![quote! {

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -6,7 +6,7 @@
 use crate::generator::{
     naming::{property::QPropertyName, qobject::QObjectName},
     rust::fragment::RustFragmentPair,
-    utils::rust::syn_type_cxx_bridge_to_qualified,
+    utils::rust::{syn_ident_cxx_bridge_to_qualified_impl, syn_type_cxx_bridge_to_qualified},
 };
 use quote::quote;
 use std::collections::BTreeMap;
@@ -24,6 +24,8 @@ pub fn generate(
     let ident = &idents.name.rust;
     let ident_str = ident.to_string();
     let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, qualified_mappings);
+    let qualified_impl =
+        syn_ident_cxx_bridge_to_qualified_impl(cpp_class_name_rust, qualified_mappings);
 
     RustFragmentPair {
         cxx_bridge: vec![quote! {
@@ -33,7 +35,7 @@ pub fn generate(
             }
         }],
         implementation: vec![quote! {
-            impl #cpp_class_name_rust {
+            impl #qualified_impl {
                 #[doc = "Getter for the Q_PROPERTY "]
                 #[doc = #ident_str]
                 pub fn #getter_rust(&self) -> &#qualified_ty {

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -140,6 +140,7 @@ mod tests {
                     #[doc = "Setter for the Q_PROPERTY "]
                     #[doc = "trivial_property"]
                     pub fn set_trivial_property(mut self: core::pin::Pin<&mut Self>, value: i32) {
+                        use cxx_qt::CxxQtType;
                         if self.trivial_property == value {
                             return;
                         }
@@ -192,6 +193,7 @@ mod tests {
                     #[doc = "Setter for the Q_PROPERTY "]
                     #[doc = "opaque_property"]
                     pub fn set_opaque_property(mut self: core::pin::Pin<&mut Self>, value: cxx::UniquePtr<QColor>) {
+                        use cxx_qt::CxxQtType;
                         if self.opaque_property == value {
                             return;
                         }
@@ -244,6 +246,7 @@ mod tests {
                     #[doc = "Setter for the Q_PROPERTY "]
                     #[doc = "unsafe_property"]
                     pub fn set_unsafe_property(mut self: core::pin::Pin<&mut Self>, value: *mut T) {
+                        use cxx_qt::CxxQtType;
                         if self.unsafe_property == value {
                             return;
                         }

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -10,7 +10,7 @@ pub mod signal;
 use crate::{
     generator::{
         naming::{property::QPropertyName, qobject::QObjectName},
-        rust::qobject::GeneratedRustQObjectBlocks,
+        rust::qobject::GeneratedRustQObject,
     },
     parser::property::ParsedQProperty,
 };
@@ -23,8 +23,8 @@ pub fn generate_rust_properties(
     properties: &Vec<ParsedQProperty>,
     qobject_idents: &QObjectName,
     qualified_mappings: &BTreeMap<Ident, Path>,
-) -> Result<GeneratedRustQObjectBlocks> {
-    let mut generated = GeneratedRustQObjectBlocks::default();
+) -> Result<GeneratedRustQObject> {
+    let mut generated = GeneratedRustQObject::default();
     let mut signals = vec![];
 
     for property in properties {

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -9,12 +9,14 @@ use crate::generator::{
     utils::rust::{syn_type_cxx_bridge_to_qualified, syn_type_is_cxx_bridge_unsafe},
 };
 use quote::quote;
-use syn::Type;
+use std::collections::BTreeMap;
+use syn::{Ident, Path, Type};
 
 pub fn generate(
     idents: &QPropertyName,
     qobject_idents: &QObjectName,
     cxx_ty: &Type,
+    qualified_mappings: &BTreeMap<Ident, Path>,
 ) -> RustFragmentPair {
     let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
     let setter_wrapper_cpp = idents.setter_wrapper.cpp.to_string();
@@ -22,7 +24,7 @@ pub fn generate(
     let ident = &idents.name.rust;
     let ident_str = ident.to_string();
     let notify_ident = &idents.notify.rust;
-    let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty);
+    let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, qualified_mappings);
 
     // Determine if unsafe is required due to an unsafe type
     let has_unsafe = if syn_type_is_cxx_bridge_unsafe(cxx_ty) {

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -6,7 +6,10 @@
 use crate::generator::{
     naming::{property::QPropertyName, qobject::QObjectName},
     rust::fragment::RustFragmentPair,
-    utils::rust::{syn_type_cxx_bridge_to_qualified, syn_type_is_cxx_bridge_unsafe},
+    utils::rust::{
+        syn_ident_cxx_bridge_to_qualified_impl, syn_type_cxx_bridge_to_qualified,
+        syn_type_is_cxx_bridge_unsafe,
+    },
 };
 use quote::quote;
 use std::collections::BTreeMap;
@@ -25,6 +28,8 @@ pub fn generate(
     let ident_str = ident.to_string();
     let notify_ident = &idents.notify.rust;
     let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, qualified_mappings);
+    let qualified_impl =
+        syn_ident_cxx_bridge_to_qualified_impl(cpp_class_name_rust, qualified_mappings);
 
     // Determine if unsafe is required due to an unsafe type
     let has_unsafe = if syn_type_is_cxx_bridge_unsafe(cxx_ty) {
@@ -41,7 +46,7 @@ pub fn generate(
             }
         }],
         implementation: vec![quote! {
-            impl #cpp_class_name_rust {
+            impl #qualified_impl {
                 #[doc = "Setter for the Q_PROPERTY "]
                 #[doc = #ident_str]
                 pub fn #setter_rust(mut self: core::pin::Pin<&mut Self>, value: #qualified_ty) {

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -50,6 +50,7 @@ pub fn generate(
                 #[doc = "Setter for the Q_PROPERTY "]
                 #[doc = #ident_str]
                 pub fn #setter_rust(mut self: core::pin::Pin<&mut Self>, value: #qualified_ty) {
+                    use cxx_qt::CxxQtType;
                     if self.#ident == value {
                         // don't want to set the value again and reemit the signal,
                         // as this can cause binding loops

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -151,6 +151,7 @@ impl GeneratedRustQObject {
             &qobject.constructors,
             &qobject_idents,
             &namespace_idents,
+            qualified_mappings,
         )?);
 
         generated.blocks.append(&mut cxxqttype::generate(

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -18,7 +18,7 @@ use crate::{
     parser::qobject::ParsedQObject,
 };
 use quote::quote;
-use syn::{parse_quote, Ident, ImplItem, Item, Path, Result};
+use syn::{Ident, ImplItem, Item, Path, Result};
 
 #[derive(Default)]
 pub struct GeneratedRustQObjectBlocks {
@@ -69,16 +69,6 @@ impl GeneratedRustQObject {
         generated
             .blocks
             .append(&mut generate_qobject_definitions(&qobject_idents)?);
-
-        // Add a type alias so that generated code can still find T
-        //
-        // TODO: this should be removed once generated methods aren't in the hidden module
-        generated.blocks.cxx_qt_mod_contents.push({
-            let rust_struct_name_rust = &qobject_idents.rust_struct.rust;
-            parse_quote! {
-                type #rust_struct_name_rust = super::#rust_struct_name_rust;
-            }
-        });
 
         // Generate methods for the properties, invokables, signals
         generated.blocks.append(&mut generate_rust_properties(

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -51,6 +51,7 @@ impl GeneratedRustQObject {
     pub fn from(
         qobject: &ParsedQObject,
         qualified_mappings: &BTreeMap<Ident, Path>,
+        module_ident: &Ident,
     ) -> Result<GeneratedRustQObject> {
         // Create the base object
         let qobject_idents = QObjectName::from(qobject);
@@ -127,6 +128,7 @@ impl GeneratedRustQObject {
                 &qobject_idents,
                 &namespace_idents,
                 qualified_mappings,
+                module_ident,
             )?);
         }
 
@@ -152,6 +154,7 @@ impl GeneratedRustQObject {
             &qobject_idents,
             &namespace_idents,
             qualified_mappings,
+            module_ident,
         )?);
 
         generated.blocks.append(&mut cxxqttype::generate(
@@ -230,6 +233,7 @@ mod tests {
 
     use crate::parser::Parser;
     use crate::tests::assert_tokens_eq;
+    use quote::format_ident;
     use syn::{parse_quote, ItemMod};
 
     #[test]
@@ -248,6 +252,7 @@ mod tests {
         let rust = GeneratedRustQObject::from(
             parser.cxx_qt_data.qobjects.values().next().unwrap(),
             &BTreeMap::<Ident, Path>::default(),
+            &format_ident!("ffi"),
         )
         .unwrap();
         assert_eq!(rust.cpp_struct_ident, "MyObject");
@@ -271,6 +276,7 @@ mod tests {
         let rust = GeneratedRustQObject::from(
             parser.cxx_qt_data.qobjects.values().next().unwrap(),
             &BTreeMap::<Ident, Path>::default(),
+            &format_ident!("ffi"),
         )
         .unwrap();
         assert_eq!(rust.cpp_struct_ident, "MyObject");
@@ -294,6 +300,7 @@ mod tests {
         let rust = GeneratedRustQObject::from(
             parser.cxx_qt_data.qobjects.values().next().unwrap(),
             &BTreeMap::<Ident, Path>::default(),
+            &format_ident!("ffi"),
         )
         .unwrap();
         assert_eq!(rust.blocks.cxx_mod_contents.len(), 6);

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use crate::{
     generator::{
         naming::{qobject::QObjectName, signals::QSignalName},
-        rust::{fragment::RustFragmentPair, qobject::GeneratedRustQObjectBlocks},
+        rust::{fragment::RustFragmentPair, qobject::GeneratedRustQObject},
         utils::rust::{syn_ident_cxx_bridge_to_qualified_impl, syn_type_cxx_bridge_to_qualified},
     },
     parser::signals::ParsedSignal,
@@ -20,8 +20,8 @@ pub fn generate_rust_signals(
     signals: &Vec<ParsedSignal>,
     qobject_idents: &QObjectName,
     qualified_mappings: &BTreeMap<Ident, Path>,
-) -> Result<GeneratedRustQObjectBlocks> {
-    let mut generated = GeneratedRustQObjectBlocks::default();
+) -> Result<GeneratedRustQObject> {
+    let mut generated = GeneratedRustQObject::default();
     let qobject_name = &qobject_idents.cpp_class.rust;
 
     // Create the methods for the other signals

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -9,7 +9,7 @@ use crate::{
     generator::{
         naming::{qobject::QObjectName, signals::QSignalName},
         rust::{fragment::RustFragmentPair, qobject::GeneratedRustQObjectBlocks},
-        utils::rust::syn_type_cxx_bridge_to_qualified,
+        utils::rust::{syn_ident_cxx_bridge_to_qualified_impl, syn_type_cxx_bridge_to_qualified},
     },
     parser::signals::ParsedSignal,
 };
@@ -64,6 +64,8 @@ pub fn generate_rust_signals(
         };
         let self_type_qualified =
             syn_type_cxx_bridge_to_qualified(&self_type_cxx, qualified_mappings);
+        let qualified_impl =
+            syn_ident_cxx_bridge_to_qualified_impl(qobject_name, qualified_mappings);
 
         let mut unsafe_block = None;
         let mut unsafe_call = Some(quote! { unsafe });
@@ -94,7 +96,7 @@ pub fn generate_rust_signals(
                 },
             ],
             implementation: vec![quote! {
-                impl #qobject_name {
+                impl #qualified_impl {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = #signal_name_cpp_str]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]

--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -10,7 +10,7 @@ use crate::generator::{
         namespace::{namespace_combine_ident, NamespaceName},
         qobject::QObjectName,
     },
-    rust::qobject::GeneratedRustQObjectBlocks,
+    rust::qobject::GeneratedRustQObject,
     utils::rust::syn_ident_cxx_bridge_to_qualified_impl,
 };
 use quote::quote;
@@ -23,8 +23,8 @@ pub fn generate(
     namespace_ident: &NamespaceName,
     qualified_mappings: &BTreeMap<Ident, Path>,
     module_ident: &Ident,
-) -> Result<GeneratedRustQObjectBlocks> {
-    let mut blocks = GeneratedRustQObjectBlocks::default();
+) -> Result<GeneratedRustQObject> {
+    let mut blocks = GeneratedRustQObject::default();
 
     let cpp_struct_ident = &qobject_ident.cpp_class.rust;
     let cxx_qt_thread_ident = &qobject_ident.cxx_qt_thread_class;

--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -22,6 +22,7 @@ pub fn generate(
     qobject_ident: &QObjectName,
     namespace_ident: &NamespaceName,
     qualified_mappings: &BTreeMap<Ident, Path>,
+    module_ident: &Ident,
 ) -> Result<GeneratedRustQObjectBlocks> {
     let mut blocks = GeneratedRustQObjectBlocks::default();
 
@@ -91,13 +92,13 @@ pub fn generate(
                     type BoxedQueuedFn = #cxx_qt_thread_queued_fn_ident;
                     type ThreadingTypeId = cxx::type_id!(#cxx_qt_thread_ident_type_id_str);
 
-                    fn qt_thread(&self) -> #cxx_qt_thread_ident
+                    fn qt_thread(&self) -> #module_ident::#cxx_qt_thread_ident
                     {
                         self.cxx_qt_ffi_qt_thread()
                     }
 
                     #[doc(hidden)]
-                    fn queue<F>(cxx_qt_thread: &#cxx_qt_thread_ident, f: F) -> std::result::Result<(), cxx::Exception>
+                    fn queue<F>(cxx_qt_thread: &#module_ident::#cxx_qt_thread_ident, f: F) -> std::result::Result<(), cxx::Exception>
                     where
                         F: FnOnce(core::pin::Pin<&mut #qualified_impl>),
                         F: Send + 'static,
@@ -114,19 +115,19 @@ pub fn generate(
                             (arg.inner)(obj)
                         }
                         let arg = #cxx_qt_thread_queued_fn_ident { inner: std::boxed::Box::new(f) };
-                        #cxx_qt_thread_queue_fn(cxx_qt_thread, func, std::boxed::Box::new(arg))
+                        #module_ident::#cxx_qt_thread_queue_fn(cxx_qt_thread, func, std::boxed::Box::new(arg))
                     }
 
                     #[doc(hidden)]
-                    fn threading_clone(cxx_qt_thread: &#cxx_qt_thread_ident) -> #cxx_qt_thread_ident
+                    fn threading_clone(cxx_qt_thread: &#module_ident::#cxx_qt_thread_ident) -> #module_ident::#cxx_qt_thread_ident
                     {
-                        #cxx_qt_thread_clone(cxx_qt_thread)
+                        #module_ident::#cxx_qt_thread_clone(cxx_qt_thread)
                     }
 
                     #[doc(hidden)]
-                    fn threading_drop(cxx_qt_thread: &mut #cxx_qt_thread_ident)
+                    fn threading_drop(cxx_qt_thread: &mut #module_ident::#cxx_qt_thread_ident)
                     {
-                        #cxx_qt_thread_drop(cxx_qt_thread);
+                        #module_ident::#cxx_qt_thread_drop(cxx_qt_thread);
                     }
                 }
             },
@@ -159,6 +160,8 @@ mod tests {
 
     use crate::parser::qobject::tests::create_parsed_qobject;
 
+    use quote::format_ident;
+
     #[test]
     fn test_generate_rust_threading() {
         let qobject = create_parsed_qobject();
@@ -169,6 +172,7 @@ mod tests {
             &qobject_idents,
             &namespace_ident,
             &BTreeMap::<Ident, Path>::default(),
+            &format_ident!("ffi"),
         )
         .unwrap();
 
@@ -231,13 +235,13 @@ mod tests {
                     type BoxedQueuedFn = MyObjectCxxQtThreadQueuedFn;
                     type ThreadingTypeId = cxx::type_id!("MyObjectCxxQtThread");
 
-                    fn qt_thread(&self) -> MyObjectCxxQtThread
+                    fn qt_thread(&self) -> ffi::MyObjectCxxQtThread
                     {
                         self.cxx_qt_ffi_qt_thread()
                     }
 
                     #[doc(hidden)]
-                    fn queue<F>(cxx_qt_thread: &MyObjectCxxQtThread, f: F) -> std::result::Result<(), cxx::Exception>
+                    fn queue<F>(cxx_qt_thread: &ffi::MyObjectCxxQtThread, f: F) -> std::result::Result<(), cxx::Exception>
                     where
                         F: FnOnce(core::pin::Pin<&mut MyObject>),
                         F: Send + 'static,
@@ -254,19 +258,19 @@ mod tests {
                             (arg.inner)(obj)
                         }
                         let arg = MyObjectCxxQtThreadQueuedFn { inner: std::boxed::Box::new(f) };
-                        cxx_qt_ffi_my_object_queue_boxed_fn(cxx_qt_thread, func, std::boxed::Box::new(arg))
+                        ffi::cxx_qt_ffi_my_object_queue_boxed_fn(cxx_qt_thread, func, std::boxed::Box::new(arg))
                     }
 
                     #[doc(hidden)]
-                    fn threading_clone(cxx_qt_thread: &MyObjectCxxQtThread) -> MyObjectCxxQtThread
+                    fn threading_clone(cxx_qt_thread: &ffi::MyObjectCxxQtThread) -> ffi::MyObjectCxxQtThread
                     {
-                        cxx_qt_ffi_my_object_threading_clone(cxx_qt_thread)
+                        ffi::cxx_qt_ffi_my_object_threading_clone(cxx_qt_thread)
                     }
 
                     #[doc(hidden)]
-                    fn threading_drop(cxx_qt_thread: &mut MyObjectCxxQtThread)
+                    fn threading_drop(cxx_qt_thread: &mut ffi::MyObjectCxxQtThread)
                     {
-                        cxx_qt_ffi_my_object_threading_drop(cxx_qt_thread);
+                        ffi::cxx_qt_ffi_my_object_threading_drop(cxx_qt_thread);
                     }
                 }
             },

--- a/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
+++ b/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
@@ -62,8 +62,6 @@ pub struct ParsedCxxQtData {
     pub qobjects: BTreeMap<Ident, ParsedQObject>,
     /// The namespace of the CXX-Qt module
     pub namespace: String,
-    /// Any `use` statements end up in the CXX-Qt generated module
-    pub uses: Vec<Item>,
 }
 
 impl ParsedCxxQtData {
@@ -202,11 +200,6 @@ impl ParsedCxxQtData {
     pub fn parse_cxx_qt_item(&mut self, item: Item) -> Result<Option<Item>> {
         match item {
             Item::Impl(imp) => self.parse_impl(imp),
-            Item::Use(_) => {
-                // Any use statements go into the CXX-Qt generated block
-                self.uses.push(item);
-                Ok(None)
-            }
             Item::ForeignMod(foreign_mod) => self.parse_foreign_mod(foreign_mod),
             _ => Ok(Some(item)),
         }
@@ -521,18 +514,6 @@ mod tests {
         let result = cxx_qt_data.parse_cxx_qt_item(item).unwrap();
         assert!(result.is_none());
         assert_eq!(cxx_qt_data.qobjects[&qobject_ident()].others.len(), 1);
-    }
-
-    #[test]
-    fn test_find_and_merge_cxx_qt_item_uses() {
-        let mut cxx_qt_data = create_parsed_cxx_qt_data();
-
-        let item: Item = parse_quote! {
-            use std::collections::HashMap;
-        };
-        let result = cxx_qt_data.parse_cxx_qt_item(item).unwrap();
-        assert!(result.is_none());
-        assert_eq!(cxx_qt_data.uses.len(), 1);
     }
 
     #[test]

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -77,7 +77,11 @@ impl Parser {
                     // qobject. Otherwise return them to be added to other
                     if let Some(other) = cxx_qt_data.parse_cxx_qt_item(item)? {
                         // Load any CXX name mappings
-                        cxx_qt_data.populate_cxx_mappings_from_item(&other, &bridge_namespace)?;
+                        cxx_qt_data.populate_mappings_from_item(
+                            &other,
+                            &bridge_namespace,
+                            &module.ident,
+                        )?;
 
                         // Unknown item so add to the other list
                         others.push(other);
@@ -86,7 +90,11 @@ impl Parser {
             } else {
                 // Load any CXX name mappings
                 for item in &items.1 {
-                    cxx_qt_data.populate_cxx_mappings_from_item(item, &bridge_namespace)?;
+                    cxx_qt_data.populate_mappings_from_item(
+                        item,
+                        &bridge_namespace,
+                        &module.ident,
+                    )?;
                 }
 
                 // No qobjects found so pass everything through

--- a/crates/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/rust/mod.rs
@@ -85,6 +85,8 @@ pub fn write_rust(generated: &GeneratedRustBlocks) -> TokenStream {
         //
         /// Internal CXX-Qt module, made public temporarily between API changes
         pub mod #cxx_qt_mod_ident {
+            // Temporary hack so that qualified types still work, this will be removed in the next commit
+            use super::*;
             use super::#cxx_mod_ident::*;
             use cxx_qt::CxxQtType;
 
@@ -277,6 +279,7 @@ mod tests {
             use self::cxx_qt_ffi::*;
             #[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
             pub mod cxx_qt_ffi {
+                use super::*;
                 use super::ffi::*;
                 use cxx_qt::CxxQtType;
 
@@ -344,6 +347,7 @@ mod tests {
             use self::cxx_qt_ffi::*;
             #[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
             pub mod cxx_qt_ffi {
+                use super::*;
                 use super::ffi::*;
                 use cxx_qt::CxxQtType;
 

--- a/crates/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/rust/mod.rs
@@ -42,8 +42,8 @@ pub fn write_rust(generated: &GeneratedRustBlocks) -> TokenStream {
 
     for qobject in &generated.qobjects {
         // Add the blocks from the QObject
-        cxx_mod_contents.extend_from_slice(&qobject.blocks.cxx_mod_contents);
-        cxx_qt_mod_contents.extend_from_slice(&qobject.blocks.cxx_qt_mod_contents);
+        cxx_mod_contents.extend_from_slice(&qobject.cxx_mod_contents);
+        cxx_qt_mod_contents.extend_from_slice(&qobject.cxx_qt_mod_contents);
     }
 
     // Inject the CXX blocks
@@ -66,9 +66,8 @@ pub fn write_rust(generated: &GeneratedRustBlocks) -> TokenStream {
 mod tests {
     use super::*;
 
-    use crate::generator::rust::qobject::{GeneratedRustQObject, GeneratedRustQObjectBlocks};
+    use crate::generator::rust::qobject::GeneratedRustQObject;
     use pretty_assertions::assert_str_eq;
-    use quote::format_ident;
     use syn::parse_quote;
 
     /// Helper to create a GeneratedRustBlocks for testing
@@ -87,36 +86,31 @@ mod tests {
             }],
             namespace: "cxx_qt::my_object".to_owned(),
             qobjects: vec![GeneratedRustQObject {
-                cpp_struct_ident: format_ident!("MyObject"),
-                namespace_internals: "cxx_qt::my_object::cxx_qt_my_object".to_owned(),
-                rust_struct_ident: format_ident!("MyObjectRust"),
-                blocks: GeneratedRustQObjectBlocks {
-                    cxx_mod_contents: vec![
-                        parse_quote! {
-                            unsafe extern "C++" {
-                                type MyObject;
-                            }
-                        },
-                        parse_quote! {
-                            extern "Rust" {
-                                type MyObjectRust;
-                            }
-                        },
-                    ],
-                    cxx_qt_mod_contents: vec![
-                        parse_quote! {
-                            #[derive(Default)]
-                            pub struct MyObjectRust;
-                        },
-                        parse_quote! {
-                            impl MyObjectRust {
-                                fn rust_method(&self) {
+                cxx_mod_contents: vec![
+                    parse_quote! {
+                        unsafe extern "C++" {
+                            type MyObject;
+                        }
+                    },
+                    parse_quote! {
+                        extern "Rust" {
+                            type MyObjectRust;
+                        }
+                    },
+                ],
+                cxx_qt_mod_contents: vec![
+                    parse_quote! {
+                        #[derive(Default)]
+                        pub struct MyObjectRust;
+                    },
+                    parse_quote! {
+                        impl MyObjectRust {
+                            fn rust_method(&self) {
 
-                                }
                             }
-                        },
-                    ],
-                },
+                        }
+                    },
+                ],
             }],
         }
     }
@@ -138,68 +132,58 @@ mod tests {
             namespace: "cxx_qt".to_owned(),
             qobjects: vec![
                 GeneratedRustQObject {
-                    cpp_struct_ident: format_ident!("FirstObject"),
-                    namespace_internals: "cxx_qt::cxx_qt_first_object".to_owned(),
-                    rust_struct_ident: format_ident!("FirstObjectRust"),
-                    blocks: GeneratedRustQObjectBlocks {
-                        cxx_mod_contents: vec![
-                            parse_quote! {
-                                unsafe extern "C++" {
-                                    type FirstObject;
-                                }
-                            },
-                            parse_quote! {
-                                extern "Rust" {
-                                    type FirstObjectRust;
-                                }
-                            },
-                        ],
-                        cxx_qt_mod_contents: vec![
-                            parse_quote! {
-                                #[derive(Default)]
-                                pub struct FirstObjectRust;
-                            },
-                            parse_quote! {
-                                impl FirstObjectRust {
-                                    fn rust_method(&self) {
+                    cxx_mod_contents: vec![
+                        parse_quote! {
+                            unsafe extern "C++" {
+                                type FirstObject;
+                            }
+                        },
+                        parse_quote! {
+                            extern "Rust" {
+                                type FirstObjectRust;
+                            }
+                        },
+                    ],
+                    cxx_qt_mod_contents: vec![
+                        parse_quote! {
+                            #[derive(Default)]
+                            pub struct FirstObjectRust;
+                        },
+                        parse_quote! {
+                            impl FirstObjectRust {
+                                fn rust_method(&self) {
 
-                                    }
                                 }
-                            },
-                        ],
-                    },
+                            }
+                        },
+                    ],
                 },
                 GeneratedRustQObject {
-                    cpp_struct_ident: format_ident!("SecondObject"),
-                    namespace_internals: "cxx_qt::cxx_qt_second_object".to_owned(),
-                    rust_struct_ident: format_ident!("SecondObjectRust"),
-                    blocks: GeneratedRustQObjectBlocks {
-                        cxx_mod_contents: vec![
-                            parse_quote! {
-                                unsafe extern "C++" {
-                                    type SecondObject;
-                                }
-                            },
-                            parse_quote! {
-                                extern "Rust" {
-                                    type SecondObjectRust;
-                                }
-                            },
-                        ],
-                        cxx_qt_mod_contents: vec![
-                            parse_quote! {
-                                #[derive(Default)]
-                                pub struct SecondObjectRust;
-                            },
-                            parse_quote! {
-                                impl SecondObjectRust {
-                                    fn rust_method(&self) {
+                    cxx_mod_contents: vec![
+                        parse_quote! {
+                            unsafe extern "C++" {
+                                type SecondObject;
+                            }
+                        },
+                        parse_quote! {
+                            extern "Rust" {
+                                type SecondObjectRust;
+                            }
+                        },
+                    ],
+                    cxx_qt_mod_contents: vec![
+                        parse_quote! {
+                            #[derive(Default)]
+                            pub struct SecondObjectRust;
+                        },
+                        parse_quote! {
+                            impl SecondObjectRust {
+                                fn rust_method(&self) {
 
-                                    }
                                 }
-                            },
-                        ],
-                    },
+                            }
+                        },
+                    ],
                 },
             ],
         }

--- a/crates/cxx-qt-gen/test_inputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_inputs/invokables.rs
@@ -6,6 +6,8 @@ mod ffi {
         type QColor = cxx_qt_lib::QColor;
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = cxx_qt_lib::QPoint;
+        include!(<QtCore/QObject>);
+        type QObject;
     }
 
     unsafe extern "RustQt" {

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -74,6 +74,7 @@ use self::cxx_qt_inheritance::*;
 #[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
 pub mod cxx_qt_inheritance {
     use super::inheritance::*;
+    use super::*;
     use cxx_qt::CxxQtType;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -70,33 +70,23 @@ mod inheritance {
         fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObject>) -> Pin<&mut MyObjectRust>;
     }
 }
-use self::cxx_qt_inheritance::*;
-#[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
-pub mod cxx_qt_inheritance {
-    use super::inheritance::*;
-    use super::*;
-    use cxx_qt::CxxQtType;
-    #[doc(hidden)]
-    type UniquePtr<T> = cxx::UniquePtr<T>;
-    type MyObjectRust = super::MyObjectRust;
-    impl cxx_qt::Locking for inheritance::MyObject {}
-    #[doc(hidden)]
-    pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
-        std::boxed::Box::new(core::default::Default::default())
+impl cxx_qt::Locking for inheritance::MyObject {}
+#[doc(hidden)]
+pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
+    std::boxed::Box::new(core::default::Default::default())
+}
+impl core::ops::Deref for inheritance::MyObject {
+    type Target = MyObjectRust;
+    fn deref(&self) -> &Self::Target {
+        self.cxx_qt_ffi_rust()
     }
-    impl core::ops::Deref for inheritance::MyObject {
-        type Target = MyObjectRust;
-        fn deref(&self) -> &Self::Target {
-            self.cxx_qt_ffi_rust()
-        }
+}
+impl cxx_qt::CxxQtType for inheritance::MyObject {
+    type Rust = MyObjectRust;
+    fn rust(&self) -> &Self::Rust {
+        self.cxx_qt_ffi_rust()
     }
-    impl cxx_qt::CxxQtType for inheritance::MyObject {
-        type Rust = MyObjectRust;
-        fn rust(&self) -> &Self::Rust {
-            self.cxx_qt_ffi_rust()
-        }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
-            self.cxx_qt_ffi_rust_mut()
-        }
+    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+        self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -79,18 +79,18 @@ pub mod cxx_qt_inheritance {
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
-    impl cxx_qt::Locking for MyObject {}
+    impl cxx_qt::Locking for inheritance::MyObject {}
     #[doc(hidden)]
     pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
         std::boxed::Box::new(core::default::Default::default())
     }
-    impl core::ops::Deref for MyObject {
+    impl core::ops::Deref for inheritance::MyObject {
         type Target = MyObjectRust;
         fn deref(&self) -> &Self::Target {
             self.cxx_qt_ffi_rust()
         }
     }
-    impl cxx_qt::CxxQtType for MyObject {
+    impl cxx_qt::CxxQtType for inheritance::MyObject {
         type Rust = MyObjectRust;
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -229,7 +229,9 @@ pub mod cxx_qt_ffi {
         #[allow(unused_variables)]
         #[allow(clippy::let_unit_value)]
         let (new_arguments, base_arguments, initialize_arguments) =
-            <MyObject as cxx_qt::Constructor<(i32, *mut QObject)>>::route_arguments((arg0, arg1));
+            <ffi::MyObject as cxx_qt::Constructor<(i32, *mut QObject)>>::route_arguments((
+                arg0, arg1,
+            ));
         CxxQtConstructorArgumentsMyObject0 {
             base: CxxQtConstructorBaseArgumentsMyObject0 {
                 arg0: base_arguments.0,
@@ -245,17 +247,18 @@ pub mod cxx_qt_ffi {
     pub fn new_rs_my_object_0(
         new_arguments: CxxQtConstructorNewArgumentsMyObject0,
     ) -> std::boxed::Box<MyObjectRust> {
-        std::boxed::Box::new(<MyObject as cxx_qt::Constructor<(i32, *mut QObject)>>::new(
-            (new_arguments.arg0,),
-        ))
+        std::boxed::Box::new(<ffi::MyObject as cxx_qt::Constructor<(
+            i32,
+            *mut QObject,
+        )>>::new((new_arguments.arg0,)))
     }
     #[doc(hidden)]
     #[allow(unused_variables)]
     pub fn initialize_my_object_0(
-        qobject: core::pin::Pin<&mut MyObject>,
+        qobject: core::pin::Pin<&mut ffi::MyObject>,
         initialize_arguments: CxxQtConstructorInitializeArgumentsMyObject0,
     ) {
-        <MyObject as cxx_qt::Constructor<(i32, *mut QObject)>>::initialize(qobject, ());
+        <ffi::MyObject as cxx_qt::Constructor<(i32, *mut QObject)>>::initialize(qobject, ());
     }
     impl core::ops::Deref for ffi::MyObject {
         type Target = MyObjectRust;

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -174,6 +174,7 @@ use self::cxx_qt_ffi::*;
 #[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
 pub mod cxx_qt_ffi {
     use super::ffi::*;
+    use super::*;
     use cxx_qt::CxxQtType;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -6,6 +6,8 @@ mod ffi {
         type QColor = cxx_qt_lib::QColor;
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = cxx_qt_lib::QPoint;
+        include ! (< QtCore / QObject >);
+        type QObject;
     }
     unsafe extern "C++" {
         include ! (< QtCore / QObject >);
@@ -224,12 +226,12 @@ pub mod cxx_qt_ffi {
     #[doc(hidden)]
     pub fn route_arguments_my_object_0(
         arg0: i32,
-        arg1: *mut QObject,
+        arg1: *mut ffi::QObject,
     ) -> ffi::CxxQtConstructorArgumentsMyObject0 {
         #[allow(unused_variables)]
         #[allow(clippy::let_unit_value)]
         let (new_arguments, base_arguments, initialize_arguments) =
-            <ffi::MyObject as cxx_qt::Constructor<(i32, *mut QObject)>>::route_arguments((
+            <ffi::MyObject as cxx_qt::Constructor<(i32, *mut ffi::QObject)>>::route_arguments((
                 arg0, arg1,
             ));
         ffi::CxxQtConstructorArgumentsMyObject0 {
@@ -249,7 +251,7 @@ pub mod cxx_qt_ffi {
     ) -> std::boxed::Box<MyObjectRust> {
         std::boxed::Box::new(<ffi::MyObject as cxx_qt::Constructor<(
             i32,
-            *mut QObject,
+            *mut ffi::QObject,
         )>>::new((new_arguments.arg0,)))
     }
     #[doc(hidden)]
@@ -258,7 +260,7 @@ pub mod cxx_qt_ffi {
         qobject: core::pin::Pin<&mut ffi::MyObject>,
         initialize_arguments: ffi::CxxQtConstructorInitializeArgumentsMyObject0,
     ) {
-        <ffi::MyObject as cxx_qt::Constructor<(i32, *mut QObject)>>::initialize(qobject, ());
+        <ffi::MyObject as cxx_qt::Constructor<(i32, *mut ffi::QObject)>>::initialize(qobject, ());
     }
     impl core::ops::Deref for ffi::MyObject {
         type Target = MyObjectRust;

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -172,109 +172,99 @@ mod ffi {
         fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObject>) -> Pin<&mut MyObjectRust>;
     }
 }
-use self::cxx_qt_ffi::*;
-#[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
-pub mod cxx_qt_ffi {
-    use super::ffi::*;
-    use super::*;
-    use cxx_qt::CxxQtType;
-    #[doc(hidden)]
-    type UniquePtr<T> = cxx::UniquePtr<T>;
-    type MyObjectRust = super::MyObjectRust;
-    impl cxx_qt::Threading for ffi::MyObject {
-        type BoxedQueuedFn = MyObjectCxxQtThreadQueuedFn;
-        type ThreadingTypeId = cxx::type_id!("cxx_qt::my_object::MyObjectCxxQtThread");
-        fn qt_thread(&self) -> ffi::MyObjectCxxQtThread {
-            self.cxx_qt_ffi_qt_thread()
-        }
-        #[doc(hidden)]
-        fn queue<F>(
-            cxx_qt_thread: &ffi::MyObjectCxxQtThread,
-            f: F,
-        ) -> std::result::Result<(), cxx::Exception>
-        where
-            F: FnOnce(core::pin::Pin<&mut ffi::MyObject>),
-            F: Send + 'static,
-        {
-            #[allow(clippy::boxed_local)]
-            #[doc(hidden)]
-            fn func(
-                obj: core::pin::Pin<&mut ffi::MyObject>,
-                arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
-            ) {
-                (arg.inner)(obj)
-            }
-            let arg = MyObjectCxxQtThreadQueuedFn {
-                inner: std::boxed::Box::new(f),
-            };
-            ffi::cxx_qt_ffi_my_object_queue_boxed_fn(cxx_qt_thread, func, std::boxed::Box::new(arg))
-        }
-        #[doc(hidden)]
-        fn threading_clone(cxx_qt_thread: &ffi::MyObjectCxxQtThread) -> ffi::MyObjectCxxQtThread {
-            ffi::cxx_qt_ffi_my_object_threading_clone(cxx_qt_thread)
-        }
-        #[doc(hidden)]
-        fn threading_drop(cxx_qt_thread: &mut ffi::MyObjectCxxQtThread) {
-            ffi::cxx_qt_ffi_my_object_threading_drop(cxx_qt_thread);
-        }
+impl cxx_qt::Threading for ffi::MyObject {
+    type BoxedQueuedFn = MyObjectCxxQtThreadQueuedFn;
+    type ThreadingTypeId = cxx::type_id!("cxx_qt::my_object::MyObjectCxxQtThread");
+    fn qt_thread(&self) -> ffi::MyObjectCxxQtThread {
+        self.cxx_qt_ffi_qt_thread()
     }
     #[doc(hidden)]
-    pub struct MyObjectCxxQtThreadQueuedFn {
-        inner: std::boxed::Box<dyn FnOnce(core::pin::Pin<&mut ffi::MyObject>) + Send>,
-    }
-    impl cxx_qt::Locking for ffi::MyObject {}
-    #[doc(hidden)]
-    pub fn route_arguments_my_object_0(
-        arg0: i32,
-        arg1: *mut ffi::QObject,
-    ) -> ffi::CxxQtConstructorArgumentsMyObject0 {
-        #[allow(unused_variables)]
-        #[allow(clippy::let_unit_value)]
-        let (new_arguments, base_arguments, initialize_arguments) =
-            <ffi::MyObject as cxx_qt::Constructor<(i32, *mut ffi::QObject)>>::route_arguments((
-                arg0, arg1,
-            ));
-        ffi::CxxQtConstructorArgumentsMyObject0 {
-            base: ffi::CxxQtConstructorBaseArgumentsMyObject0 {
-                arg0: base_arguments.0,
-            },
-            initialize: ffi::CxxQtConstructorInitializeArgumentsMyObject0 { not_empty: 0 },
-            new: ffi::CxxQtConstructorNewArgumentsMyObject0 {
-                arg0: new_arguments.0,
-            },
+    fn queue<F>(
+        cxx_qt_thread: &ffi::MyObjectCxxQtThread,
+        f: F,
+    ) -> std::result::Result<(), cxx::Exception>
+    where
+        F: FnOnce(core::pin::Pin<&mut ffi::MyObject>),
+        F: Send + 'static,
+    {
+        #[allow(clippy::boxed_local)]
+        #[doc(hidden)]
+        fn func(
+            obj: core::pin::Pin<&mut ffi::MyObject>,
+            arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
+        ) {
+            (arg.inner)(obj)
         }
+        let arg = MyObjectCxxQtThreadQueuedFn {
+            inner: std::boxed::Box::new(f),
+        };
+        ffi::cxx_qt_ffi_my_object_queue_boxed_fn(cxx_qt_thread, func, std::boxed::Box::new(arg))
     }
     #[doc(hidden)]
+    fn threading_clone(cxx_qt_thread: &ffi::MyObjectCxxQtThread) -> ffi::MyObjectCxxQtThread {
+        ffi::cxx_qt_ffi_my_object_threading_clone(cxx_qt_thread)
+    }
+    #[doc(hidden)]
+    fn threading_drop(cxx_qt_thread: &mut ffi::MyObjectCxxQtThread) {
+        ffi::cxx_qt_ffi_my_object_threading_drop(cxx_qt_thread);
+    }
+}
+#[doc(hidden)]
+pub struct MyObjectCxxQtThreadQueuedFn {
+    inner: std::boxed::Box<dyn FnOnce(core::pin::Pin<&mut ffi::MyObject>) + Send>,
+}
+impl cxx_qt::Locking for ffi::MyObject {}
+#[doc(hidden)]
+pub fn route_arguments_my_object_0(
+    arg0: i32,
+    arg1: *mut ffi::QObject,
+) -> ffi::CxxQtConstructorArgumentsMyObject0 {
     #[allow(unused_variables)]
-    pub fn new_rs_my_object_0(
-        new_arguments: ffi::CxxQtConstructorNewArgumentsMyObject0,
-    ) -> std::boxed::Box<MyObjectRust> {
-        std::boxed::Box::new(<ffi::MyObject as cxx_qt::Constructor<(
-            i32,
-            *mut ffi::QObject,
-        )>>::new((new_arguments.arg0,)))
+    #[allow(clippy::let_unit_value)]
+    let (new_arguments, base_arguments, initialize_arguments) =
+        <ffi::MyObject as cxx_qt::Constructor<(i32, *mut ffi::QObject)>>::route_arguments((
+            arg0, arg1,
+        ));
+    ffi::CxxQtConstructorArgumentsMyObject0 {
+        base: ffi::CxxQtConstructorBaseArgumentsMyObject0 {
+            arg0: base_arguments.0,
+        },
+        initialize: ffi::CxxQtConstructorInitializeArgumentsMyObject0 { not_empty: 0 },
+        new: ffi::CxxQtConstructorNewArgumentsMyObject0 {
+            arg0: new_arguments.0,
+        },
     }
-    #[doc(hidden)]
-    #[allow(unused_variables)]
-    pub fn initialize_my_object_0(
-        qobject: core::pin::Pin<&mut ffi::MyObject>,
-        initialize_arguments: ffi::CxxQtConstructorInitializeArgumentsMyObject0,
-    ) {
-        <ffi::MyObject as cxx_qt::Constructor<(i32, *mut ffi::QObject)>>::initialize(qobject, ());
+}
+#[doc(hidden)]
+#[allow(unused_variables)]
+pub fn new_rs_my_object_0(
+    new_arguments: ffi::CxxQtConstructorNewArgumentsMyObject0,
+) -> std::boxed::Box<MyObjectRust> {
+    std::boxed::Box::new(<ffi::MyObject as cxx_qt::Constructor<(
+        i32,
+        *mut ffi::QObject,
+    )>>::new((new_arguments.arg0,)))
+}
+#[doc(hidden)]
+#[allow(unused_variables)]
+pub fn initialize_my_object_0(
+    qobject: core::pin::Pin<&mut ffi::MyObject>,
+    initialize_arguments: ffi::CxxQtConstructorInitializeArgumentsMyObject0,
+) {
+    <ffi::MyObject as cxx_qt::Constructor<(i32, *mut ffi::QObject)>>::initialize(qobject, ());
+}
+impl core::ops::Deref for ffi::MyObject {
+    type Target = MyObjectRust;
+    fn deref(&self) -> &Self::Target {
+        self.cxx_qt_ffi_rust()
     }
-    impl core::ops::Deref for ffi::MyObject {
-        type Target = MyObjectRust;
-        fn deref(&self) -> &Self::Target {
-            self.cxx_qt_ffi_rust()
-        }
+}
+impl cxx_qt::CxxQtType for ffi::MyObject {
+    type Rust = MyObjectRust;
+    fn rust(&self) -> &Self::Rust {
+        self.cxx_qt_ffi_rust()
     }
-    impl cxx_qt::CxxQtType for ffi::MyObject {
-        type Rust = MyObjectRust;
-        fn rust(&self) -> &Self::Rust {
-            self.cxx_qt_ffi_rust()
-        }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
-            self.cxx_qt_ffi_rust_mut()
-        }
+    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+        self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -182,12 +182,12 @@ pub mod cxx_qt_ffi {
     impl cxx_qt::Threading for ffi::MyObject {
         type BoxedQueuedFn = MyObjectCxxQtThreadQueuedFn;
         type ThreadingTypeId = cxx::type_id!("cxx_qt::my_object::MyObjectCxxQtThread");
-        fn qt_thread(&self) -> MyObjectCxxQtThread {
+        fn qt_thread(&self) -> ffi::MyObjectCxxQtThread {
             self.cxx_qt_ffi_qt_thread()
         }
         #[doc(hidden)]
         fn queue<F>(
-            cxx_qt_thread: &MyObjectCxxQtThread,
+            cxx_qt_thread: &ffi::MyObjectCxxQtThread,
             f: F,
         ) -> std::result::Result<(), cxx::Exception>
         where
@@ -205,15 +205,15 @@ pub mod cxx_qt_ffi {
             let arg = MyObjectCxxQtThreadQueuedFn {
                 inner: std::boxed::Box::new(f),
             };
-            cxx_qt_ffi_my_object_queue_boxed_fn(cxx_qt_thread, func, std::boxed::Box::new(arg))
+            ffi::cxx_qt_ffi_my_object_queue_boxed_fn(cxx_qt_thread, func, std::boxed::Box::new(arg))
         }
         #[doc(hidden)]
-        fn threading_clone(cxx_qt_thread: &MyObjectCxxQtThread) -> MyObjectCxxQtThread {
-            cxx_qt_ffi_my_object_threading_clone(cxx_qt_thread)
+        fn threading_clone(cxx_qt_thread: &ffi::MyObjectCxxQtThread) -> ffi::MyObjectCxxQtThread {
+            ffi::cxx_qt_ffi_my_object_threading_clone(cxx_qt_thread)
         }
         #[doc(hidden)]
-        fn threading_drop(cxx_qt_thread: &mut MyObjectCxxQtThread) {
-            cxx_qt_ffi_my_object_threading_drop(cxx_qt_thread);
+        fn threading_drop(cxx_qt_thread: &mut ffi::MyObjectCxxQtThread) {
+            ffi::cxx_qt_ffi_my_object_threading_drop(cxx_qt_thread);
         }
     }
     #[doc(hidden)]
@@ -225,19 +225,19 @@ pub mod cxx_qt_ffi {
     pub fn route_arguments_my_object_0(
         arg0: i32,
         arg1: *mut QObject,
-    ) -> CxxQtConstructorArgumentsMyObject0 {
+    ) -> ffi::CxxQtConstructorArgumentsMyObject0 {
         #[allow(unused_variables)]
         #[allow(clippy::let_unit_value)]
         let (new_arguments, base_arguments, initialize_arguments) =
             <ffi::MyObject as cxx_qt::Constructor<(i32, *mut QObject)>>::route_arguments((
                 arg0, arg1,
             ));
-        CxxQtConstructorArgumentsMyObject0 {
-            base: CxxQtConstructorBaseArgumentsMyObject0 {
+        ffi::CxxQtConstructorArgumentsMyObject0 {
+            base: ffi::CxxQtConstructorBaseArgumentsMyObject0 {
                 arg0: base_arguments.0,
             },
-            initialize: CxxQtConstructorInitializeArgumentsMyObject0 { not_empty: 0 },
-            new: CxxQtConstructorNewArgumentsMyObject0 {
+            initialize: ffi::CxxQtConstructorInitializeArgumentsMyObject0 { not_empty: 0 },
+            new: ffi::CxxQtConstructorNewArgumentsMyObject0 {
                 arg0: new_arguments.0,
             },
         }
@@ -245,7 +245,7 @@ pub mod cxx_qt_ffi {
     #[doc(hidden)]
     #[allow(unused_variables)]
     pub fn new_rs_my_object_0(
-        new_arguments: CxxQtConstructorNewArgumentsMyObject0,
+        new_arguments: ffi::CxxQtConstructorNewArgumentsMyObject0,
     ) -> std::boxed::Box<MyObjectRust> {
         std::boxed::Box::new(<ffi::MyObject as cxx_qt::Constructor<(
             i32,
@@ -256,7 +256,7 @@ pub mod cxx_qt_ffi {
     #[allow(unused_variables)]
     pub fn initialize_my_object_0(
         qobject: core::pin::Pin<&mut ffi::MyObject>,
-        initialize_arguments: CxxQtConstructorInitializeArgumentsMyObject0,
+        initialize_arguments: ffi::CxxQtConstructorInitializeArgumentsMyObject0,
     ) {
         <ffi::MyObject as cxx_qt::Constructor<(i32, *mut QObject)>>::initialize(qobject, ());
     }

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -179,7 +179,7 @@ pub mod cxx_qt_ffi {
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
-    impl cxx_qt::Threading for MyObject {
+    impl cxx_qt::Threading for ffi::MyObject {
         type BoxedQueuedFn = MyObjectCxxQtThreadQueuedFn;
         type ThreadingTypeId = cxx::type_id!("cxx_qt::my_object::MyObjectCxxQtThread");
         fn qt_thread(&self) -> MyObjectCxxQtThread {
@@ -191,13 +191,13 @@ pub mod cxx_qt_ffi {
             f: F,
         ) -> std::result::Result<(), cxx::Exception>
         where
-            F: FnOnce(core::pin::Pin<&mut MyObject>),
+            F: FnOnce(core::pin::Pin<&mut ffi::MyObject>),
             F: Send + 'static,
         {
             #[allow(clippy::boxed_local)]
             #[doc(hidden)]
             fn func(
-                obj: core::pin::Pin<&mut MyObject>,
+                obj: core::pin::Pin<&mut ffi::MyObject>,
                 arg: std::boxed::Box<MyObjectCxxQtThreadQueuedFn>,
             ) {
                 (arg.inner)(obj)
@@ -218,9 +218,9 @@ pub mod cxx_qt_ffi {
     }
     #[doc(hidden)]
     pub struct MyObjectCxxQtThreadQueuedFn {
-        inner: std::boxed::Box<dyn FnOnce(core::pin::Pin<&mut MyObject>) + Send>,
+        inner: std::boxed::Box<dyn FnOnce(core::pin::Pin<&mut ffi::MyObject>) + Send>,
     }
-    impl cxx_qt::Locking for MyObject {}
+    impl cxx_qt::Locking for ffi::MyObject {}
     #[doc(hidden)]
     pub fn route_arguments_my_object_0(
         arg0: i32,
@@ -257,13 +257,13 @@ pub mod cxx_qt_ffi {
     ) {
         <MyObject as cxx_qt::Constructor<(i32, *mut QObject)>>::initialize(qobject, ());
     }
-    impl core::ops::Deref for MyObject {
+    impl core::ops::Deref for ffi::MyObject {
         type Target = MyObjectRust;
         fn deref(&self) -> &Self::Target {
             self.cxx_qt_ffi_rust()
         }
     }
-    impl cxx_qt::CxxQtType for MyObject {
+    impl cxx_qt::CxxQtType for ffi::MyObject {
         type Rust = MyObjectRust;
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -208,148 +208,137 @@ pub mod ffi {
         fn cxx_qt_ffi_rust_mut(self: Pin<&mut SecondObject>) -> Pin<&mut SecondObjectRust>;
     }
 }
-pub use self::cxx_qt_ffi::*;
-#[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
-pub mod cxx_qt_ffi {
-    use super::ffi::*;
-    use super::*;
-    use cxx_qt::CxxQtType;
-    #[doc(hidden)]
-    type UniquePtr<T> = cxx::UniquePtr<T>;
-    use super::MyTrait;
-    type MyObjectRust = super::MyObjectRust;
-    impl ffi::MyObject {
-        #[doc = "Getter for the Q_PROPERTY "]
-        #[doc = "property_name"]
-        pub fn property_name(&self) -> &i32 {
-            &self.property_name
-        }
+use super::MyTrait;
+impl ffi::MyObject {
+    #[doc = "Getter for the Q_PROPERTY "]
+    #[doc = "property_name"]
+    pub fn property_name(&self) -> &i32 {
+        &self.property_name
     }
-    impl ffi::MyObject {
-        #[doc = "Setter for the Q_PROPERTY "]
-        #[doc = "property_name"]
-        pub fn set_property_name(mut self: core::pin::Pin<&mut Self>, value: i32) {
-            use cxx_qt::CxxQtType;
-            if self.property_name == value {
-                return;
-            }
-            self.as_mut().rust_mut().property_name = value;
-            self.as_mut().property_name_changed();
+}
+impl ffi::MyObject {
+    #[doc = "Setter for the Q_PROPERTY "]
+    #[doc = "property_name"]
+    pub fn set_property_name(mut self: core::pin::Pin<&mut Self>, value: i32) {
+        use cxx_qt::CxxQtType;
+        if self.property_name == value {
+            return;
         }
+        self.as_mut().rust_mut().property_name = value;
+        self.as_mut().property_name_changed();
     }
-    impl ffi::MyObject {
-        #[doc = "Connect the given function pointer to the signal "]
-        #[doc = "propertyNameChanged"]
-        #[doc = ", so that when the signal is emitted the function pointer is executed."]
-        #[doc = "\n"]
-        #[doc = "Note that this method uses a AutoConnection connection type."]
-        #[must_use]
-        pub fn on_property_name_changed(
-            self: core::pin::Pin<&mut ffi::MyObject>,
-            func: fn(core::pin::Pin<&mut ffi::MyObject>),
-        ) -> cxx_qt_lib::QMetaObjectConnection {
-            self.connect_property_name_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
-        }
+}
+impl ffi::MyObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "propertyNameChanged"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[doc = "\n"]
+    #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[must_use]
+    pub fn on_property_name_changed(
+        self: core::pin::Pin<&mut ffi::MyObject>,
+        func: fn(core::pin::Pin<&mut ffi::MyObject>),
+    ) -> cxx_qt_lib::QMetaObjectConnection {
+        self.connect_property_name_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
     }
-    impl ffi::MyObject {
-        #[doc = "Connect the given function pointer to the signal "]
-        #[doc = "ready"]
-        #[doc = ", so that when the signal is emitted the function pointer is executed."]
-        #[doc = "\n"]
-        #[doc = "Note that this method uses a AutoConnection connection type."]
-        #[must_use]
-        pub fn on_ready(
-            self: core::pin::Pin<&mut ffi::MyObject>,
-            func: fn(core::pin::Pin<&mut ffi::MyObject>),
-        ) -> cxx_qt_lib::QMetaObjectConnection {
-            self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
-        }
+}
+impl ffi::MyObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "ready"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[doc = "\n"]
+    #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[must_use]
+    pub fn on_ready(
+        self: core::pin::Pin<&mut ffi::MyObject>,
+        func: fn(core::pin::Pin<&mut ffi::MyObject>),
+    ) -> cxx_qt_lib::QMetaObjectConnection {
+        self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
     }
-    impl cxx_qt::Locking for ffi::MyObject {}
-    #[doc(hidden)]
-    pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
-        std::boxed::Box::new(core::default::Default::default())
+}
+impl cxx_qt::Locking for ffi::MyObject {}
+#[doc(hidden)]
+pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
+    std::boxed::Box::new(core::default::Default::default())
+}
+impl core::ops::Deref for ffi::MyObject {
+    type Target = MyObjectRust;
+    fn deref(&self) -> &Self::Target {
+        self.cxx_qt_ffi_rust()
     }
-    impl core::ops::Deref for ffi::MyObject {
-        type Target = MyObjectRust;
-        fn deref(&self) -> &Self::Target {
-            self.cxx_qt_ffi_rust()
-        }
+}
+impl cxx_qt::CxxQtType for ffi::MyObject {
+    type Rust = MyObjectRust;
+    fn rust(&self) -> &Self::Rust {
+        self.cxx_qt_ffi_rust()
     }
-    impl cxx_qt::CxxQtType for ffi::MyObject {
-        type Rust = MyObjectRust;
-        fn rust(&self) -> &Self::Rust {
-            self.cxx_qt_ffi_rust()
-        }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
-            self.cxx_qt_ffi_rust_mut()
-        }
+    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+        self.cxx_qt_ffi_rust_mut()
     }
-    type SecondObjectRust = super::SecondObjectRust;
-    impl ffi::SecondObject {
-        #[doc = "Getter for the Q_PROPERTY "]
-        #[doc = "property_name"]
-        pub fn property_name(&self) -> &i32 {
-            &self.property_name
-        }
+}
+impl ffi::SecondObject {
+    #[doc = "Getter for the Q_PROPERTY "]
+    #[doc = "property_name"]
+    pub fn property_name(&self) -> &i32 {
+        &self.property_name
     }
-    impl ffi::SecondObject {
-        #[doc = "Setter for the Q_PROPERTY "]
-        #[doc = "property_name"]
-        pub fn set_property_name(mut self: core::pin::Pin<&mut Self>, value: i32) {
-            use cxx_qt::CxxQtType;
-            if self.property_name == value {
-                return;
-            }
-            self.as_mut().rust_mut().property_name = value;
-            self.as_mut().property_name_changed();
+}
+impl ffi::SecondObject {
+    #[doc = "Setter for the Q_PROPERTY "]
+    #[doc = "property_name"]
+    pub fn set_property_name(mut self: core::pin::Pin<&mut Self>, value: i32) {
+        use cxx_qt::CxxQtType;
+        if self.property_name == value {
+            return;
         }
+        self.as_mut().rust_mut().property_name = value;
+        self.as_mut().property_name_changed();
     }
-    impl ffi::SecondObject {
-        #[doc = "Connect the given function pointer to the signal "]
-        #[doc = "propertyNameChanged"]
-        #[doc = ", so that when the signal is emitted the function pointer is executed."]
-        #[doc = "\n"]
-        #[doc = "Note that this method uses a AutoConnection connection type."]
-        #[must_use]
-        pub fn on_property_name_changed(
-            self: core::pin::Pin<&mut ffi::SecondObject>,
-            func: fn(core::pin::Pin<&mut ffi::SecondObject>),
-        ) -> cxx_qt_lib::QMetaObjectConnection {
-            self.connect_property_name_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
-        }
+}
+impl ffi::SecondObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "propertyNameChanged"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[doc = "\n"]
+    #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[must_use]
+    pub fn on_property_name_changed(
+        self: core::pin::Pin<&mut ffi::SecondObject>,
+        func: fn(core::pin::Pin<&mut ffi::SecondObject>),
+    ) -> cxx_qt_lib::QMetaObjectConnection {
+        self.connect_property_name_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
     }
-    impl ffi::SecondObject {
-        #[doc = "Connect the given function pointer to the signal "]
-        #[doc = "ready"]
-        #[doc = ", so that when the signal is emitted the function pointer is executed."]
-        #[doc = "\n"]
-        #[doc = "Note that this method uses a AutoConnection connection type."]
-        #[must_use]
-        pub fn on_ready(
-            self: core::pin::Pin<&mut ffi::SecondObject>,
-            func: fn(core::pin::Pin<&mut ffi::SecondObject>),
-        ) -> cxx_qt_lib::QMetaObjectConnection {
-            self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
-        }
+}
+impl ffi::SecondObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "ready"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[doc = "\n"]
+    #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[must_use]
+    pub fn on_ready(
+        self: core::pin::Pin<&mut ffi::SecondObject>,
+        func: fn(core::pin::Pin<&mut ffi::SecondObject>),
+    ) -> cxx_qt_lib::QMetaObjectConnection {
+        self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
     }
-    #[doc(hidden)]
-    pub fn create_rs_second_object_rust() -> std::boxed::Box<SecondObjectRust> {
-        std::boxed::Box::new(core::default::Default::default())
+}
+#[doc(hidden)]
+pub fn create_rs_second_object_rust() -> std::boxed::Box<SecondObjectRust> {
+    std::boxed::Box::new(core::default::Default::default())
+}
+impl core::ops::Deref for ffi::SecondObject {
+    type Target = SecondObjectRust;
+    fn deref(&self) -> &Self::Target {
+        self.cxx_qt_ffi_rust()
     }
-    impl core::ops::Deref for ffi::SecondObject {
-        type Target = SecondObjectRust;
-        fn deref(&self) -> &Self::Target {
-            self.cxx_qt_ffi_rust()
-        }
+}
+impl cxx_qt::CxxQtType for ffi::SecondObject {
+    type Rust = SecondObjectRust;
+    fn rust(&self) -> &Self::Rust {
+        self.cxx_qt_ffi_rust()
     }
-    impl cxx_qt::CxxQtType for ffi::SecondObject {
-        type Rust = SecondObjectRust;
-        fn rust(&self) -> &Self::Rust {
-            self.cxx_qt_ffi_rust()
-        }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
-            self.cxx_qt_ffi_rust_mut()
-        }
+    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+        self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -229,6 +229,7 @@ pub mod cxx_qt_ffi {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "property_name"]
         pub fn set_property_name(mut self: core::pin::Pin<&mut Self>, value: i32) {
+            use cxx_qt::CxxQtType;
             if self.property_name == value {
                 return;
             }
@@ -296,6 +297,7 @@ pub mod cxx_qt_ffi {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "property_name"]
         pub fn set_property_name(mut self: core::pin::Pin<&mut Self>, value: i32) {
+            use cxx_qt::CxxQtType;
             if self.property_name == value {
                 return;
             }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -218,14 +218,14 @@ pub mod cxx_qt_ffi {
     type UniquePtr<T> = cxx::UniquePtr<T>;
     use super::MyTrait;
     type MyObjectRust = super::MyObjectRust;
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "property_name"]
         pub fn property_name(&self) -> &i32 {
             &self.property_name
         }
     }
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "property_name"]
         pub fn set_property_name(mut self: core::pin::Pin<&mut Self>, value: i32) {
@@ -236,7 +236,7 @@ pub mod cxx_qt_ffi {
             self.as_mut().property_name_changed();
         }
     }
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "propertyNameChanged"]
         #[doc = ", so that when the signal is emitted the function pointer is executed."]
@@ -250,7 +250,7 @@ pub mod cxx_qt_ffi {
             self.connect_property_name_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
     }
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "ready"]
         #[doc = ", so that when the signal is emitted the function pointer is executed."]
@@ -264,18 +264,18 @@ pub mod cxx_qt_ffi {
             self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
     }
-    impl cxx_qt::Locking for MyObject {}
+    impl cxx_qt::Locking for ffi::MyObject {}
     #[doc(hidden)]
     pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
         std::boxed::Box::new(core::default::Default::default())
     }
-    impl core::ops::Deref for MyObject {
+    impl core::ops::Deref for ffi::MyObject {
         type Target = MyObjectRust;
         fn deref(&self) -> &Self::Target {
             self.cxx_qt_ffi_rust()
         }
     }
-    impl cxx_qt::CxxQtType for MyObject {
+    impl cxx_qt::CxxQtType for ffi::MyObject {
         type Rust = MyObjectRust;
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()
@@ -285,14 +285,14 @@ pub mod cxx_qt_ffi {
         }
     }
     type SecondObjectRust = super::SecondObjectRust;
-    impl SecondObject {
+    impl ffi::SecondObject {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "property_name"]
         pub fn property_name(&self) -> &i32 {
             &self.property_name
         }
     }
-    impl SecondObject {
+    impl ffi::SecondObject {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "property_name"]
         pub fn set_property_name(mut self: core::pin::Pin<&mut Self>, value: i32) {
@@ -303,7 +303,7 @@ pub mod cxx_qt_ffi {
             self.as_mut().property_name_changed();
         }
     }
-    impl SecondObject {
+    impl ffi::SecondObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "propertyNameChanged"]
         #[doc = ", so that when the signal is emitted the function pointer is executed."]
@@ -317,7 +317,7 @@ pub mod cxx_qt_ffi {
             self.connect_property_name_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
     }
-    impl SecondObject {
+    impl ffi::SecondObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "ready"]
         #[doc = ", so that when the signal is emitted the function pointer is executed."]
@@ -335,13 +335,13 @@ pub mod cxx_qt_ffi {
     pub fn create_rs_second_object_rust() -> std::boxed::Box<SecondObjectRust> {
         std::boxed::Box::new(core::default::Default::default())
     }
-    impl core::ops::Deref for SecondObject {
+    impl core::ops::Deref for ffi::SecondObject {
         type Target = SecondObjectRust;
         fn deref(&self) -> &Self::Target {
             self.cxx_qt_ffi_rust()
         }
     }
-    impl cxx_qt::CxxQtType for SecondObject {
+    impl cxx_qt::CxxQtType for ffi::SecondObject {
         type Rust = SecondObjectRust;
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -41,6 +41,7 @@ pub mod ffi {
         x: A,
         y: B,
     }
+    use super::MyTrait;
     unsafe extern "C++" {
         include ! (< QtCore / QStringListModel >);
     }
@@ -208,7 +209,6 @@ pub mod ffi {
         fn cxx_qt_ffi_rust_mut(self: Pin<&mut SecondObject>) -> Pin<&mut SecondObjectRust>;
     }
 }
-use super::MyTrait;
 impl ffi::MyObject {
     #[doc = "Getter for the Q_PROPERTY "]
     #[doc = "property_name"]

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -212,6 +212,7 @@ pub use self::cxx_qt_ffi::*;
 #[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
 pub mod cxx_qt_ffi {
     use super::ffi::*;
+    use super::*;
     use cxx_qt::CxxQtType;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
@@ -243,8 +244,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_property_name_changed(
-            self: core::pin::Pin<&mut MyObject>,
-            func: fn(core::pin::Pin<&mut MyObject>),
+            self: core::pin::Pin<&mut ffi::MyObject>,
+            func: fn(core::pin::Pin<&mut ffi::MyObject>),
         ) -> cxx_qt_lib::QMetaObjectConnection {
             self.connect_property_name_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
@@ -257,8 +258,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_ready(
-            self: core::pin::Pin<&mut MyObject>,
-            func: fn(core::pin::Pin<&mut MyObject>),
+            self: core::pin::Pin<&mut ffi::MyObject>,
+            func: fn(core::pin::Pin<&mut ffi::MyObject>),
         ) -> cxx_qt_lib::QMetaObjectConnection {
             self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
@@ -310,8 +311,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_property_name_changed(
-            self: core::pin::Pin<&mut SecondObject>,
-            func: fn(core::pin::Pin<&mut SecondObject>),
+            self: core::pin::Pin<&mut ffi::SecondObject>,
+            func: fn(core::pin::Pin<&mut ffi::SecondObject>),
         ) -> cxx_qt_lib::QMetaObjectConnection {
             self.connect_property_name_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
@@ -324,8 +325,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_ready(
-            self: core::pin::Pin<&mut SecondObject>,
-            func: fn(core::pin::Pin<&mut SecondObject>),
+            self: core::pin::Pin<&mut ffi::SecondObject>,
+            func: fn(core::pin::Pin<&mut ffi::SecondObject>),
         ) -> cxx_qt_lib::QMetaObjectConnection {
             self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -108,14 +108,14 @@ pub mod cxx_qt_ffi {
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "primitive"]
         pub fn primitive(&self) -> &i32 {
             &self.primitive
         }
     }
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "primitive"]
         pub fn set_primitive(mut self: core::pin::Pin<&mut Self>, value: i32) {
@@ -126,14 +126,14 @@ pub mod cxx_qt_ffi {
             self.as_mut().primitive_changed();
         }
     }
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "trivial"]
         pub fn trivial(&self) -> &ffi::QPoint {
             &self.trivial
         }
     }
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "trivial"]
         pub fn set_trivial(mut self: core::pin::Pin<&mut Self>, value: ffi::QPoint) {
@@ -144,7 +144,7 @@ pub mod cxx_qt_ffi {
             self.as_mut().trivial_changed();
         }
     }
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "primitiveChanged"]
         #[doc = ", so that when the signal is emitted the function pointer is executed."]
@@ -158,7 +158,7 @@ pub mod cxx_qt_ffi {
             self.connect_primitive_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
     }
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "trivialChanged"]
         #[doc = ", so that when the signal is emitted the function pointer is executed."]
@@ -172,18 +172,18 @@ pub mod cxx_qt_ffi {
             self.connect_trivial_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
     }
-    impl cxx_qt::Locking for MyObject {}
+    impl cxx_qt::Locking for ffi::MyObject {}
     #[doc(hidden)]
     pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
         std::boxed::Box::new(core::default::Default::default())
     }
-    impl core::ops::Deref for MyObject {
+    impl core::ops::Deref for ffi::MyObject {
         type Target = MyObjectRust;
         fn deref(&self) -> &Self::Target {
             self.cxx_qt_ffi_rust()
         }
     }
-    impl cxx_qt::CxxQtType for MyObject {
+    impl cxx_qt::CxxQtType for ffi::MyObject {
         type Rust = MyObjectRust;
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -103,6 +103,7 @@ use self::cxx_qt_ffi::*;
 #[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
 pub mod cxx_qt_ffi {
     use super::ffi::*;
+    use super::*;
     use cxx_qt::CxxQtType;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
@@ -128,14 +129,14 @@ pub mod cxx_qt_ffi {
     impl MyObject {
         #[doc = "Getter for the Q_PROPERTY "]
         #[doc = "trivial"]
-        pub fn trivial(&self) -> &QPoint {
+        pub fn trivial(&self) -> &ffi::QPoint {
             &self.trivial
         }
     }
     impl MyObject {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "trivial"]
-        pub fn set_trivial(mut self: core::pin::Pin<&mut Self>, value: QPoint) {
+        pub fn set_trivial(mut self: core::pin::Pin<&mut Self>, value: ffi::QPoint) {
             if self.trivial == value {
                 return;
             }
@@ -151,8 +152,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_primitive_changed(
-            self: core::pin::Pin<&mut MyObject>,
-            func: fn(core::pin::Pin<&mut MyObject>),
+            self: core::pin::Pin<&mut ffi::MyObject>,
+            func: fn(core::pin::Pin<&mut ffi::MyObject>),
         ) -> cxx_qt_lib::QMetaObjectConnection {
             self.connect_primitive_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
@@ -165,8 +166,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_trivial_changed(
-            self: core::pin::Pin<&mut MyObject>,
-            func: fn(core::pin::Pin<&mut MyObject>),
+            self: core::pin::Pin<&mut ffi::MyObject>,
+            func: fn(core::pin::Pin<&mut ffi::MyObject>),
         ) -> cxx_qt_lib::QMetaObjectConnection {
             self.connect_trivial_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -119,6 +119,7 @@ pub mod cxx_qt_ffi {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "primitive"]
         pub fn set_primitive(mut self: core::pin::Pin<&mut Self>, value: i32) {
+            use cxx_qt::CxxQtType;
             if self.primitive == value {
                 return;
             }
@@ -137,6 +138,7 @@ pub mod cxx_qt_ffi {
         #[doc = "Setter for the Q_PROPERTY "]
         #[doc = "trivial"]
         pub fn set_trivial(mut self: core::pin::Pin<&mut Self>, value: ffi::QPoint) {
+            use cxx_qt::CxxQtType;
             if self.trivial == value {
                 return;
             }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -99,99 +99,89 @@ mod ffi {
         fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObject>) -> Pin<&mut MyObjectRust>;
     }
 }
-use self::cxx_qt_ffi::*;
-#[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
-pub mod cxx_qt_ffi {
-    use super::ffi::*;
-    use super::*;
-    use cxx_qt::CxxQtType;
-    #[doc(hidden)]
-    type UniquePtr<T> = cxx::UniquePtr<T>;
-    type MyObjectRust = super::MyObjectRust;
-    impl ffi::MyObject {
-        #[doc = "Getter for the Q_PROPERTY "]
-        #[doc = "primitive"]
-        pub fn primitive(&self) -> &i32 {
-            &self.primitive
-        }
+impl ffi::MyObject {
+    #[doc = "Getter for the Q_PROPERTY "]
+    #[doc = "primitive"]
+    pub fn primitive(&self) -> &i32 {
+        &self.primitive
     }
-    impl ffi::MyObject {
-        #[doc = "Setter for the Q_PROPERTY "]
-        #[doc = "primitive"]
-        pub fn set_primitive(mut self: core::pin::Pin<&mut Self>, value: i32) {
-            use cxx_qt::CxxQtType;
-            if self.primitive == value {
-                return;
-            }
-            self.as_mut().rust_mut().primitive = value;
-            self.as_mut().primitive_changed();
+}
+impl ffi::MyObject {
+    #[doc = "Setter for the Q_PROPERTY "]
+    #[doc = "primitive"]
+    pub fn set_primitive(mut self: core::pin::Pin<&mut Self>, value: i32) {
+        use cxx_qt::CxxQtType;
+        if self.primitive == value {
+            return;
         }
+        self.as_mut().rust_mut().primitive = value;
+        self.as_mut().primitive_changed();
     }
-    impl ffi::MyObject {
-        #[doc = "Getter for the Q_PROPERTY "]
-        #[doc = "trivial"]
-        pub fn trivial(&self) -> &ffi::QPoint {
-            &self.trivial
-        }
+}
+impl ffi::MyObject {
+    #[doc = "Getter for the Q_PROPERTY "]
+    #[doc = "trivial"]
+    pub fn trivial(&self) -> &ffi::QPoint {
+        &self.trivial
     }
-    impl ffi::MyObject {
-        #[doc = "Setter for the Q_PROPERTY "]
-        #[doc = "trivial"]
-        pub fn set_trivial(mut self: core::pin::Pin<&mut Self>, value: ffi::QPoint) {
-            use cxx_qt::CxxQtType;
-            if self.trivial == value {
-                return;
-            }
-            self.as_mut().rust_mut().trivial = value;
-            self.as_mut().trivial_changed();
+}
+impl ffi::MyObject {
+    #[doc = "Setter for the Q_PROPERTY "]
+    #[doc = "trivial"]
+    pub fn set_trivial(mut self: core::pin::Pin<&mut Self>, value: ffi::QPoint) {
+        use cxx_qt::CxxQtType;
+        if self.trivial == value {
+            return;
         }
+        self.as_mut().rust_mut().trivial = value;
+        self.as_mut().trivial_changed();
     }
-    impl ffi::MyObject {
-        #[doc = "Connect the given function pointer to the signal "]
-        #[doc = "primitiveChanged"]
-        #[doc = ", so that when the signal is emitted the function pointer is executed."]
-        #[doc = "\n"]
-        #[doc = "Note that this method uses a AutoConnection connection type."]
-        #[must_use]
-        pub fn on_primitive_changed(
-            self: core::pin::Pin<&mut ffi::MyObject>,
-            func: fn(core::pin::Pin<&mut ffi::MyObject>),
-        ) -> cxx_qt_lib::QMetaObjectConnection {
-            self.connect_primitive_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
-        }
+}
+impl ffi::MyObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "primitiveChanged"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[doc = "\n"]
+    #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[must_use]
+    pub fn on_primitive_changed(
+        self: core::pin::Pin<&mut ffi::MyObject>,
+        func: fn(core::pin::Pin<&mut ffi::MyObject>),
+    ) -> cxx_qt_lib::QMetaObjectConnection {
+        self.connect_primitive_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
     }
-    impl ffi::MyObject {
-        #[doc = "Connect the given function pointer to the signal "]
-        #[doc = "trivialChanged"]
-        #[doc = ", so that when the signal is emitted the function pointer is executed."]
-        #[doc = "\n"]
-        #[doc = "Note that this method uses a AutoConnection connection type."]
-        #[must_use]
-        pub fn on_trivial_changed(
-            self: core::pin::Pin<&mut ffi::MyObject>,
-            func: fn(core::pin::Pin<&mut ffi::MyObject>),
-        ) -> cxx_qt_lib::QMetaObjectConnection {
-            self.connect_trivial_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
-        }
+}
+impl ffi::MyObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "trivialChanged"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[doc = "\n"]
+    #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[must_use]
+    pub fn on_trivial_changed(
+        self: core::pin::Pin<&mut ffi::MyObject>,
+        func: fn(core::pin::Pin<&mut ffi::MyObject>),
+    ) -> cxx_qt_lib::QMetaObjectConnection {
+        self.connect_trivial_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
     }
-    impl cxx_qt::Locking for ffi::MyObject {}
-    #[doc(hidden)]
-    pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
-        std::boxed::Box::new(core::default::Default::default())
+}
+impl cxx_qt::Locking for ffi::MyObject {}
+#[doc(hidden)]
+pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
+    std::boxed::Box::new(core::default::Default::default())
+}
+impl core::ops::Deref for ffi::MyObject {
+    type Target = MyObjectRust;
+    fn deref(&self) -> &Self::Target {
+        self.cxx_qt_ffi_rust()
     }
-    impl core::ops::Deref for ffi::MyObject {
-        type Target = MyObjectRust;
-        fn deref(&self) -> &Self::Target {
-            self.cxx_qt_ffi_rust()
-        }
+}
+impl cxx_qt::CxxQtType for ffi::MyObject {
+    type Rust = MyObjectRust;
+    fn rust(&self) -> &Self::Rust {
+        self.cxx_qt_ffi_rust()
     }
-    impl cxx_qt::CxxQtType for ffi::MyObject {
-        type Rust = MyObjectRust;
-        fn rust(&self) -> &Self::Rust {
-            self.cxx_qt_ffi_rust()
-        }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
-            self.cxx_qt_ffi_rust_mut()
-        }
+    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+        self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -130,6 +130,7 @@ use self::cxx_qt_ffi::*;
 #[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
 pub mod cxx_qt_ffi {
     use super::ffi::*;
+    use super::*;
     use cxx_qt::CxxQtType;
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
@@ -142,8 +143,8 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_ready(
-            self: core::pin::Pin<&mut MyObject>,
-            func: fn(core::pin::Pin<&mut MyObject>),
+            self: core::pin::Pin<&mut ffi::MyObject>,
+            func: fn(core::pin::Pin<&mut ffi::MyObject>),
         ) -> cxx_qt_lib::QMetaObjectConnection {
             self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
@@ -156,13 +157,13 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_data_changed(
-            self: core::pin::Pin<&mut MyObject>,
+            self: core::pin::Pin<&mut ffi::MyObject>,
             func: fn(
-                core::pin::Pin<&mut MyObject>,
+                core::pin::Pin<&mut ffi::MyObject>,
                 first: i32,
                 second: cxx::UniquePtr<Opaque>,
-                third: QPoint,
-                fourth: &'a QPoint,
+                third: ffi::QPoint,
+                fourth: &'a ffi::QPoint,
             ),
         ) -> cxx_qt_lib::QMetaObjectConnection {
             self.connect_data_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
@@ -176,13 +177,13 @@ pub mod cxx_qt_ffi {
         #[doc = "Note that this method uses a AutoConnection connection type."]
         #[must_use]
         pub fn on_base_class_new_data(
-            self: core::pin::Pin<&mut MyObject>,
+            self: core::pin::Pin<&mut ffi::MyObject>,
             func: fn(
-                core::pin::Pin<&mut MyObject>,
+                core::pin::Pin<&mut ffi::MyObject>,
                 first: i32,
                 second: cxx::UniquePtr<Opaque>,
-                third: QPoint,
-                fourth: &'a QPoint,
+                third: ffi::QPoint,
+                fourth: &'a ffi::QPoint,
             ),
         ) -> cxx_qt_lib::QMetaObjectConnection {
             self.connect_base_class_new_data(func, cxx_qt_lib::ConnectionType::AutoConnection)

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -126,87 +126,77 @@ mod ffi {
         fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObject>) -> Pin<&mut MyObjectRust>;
     }
 }
-use self::cxx_qt_ffi::*;
-#[doc = r" Internal CXX-Qt module, made public temporarily between API changes"]
-pub mod cxx_qt_ffi {
-    use super::ffi::*;
-    use super::*;
-    use cxx_qt::CxxQtType;
-    #[doc(hidden)]
-    type UniquePtr<T> = cxx::UniquePtr<T>;
-    type MyObjectRust = super::MyObjectRust;
-    impl ffi::MyObject {
-        #[doc = "Connect the given function pointer to the signal "]
-        #[doc = "ready"]
-        #[doc = ", so that when the signal is emitted the function pointer is executed."]
-        #[doc = "\n"]
-        #[doc = "Note that this method uses a AutoConnection connection type."]
-        #[must_use]
-        pub fn on_ready(
-            self: core::pin::Pin<&mut ffi::MyObject>,
-            func: fn(core::pin::Pin<&mut ffi::MyObject>),
-        ) -> cxx_qt_lib::QMetaObjectConnection {
-            self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
-        }
+impl ffi::MyObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "ready"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[doc = "\n"]
+    #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[must_use]
+    pub fn on_ready(
+        self: core::pin::Pin<&mut ffi::MyObject>,
+        func: fn(core::pin::Pin<&mut ffi::MyObject>),
+    ) -> cxx_qt_lib::QMetaObjectConnection {
+        self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
     }
-    impl ffi::MyObject {
-        #[doc = "Connect the given function pointer to the signal "]
-        #[doc = "dataChanged"]
-        #[doc = ", so that when the signal is emitted the function pointer is executed."]
-        #[doc = "\n"]
-        #[doc = "Note that this method uses a AutoConnection connection type."]
-        #[must_use]
-        pub fn on_data_changed(
-            self: core::pin::Pin<&mut ffi::MyObject>,
-            func: fn(
-                core::pin::Pin<&mut ffi::MyObject>,
-                first: i32,
-                second: cxx::UniquePtr<Opaque>,
-                third: ffi::QPoint,
-                fourth: &'a ffi::QPoint,
-            ),
-        ) -> cxx_qt_lib::QMetaObjectConnection {
-            self.connect_data_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
-        }
+}
+impl ffi::MyObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "dataChanged"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[doc = "\n"]
+    #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[must_use]
+    pub fn on_data_changed(
+        self: core::pin::Pin<&mut ffi::MyObject>,
+        func: fn(
+            core::pin::Pin<&mut ffi::MyObject>,
+            first: i32,
+            second: cxx::UniquePtr<Opaque>,
+            third: ffi::QPoint,
+            fourth: &'a ffi::QPoint,
+        ),
+    ) -> cxx_qt_lib::QMetaObjectConnection {
+        self.connect_data_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
     }
-    impl ffi::MyObject {
-        #[doc = "Connect the given function pointer to the signal "]
-        #[doc = "newData"]
-        #[doc = ", so that when the signal is emitted the function pointer is executed."]
-        #[doc = "\n"]
-        #[doc = "Note that this method uses a AutoConnection connection type."]
-        #[must_use]
-        pub fn on_base_class_new_data(
-            self: core::pin::Pin<&mut ffi::MyObject>,
-            func: fn(
-                core::pin::Pin<&mut ffi::MyObject>,
-                first: i32,
-                second: cxx::UniquePtr<Opaque>,
-                third: ffi::QPoint,
-                fourth: &'a ffi::QPoint,
-            ),
-        ) -> cxx_qt_lib::QMetaObjectConnection {
-            self.connect_base_class_new_data(func, cxx_qt_lib::ConnectionType::AutoConnection)
-        }
+}
+impl ffi::MyObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "newData"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[doc = "\n"]
+    #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[must_use]
+    pub fn on_base_class_new_data(
+        self: core::pin::Pin<&mut ffi::MyObject>,
+        func: fn(
+            core::pin::Pin<&mut ffi::MyObject>,
+            first: i32,
+            second: cxx::UniquePtr<Opaque>,
+            third: ffi::QPoint,
+            fourth: &'a ffi::QPoint,
+        ),
+    ) -> cxx_qt_lib::QMetaObjectConnection {
+        self.connect_base_class_new_data(func, cxx_qt_lib::ConnectionType::AutoConnection)
     }
-    impl cxx_qt::Locking for ffi::MyObject {}
-    #[doc(hidden)]
-    pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
-        std::boxed::Box::new(core::default::Default::default())
+}
+impl cxx_qt::Locking for ffi::MyObject {}
+#[doc(hidden)]
+pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
+    std::boxed::Box::new(core::default::Default::default())
+}
+impl core::ops::Deref for ffi::MyObject {
+    type Target = MyObjectRust;
+    fn deref(&self) -> &Self::Target {
+        self.cxx_qt_ffi_rust()
     }
-    impl core::ops::Deref for ffi::MyObject {
-        type Target = MyObjectRust;
-        fn deref(&self) -> &Self::Target {
-            self.cxx_qt_ffi_rust()
-        }
+}
+impl cxx_qt::CxxQtType for ffi::MyObject {
+    type Rust = MyObjectRust;
+    fn rust(&self) -> &Self::Rust {
+        self.cxx_qt_ffi_rust()
     }
-    impl cxx_qt::CxxQtType for ffi::MyObject {
-        type Rust = MyObjectRust;
-        fn rust(&self) -> &Self::Rust {
-            self.cxx_qt_ffi_rust()
-        }
-        fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
-            self.cxx_qt_ffi_rust_mut()
-        }
+    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+        self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -135,7 +135,7 @@ pub mod cxx_qt_ffi {
     #[doc(hidden)]
     type UniquePtr<T> = cxx::UniquePtr<T>;
     type MyObjectRust = super::MyObjectRust;
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "ready"]
         #[doc = ", so that when the signal is emitted the function pointer is executed."]
@@ -149,7 +149,7 @@ pub mod cxx_qt_ffi {
             self.connect_ready(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
     }
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "dataChanged"]
         #[doc = ", so that when the signal is emitted the function pointer is executed."]
@@ -169,7 +169,7 @@ pub mod cxx_qt_ffi {
             self.connect_data_changed(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
     }
-    impl MyObject {
+    impl ffi::MyObject {
         #[doc = "Connect the given function pointer to the signal "]
         #[doc = "newData"]
         #[doc = ", so that when the signal is emitted the function pointer is executed."]
@@ -189,18 +189,18 @@ pub mod cxx_qt_ffi {
             self.connect_base_class_new_data(func, cxx_qt_lib::ConnectionType::AutoConnection)
         }
     }
-    impl cxx_qt::Locking for MyObject {}
+    impl cxx_qt::Locking for ffi::MyObject {}
     #[doc(hidden)]
     pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
         std::boxed::Box::new(core::default::Default::default())
     }
-    impl core::ops::Deref for MyObject {
+    impl core::ops::Deref for ffi::MyObject {
         type Target = MyObjectRust;
         fn deref(&self) -> &Self::Target {
             self.cxx_qt_ffi_rust()
         }
     }
-    impl cxx_qt::CxxQtType for MyObject {
+    impl cxx_qt::CxxQtType for ffi::MyObject {
         type Rust = MyObjectRust;
         fn rust(&self) -> &Self::Rust {
             self.cxx_qt_ffi_rust()


### PR DESCRIPTION
Requires #617 #587 #620

And needs

- [x] Fully qualified types in generated methods, like parameters from signals `UniquePtr` -> `cxx::UniquePtr` (should be able to make a mechanism in the new `utils/` to qualify a given syn type, then use that for other types like `Pin` too (slightly related to #587) Have a generic mechanism in utils to do Pin, UniquePtr, SharedPtr etc which then removes the double definitions in #587 
- [x] `impl MyObject` needs to be `impl module::MyObject` or have a type/use to bring it in
- [x] Rust setters might need to have `use cxx_qt::CxxQtType` to be able to use `rust_mut()` in their methods, but we also don't want to import and "leak" that into the outside scope, so should just be in the method scope if required
- [x] Removed `uses` from `ParsedCxxQtData`
- [x] Qualify free methods calls to the bridge with the module ident
- [x] Arguments in the constructor need to pass through qualify