### PR TITLE
cxx-qt-lib: workaround GCC bug for explicit specialisation outside namespace

### DIFF
--- a/crates/cxx-qt-gen/include/cxxqt_thread.h
+++ b/crates/cxx-qt-gen/include/cxxqt_thread.h
@@ -118,7 +118,13 @@ cxxQtThreadQueue(const CxxQtThread<T>& cxxQtThread,
 } // namespace cxxqtlib1
 } // namespace rust
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 template<typename T>
-struct rust::IsRelocatable<::rust::cxxqtlib1::CxxQtThread<T>> : ::std::true_type
+struct IsRelocatable<::rust::cxxqtlib1::CxxQtThread<T>> : ::std::true_type
 {
 };
+
+} // namespace rust

--- a/crates/cxx-qt-lib-headers/include/core/qbytearray.h
+++ b/crates/cxx-qt-lib-headers/include/core/qbytearray.h
@@ -12,10 +12,16 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 template<>
-struct rust::IsRelocatable<QByteArray> : ::std::true_type
+struct IsRelocatable<QByteArray> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/core/qdatetime.h
+++ b/crates/cxx-qt-lib-headers/include/core/qdatetime.h
@@ -15,10 +15,16 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 template<>
-struct rust::IsRelocatable<QDateTime> : ::std::true_type
+struct IsRelocatable<QDateTime> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/core/qhash.h
+++ b/crates/cxx-qt-lib-headers/include/core/qhash.h
@@ -16,11 +16,17 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename K, typename V>
-struct rust::IsRelocatable<QHash<K, V>> : ::std::true_type
+struct IsRelocatable<QHash<K, V>> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/core/qlist.h
+++ b/crates/cxx-qt-lib-headers/include/core/qlist.h
@@ -38,11 +38,17 @@
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #include "qlist_qvector.h"
 #else
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename T>
-struct rust::IsRelocatable<QList<T>> : ::std::true_type
+struct IsRelocatable<QList<T>> : ::std::true_type
 {
 };
+
+} // namespace rust
 #endif
 
 namespace rust {

--- a/crates/cxx-qt-lib-headers/include/core/qlist_qvector.h
+++ b/crates/cxx-qt-lib-headers/include/core/qlist_qvector.h
@@ -16,10 +16,16 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename T>
-struct rust::IsRelocatable<QList<T>> : ::std::true_type
+struct IsRelocatable<QList<T>> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 #endif

--- a/crates/cxx-qt-lib-headers/include/core/qmap.h
+++ b/crates/cxx-qt-lib-headers/include/core/qmap.h
@@ -13,11 +13,17 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename K, typename V>
-struct rust::IsRelocatable<QMap<K, V>> : ::std::true_type
+struct IsRelocatable<QMap<K, V>> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/core/qmetaobjectconnection.h
+++ b/crates/cxx-qt-lib-headers/include/core/qmetaobjectconnection.h
@@ -12,10 +12,16 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 template<>
-struct rust::IsRelocatable<::QMetaObject::Connection> : ::std::true_type
+struct IsRelocatable<::QMetaObject::Connection> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/core/qpersistentmodelindex.h
+++ b/crates/cxx-qt-lib-headers/include/core/qpersistentmodelindex.h
@@ -10,8 +10,14 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 // This has static asserts in the cpp file to ensure this is valid.
 template<>
-struct rust::IsRelocatable<QPersistentModelIndex> : ::std::true_type
+struct IsRelocatable<QPersistentModelIndex> : ::std::true_type
 {
 };
+
+} // namespace rust

--- a/crates/cxx-qt-lib-headers/include/core/qset.h
+++ b/crates/cxx-qt-lib-headers/include/core/qset.h
@@ -20,11 +20,17 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename T>
-struct rust::IsRelocatable<QSet<T>> : ::std::true_type
+struct IsRelocatable<QSet<T>> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/core/qstring.h
+++ b/crates/cxx-qt-lib-headers/include/core/qstring.h
@@ -14,10 +14,16 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 template<>
-struct rust::IsRelocatable<QString> : ::std::true_type
+struct IsRelocatable<QString> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/core/qstringlist.h
+++ b/crates/cxx-qt-lib-headers/include/core/qstringlist.h
@@ -12,10 +12,16 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 template<>
-struct rust::IsRelocatable<QStringList> : ::std::true_type
+struct IsRelocatable<QStringList> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/core/qurl.h
+++ b/crates/cxx-qt-lib-headers/include/core/qurl.h
@@ -14,10 +14,16 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 template<>
-struct rust::IsRelocatable<QUrl> : ::std::true_type
+struct IsRelocatable<QUrl> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/core/qvariant.h
+++ b/crates/cxx-qt-lib-headers/include/core/qvariant.h
@@ -33,10 +33,16 @@
 
 #include "rust/cxx.h"
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 template<>
-struct rust::IsRelocatable<QVariant> : ::std::true_type
+struct IsRelocatable<QVariant> : ::std::true_type
 {
 };
+
+} // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {

--- a/crates/cxx-qt-lib-headers/include/core/qvector.h
+++ b/crates/cxx-qt-lib-headers/include/core/qvector.h
@@ -38,11 +38,17 @@
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #include "qlist_qvector.h"
 #else
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename T>
-struct rust::IsRelocatable<QVector<T>> : ::std::true_type
+struct IsRelocatable<QVector<T>> : ::std::true_type
 {
 };
+
+} // namespace rust
 #endif
 
 namespace rust {

--- a/crates/cxx-qt-lib-headers/include/gui/qcolor.h
+++ b/crates/cxx-qt-lib-headers/include/gui/qcolor.h
@@ -18,10 +18,16 @@
 // QColor still had copy & move constructors in Qt 5 but they were basically
 // trivial.
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust {
+
 template<>
-struct rust::IsRelocatable<QColor> : ::std::true_type
+struct IsRelocatable<QColor> : ::std::true_type
 {
 };
+
+} // namespace rust
 #endif
 
 namespace rust {


### PR DESCRIPTION
This works around issues such as below with MinGW81 specialization of 'template<class T> struct rust::cxxbridge1::IsRelocatable' in different namespace

Due to the following bug that was solved in GCC 7
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480 https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#374

Related to #640