### PR TITLE
move QML element registration to build.rs instead of bridge

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -214,7 +214,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 extern "RustQt" {
-                    #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_name = "MyQmlElement")]
+                    #[cxx_qt::qobject(qml_element = "MyQmlElement")]
                     type MyNamedObject = super::MyNamedObjectRust;
                 }
             }
@@ -240,7 +240,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 extern "RustQt" {
-                    #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_singleton)]
+                    #[cxx_qt::qobject(qml_element, qml_singleton)]
                     type MyObject = super::MyObjectRust;
                 }
             }
@@ -267,7 +267,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 extern "RustQt" {
-                    #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_uncreatable)]
+                    #[cxx_qt::qobject(qml_element, qml_uncreatable)]
                     type MyObject = super::MyObjectRust;
                 }
             }

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -259,7 +259,7 @@ mod tests {
             #[cxx_qt::bridge(namespace = "cxx_qt")]
             mod ffi {
                 extern "RustQt" {
-                    #[cxx_qt::qobject(qml_uri = "com.kdab", qml_version = "1.0", qml_singleton)]
+                    #[cxx_qt::qobject(qml_element, qml_singleton)]
                     type MyObject = super::MyObjectRust;
                 }
             }

--- a/examples/cargo_without_cmake/build.rs
+++ b/examples/cargo_without_cmake/build.rs
@@ -14,8 +14,7 @@ fn main() {
         // - Qt Qml is linked by enabling the qt_qml Cargo feature (default).
         // - Qt Qml requires linking Qt Network on macOS
         .qt_module("Network")
-        // Generate C++ from the `#[cxx_qt::bridge]` module
-        .file("src/cxxqt_object.rs")
+        .qml_module("com.kdab.cxx_qt.demo", 1, 0, &["src/cxxqt_object.rs"])
         // Generate C++ code from the .qrc file with the rcc tool
         // https://doc.qt.io/qt-6/resources.html
         .qrc("qml/qml.qrc")

--- a/examples/demo_threading/rust/build.rs
+++ b/examples/demo_threading/rust/build.rs
@@ -5,5 +5,7 @@
 use cxx_qt_build::CxxQtBuilder;
 
 fn main() {
-    CxxQtBuilder::new().file("src/lib.rs").build();
+    CxxQtBuilder::new()
+        .qml_module("com.kdab.energy", 1, 0, &["src/lib.rs"])
+        .build();
 }

--- a/examples/demo_threading/rust/src/lib.rs
+++ b/examples/demo_threading/rust/src/lib.rs
@@ -18,7 +18,7 @@ mod qobject {
     }
 
     extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.energy", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(f64, average_use)]
         #[qproperty(u32, sensors)]
         #[qproperty(f64, total_use)]

--- a/examples/qml_features/rust/build.rs
+++ b/examples/qml_features/rust/build.rs
@@ -9,19 +9,26 @@ use cxx_qt_build::CxxQtBuilder;
 
 fn main() {
     CxxQtBuilder::new()
-        .file("src/containers.rs")
-        .file("src/custom_base_class.rs")
-        .file("src/custom_parent_class.rs")
-        .file("src/invokables.rs")
-        .file("src/multiple_qobjects.rs")
-        .file("src/nested_qobjects.rs")
-        .file("src/serialisation.rs")
-        .file("src/signals.rs")
-        .file("src/singleton.rs")
-        .file("src/properties.rs")
-        .file("src/threading.rs")
-        .file("src/types.rs")
-        .file("src/uncreatable.rs")
+        .qml_module(
+            "com.kdab.cxx_qt.demo",
+            1,
+            0,
+            &[
+                "src/containers.rs",
+                "src/custom_base_class.rs",
+                "src/custom_parent_class.rs",
+                "src/invokables.rs",
+                "src/multiple_qobjects.rs",
+                "src/nested_qobjects.rs",
+                "src/serialisation.rs",
+                "src/signals.rs",
+                "src/singleton.rs",
+                "src/properties.rs",
+                "src/threading.rs",
+                "src/types.rs",
+                "src/uncreatable.rs",
+            ],
+        )
         // custom_object.cpp/h need to be handled here rather than CMakeLists.txt,
         // otherwise linking cargo tests fails because the symbols from those files are not found.
         .cc_builder(|cc| {

--- a/examples/qml_features/rust/src/containers.rs
+++ b/examples/qml_features/rust/src/containers.rs
@@ -33,7 +33,7 @@ pub mod qobject {
     }
 
     unsafe extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(QString, string_hash)]
         #[qproperty(QString, string_list)]
         #[qproperty(QString, string_map)]

--- a/examples/qml_features/rust/src/custom_base_class.rs
+++ b/examples/qml_features/rust/src/custom_base_class.rs
@@ -34,11 +34,7 @@ pub mod qobject {
     // ANCHOR: book_inherit_qalm
     // ANCHOR: book_qobject_base
     extern "RustQt" {
-        #[cxx_qt::qobject(
-            base = "QAbstractListModel",
-            qml_uri = "com.kdab.cxx_qt.demo",
-            qml_version = "1.0"
-        )]
+        #[cxx_qt::qobject(base = "QAbstractListModel", qml_element)]
         type CustomBaseClass = super::CustomBaseClassRust;
     }
     // ANCHOR_END: book_qobject_base

--- a/examples/qml_features/rust/src/invokables.rs
+++ b/examples/qml_features/rust/src/invokables.rs
@@ -16,7 +16,7 @@ pub mod qobject {
     }
 
     unsafe extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         type RustInvokables = super::RustInvokablesRust;
     }
 

--- a/examples/qml_features/rust/src/multiple_qobjects.rs
+++ b/examples/qml_features/rust/src/multiple_qobjects.rs
@@ -18,7 +18,7 @@ pub mod qobject {
     }
 
     extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(i32, counter)]
         #[qproperty(QColor, color)]
         type FirstObject = super::FirstObjectRust;
@@ -44,7 +44,7 @@ pub mod qobject {
     }
 
     extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(i32, counter)]
         #[qproperty(QUrl, url)]
         type SecondObject = super::SecondObjectRust;

