### PR TITLE
cxx-qt-gen: parse all items and use Path::get_ident instead of helper

### DIFF
--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -72,35 +72,21 @@ impl Parser {
             // Find any QObject structs
             cxx_qt_data.find_qobject_types(&items.1)?;
 
-            // Loop through any qobjects that were found
-            if !cxx_qt_data.qobjects.is_empty() {
-                for item in items.1.drain(..) {
-                    // Try to find any CXX-Qt items, if found add them to the relevant
-                    // qobject. Otherwise return them to be added to other
-                    if let Some(other) = cxx_qt_data.parse_cxx_qt_item(item)? {
-                        // Load any CXX name mappings
-                        cxx_qt_data.populate_mappings_from_item(
-                            &other,
-                            &bridge_namespace,
-                            &module.ident,
-                        )?;
-
-                        // Unknown item so add to the other list
-                        others.push(other);
-                    }
-                }
-            } else {
-                // Load any CXX name mappings
-                for item in &items.1 {
+            // Loop through items and load into qobject or others and populate mappings
+            for item in items.1.drain(..) {
+                // Try to find any CXX-Qt items, if found add them to the relevant
+                // qobject. Otherwise return them to be added to other
+                if let Some(other) = cxx_qt_data.parse_cxx_qt_item(item)? {
+                    // Load any CXX name mappings
                     cxx_qt_data.populate_mappings_from_item(
-                        item,
+                        &other,
                         &bridge_namespace,
                         &module.ident,
                     )?;
-                }
 
-                // No qobjects found so pass everything through
-                others.extend(items.1);
+                    // Unknown item so add to the other list
+                    others.push(other);
+                }
             }
 
             // Add all the QObject types to the qualified mappings

--- a/crates/cxx-qt-gen/src/syntax/path.rs
+++ b/crates/cxx-qt-gen/src/syntax/path.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use syn::{spanned::Spanned, Error, Ident, Path, Result};
+use syn::Path;
 
 /// Returns whether the [syn::Path] matches a given string slice
 pub fn path_compare_str(path: &Path, string: &[&str]) -> bool {
@@ -20,18 +20,6 @@ pub fn path_compare_str(path: &Path, string: &[&str]) -> bool {
             == 0
 }
 
-/// Returns the first [syn::Ident] from the [syn::Path] segments, errors if there are none or many
-pub fn path_to_single_ident(path: &Path) -> Result<Ident> {
-    if path.segments.len() == 1 {
-        Ok(path.segments[0].ident.clone())
-    } else {
-        Err(Error::new(
-            path.span(),
-            "Expected only one segment in the Path",
-        ))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use syn::parse_quote;
@@ -45,15 +33,5 @@ mod tests {
         assert!(path_compare_str(&path, &["a", "b", "c"]));
         assert!(!path_compare_str(&path, &["a", "c", "b"]));
         assert!(!path_compare_str(&path, &["a", "b", "c", "d"]));
-    }
-
-    #[test]
-    fn test_path_to_single_ident() {
-        let path: Path = parse_quote! { a::b::c };
-        assert!(path_to_single_ident(&path).is_err());
-
-        let path: Path = parse_quote! { a };
-        let ident = path_to_single_ident(&path).unwrap();
-        assert_eq!(ident, "a");
     }
 }


### PR DESCRIPTION
This then allows us to easily parse extern "C++Qt" later.
    
Related to #577

Requires #618 and starts splitting up #622 into commits.