### PR TITLE
cxx-qt-gen: store module ident in parser and simplify populating mapping

### DIFF
--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -14,9 +14,7 @@ pub mod signals;
 
 use crate::syntax::attribute::{attribute_find_path, attribute_tokens_to_map, AttributeDefault};
 use cxxqtdata::ParsedCxxQtData;
-use syn::{
-    spanned::Spanned, token::Brace, Error, Ident, ItemMod, LitStr, Path, PathSegment, Result,
-};
+use syn::{spanned::Spanned, token::Brace, Error, Ident, ItemMod, LitStr, Result};
 
 /// A struct representing a module block with CXX-Qt relevant [syn::Item]'s
 /// parsed into ParsedCxxQtData, to be used later to generate Rust & C++ code.
@@ -81,13 +79,6 @@ impl Parser {
                     // Unknown item so add to the other list
                     others.push(other);
                 }
-            }
-
-            // Add all the QObject types to the qualified mappings
-            for ident in cxx_qt_data.qobjects.keys() {
-                let mut path = Path::from(module.ident.clone());
-                path.segments.push(PathSegment::from(ident.clone()));
-                cxx_qt_data.qualified_mappings.insert(ident.clone(), path);
             }
         }
 

--- a/crates/cxx-qt-gen/src/syntax/path.rs
+++ b/crates/cxx-qt-gen/src/syntax/path.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use syn::Path;
+use syn::{Ident, Path, PathSegment};
 
 /// Returns whether the [syn::Path] matches a given string slice
 pub fn path_compare_str(path: &Path, string: &[&str]) -> bool {
@@ -20,8 +20,20 @@ pub fn path_compare_str(path: &Path, string: &[&str]) -> bool {
             == 0
 }
 
+/// For a given ident and base ident build a qualified path
+///
+/// Eg `module` and `T` build `module::T`
+pub fn path_from_idents(base: &Ident, ident: &Ident) -> Path {
+    let mut qualified_path = Path::from(base.clone());
+    qualified_path
+        .segments
+        .push(PathSegment::from(ident.clone()));
+    qualified_path
+}
+
 #[cfg(test)]
 mod tests {
+    use quote::format_ident;
     use syn::parse_quote;
 
     use super::*;
@@ -33,5 +45,12 @@ mod tests {
         assert!(path_compare_str(&path, &["a", "b", "c"]));
         assert!(!path_compare_str(&path, &["a", "c", "b"]));
         assert!(!path_compare_str(&path, &["a", "b", "c", "d"]));
+    }
+
+    #[test]
+    fn test_path_from_idents() {
+        let path = path_from_idents(&format_ident!("ffi"), &format_ident!("T"));
+        let expected_path: Path = parse_quote! { ffi::T };
+        assert_eq!(path, expected_path);
     }
 }


### PR DESCRIPTION
This also simplifies extern "C++Qt" support later.
    
Related to #577