--- a/examples/qml_features/rust/src/nested_qobjects.rs
+++ b/examples/qml_features/rust/src/nested_qobjects.rs
@@ -11,7 +11,7 @@
 pub mod qobject {
     // ANCHOR: book_extern_block
     extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(i32, counter)]
         type InnerObject = super::InnerObjectRust;
     }
@@ -24,7 +24,7 @@ pub mod qobject {
     }
 
     extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(*mut InnerObject, inner)]
         type OuterObject = super::OuterObjectRust;
 

--- a/examples/qml_features/rust/src/properties.rs
+++ b/examples/qml_features/rust/src/properties.rs
@@ -19,7 +19,7 @@ pub mod qobject {
 
     unsafe extern "RustQt" {
         // ANCHOR: book_properties_struct
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(bool, connected)]
         #[qproperty(QUrl, connected_url)]
         #[qproperty(QUrl, previous_connected_url)]

--- a/examples/qml_features/rust/src/serialisation.rs
+++ b/examples/qml_features/rust/src/serialisation.rs
@@ -36,7 +36,7 @@ pub mod qobject {
     }
 
     unsafe extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(i32, number)]
         #[qproperty(QString, string)]
         type Serialisation = super::SerialisationRust;

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -36,7 +36,7 @@ pub mod qobject {
 
     unsafe extern "RustQt" {
         // ANCHOR: book_signals_struct
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(bool, logging_enabled)]
         type RustSignals = super::RustSignalsRust;
     }

--- a/examples/qml_features/rust/src/singleton.rs
+++ b/examples/qml_features/rust/src/singleton.rs
@@ -10,7 +10,7 @@
 #[cxx_qt::bridge(cxx_file_stem = "rust_singleton")]
 pub mod qobject {
     unsafe extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0", qml_singleton)]
+        #[cxx_qt::qobject(qml_element, qml_singleton)]
         #[qproperty(i32, persistent_value)]
         type RustSingleton = super::RustSingletonRust;
 

--- a/examples/qml_features/rust/src/threading.rs
+++ b/examples/qml_features/rust/src/threading.rs
@@ -22,7 +22,7 @@ pub mod qobject {
     }
 
     extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(QString, title)]
         #[qproperty(QUrl, url)]
         type ThreadingWebsite = super::ThreadingWebsiteRust;

--- a/examples/qml_features/rust/src/types.rs
+++ b/examples/qml_features/rust/src/types.rs
@@ -74,7 +74,7 @@ pub mod ffi {
     }
 
     unsafe extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(bool, boolean)]
         #[qproperty(QPointF, point)]
         #[qproperty(QUrl, url)]

--- a/examples/qml_features/rust/src/uncreatable.rs
+++ b/examples/qml_features/rust/src/uncreatable.rs
@@ -10,7 +10,7 @@
 #[cxx_qt::bridge(cxx_file_stem = "rust_uncreatable")]
 pub mod ffi {
     extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0", qml_uncreatable)]
+        #[cxx_qt::qobject(qml_element, qml_uncreatable)]
         #[qproperty(i32, value)]
         type RustUncreatable = super::RustUncreatableRust;
     }

--- a/examples/qml_minimal/rust/build.rs
+++ b/examples/qml_minimal/rust/build.rs
@@ -8,6 +8,8 @@
 use cxx_qt_build::CxxQtBuilder;
 
 fn main() {
-    CxxQtBuilder::new().file("src/cxxqt_object.rs").build();
+    CxxQtBuilder::new()
+        .qml_module("com.kdab.cxx_qt.demo", 1, 0, &["src/cxxqt_object.rs"])
+        .build();
 }
 // ANCHOR_END: book_build_rs

--- a/examples/qml_minimal/rust/src/cxxqt_object.rs
+++ b/examples/qml_minimal/rust/src/cxxqt_object.rs
@@ -23,7 +23,7 @@ pub mod qobject {
 
     // ANCHOR: book_rustobj_struct_signature
     unsafe extern "RustQt" {
-        #[cxx_qt::qobject(qml_uri = "com.kdab.cxx_qt.demo", qml_version = "1.0")]
+        #[cxx_qt::qobject(qml_element)]
         #[qproperty(i32, number)]
         #[qproperty(QString, string)]
         type MyObject = super::MyObjectRust;


### PR DESCRIPTION
This avoids the need to repeatedly specify the URI and version of the QML module in the bridges. QObjects that are registered as QML elements are now marked by
[cxx_qt::qobject(qml_element = "OptionalName")]

This is a precursor to generating qmldir files which are required for qmlcachegen and qmltc
(https://github.com/KDAB/cxx-qt/issues/242)