### PR TITLE
examples: ensure mod and fn are pub so that doc page works

### DIFF
--- a/examples/demo_threading/rust/src/lib.rs
+++ b/examples/demo_threading/rust/src/lib.rs
@@ -10,7 +10,7 @@ mod workers;
 
 // This mod defines our QObject called EnergyUsage
 #[cxx_qt::bridge(cxx_file_stem = "energy_usage", namespace = "cxx_qt::energy_usage")]
-mod qobject {
+pub mod qobject {
     #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");
@@ -101,7 +101,7 @@ impl Default for EnergyUsageRust {
 
 impl qobject::EnergyUsage {
     /// A Q_INVOKABLE that returns the current power usage for a given uuid
-    fn sensor_power(self: Pin<&mut Self>, uuid: &QString) -> f64 {
+    pub fn sensor_power(self: Pin<&mut Self>, uuid: &QString) -> f64 {
         let sensors = SensorsWorker::read_sensors(&self.rust_mut().sensors_map);
 
         if let Ok(uuid) = Uuid::parse_str(&uuid.to_string()) {

--- a/examples/qml_extension_plugin/plugin/rust/src/lib.rs
+++ b/examples/qml_extension_plugin/plugin/rust/src/lib.rs
@@ -27,7 +27,7 @@ impl From<&MyObjectRust> for DataSerde {
 const DEFAULT_STR: &str = r#"{"number": 1, "string": "Hello World!"}"#;
 
 #[cxx_qt::bridge(cxx_file_stem = "my_object", namespace = "core")]
-mod qobject {
+pub mod qobject {
     #[namespace = ""]
     unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");

--- a/examples/qml_features/rust/src/containers.rs
+++ b/examples/qml_features/rust/src/containers.rs
@@ -96,7 +96,7 @@ pub struct RustContainersRust {
 
 impl qobject::RustContainers {
     /// Reset all the containers
-    fn reset(mut self: Pin<&mut Self>) {
+    pub fn reset(mut self: Pin<&mut Self>) {
         // Update the private rust fields via the rust_mut
         {
             let mut rust_mut = self.as_mut().rust_mut();
@@ -113,35 +113,35 @@ impl qobject::RustContainers {
     }
 
     /// Append the given number to the vector container
-    fn append_vector(mut self: Pin<&mut Self>, value: i32) {
+    pub fn append_vector(mut self: Pin<&mut Self>, value: i32) {
         self.as_mut().rust_mut().vector.append(value);
 
         self.update_strings();
     }
 
     /// Append the given number to the list container
-    fn append_list(mut self: Pin<&mut Self>, value: i32) {
+    pub fn append_list(mut self: Pin<&mut Self>, value: i32) {
         self.as_mut().rust_mut().list.append(value);
 
         self.update_strings();
     }
 
     /// Insert the given number into the set container
-    fn insert_set(mut self: Pin<&mut Self>, value: i32) {
+    pub fn insert_set(mut self: Pin<&mut Self>, value: i32) {
         self.as_mut().rust_mut().set.insert(value);
 
         self.update_strings();
     }
 
     /// Insert the given string and variant to the hash container
-    fn insert_hash(mut self: Pin<&mut Self>, key: QString, value: QVariant) {
+    pub fn insert_hash(mut self: Pin<&mut Self>, key: QString, value: QVariant) {
         self.as_mut().rust_mut().hash.insert(key, value);
 
         self.update_strings();
     }
 
     /// Insert the given string and variant to the map container
-    fn insert_map(mut self: Pin<&mut Self>, key: QString, value: QVariant) {
+    pub fn insert_map(mut self: Pin<&mut Self>, key: QString, value: QVariant) {
         // Note: map is a Q_PROPERTY so ensure we manually trigger changed
         self.as_mut().rust_mut().map.insert(key, value);
         self.as_mut().map_changed();

--- a/examples/qml_features/rust/src/custom_base_class.rs
+++ b/examples/qml_features/rust/src/custom_base_class.rs
@@ -277,7 +277,8 @@ impl qobject::CustomBaseClass {
     /// i32 representing the value role
     pub const VALUE_ROLE: i32 = 1;
 
-    fn data(&self, index: &QModelIndex, role: i32) -> QVariant {
+    /// Retrieve the data for a given index and role
+    pub fn data(&self, index: &QModelIndex, role: i32) -> QVariant {
         if let Some((id, value)) = self.vector.get(index.row() as usize) {
             return match role {
                 Self::ID_ROLE => QVariant::from(id),

--- a/examples/qml_features/rust/src/custom_parent_class.rs
+++ b/examples/qml_features/rust/src/custom_parent_class.rs
@@ -7,7 +7,7 @@
 
 /// A CXX-Qt bridge which shows a custom parent class can be used
 #[cxx_qt::bridge(cxx_file_stem = "custom_parent_class")]
-mod qobject {
+pub mod qobject {
     unsafe extern "C++" {
         /// QColor from cxx_qt_lib
         type QColor = cxx_qt_lib::QColor;
@@ -56,11 +56,11 @@ mod qobject {
         #[cxx_override]
         unsafe fn paint(self: Pin<&mut CustomParentClass>, painter: *mut QPainter);
 
-        // Define that we need to inherit size() from the base class
+        /// Define that we need to inherit size() from the base class
         #[inherit]
         fn size(self: &CustomParentClass) -> QSizeF;
 
-        // Define that we need to inherit update() from the base class
+        /// Define that we need to inherit update() from the base class
         #[inherit]
         fn update(self: Pin<&mut CustomParentClass>);
     }
@@ -81,10 +81,14 @@ pub struct CustomParentClassRust {
 
 impl qobject::CustomParentClass {
     /// Override QQuickPaintedItem::paint to draw two rectangles in Rust using QPainter
-    fn paint(self: Pin<&mut Self>, painter: *mut qobject::QPainter) {
+    ///
+    /// # Safety
+    ///
+    /// As we deref a pointer in a public method this needs to be marked as unsafe
+    pub unsafe fn paint(self: Pin<&mut Self>, painter: *mut qobject::QPainter) {
         // We need to convert the *mut QPainter to a Pin<&mut QPainter> so that we can reach the methods
-        if let Some(painter) = unsafe { painter.as_mut() } {
-            let mut pinned_painter = unsafe { Pin::new_unchecked(painter) };
+        if let Some(painter) = painter.as_mut() {
+            let mut pinned_painter = Pin::new_unchecked(painter);
 
             // Now pinned painter can be used as normal
             // to render a rectangle with two colours

--- a/examples/qml_features/rust/src/invokables.rs
+++ b/examples/qml_features/rust/src/invokables.rs
@@ -64,22 +64,22 @@ impl Default for RustInvokablesRust {
 // ANCHOR: book_invokable_impl
 impl qobject::RustInvokables {
     /// Immutable invokable method that returns the QColor
-    fn load_color(&self) -> Result<QColor, i32> {
+    pub fn load_color(&self) -> Result<QColor, i32> {
         Ok(self.as_qcolor())
     }
 
     /// Mutable invokable method that stores a color
-    fn store_color(self: Pin<&mut Self>, red: f32, green: f32, blue: f32) {
+    pub fn store_color(self: Pin<&mut Self>, red: f32, green: f32, blue: f32) {
         self.store_helper(red, green, blue);
     }
 
     /// Mutable invokable method with no parameters that resets the color
-    fn reset(self: Pin<&mut Self>) {
+    pub fn reset(self: Pin<&mut Self>) {
         self.store_helper(0.0, 0.4667, 0.7843);
     }
 
     /// C++ only method which returns the red value
-    fn red_value(&self) -> f32 {
+    pub fn red_value(&self) -> f32 {
         self.red
     }
 
@@ -95,7 +95,7 @@ impl qobject::RustInvokables {
 
 impl RustInvokablesRust {
     /// Immutable Rust context method that returns the QColor
-    fn as_qcolor(&self) -> QColor {
+    pub fn as_qcolor(&self) -> QColor {
         QColor::from_rgb(
             (self.red * 255.0).round() as i32,
             (self.green * 255.0).round() as i32,

--- a/examples/qml_features/rust/src/multiple_qobjects.rs
+++ b/examples/qml_features/rust/src/multiple_qobjects.rs
@@ -90,7 +90,7 @@ impl Default for FirstObjectRust {
 
 impl qobject::FirstObject {
     /// A Q_INVOKABLE on the first QObject which increments a counter
-    fn increment(mut self: Pin<&mut Self>) {
+    pub fn increment(mut self: Pin<&mut Self>) {
         let new_value = self.as_ref().counter() + 1;
         self.as_mut().set_counter(new_value);
 
@@ -121,7 +121,7 @@ impl Default for SecondObjectRust {
 
 impl qobject::SecondObject {
     /// A Q_INVOKABLE on the second QObject which increments a counter
-    fn increment(mut self: Pin<&mut Self>) {
+    pub fn increment(mut self: Pin<&mut Self>) {
         let new_value = self.as_ref().counter() + 1;
         self.as_mut().set_counter(new_value);
 

--- a/examples/qml_features/rust/src/nested_qobjects.rs
+++ b/examples/qml_features/rust/src/nested_qobjects.rs
@@ -35,9 +35,6 @@ pub mod qobject {
 
     unsafe extern "RustQt" {
         /// Print the count of the given inner QObject
-        //
-        // This method needs to be unsafe otherwise clippy complains that the
-        // public method might dereference the raw pointer.
         #[qinvokable]
         unsafe fn print_count(self: Pin<&mut OuterObject>, inner: *mut InnerObject);
 
@@ -72,21 +69,20 @@ impl Default for OuterObjectRust {
 
 impl qobject::OuterObject {
     /// Print the count of the given inner QObject
-    //
-    // This method needs to be unsafe otherwise clippy complains that the
-    // public method might dereference the raw pointer.
-    unsafe fn print_count(self: Pin<&mut Self>, inner: *mut qobject::InnerObject) {
-        if let Some(inner) = unsafe { inner.as_ref() } {
+    ///
+    /// # Safety
+    ///
+    /// As we deref a pointer in a public method this needs to be marked as unsafe
+    pub unsafe fn print_count(self: Pin<&mut Self>, inner: *mut qobject::InnerObject) {
+        if let Some(inner) = inner.as_ref() {
             println!("Inner object's counter property: {}", inner.counter());
         }
 
-        unsafe {
-            self.called(inner);
-        }
+        self.called(inner);
     }
 
     /// Reset the counter of the inner QObject stored in the Q_PROPERTY
-    fn reset(self: Pin<&mut Self>) {
+    pub fn reset(self: Pin<&mut Self>) {
         // We need to convert the *mut T to a Pin<&mut T> so that we can reach the methods
         if let Some(inner) = unsafe { self.inner().as_mut() } {
             let pinned_inner = unsafe { Pin::new_unchecked(inner) };

--- a/examples/qml_features/rust/src/properties.rs
+++ b/examples/qml_features/rust/src/properties.rs
@@ -71,7 +71,7 @@ impl Default for RustPropertiesRust {
 
 impl qobject::RustProperties {
     /// Connect to the given url
-    fn connect(mut self: Pin<&mut Self>, mut url: QUrl) {
+    pub fn connect(mut self: Pin<&mut Self>, mut url: QUrl) {
         // Check that the url starts with kdab
         if url.to_string().starts_with("https://kdab.com") {
             self.as_mut().set_connected(true);
@@ -91,7 +91,7 @@ impl qobject::RustProperties {
     }
 
     /// Disconnect from the stored url
-    fn disconnect(mut self: Pin<&mut Self>) {
+    pub fn disconnect(mut self: Pin<&mut Self>) {
         self.as_mut().set_connected(false);
         self.as_mut()
             .set_status_message(QString::from("Disconnected"));

--- a/examples/qml_features/rust/src/serialisation.rs
+++ b/examples/qml_features/rust/src/serialisation.rs
@@ -88,7 +88,7 @@ impl From<DataSerde> for SerialisationRust {
 
 impl qobject::Serialisation {
     /// Retrieve the JSON form of this QObject
-    fn as_json_str(self: Pin<&mut Self>) -> QString {
+    pub fn as_json_str(self: Pin<&mut Self>) -> QString {
         let data_serde = DataSerde::from(self.rust());
         match serde_json::to_string(&data_serde) {
             Ok(data_string) => QString::from(&data_string),
@@ -101,7 +101,7 @@ impl qobject::Serialisation {
 
     /// From a given JSON string try to load values for the Q_PROPERTYs
     // ANCHOR: book_grab_values
-    fn from_json_str(mut self: Pin<&mut Self>, string: &QString) {
+    pub fn from_json_str(mut self: Pin<&mut Self>, string: &QString) {
         match serde_json::from_str::<DataSerde>(&string.to_string()) {
             Ok(data_serde) => {
                 self.as_mut().set_number(data_serde.number);

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -70,7 +70,7 @@ pub struct RustSignalsRust {
 
 impl qobject::RustSignals {
     /// Connect to the given url
-    fn connect(self: Pin<&mut Self>, url: &QUrl) {
+    pub fn connect(self: Pin<&mut Self>, url: &QUrl) {
         // Check that the url starts with kdab
         if url.to_string().starts_with("https://kdab.com") {
             // Emit a signal to QML stating that we have connected
@@ -82,7 +82,7 @@ impl qobject::RustSignals {
     }
 
     /// Disconnect
-    fn disconnect(self: Pin<&mut Self>) {
+    pub fn disconnect(self: Pin<&mut Self>) {
         // Emit a signal to QML stating that we have disconnected
         self.disconnected();
     }

--- a/examples/qml_features/rust/src/singleton.rs
+++ b/examples/qml_features/rust/src/singleton.rs
@@ -31,7 +31,7 @@ pub struct RustSingletonRust {
 
 impl qobject::RustSingleton {
     /// Increment the persistent value Q_PROPERTY of the QML_SINGLETON
-    fn increment(self: Pin<&mut Self>) {
+    pub fn increment(self: Pin<&mut Self>) {
         let new_value = self.persistent_value() + 1;
         self.set_persistent_value(new_value);
     }

--- a/examples/qml_features/rust/src/threading.rs
+++ b/examples/qml_features/rust/src/threading.rs
@@ -71,7 +71,7 @@ impl Default for ThreadingWebsiteRust {
 
 impl qobject::ThreadingWebsite {
     /// Swap the URL between kdab.com and github.com
-    fn change_url(self: Pin<&mut Self>) {
+    pub fn change_url(self: Pin<&mut Self>) {
         let new_url = if self.url().to_string() == "https://kdab.com" {
             "https://github.com/kdab/cxx-qt"
         } else {
@@ -81,7 +81,7 @@ impl qobject::ThreadingWebsite {
     }
 
     /// Simulate delay of a network request to retrieve the title of the website
-    fn fetch_title(mut self: Pin<&mut Self>) {
+    pub fn fetch_title(mut self: Pin<&mut Self>) {
         // Check that we aren't already retrieving a title
         if self
             .rust()

--- a/examples/qml_features/rust/src/types.rs
+++ b/examples/qml_features/rust/src/types.rs
@@ -115,7 +115,7 @@ impl Default for TypesRust {
 
 impl ffi::Types {
     /// Load the value from a QVariant
-    fn load_from_variant(self: Pin<&mut Self>, variant: &QVariant) {
+    pub fn load_from_variant(self: Pin<&mut Self>, variant: &QVariant) {
         if let Some(boolean) = variant.value::<bool>() {
             self.set_boolean(boolean);
         } else if let Some(point) = variant.value::<QPointF>() {
@@ -130,7 +130,7 @@ impl ffi::Types {
     }
 
     /// Toggle the boolean Q_PROPERTY
-    fn toggle_boolean(self: Pin<&mut Self>) {
+    pub fn toggle_boolean(self: Pin<&mut Self>) {
         let new_boolean = !self.as_ref().boolean();
         self.set_boolean(new_boolean);
     }

--- a/examples/qml_minimal/rust/src/lib.rs
+++ b/examples/qml_minimal/rust/src/lib.rs
@@ -6,5 +6,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 // ANCHOR: book_mod_statement
-mod cxxqt_object;
+pub mod cxxqt_object;
 // ANCHOR_END: book_mod_statement


### PR DESCRIPTION
This then shows how a doc page is generated correctly for our QObjects.

Closes #529