### PR TITLE
Allow lifetime parameters in cxx_qt::Constructors

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
@@ -153,6 +153,8 @@ mod tests {
             base_arguments: vec![],
             new_arguments: vec![],
             initialize_arguments: vec![],
+            lifetime: None,
+            // dummy impl
             imp: parse_quote! { impl X {} },
         }
     }
@@ -275,6 +277,7 @@ mod tests {
                 new_arguments: vec![parse_quote! { i16}, parse_quote! { i32 }],
                 initialize_arguments: vec![parse_quote! { i32 }, parse_quote! { i64 }],
                 base_arguments: vec![parse_quote! { i64 }, parse_quote! { *mut QObject }],
+                lifetime: Some(parse_quote! { 'a_lifetime }),
                 ..mock_constructor()
             }],
             &["initializer".to_string()],

--- a/crates/cxx-qt-gen/src/syntax/lifetimes.rs
+++ b/crates/cxx-qt-gen/src/syntax/lifetimes.rs
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use syn::{Error, GenericArgument, Lifetime, PathArguments, PathSegment, Result, Type};
+
+fn err_unsupported_type<T: quote::ToTokens>(ty: &T) -> Error {
+    Error::new_spanned(ty, "Type not supported by CXX-Qt!")
+}
+
+fn from_generic_argument(argument: &GenericArgument) -> Result<Vec<Lifetime>> {
+    match argument {
+        GenericArgument::Lifetime(lifetime) => Ok(vec![lifetime.clone()]),
+        GenericArgument::Type(ty) => from_type(ty),
+        _ => Err(err_unsupported_type(argument)),
+    }
+}
+
+fn from_pathsegment(segment: &PathSegment) -> Result<Vec<Lifetime>> {
+    match segment.arguments {
+        PathArguments::None => Ok(vec![]),
+        PathArguments::AngleBracketed(ref angles) => Ok(angles
+            .args
+            .iter()
+            .map(from_generic_argument)
+            .collect::<Result<Vec<Vec<Lifetime>>>>()?
+            .into_iter()
+            .flatten()
+            .collect()),
+        PathArguments::Parenthesized(ref parens) => Ok(parens
+            .inputs
+            .iter()
+            .map(from_type)
+            .collect::<Result<Vec<Vec<Lifetime>>>>()?
+            .into_iter()
+            .flatten()
+            .chain(
+                if let syn::ReturnType::Type(_arrow, ref return_ty) = parens.output {
+                    from_type(return_ty)?
+                } else {
+                    vec![]
+                },
+            )
+            .collect()),
+    }
+}
+
+pub fn from_type(ty: &Type) -> Result<Vec<Lifetime>> {
+    match ty {
+        Type::Array(array) => from_type(&array.elem),
+        Type::Group(group) => from_type(&group.elem),
+        Type::Paren(paren) => from_type(&paren.elem),
+        Type::Ptr(pointer) => from_type(&pointer.elem),
+        Type::Slice(slice) => from_type(&slice.elem),
+        Type::Path(path) => {
+            if path.qself.is_some() {
+                Err(err_unsupported_type(ty))
+            } else {
+                Ok(path
+                    .path
+                    .segments
+                    .iter()
+                    .map(from_pathsegment)
+                    .collect::<Result<Vec<Vec<Lifetime>>>>()?
+                    .into_iter()
+                    .flatten()
+                    .collect())
+            }
+        }
+        Type::Reference(reference) => Ok(from_type(&reference.elem)?
+            .into_iter()
+            .chain(reference.lifetime.clone())
+            .collect()),
+        Type::Tuple(tuple) => Ok(tuple
+            .elems
+            .iter()
+            .map(from_type)
+            .collect::<Result<Vec<Vec<Lifetime>>>>()?
+            .into_iter()
+            .flatten()
+            .collect()),
+        _ => Err(err_unsupported_type(ty)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_quote;
+
+    macro_rules! assert_no_lifetimes {
+        ($($tt:tt)*) => {
+            assert!(super::from_type(&parse_quote! { $($tt)* })
+                .unwrap()
+                .is_empty());
+        };
+    }
+
+    #[test]
+    fn extract_no_lifetimes() {
+        assert_no_lifetimes! { () };
+        assert_no_lifetimes! { T };
+        assert_no_lifetimes! { T<A> };
+        assert_no_lifetimes! { *mut X };
+        assert_no_lifetimes! { *const X };
+        assert_no_lifetimes! { Pin<*mut T> };
+        assert_no_lifetimes! { &T };
+        assert_no_lifetimes! { &mut T };
+        assert_no_lifetimes! { [T] };
+        assert_no_lifetimes! { [T;4] };
+        assert_no_lifetimes! { (X, Y) };
+    }
+
+    macro_rules! assert_lifetimes {
+        ([$($lifetime:lifetime),*] $($tt:tt)*) => {
+            assert_eq!(
+                super::from_type(&parse_quote! { $($tt)* }).unwrap(),
+                vec![$(parse_quote! { $lifetime }),*]
+            );
+        }
+    }
+
+    #[test]
+    fn assert_lifetimes() {
+        assert_lifetimes! { ['a] &'a T };
+        assert_lifetimes! { ['a] [&'a T] };
+        assert_lifetimes! { ['a] [&'a T;5] };
+
+        assert_lifetimes! { ['a, 'a] (&'a A, &'a mut B) };
+        assert_lifetimes! { ['a, 'a] &'a A<'a> };
+
+        assert_lifetimes! { ['a, 'b] &'b &'a mut T };
+        assert_lifetimes! { ['a, 'b] Pin<&'a X, &'b mut Y> };
+        assert_lifetimes! { ['a, 'b] (&'a A, &'b mut B) };
+
+        assert_lifetimes! { ['lifetime] A<'lifetime> };
+    }
+
+    macro_rules! assert_unsupported_type {
+        ($( $tt:tt )*) => {
+            assert!(super::from_type(&parse_quote! { $($tt)* }).is_err());
+        };
+    }
+
+    #[test]
+    fn extract_lifetimes_unsupported_types() {
+        assert_unsupported_type! { dyn Foo };
+        assert_unsupported_type! { &dyn Foo };
+        assert_unsupported_type! { fn(A) };
+        assert_unsupported_type! { fn(i64) -> i32 };
+    }
+}

--- a/crates/cxx-qt-gen/src/syntax/mod.rs
+++ b/crates/cxx-qt-gen/src/syntax/mod.rs
@@ -6,6 +6,7 @@
 pub mod attribute;
 pub mod expr;
 pub mod foreignmod;
+pub mod lifetimes;
 pub mod path;
 mod qtfile;
 mod qtitem;

--- a/crates/cxx-qt-gen/test_inputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_inputs/invokables.rs
@@ -52,12 +52,14 @@ mod ffi {
 
     impl cxx_qt::Threading for MyObject {}
 
-    impl
+    impl<'a>
         cxx_qt::Constructor<
-            (i32, *mut QObject),
+            (i32, &'a QString),
             BaseArguments = (*mut QObject,),
-            NewArguments = (i32,),
+            NewArguments = (&'a QString,),
         > for MyObject
     {
     }
+
+    impl cxx_qt::Constructor<()> for MyObject {}
 }

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -110,10 +110,15 @@ MyObject::qtThread() const
   return MyObjectCxxQtThread(m_cxxQtThreadObj, m_rustObjMutex);
 }
 
-MyObject::MyObject(::std::int32_t arg0, QObject* arg1)
+MyObject::MyObject(::std::int32_t arg0, QString const& arg1)
   : MyObject(
       ::cxx_qt::my_object::cxx_qt_my_object::routeArguments0(::std::move(arg0),
                                                              ::std::move(arg1)))
+{
+}
+
+MyObject::MyObject()
+  : MyObject(::cxx_qt::my_object::cxx_qt_my_object::routeArguments1())
 {
 }
 
@@ -128,6 +133,20 @@ MyObject::MyObject(
         this))
 {
   ::cxx_qt::my_object::cxx_qt_my_object::initialize0(
+    *this, ::std::move(args.initialize));
+}
+
+MyObject::MyObject(
+  ::cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments1&& args)
+  : QObject()
+  , m_rustObj(
+      ::cxx_qt::my_object::cxx_qt_my_object::newRs1(::std::move(args.new_)))
+  , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
+  , m_cxxQtThreadObj(
+      ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(
+        this))
+{
+  ::cxx_qt::my_object::cxx_qt_my_object::initialize1(
     *this, ::std::move(args.initialize));
 }
 

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -40,7 +40,8 @@ public:
   Q_INVOKABLE void invokableResultTuple() const;
   Q_INVOKABLE ::rust::String invokableResultType() const;
   MyObjectCxxQtThread qtThread() const;
-  explicit MyObject(::std::int32_t arg0, QObject* arg1);
+  explicit MyObject(::std::int32_t arg0, QString const& arg1);
+  explicit MyObject();
 
 private:
   void cppMethodWrapper() const noexcept;
@@ -58,6 +59,8 @@ private:
   ::rust::String invokableResultTypeWrapper() const;
   explicit MyObject(
     ::cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments0&& args);
+  explicit MyObject(
+    ::cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments1&& args);
 
 private:
   ::rust::Box<MyObjectRust> m_rustObj;

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -125,10 +125,10 @@ mod ffi {
     #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
     #[cxx_name = "CxxQtConstructorArguments0"]
     #[doc(hidden)]
-    struct CxxQtConstructorArgumentsMyObject0 {
+    struct CxxQtConstructorArgumentsMyObject0<'a> {
         base: CxxQtConstructorBaseArgumentsMyObject0,
         #[cxx_name = "new_"]
-        new: CxxQtConstructorNewArgumentsMyObject0,
+        new: CxxQtConstructorNewArgumentsMyObject0<'a>,
         initialize: CxxQtConstructorInitializeArgumentsMyObject0,
     }
     #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
@@ -140,8 +140,8 @@ mod ffi {
     #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
     #[cxx_name = "CxxQtConstructorNewArguments0"]
     #[doc(hidden)]
-    struct CxxQtConstructorNewArgumentsMyObject0 {
-        arg0: i32,
+    struct CxxQtConstructorNewArgumentsMyObject0<'a> {
+        arg0: &'a QString,
     }
     #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
     #[cxx_name = "CxxQtConstructorInitializeArguments0"]
@@ -152,18 +152,61 @@ mod ffi {
     extern "Rust" {
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         #[cxx_name = "routeArguments0"]
-        unsafe fn route_arguments_my_object_0(
+        unsafe fn route_arguments_my_object_0<'a>(
             arg0: i32,
-            arg1: *mut QObject,
-        ) -> CxxQtConstructorArgumentsMyObject0;
+            arg1: &'a QString,
+        ) -> CxxQtConstructorArgumentsMyObject0<'a>;
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         #[cxx_name = "newRs0"]
-        fn new_rs_my_object_0(args: CxxQtConstructorNewArgumentsMyObject0) -> Box<MyObjectRust>;
+        unsafe fn new_rs_my_object_0<'a>(
+            args: CxxQtConstructorNewArgumentsMyObject0<'a>,
+        ) -> Box<MyObjectRust>;
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         #[cxx_name = "initialize0"]
-        fn initialize_my_object_0(
+        unsafe fn initialize_my_object_0(
             qobject: Pin<&mut MyObject>,
             args: CxxQtConstructorInitializeArgumentsMyObject0,
+        );
+    }
+    #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+    #[cxx_name = "CxxQtConstructorArguments1"]
+    #[doc(hidden)]
+    struct CxxQtConstructorArgumentsMyObject1 {
+        base: CxxQtConstructorBaseArgumentsMyObject1,
+        #[cxx_name = "new_"]
+        new: CxxQtConstructorNewArgumentsMyObject1,
+        initialize: CxxQtConstructorInitializeArgumentsMyObject1,
+    }
+    #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+    #[cxx_name = "CxxQtConstructorBaseArguments1"]
+    #[doc(hidden)]
+    struct CxxQtConstructorBaseArgumentsMyObject1 {
+        not_empty: i8,
+    }
+    #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+    #[cxx_name = "CxxQtConstructorNewArguments1"]
+    #[doc(hidden)]
+    struct CxxQtConstructorNewArgumentsMyObject1 {
+        not_empty: i8,
+    }
+    #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+    #[cxx_name = "CxxQtConstructorInitializeArguments1"]
+    #[doc(hidden)]
+    struct CxxQtConstructorInitializeArgumentsMyObject1 {
+        not_empty: i8,
+    }
+    extern "Rust" {
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        #[cxx_name = "routeArguments1"]
+        fn route_arguments_my_object_1() -> CxxQtConstructorArgumentsMyObject1;
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        #[cxx_name = "newRs1"]
+        fn new_rs_my_object_1(args: CxxQtConstructorNewArgumentsMyObject1) -> Box<MyObjectRust>;
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        #[cxx_name = "initialize1"]
+        fn initialize_my_object_1(
+            qobject: Pin<&mut MyObject>,
+            args: CxxQtConstructorInitializeArgumentsMyObject1,
         );
     }
     unsafe extern "C++" {
@@ -220,16 +263,14 @@ pub struct MyObjectCxxQtThreadQueuedFn {
 }
 impl cxx_qt::Locking for ffi::MyObject {}
 #[doc(hidden)]
-pub fn route_arguments_my_object_0(
+pub fn route_arguments_my_object_0<'a>(
     arg0: i32,
-    arg1: *mut ffi::QObject,
-) -> ffi::CxxQtConstructorArgumentsMyObject0 {
+    arg1: &'a QString,
+) -> ffi::CxxQtConstructorArgumentsMyObject0<'a> {
     #[allow(unused_variables)]
     #[allow(clippy::let_unit_value)]
     let (new_arguments, base_arguments, initialize_arguments) =
-        <ffi::MyObject as cxx_qt::Constructor<(i32, *mut ffi::QObject)>>::route_arguments((
-            arg0, arg1,
-        ));
+        <ffi::MyObject as cxx_qt::Constructor<(i32, &'a QString)>>::route_arguments((arg0, arg1));
     ffi::CxxQtConstructorArgumentsMyObject0 {
         base: ffi::CxxQtConstructorBaseArgumentsMyObject0 {
             arg0: base_arguments.0,
@@ -242,21 +283,51 @@ pub fn route_arguments_my_object_0(
 }
 #[doc(hidden)]
 #[allow(unused_variables)]
-pub fn new_rs_my_object_0(
-    new_arguments: ffi::CxxQtConstructorNewArgumentsMyObject0,
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn new_rs_my_object_0<'a>(
+    new_arguments: ffi::CxxQtConstructorNewArgumentsMyObject0<'a>,
 ) -> std::boxed::Box<MyObjectRust> {
-    std::boxed::Box::new(<ffi::MyObject as cxx_qt::Constructor<(
-        i32,
-        *mut ffi::QObject,
-    )>>::new((new_arguments.arg0,)))
+    std::boxed::Box::new(
+        <ffi::MyObject as cxx_qt::Constructor<(i32, &'a QString)>>::new((new_arguments.arg0,)),
+    )
 }
 #[doc(hidden)]
 #[allow(unused_variables)]
-pub fn initialize_my_object_0(
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn initialize_my_object_0<'a>(
     qobject: core::pin::Pin<&mut ffi::MyObject>,
     initialize_arguments: ffi::CxxQtConstructorInitializeArgumentsMyObject0,
 ) {
-    <ffi::MyObject as cxx_qt::Constructor<(i32, *mut ffi::QObject)>>::initialize(qobject, ());
+    <ffi::MyObject as cxx_qt::Constructor<(i32, &'a QString)>>::initialize(qobject, ());
+}
+#[doc(hidden)]
+pub fn route_arguments_my_object_1() -> ffi::CxxQtConstructorArgumentsMyObject1 {
+    #[allow(unused_variables)]
+    #[allow(clippy::let_unit_value)]
+    let (new_arguments, base_arguments, initialize_arguments) =
+        <ffi::MyObject as cxx_qt::Constructor<()>>::route_arguments(());
+    ffi::CxxQtConstructorArgumentsMyObject1 {
+        base: ffi::CxxQtConstructorBaseArgumentsMyObject1 { not_empty: 0 },
+        initialize: ffi::CxxQtConstructorInitializeArgumentsMyObject1 { not_empty: 0 },
+        new: ffi::CxxQtConstructorNewArgumentsMyObject1 { not_empty: 0 },
+    }
+}
+#[doc(hidden)]
+#[allow(unused_variables)]
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn new_rs_my_object_1(
+    new_arguments: ffi::CxxQtConstructorNewArgumentsMyObject1,
+) -> std::boxed::Box<MyObjectRust> {
+    std::boxed::Box::new(<ffi::MyObject as cxx_qt::Constructor<()>>::new(()))
+}
+#[doc(hidden)]
+#[allow(unused_variables)]
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn initialize_my_object_1(
+    qobject: core::pin::Pin<&mut ffi::MyObject>,
+    initialize_arguments: ffi::CxxQtConstructorInitializeArgumentsMyObject1,
+) {
+    <ffi::MyObject as cxx_qt::Constructor<()>>::initialize(qobject, ());
 }
 impl core::ops::Deref for ffi::MyObject {
     type Target = MyObjectRust;

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -55,6 +55,8 @@ pub mod qobject {
     // ANCHOR_END: book_rust_obj_impl
 
     impl cxx_qt::Constructor<()> for RustSignals {}
+
+    impl<'a> cxx_qt::Constructor<(&'a QUrl,), InitializeArguments = (&'a QUrl,)> for RustSignals {}
 }
 
 use core::pin::Pin;
@@ -144,6 +146,32 @@ impl cxx_qt::Constructor<()> for qobject::RustSignals {
             }
         })
         .release();
+    }
+}
+
+impl<'a> cxx_qt::Constructor<(&'a QUrl,)> for qobject::RustSignals {
+    type NewArguments = ();
+    type BaseArguments = ();
+    type InitializeArguments = (&'a QUrl,);
+
+    fn route_arguments(
+        (url,): (&'a QUrl,),
+    ) -> (
+        Self::NewArguments,
+        Self::BaseArguments,
+        Self::InitializeArguments,
+    ) {
+        ((), (), (url,))
+    }
+
+    fn new(_arguments: Self::NewArguments) -> <Self as CxxQtType>::Rust {
+        Default::default()
+    }
+
+    fn initialize(mut self: core::pin::Pin<&mut Self>, (url,): Self::InitializeArguments) {
+        <Self as cxx_qt::Constructor<()>>::initialize(self.as_mut(), ());
+
+        self.connect(url);
     }
 }
 // ANCHOR_END: book_macro_code


### PR DESCRIPTION
This makes it possible to have constructors take arguments by-reference, which is the default in C++.