### PR TITLE
cxx-qt-gen: use mixins for CxxQtType, CxxQtLocking, CxxQtThreading

### DIFF
--- a/crates/cxx-qt-gen/include/cxxqt_locking.h
+++ b/crates/cxx-qt-gen/include/cxxqt_locking.h
@@ -1,0 +1,34 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+
+namespace rust::cxxqtlib1 {
+
+class CxxQtLocking
+{
+public:
+  explicit CxxQtLocking()
+    : m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
+  {
+  }
+
+  virtual ~CxxQtLocking() = default;
+
+protected:
+  [[nodiscard]] ::std::lock_guard<::std::recursive_mutex> unsafeRustLock() const
+  {
+    return ::std::lock_guard<::std::recursive_mutex>(*m_rustObjMutex);
+  }
+
+  ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
+};
+
+}

--- a/crates/cxx-qt-gen/include/cxxqt_thread.h
+++ b/crates/cxx-qt-gen/include/cxxqt_thread.h
@@ -20,7 +20,7 @@ namespace rust {
 namespace cxxqtlib1 {
 
 template<typename T>
-class CxxQtGuardedPointer
+class CxxQtGuardedPointer final
 {
 public:
   explicit CxxQtGuardedPointer(T* ptr)
@@ -33,7 +33,7 @@ public:
 };
 
 template<typename T>
-class CxxQtThread
+class CxxQtThread final
 {
 public:
   CxxQtThread(::std::shared_ptr<CxxQtGuardedPointer<T>> obj,

--- a/crates/cxx-qt-gen/include/cxxqt_threading.h
+++ b/crates/cxx-qt-gen/include/cxxqt_threading.h
@@ -1,0 +1,42 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+
+#include <cxx-qt-common/cxxqt_locking.h>
+#include <cxx-qt-common/cxxqt_thread.h>
+
+namespace rust::cxxqtlib1 {
+
+template<typename T>
+class CxxQtThreading : public CxxQtLocking
+{
+public:
+  explicit CxxQtThreading(T* obj)
+    : m_cxxQtThreadObj(::std::make_shared<CxxQtGuardedPointer<T>>(obj))
+  {
+  }
+
+  virtual ~CxxQtThreading()
+  {
+    const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
+    m_cxxQtThreadObj->ptr = nullptr;
+  }
+
+  CxxQtThread<T> qtThread() const
+  {
+    return CxxQtThread<T>(m_cxxQtThreadObj, m_rustObjMutex);
+  }
+
+private:
+  ::std::shared_ptr<CxxQtGuardedPointer<T>> m_cxxQtThreadObj;
+};
+
+}

--- a/crates/cxx-qt-gen/include/cxxqt_type.h
+++ b/crates/cxx-qt-gen/include/cxxqt_type.h
@@ -1,0 +1,35 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+
+#include "rust/cxx.h"
+
+namespace rust::cxxqtlib1 {
+
+template<typename T>
+class CxxQtType
+{
+public:
+  explicit CxxQtType(::rust::Box<T>&& rustObj)
+    : m_rustObj(::std::move(rustObj))
+  {
+  }
+
+  virtual ~CxxQtType() = default;
+
+  T const& unsafeRust() const { return *m_rustObj; }
+  T& unsafeRustMut() { return *m_rustObj; }
+
+protected:
+  ::rust::Box<T> m_rustObj;
+};
+
+}

--- a/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
@@ -29,11 +29,12 @@ fn default_constructor(
                 r#"
             {class_name}::{class_name}(QObject* parent)
               : {base_class}(parent)
-              , m_rustObj(::{namespace_internals}::createRs()){initializers}
+              , ::rust::cxxqtlib1::CxxQtType<{rust_obj}>(::{namespace_internals}::createRs()){initializers}
             {{ }}
             "#,
                 class_name = qobject.ident,
                 namespace_internals = qobject.namespace_internals,
+                rust_obj = qobject.rust_ident,
             ),
         }],
         ..Default::default()
@@ -78,6 +79,7 @@ pub fn generate(
     generated.base_classes.push(base_class.clone());
 
     let class_name = qobject.ident.as_str();
+    let rust_obj = qobject.rust_ident.as_str();
     let namespace_internals = &qobject.namespace_internals;
     for (index, constructor) in constructors.iter().enumerate() {
         let argument_list = expand_arguments(&constructor.arguments, cxx_mappings)?;
@@ -119,7 +121,7 @@ pub fn generate(
                 r#"
                 {class_name}::{class_name}(::{namespace_internals}::CxxQtConstructorArguments{index}&& args)
                   : {base_class}({base_args})
-                  , m_rustObj(::{namespace_internals}::newRs{index}(::std::move(args.new_))){initializers}
+                  , ::rust::cxxqtlib1::CxxQtType<{rust_obj}>(::{namespace_internals}::newRs{index}(::std::move(args.new_))){initializers}
                 {{
                   ::{namespace_internals}::initialize{index}(*this, ::std::move(args.initialize));
                 }}
@@ -141,7 +143,7 @@ mod tests {
     fn qobject_for_testing() -> GeneratedCppQObject {
         GeneratedCppQObject {
             ident: "MyObject".to_string(),
-            rust_ident: "MyObjectQt".to_string(),
+            rust_ident: "MyObjectRust".to_string(),
             namespace_internals: "rust".to_string(),
             blocks: GeneratedCppQObjectBlocks::default(),
         }
@@ -187,7 +189,7 @@ mod tests {
                     "
                     MyObject::MyObject(QObject* parent)
                       : BaseClass(parent)
-                      , m_rustObj(::rust::createRs())
+                      , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(::rust::createRs())
                       , member1(1)
                       , member2{{ 2 }}
                     {{ }}
@@ -217,7 +219,7 @@ mod tests {
                     "
                     MyObject::MyObject(QObject* parent)
                       : BaseClass(parent)
-                      , m_rustObj(::rust::createRs())
+                      , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(::rust::createRs())
                     {{ }}
                     "
                 ),
@@ -248,7 +250,7 @@ mod tests {
                     "
                     MyObject::MyObject(::rust::CxxQtConstructorArguments0&& args)
                       : BaseClass()
-                      , m_rustObj(::rust::newRs0(::std::move(args.new_)))
+                      , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(::rust::newRs0(::std::move(args.new_)))
                     {{
                       ::rust::initialize0(*this, ::std::move(args.initialize));
                     }}
@@ -311,7 +313,7 @@ mod tests {
                     "
                     MyObject::MyObject(::rust::CxxQtConstructorArguments0&& args)
                       : BaseClass(::std::move(args.base.arg0), ::std::move(args.base.arg1))
-                      , m_rustObj(::rust::newRs0(::std::move(args.new_)))
+                      , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(::rust::newRs0(::std::move(args.new_)))
                       , initializer
                     {{
                       ::rust::initialize0(*this, ::std::move(args.initialize));
@@ -381,7 +383,7 @@ mod tests {
                         "
                         MyObject::MyObject(::rust::CxxQtConstructorArguments0&& args)
                           : BaseClass()
-                          , m_rustObj(::rust::newRs0(::std::move(args.new_)))
+                          , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(::rust::newRs0(::std::move(args.new_)))
                           , initializer
                         {{
                           ::rust::initialize0(*this, ::std::move(args.initialize));
@@ -396,7 +398,7 @@ mod tests {
                         "
                         MyObject::MyObject(::rust::CxxQtConstructorArguments1&& args)
                           : BaseClass(::std::move(args.base.arg0))
-                          , m_rustObj(::rust::newRs1(::std::move(args.new_)))
+                          , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(::rust::newRs1(::std::move(args.new_)))
                           , initializer
                         {{
                           ::rust::initialize1(*this, ::std::move(args.initialize));

--- a/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
@@ -19,7 +19,6 @@ fn default_constructor(
     initializers: String,
 ) -> GeneratedCppQObjectBlocks {
     GeneratedCppQObjectBlocks {
-        base_classes: vec![base_class.clone()],
         methods: vec![CppFragment::Pair {
             header: format!(
                 "explicit {class_name}(QObject* parent = nullptr);",
@@ -76,7 +75,6 @@ pub fn generate(
     }
 
     let mut generated = GeneratedCppQObjectBlocks::default();
-    generated.base_classes.push(base_class.clone());
 
     let class_name = qobject.ident.as_str();
     let rust_obj = qobject.rust_ident.as_str();

--- a/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
@@ -162,7 +162,6 @@ mod tests {
     }
 
     fn assert_empty_blocks(blocks: &GeneratedCppQObjectBlocks) {
-        assert!(blocks.members.is_empty());
         assert!(blocks.metaobjects.is_empty());
         assert!(blocks.forward_declares.is_empty());
     }

--- a/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
@@ -165,7 +165,6 @@ mod tests {
         assert!(blocks.members.is_empty());
         assert!(blocks.metaobjects.is_empty());
         assert!(blocks.forward_declares.is_empty());
-        assert!(blocks.deconstructors.is_empty());
     }
 
     #[test]

--- a/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
@@ -62,10 +62,10 @@ pub fn generate(
     qobject: &GeneratedCppQObject,
     constructors: &[Constructor],
     base_class: String,
-    member_initializers: &[String],
+    class_initializers: &[String],
     cxx_mappings: &ParsedCxxMappings,
 ) -> Result<GeneratedCppQObjectBlocks> {
-    let initializers = member_initializers
+    let initializers = class_initializers
         .iter()
         .map(|initializer| format!("\n  , {initializer}"))
         .collect::<Vec<_>>()

--- a/crates/cxx-qt-gen/src/generator/cpp/cxxqttype.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/cxxqttype.rs
@@ -3,48 +3,21 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::generator::{
-    cpp::{fragment::CppFragment, qobject::GeneratedCppQObjectBlocks},
-    naming::qobject::QObjectName,
-};
-use indoc::formatdoc;
+use crate::generator::{cpp::qobject::GeneratedCppQObjectBlocks, naming::qobject::QObjectName};
 use syn::Result;
 
 pub fn generate(qobject_idents: &QObjectName) -> Result<GeneratedCppQObjectBlocks> {
     let mut result = GeneratedCppQObjectBlocks::default();
 
     let rust_ident = qobject_idents.rust_struct.cpp.to_string();
-    let qobject_ident = qobject_idents.cpp_class.cpp.to_string();
-
-    result.includes.insert("#include <memory>".to_owned());
-
-    result.methods.push(CppFragment::Pair {
-        header: formatdoc! {
-            r#"
-            {rust_ident} const& unsafeRust() const;
-            {rust_ident}& unsafeRustMut();
-            "#
-        },
-        source: formatdoc! {
-            r#"
-            {rust_ident} const&
-            {qobject_ident}::unsafeRust() const
-            {{
-              return *m_rustObj;
-            }}
-
-            {rust_ident}&
-            {qobject_ident}::unsafeRustMut()
-            {{
-              return *m_rustObj;
-            }}
-            "#
-        },
-    });
 
     result
-        .members
-        .push(format!("::rust::Box<{rust_ident}> m_rustObj;"));
+        .includes
+        .insert("#include <cxx-qt-common/cxxqt_type.h>".to_owned());
+
+    result
+        .base_classes
+        .push(format!("::rust::cxxqtlib1::CxxQtType<{rust_ident}>"));
 
     Ok(result)
 }
@@ -54,56 +27,24 @@ mod tests {
     use super::*;
 
     use crate::generator::naming::qobject::tests::create_qobjectname;
-    use indoc::indoc;
-    use pretty_assertions::assert_str_eq;
 
     #[test]
-    fn test_generate_cpp_locking() {
+    fn test_generate_cpp_cxxqt_type() {
         let qobject_idents = create_qobjectname();
 
         let generated = generate(&qobject_idents).unwrap();
 
         // includes
         assert_eq!(generated.includes.len(), 1);
-        assert!(generated.includes.contains("#include <memory>"));
+        assert!(generated
+            .includes
+            .contains("#include <cxx-qt-common/cxxqt_type.h>"));
 
-        // members
-        assert_eq!(generated.members.len(), 1);
-        assert_str_eq!(
-            &generated.members[0],
-            "::rust::Box<MyObjectRust> m_rustObj;"
-        );
-
-        // methods
-        assert_eq!(generated.methods.len(), 1);
-
-        let (header, source) = if let CppFragment::Pair { header, source } = &generated.methods[0] {
-            (header, source)
-        } else {
-            panic!("Expected pair")
-        };
-        assert_str_eq!(
-            header,
-            indoc! {r#"
-            MyObjectRust const& unsafeRust() const;
-            MyObjectRust& unsafeRustMut();
-            "#}
-        );
-        assert_str_eq!(
-            source,
-            indoc! {r#"
-            MyObjectRust const&
-            MyObject::unsafeRust() const
-            {
-              return *m_rustObj;
-            }
-
-            MyObjectRust&
-            MyObject::unsafeRustMut()
-            {
-              return *m_rustObj;
-            }
-            "#}
+        // base class
+        assert_eq!(generated.base_classes.len(), 1);
+        assert_eq!(
+            generated.base_classes[0],
+            "::rust::cxxqtlib1::CxxQtType<MyObjectRust>"
         );
     }
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/locking.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/locking.rs
@@ -3,95 +3,39 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::generator::{
-    cpp::{fragment::CppFragment, qobject::GeneratedCppQObjectBlocks},
-    naming::qobject::QObjectName,
-};
-use indoc::formatdoc;
+use crate::generator::cpp::qobject::GeneratedCppQObjectBlocks;
 use syn::Result;
 
-pub fn generate(qobject_idents: &QObjectName) -> Result<(String, GeneratedCppQObjectBlocks)> {
+pub fn generate() -> Result<GeneratedCppQObjectBlocks> {
     let mut result = GeneratedCppQObjectBlocks::default();
 
-    let lock_guard_mutex = "::std::lock_guard<::std::recursive_mutex>";
-    let qobject_ident = qobject_idents.cpp_class.cpp.to_string();
-
-    result.includes.insert("#include <mutex>".to_owned());
-
-    result.private_methods.push(CppFragment::Pair {
-        header: format!("[[nodiscard]] {lock_guard_mutex} unsafeRustLock() const;"),
-        source: formatdoc! {
-            r#"
-            {lock_guard_mutex}
-            {qobject_ident}::unsafeRustLock() const
-            {{
-              return {lock_guard_mutex}(*m_rustObjMutex);
-            }}
-            "#
-        },
-    });
+    result
+        .includes
+        .insert("#include <cxx-qt-common/cxxqt_locking.h>".to_owned());
 
     result
-        .members
-        .push("::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;".to_owned());
+        .base_classes
+        .push("::rust::cxxqtlib1::CxxQtLocking".to_owned());
 
-    let member_initializer =
-        "m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())".to_owned();
-
-    Ok((member_initializer, result))
+    Ok(result)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use crate::generator::naming::qobject::tests::create_qobjectname;
-    use indoc::indoc;
-    use pretty_assertions::assert_str_eq;
-
     #[test]
     fn test_generate_cpp_locking() {
-        let qobject_idents = create_qobjectname();
-
-        let (initializer, generated) = generate(&qobject_idents).unwrap();
+        let generated = generate().unwrap();
 
         // includes
         assert_eq!(generated.includes.len(), 1);
-        assert!(generated.includes.contains("#include <mutex>"));
+        assert!(generated
+            .includes
+            .contains("#include <cxx-qt-common/cxxqt_locking.h>"));
 
-        // members
-        assert_eq!(generated.members.len(), 1);
-        assert_str_eq!(
-            &generated.members[0],
-            "::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;"
-        );
-        assert_str_eq!(
-            initializer,
-            "m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())"
-        );
-
-        // private methods
-        assert_eq!(generated.private_methods.len(), 1);
-
-        let (header, source) =
-            if let CppFragment::Pair { header, source } = &generated.private_methods[0] {
-                (header, source)
-            } else {
-                panic!("Expected pair")
-            };
-        assert_str_eq!(
-            header,
-            "[[nodiscard]] ::std::lock_guard<::std::recursive_mutex> unsafeRustLock() const;"
-        );
-        assert_str_eq!(
-            source,
-            indoc! {r#"
-            ::std::lock_guard<::std::recursive_mutex>
-            MyObject::unsafeRustLock() const
-            {
-              return ::std::lock_guard<::std::recursive_mutex>(*m_rustObjMutex);
-            }
-            "#}
-        );
+        // base class
+        assert_eq!(generated.base_classes.len(), 1);
+        assert_eq!(generated.base_classes[0], "::rust::cxxqtlib1::CxxQtLocking");
     }
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/locking.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/locking.rs
@@ -6,7 +6,7 @@
 use crate::generator::cpp::qobject::GeneratedCppQObjectBlocks;
 use syn::Result;
 
-pub fn generate() -> Result<GeneratedCppQObjectBlocks> {
+pub fn generate() -> Result<(String, GeneratedCppQObjectBlocks)> {
     let mut result = GeneratedCppQObjectBlocks::default();
 
     result
@@ -17,7 +17,9 @@ pub fn generate() -> Result<GeneratedCppQObjectBlocks> {
         .base_classes
         .push("::rust::cxxqtlib1::CxxQtLocking".to_owned());
 
-    Ok(result)
+    let class_initializer = "::rust::cxxqtlib1::CxxQtLocking()".to_owned();
+
+    Ok((class_initializer, result))
 }
 
 #[cfg(test)]
@@ -26,7 +28,10 @@ mod tests {
 
     #[test]
     fn test_generate_cpp_locking() {
-        let generated = generate().unwrap();
+        let (initializer, generated) = generate().unwrap();
+
+        // initializer
+        assert_eq!(initializer, "::rust::cxxqtlib1::CxxQtLocking()");
 
         // includes
         assert_eq!(generated.includes.len(), 1);

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -139,9 +139,7 @@ impl GeneratedCppQObject {
 
         // If this type has locking enabled then add generation
         if qobject.locking {
-            let (initializer, mut blocks) = locking::generate(&qobject_idents)?;
-            generated.blocks.append(&mut blocks);
-            member_initializers.push(initializer);
+            generated.blocks.append(&mut locking::generate()?);
         }
 
         // If this type has threading enabled then add generation
@@ -200,8 +198,12 @@ mod tests {
         assert_eq!(cpp.ident, "MyObject");
         assert_eq!(cpp.rust_ident, "MyObjectRust");
         assert_eq!(cpp.namespace_internals, "cxx_qt_my_object");
-        assert_eq!(cpp.blocks.base_classes.len(), 1);
+        assert_eq!(cpp.blocks.base_classes.len(), 2);
         assert_eq!(cpp.blocks.base_classes[0], "QObject");
+        assert_eq!(
+            cpp.blocks.base_classes[1],
+            "::rust::cxxqtlib1::CxxQtLocking"
+        );
         assert_eq!(cpp.blocks.metaobjects.len(), 0);
     }
 
@@ -225,8 +227,12 @@ mod tests {
         )
         .unwrap();
         assert_eq!(cpp.namespace_internals, "cxx_qt::cxx_qt_my_object");
-        assert_eq!(cpp.blocks.base_classes.len(), 1);
+        assert_eq!(cpp.blocks.base_classes.len(), 2);
         assert_eq!(cpp.blocks.base_classes[0], "QStringListModel");
+        assert_eq!(
+            cpp.blocks.base_classes[1],
+            "::rust::cxxqtlib1::CxxQtLocking"
+        );
         assert_eq!(cpp.blocks.metaobjects.len(), 0);
     }
 

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -135,7 +135,7 @@ impl GeneratedCppQObject {
             cxx_mappings,
         )?);
 
-        let mut member_initializers = vec![];
+        let mut class_initializers = vec![];
 
         // If this type has threading enabled then add generation
         //
@@ -146,10 +146,12 @@ impl GeneratedCppQObject {
 
             let (initializer, mut blocks) = threading::generate(&qobject_idents)?;
             generated.blocks.append(&mut blocks);
-            member_initializers.push(initializer);
+            class_initializers.push(initializer);
         // If this type has locking enabled then add generation
         } else if qobject.locking {
-            generated.blocks.append(&mut locking::generate()?);
+            let (initializer, mut blocks) = locking::generate()?;
+            generated.blocks.append(&mut blocks);
+            class_initializers.push(initializer);
         }
 
         // We need the QObject base class to be first which is added last
@@ -162,7 +164,7 @@ impl GeneratedCppQObject {
                 .base_class
                 .clone()
                 .unwrap_or_else(|| "QObject".to_string()),
-            &member_initializers,
+            &class_initializers,
             cxx_mappings,
         )?);
 

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -25,8 +25,6 @@ pub struct GeneratedCppQObjectBlocks {
     pub methods: Vec<CppFragment>,
     /// List of private methods for the QObject
     pub private_methods: Vec<CppFragment>,
-    /// List of members for the QObject
-    pub members: Vec<String>,
     /// List of includes
     pub includes: BTreeSet<String>,
     /// Base class of the QObject
@@ -39,7 +37,6 @@ impl GeneratedCppQObjectBlocks {
         self.metaobjects.append(&mut other.metaobjects);
         self.methods.append(&mut other.methods);
         self.private_methods.append(&mut other.private_methods);
-        self.members.append(&mut other.members);
         self.includes.append(&mut other.includes);
         self.base_classes.append(&mut other.base_classes);
     }

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -198,10 +198,14 @@ mod tests {
         assert_eq!(cpp.ident, "MyObject");
         assert_eq!(cpp.rust_ident, "MyObjectRust");
         assert_eq!(cpp.namespace_internals, "cxx_qt_my_object");
-        assert_eq!(cpp.blocks.base_classes.len(), 2);
+        assert_eq!(cpp.blocks.base_classes.len(), 3);
         assert_eq!(cpp.blocks.base_classes[0], "QObject");
         assert_eq!(
             cpp.blocks.base_classes[1],
+            "::rust::cxxqtlib1::CxxQtType<MyObjectRust>"
+        );
+        assert_eq!(
+            cpp.blocks.base_classes[2],
             "::rust::cxxqtlib1::CxxQtLocking"
         );
         assert_eq!(cpp.blocks.metaobjects.len(), 0);
@@ -227,10 +231,14 @@ mod tests {
         )
         .unwrap();
         assert_eq!(cpp.namespace_internals, "cxx_qt::cxx_qt_my_object");
-        assert_eq!(cpp.blocks.base_classes.len(), 2);
+        assert_eq!(cpp.blocks.base_classes.len(), 3);
         assert_eq!(cpp.blocks.base_classes[0], "QStringListModel");
         assert_eq!(
             cpp.blocks.base_classes[1],
+            "::rust::cxxqtlib1::CxxQtType<MyObjectRust>"
+        );
+        assert_eq!(
+            cpp.blocks.base_classes[2],
             "::rust::cxxqtlib1::CxxQtLocking"
         );
         assert_eq!(cpp.blocks.metaobjects.len(), 0);

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -27,8 +27,6 @@ pub struct GeneratedCppQObjectBlocks {
     pub private_methods: Vec<CppFragment>,
     /// List of members for the QObject
     pub members: Vec<String>,
-    /// List of deconstructor source
-    pub deconstructors: Vec<String>,
     /// List of includes
     pub includes: BTreeSet<String>,
     /// Base class of the QObject
@@ -42,7 +40,6 @@ impl GeneratedCppQObjectBlocks {
         self.methods.append(&mut other.methods);
         self.private_methods.append(&mut other.private_methods);
         self.members.append(&mut other.members);
-        self.deconstructors.append(&mut other.deconstructors);
         self.includes.append(&mut other.includes);
         self.base_classes.append(&mut other.base_classes);
     }

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -99,6 +99,13 @@ impl GeneratedCppQObject {
             None
         };
 
+        // Build the base class
+        let base_class = qobject
+            .base_class
+            .clone()
+            .unwrap_or_else(|| "QObject".to_string());
+        generated.blocks.base_classes.push(base_class.clone());
+
         // Add the CxxQtType rust and rust_mut methods
         generated
             .blocks
@@ -148,22 +155,13 @@ impl GeneratedCppQObject {
             class_initializers.push(initializer);
         }
 
-        // We need the QObject base class to be first which is added last
-        generated.blocks.base_classes.reverse();
-
         generated.blocks.append(&mut constructor::generate(
             &generated,
             &qobject.constructors,
-            qobject
-                .base_class
-                .clone()
-                .unwrap_or_else(|| "QObject".to_string()),
+            base_class,
             &class_initializers,
             cxx_mappings,
         )?);
-
-        // We need the QObject base class to be first which is added last
-        generated.blocks.base_classes.reverse();
 
         Ok(generated)
     }

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -23,13 +23,20 @@ pub use syn::{Error, Result};
 pub fn write_headers(directory: impl AsRef<Path>) {
     let directory = directory.as_ref();
     std::fs::create_dir_all(directory).expect("Could not create cxx-qt-gen header directory");
-    let (file_contents, file_name) = (include_str!("../include/cxxqt_thread.h"), "cxxqt_thread.h");
-    // Note that we do not need rerun-if-changed for these files
-    // as include_str causes a rerun when the header changes
-    // and the files are always written to the target.
-    let h_path = format!("{}/{file_name}", directory.display());
-    let mut header = File::create(h_path).expect("Could not create cxx-qt-gen header");
-    write!(header, "{file_contents}").expect("Could not write cxx-qt-gen header");
+    for (file_contents, file_name) in [
+        (
+            include_str!("../include/cxxqt_locking.h"),
+            "cxxqt_locking.h",
+        ),
+        (include_str!("../include/cxxqt_thread.h"), "cxxqt_thread.h"),
+    ] {
+        // Note that we do not need rerun-if-changed for these files
+        // as include_str causes a rerun when the header changes
+        // and the files are always written to the target.
+        let h_path = format!("{}/{file_name}", directory.display());
+        let mut header = File::create(h_path).expect("Could not create cxx-qt-gen header");
+        write!(header, "{file_contents}").expect("Could not write cxx-qt-gen header");
+    }
 }
 
 #[cfg(test)]

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -29,6 +29,7 @@ pub fn write_headers(directory: impl AsRef<Path>) {
             "cxxqt_locking.h",
         ),
         (include_str!("../include/cxxqt_thread.h"), "cxxqt_thread.h"),
+        (include_str!("../include/cxxqt_type.h"), "cxxqt_type.h"),
     ] {
         // Note that we do not need rerun-if-changed for these files
         // as include_str causes a rerun when the header changes

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -29,6 +29,10 @@ pub fn write_headers(directory: impl AsRef<Path>) {
             "cxxqt_locking.h",
         ),
         (include_str!("../include/cxxqt_thread.h"), "cxxqt_thread.h"),
+        (
+            include_str!("../include/cxxqt_threading.h"),
+            "cxxqt_threading.h",
+        ),
         (include_str!("../include/cxxqt_type.h"), "cxxqt_type.h"),
     ] {
         // Note that we do not need rerun-if-changed for these files

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -69,7 +69,7 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
     generated.qobjects.iter().map(|qobject| {
         formatdoc! { r#"
             {namespace_start}
-            class {ident} : public {base_class}
+            class {ident} : {base_classes}
             {{
               Q_OBJECT
               {metaobjects}
@@ -90,7 +90,7 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
         ident = qobject.ident,
         namespace_start = namespace_start,
         namespace_end = namespace_end,
-        base_class = qobject.base_class,
+        base_classes = qobject.blocks.base_classes.iter().map(|base| format!("public {}", base)).collect::<Vec<String>>().join(", "),
         metaobjects = qobject.blocks.metaobjects.join("\n  "),
         public_methods = create_block("public", &qobject.blocks.methods.iter().filter_map(pair_as_header).collect::<Vec<String>>()),
         private_methods = create_block("private", &qobject.blocks.private_methods.iter().filter_map(pair_as_header).collect::<Vec<String>>()),

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -77,7 +77,7 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
               {metaobjects}
 
             public:
-              ~{ident}();
+              virtual ~{ident}() = default;
 
             {public_methods}
             {private_methods}

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -40,6 +40,8 @@ fn create_block(block: &str, items: &[String]) -> String {
 }
 
 /// For a given GeneratedCppBlocks write the forward declare
+//
+// Note that this is needed incase ObjectA refers to ObjectB in it's class
 fn forward_declare(generated: &GeneratedCppBlocks) -> Vec<String> {
     let (namespace_start, namespace_end) = namespace_pair(generated);
 
@@ -112,11 +114,6 @@ pub fn write_cpp_header(generated: &GeneratedCppBlocks) -> String {
         #pragma once
 
         {includes}
-
-        namespace rust::cxxqtlib1 {{
-        template<typename T>
-        class CxxQtThread;
-        }}
 
         {forward_declare}
         #include "cxx-qt-gen/{cxx_file_stem}.cxx.h"

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -81,7 +81,6 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
 
             {public_methods}
             {private_methods}
-            {private_members}
             }};
 
             static_assert(::std::is_base_of<QObject, {ident}>::value, "{ident} must inherit from QObject");
@@ -96,7 +95,6 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
         metaobjects = qobject.blocks.metaobjects.join("\n  "),
         public_methods = create_block("public", &qobject.blocks.methods.iter().filter_map(pair_as_header).collect::<Vec<String>>()),
         private_methods = create_block("private", &qobject.blocks.private_methods.iter().filter_map(pair_as_header).collect::<Vec<String>>()),
-        private_members = create_block("private", &qobject.blocks.members),
         metatype = if generated.namespace.is_empty() {
             qobject.ident.clone()
         } else {

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -63,11 +63,11 @@ mod tests {
                     ident: "MyObject".to_owned(),
                     rust_ident: "MyObjectRust".to_owned(),
                     namespace_internals: "cxx_qt::my_object::cxx_qt_my_object".to_owned(),
-                    base_class: "QStringListModel".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
                         deconstructors: vec![],
                         forward_declares: vec![],
                         members: vec![],
+                        base_classes: vec!["QStringListModel".to_owned()],
                         includes: {
                           let mut includes = BTreeSet::<String>::default();
                           includes.insert("#include <test>".to_owned());
@@ -185,11 +185,11 @@ mod tests {
                     ident: "FirstObject".to_owned(),
                     rust_ident: "FirstObjectRust".to_owned(),
                     namespace_internals: "cxx_qt::cxx_qt_first_object".to_owned(),
-                    base_class: "QStringListModel".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
                         deconstructors: vec![],
                         forward_declares: vec![],
                         members: vec![],
+                        base_classes: vec!["QStringListModel".to_owned()],
                         includes: {
                           let mut includes = BTreeSet::<String>::default();
                           includes.insert("#include <test>".to_owned());
@@ -230,11 +230,11 @@ mod tests {
                     ident: "SecondObject".to_owned(),
                     rust_ident: "SecondObjectRust".to_owned(),
                     namespace_internals: "cxx_qt::cxx_qt_second_object".to_owned(),
-                    base_class: "QStringListModel".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
                         deconstructors: vec![],
                         forward_declares: vec![],
                         members: vec![],
+                        base_classes: vec!["QStringListModel".to_owned()],
                         includes: {
                           let mut includes = BTreeSet::<String>::default();
                           includes.insert("#include <test>".to_owned());

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -298,11 +298,6 @@ mod tests {
 
         #include <test>
 
-        namespace rust::cxxqtlib1 {
-        template<typename T>
-        class CxxQtThread;
-        }
-
         namespace cxx_qt::my_object {
         class MyObject;
 
@@ -351,11 +346,6 @@ mod tests {
         #pragma once
 
         #include <test>
-
-        namespace rust::cxxqtlib1 {
-        template<typename T>
-        class CxxQtThread;
-        }
 
         namespace cxx_qt {
         class FirstObject;
@@ -426,11 +416,6 @@ mod tests {
         #pragma once
 
         #include <test>
-
-        namespace rust::cxxqtlib1 {
-        template<typename T>
-        class CxxQtThread;
-        }
 
 
         class MyObject;

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -65,7 +65,6 @@ mod tests {
                     namespace_internals: "cxx_qt::my_object::cxx_qt_my_object".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
                         forward_declares: vec![],
-                        members: vec![],
                         base_classes: vec!["QStringListModel".to_owned()],
                         includes: {
                           let mut includes = BTreeSet::<String>::default();
@@ -186,7 +185,6 @@ mod tests {
                     namespace_internals: "cxx_qt::cxx_qt_first_object".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
                         forward_declares: vec![],
-                        members: vec![],
                         base_classes: vec!["QStringListModel".to_owned()],
                         includes: {
                           let mut includes = BTreeSet::<String>::default();
@@ -230,7 +228,6 @@ mod tests {
                     namespace_internals: "cxx_qt::cxx_qt_second_object".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
                         forward_declares: vec![],
-                        members: vec![],
                         base_classes: vec!["QStringListModel".to_owned()],
                         includes: {
                           let mut includes = BTreeSet::<String>::default();
@@ -326,7 +323,6 @@ mod tests {
           void privateMethod() const;
           void privateMethod();
 
-
         };
 
         static_assert(::std::is_base_of<QObject, MyObject>::value, "MyObject must inherit from QObject");
@@ -371,7 +367,6 @@ mod tests {
           Q_SIGNAL void countChanged();
 
 
-
         };
 
         static_assert(::std::is_base_of<QObject, FirstObject>::value, "FirstObject must inherit from QObject");
@@ -395,7 +390,6 @@ mod tests {
 
         private:
           void privateMethod() const;
-
 
         };
 
@@ -444,7 +438,6 @@ mod tests {
         private:
           void privateMethod() const;
           void privateMethod();
-
 
         };
 

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -64,7 +64,6 @@ mod tests {
                     rust_ident: "MyObjectRust".to_owned(),
                     namespace_internals: "cxx_qt::my_object::cxx_qt_my_object".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
-                        deconstructors: vec![],
                         forward_declares: vec![],
                         members: vec![],
                         base_classes: vec!["QStringListModel".to_owned()],
@@ -186,7 +185,6 @@ mod tests {
                     rust_ident: "FirstObjectRust".to_owned(),
                     namespace_internals: "cxx_qt::cxx_qt_first_object".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
-                        deconstructors: vec![],
                         forward_declares: vec![],
                         members: vec![],
                         base_classes: vec!["QStringListModel".to_owned()],
@@ -231,7 +229,6 @@ mod tests {
                     rust_ident: "SecondObjectRust".to_owned(),
                     namespace_internals: "cxx_qt::cxx_qt_second_object".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
-                        deconstructors: vec![],
                         forward_declares: vec![],
                         members: vec![],
                         base_classes: vec!["QStringListModel".to_owned()],
@@ -313,7 +310,7 @@ mod tests {
           Q_PROPERTY(bool longPropertyNameThatWrapsInClangFormat READ getToggle WRITE setToggle NOTIFY toggleChanged)
 
         public:
-          ~MyObject();
+          virtual ~MyObject() = default;
 
         public:
           int count() const;
@@ -366,7 +363,7 @@ mod tests {
           Q_PROPERTY(int longPropertyNameThatWrapsInClangFormat READ count WRITE setCount NOTIFY countChanged)
 
         public:
-          ~FirstObject();
+          virtual ~FirstObject() = default;
 
         public:
           int count() const;
@@ -389,7 +386,7 @@ mod tests {
           Q_PROPERTY(int count READ count WRITE setCount NOTIFY countChanged)
 
         public:
-          ~SecondObject();
+          virtual ~SecondObject() = default;
 
         public:
           int count() const;
@@ -432,7 +429,7 @@ mod tests {
           Q_PROPERTY(bool longPropertyNameThatWrapsInClangFormat READ getToggle WRITE setToggle NOTIFY toggleChanged)
 
         public:
-          ~MyObject();
+          virtual ~MyObject() = default;
 
         public:
           int count() const;
@@ -465,11 +462,6 @@ mod tests {
         #include "cxx-qt-gen/cxx_file_stem.cxxqt.h"
 
         namespace cxx_qt::my_object {
-
-        MyObject::~MyObject()
-        {
-
-        }
 
         int
         MyObject::count() const
@@ -528,11 +520,6 @@ mod tests {
 
         namespace cxx_qt {
 
-        FirstObject::~FirstObject()
-        {
-
-        }
-
         int
         FirstObject::count() const
         {
@@ -548,11 +535,6 @@ mod tests {
         } // namespace cxx_qt
 
         namespace cxx_qt {
-
-        SecondObject::~SecondObject()
-        {
-
-        }
 
         int
         SecondObject::count() const
@@ -581,11 +563,6 @@ mod tests {
         #include "cxx-qt-gen/cxx_file_stem.cxxqt.h"
 
 
-
-        MyObject::~MyObject()
-        {
-
-        }
 
         int
         MyObject::count() const

--- a/crates/cxx-qt-gen/src/writer/cpp/source.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/source.rs
@@ -24,19 +24,12 @@ fn qobjects_source(generated: &GeneratedCppBlocks) -> Vec<String> {
         formatdoc! { r#"
             {namespace_start}
 
-            {ident}::~{ident}()
-            {{
-            {deconstructors}
-            }}
-
             {methods}
             {namespace_end}
         "#,
-        ident = qobject.ident,
         namespace_start = namespace_start,
         namespace_end = namespace_end,
         methods = qobject.blocks.methods.iter().chain(qobject.blocks.private_methods.iter()).filter_map(pair_as_source).collect::<Vec<String>>().join("\n"),
-        deconstructors = qobject.blocks.deconstructors.join("\n  "),
         }
   }).collect::<Vec<String>>()
 }

--- a/crates/cxx-qt-gen/test_outputs/inheritance.cpp
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.cpp
@@ -1,7 +1,5 @@
 #include "cxx-qt-gen/inheritance.cxxqt.h"
 
-MyObject::~MyObject() {}
-
 QVariant
 MyObject::data(QModelIndex const& _index, ::std::int32_t _role) const
 {

--- a/crates/cxx-qt-gen/test_outputs/inheritance.cpp
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.cpp
@@ -31,12 +31,5 @@ MyObject::hasChildren(QModelIndex const& _parent) const
 MyObject::MyObject(QObject* parent)
   : QAbstractItemModel(parent)
   , m_rustObj(::cxx_qt_my_object::createRs())
-  , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
 {
-}
-
-::std::lock_guard<::std::recursive_mutex>
-MyObject::unsafeRustLock() const
-{
-  return ::std::lock_guard<::std::recursive_mutex>(*m_rustObjMutex);
 }

--- a/crates/cxx-qt-gen/test_outputs/inheritance.cpp
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.cpp
@@ -19,5 +19,6 @@ MyObject::hasChildren(QModelIndex const& _parent) const
 MyObject::MyObject(QObject* parent)
   : QAbstractItemModel(parent)
   , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(::cxx_qt_my_object::createRs())
+  , ::rust::cxxqtlib1::CxxQtLocking()
 {
 }

--- a/crates/cxx-qt-gen/test_outputs/inheritance.cpp
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.cpp
@@ -2,18 +2,6 @@
 
 MyObject::~MyObject() {}
 
-MyObjectRust const&
-MyObject::unsafeRust() const
-{
-  return *m_rustObj;
-}
-
-MyObjectRust&
-MyObject::unsafeRustMut()
-{
-  return *m_rustObj;
-}
-
 QVariant
 MyObject::data(QModelIndex const& _index, ::std::int32_t _role) const
 {
@@ -30,6 +18,6 @@ MyObject::hasChildren(QModelIndex const& _parent) const
 
 MyObject::MyObject(QObject* parent)
   : QAbstractItemModel(parent)
-  , m_rustObj(::cxx_qt_my_object::createRs())
+  , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(::cxx_qt_my_object::createRs())
 {
 }

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -15,7 +15,7 @@ class MyObject
   Q_OBJECT
 
 public:
-  ~MyObject();
+  virtual ~MyObject() = default;
 
 public:
   Q_INVOKABLE QVariant data(QModelIndex const& _index,

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cxx-qt-common/cxxqt_locking.h>
-#include <memory>
+#include <cxx-qt-common/cxxqt_type.h>
 
 namespace rust::cxxqtlib1 {
 template<typename T>
@@ -14,6 +14,7 @@ class MyObject;
 
 class MyObject
   : public QAbstractItemModel
+  , public ::rust::cxxqtlib1::CxxQtType<MyObjectRust>
   , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
@@ -22,9 +23,6 @@ public:
   ~MyObject();
 
 public:
-  MyObjectRust const& unsafeRust() const;
-  MyObjectRust& unsafeRustMut();
-
   Q_INVOKABLE QVariant data(QModelIndex const& _index,
                             ::std::int32_t _role) const override;
   Q_INVOKABLE bool hasChildren(QModelIndex const& _parent) const override;
@@ -44,9 +42,6 @@ private:
   QVariant dataWrapper(QModelIndex const& _index,
                        ::std::int32_t _role) const noexcept;
   bool hasChildrenWrapper(QModelIndex const& _parent) const noexcept;
-
-private:
-  ::rust::Box<MyObjectRust> m_rustObj;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -3,11 +3,6 @@
 #include <cxx-qt-common/cxxqt_locking.h>
 #include <cxx-qt-common/cxxqt_type.h>
 
-namespace rust::cxxqtlib1 {
-template<typename T>
-class CxxQtThread;
-}
-
 class MyObject;
 
 #include "cxx-qt-gen/inheritance.cxx.h"

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <cxx-qt-common/cxxqt_locking.h>
 #include <memory>
-#include <mutex>
 
 namespace rust::cxxqtlib1 {
 template<typename T>
@@ -12,7 +12,9 @@ class MyObject;
 
 #include "cxx-qt-gen/inheritance.cxx.h"
 
-class MyObject : public QAbstractItemModel
+class MyObject
+  : public QAbstractItemModel
+  , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
 
@@ -42,12 +44,9 @@ private:
   QVariant dataWrapper(QModelIndex const& _index,
                        ::std::int32_t _role) const noexcept;
   bool hasChildrenWrapper(QModelIndex const& _parent) const noexcept;
-  [[nodiscard]] ::std::lock_guard<::std::recursive_mutex> unsafeRustLock()
-    const;
 
 private:
   ::rust::Box<MyObjectRust> m_rustObj;
-  ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -2,11 +2,7 @@
 
 namespace cxx_qt::my_object {
 
-MyObject::~MyObject()
-{
-  const auto guard = ::std::unique_lock(m_cxxQtThreadObj->mutex);
-  m_cxxQtThreadObj->ptr = nullptr;
-}
+MyObject::~MyObject() {}
 
 void
 MyObject::cppMethod() const
@@ -92,12 +88,6 @@ static_assert(alignof(MyObjectCxxQtThread) <= alignof(::std::size_t),
 static_assert(sizeof(MyObjectCxxQtThread) == sizeof(::std::size_t[4]),
               "unexpected size");
 
-MyObjectCxxQtThread
-MyObject::qtThread() const
-{
-  return MyObjectCxxQtThread(m_cxxQtThreadObj, m_rustObjMutex);
-}
-
 MyObject::MyObject(::std::int32_t arg0, QString const& arg1)
   : MyObject(
       ::cxx_qt::my_object::cxx_qt_my_object::routeArguments0(::std::move(arg0),
@@ -115,9 +105,7 @@ MyObject::MyObject(
   : QObject(::std::move(args.base.arg0))
   , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
       ::cxx_qt::my_object::cxx_qt_my_object::newRs0(::std::move(args.new_)))
-  , m_cxxQtThreadObj(
-      ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(
-        this))
+  , ::rust::cxxqtlib1::CxxQtThreading<MyObject>(this)
 {
   ::cxx_qt::my_object::cxx_qt_my_object::initialize0(
     *this, ::std::move(args.initialize));
@@ -128,9 +116,7 @@ MyObject::MyObject(
   : QObject()
   , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
       ::cxx_qt::my_object::cxx_qt_my_object::newRs1(::std::move(args.new_)))
-  , m_cxxQtThreadObj(
-      ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(
-        this))
+  , ::rust::cxxqtlib1::CxxQtThreading<MyObject>(this)
 {
   ::cxx_qt::my_object::cxx_qt_my_object::initialize1(
     *this, ::std::move(args.initialize));

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -122,18 +122,11 @@ MyObject::MyObject()
 {
 }
 
-::std::lock_guard<::std::recursive_mutex>
-MyObject::unsafeRustLock() const
-{
-  return ::std::lock_guard<::std::recursive_mutex>(*m_rustObjMutex);
-}
-
 MyObject::MyObject(
   ::cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments0&& args)
   : QObject(::std::move(args.base.arg0))
   , m_rustObj(
       ::cxx_qt::my_object::cxx_qt_my_object::newRs0(::std::move(args.new_)))
-  , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
   , m_cxxQtThreadObj(
       ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(
         this))
@@ -147,7 +140,6 @@ MyObject::MyObject(
   : QObject()
   , m_rustObj(
       ::cxx_qt::my_object::cxx_qt_my_object::newRs1(::std::move(args.new_)))
-  , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
   , m_cxxQtThreadObj(
       ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(
         this))

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -8,18 +8,6 @@ MyObject::~MyObject()
   m_cxxQtThreadObj->ptr = nullptr;
 }
 
-MyObjectRust const&
-MyObject::unsafeRust() const
-{
-  return *m_rustObj;
-}
-
-MyObjectRust&
-MyObject::unsafeRustMut()
-{
-  return *m_rustObj;
-}
-
 void
 MyObject::cppMethod() const
 {
@@ -125,7 +113,7 @@ MyObject::MyObject()
 MyObject::MyObject(
   ::cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments0&& args)
   : QObject(::std::move(args.base.arg0))
-  , m_rustObj(
+  , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
       ::cxx_qt::my_object::cxx_qt_my_object::newRs0(::std::move(args.new_)))
   , m_cxxQtThreadObj(
       ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(
@@ -138,7 +126,7 @@ MyObject::MyObject(
 MyObject::MyObject(
   ::cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments1&& args)
   : QObject()
-  , m_rustObj(
+  , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
       ::cxx_qt::my_object::cxx_qt_my_object::newRs1(::std::move(args.new_)))
   , m_cxxQtThreadObj(
       ::std::make_shared<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>(

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -2,8 +2,6 @@
 
 namespace cxx_qt::my_object {
 
-MyObject::~MyObject() {}
-
 void
 MyObject::cppMethod() const
 {

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -19,7 +19,7 @@ class MyObject
   Q_OBJECT
 
 public:
-  ~MyObject();
+  virtual ~MyObject() = default;
 
 public:
   void cppMethod() const;

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <cxx-qt-common/cxxqt_locking.h>
 #include <memory>
-#include <mutex>
 
 namespace rust::cxxqtlib1 {
 template<typename T>
@@ -16,7 +16,9 @@ using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;
 #include "cxx-qt-gen/ffi.cxx.h"
 
 namespace cxx_qt::my_object {
-class MyObject : public QObject
+class MyObject
+  : public QObject
+  , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
 
@@ -58,8 +60,6 @@ private:
   void invokableVirtualWrapper() const noexcept;
   void invokableResultTupleWrapper() const;
   ::rust::String invokableResultTypeWrapper() const;
-  [[nodiscard]] ::std::lock_guard<::std::recursive_mutex> unsafeRustLock()
-    const;
   explicit MyObject(
     ::cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments0&& args);
   explicit MyObject(
@@ -67,7 +67,6 @@ private:
 
 private:
   ::rust::Box<MyObjectRust> m_rustObj;
-  ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
   ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
     m_cxxQtThreadObj;
 };

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cxx-qt-common/cxxqt_locking.h>
+#include <cxx-qt-common/cxxqt_threading.h>
 #include <cxx-qt-common/cxxqt_type.h>
 
 namespace rust::cxxqtlib1 {
@@ -19,7 +19,7 @@ namespace cxx_qt::my_object {
 class MyObject
   : public QObject
   , public ::rust::cxxqtlib1::CxxQtType<MyObjectRust>
-  , public ::rust::cxxqtlib1::CxxQtLocking
+  , public ::rust::cxxqtlib1::CxxQtThreading<MyObject>
 {
   Q_OBJECT
 
@@ -40,7 +40,6 @@ public:
   Q_INVOKABLE virtual void invokableVirtual() const;
   Q_INVOKABLE void invokableResultTuple() const;
   Q_INVOKABLE ::rust::String invokableResultType() const;
-  MyObjectCxxQtThread qtThread() const;
   explicit MyObject(::std::int32_t arg0, QString const& arg1);
   explicit MyObject();
 
@@ -62,10 +61,6 @@ private:
     ::cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments0&& args);
   explicit MyObject(
     ::cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments1&& args);
-
-private:
-  ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
-    m_cxxQtThreadObj;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -3,11 +3,6 @@
 #include <cxx-qt-common/cxxqt_threading.h>
 #include <cxx-qt-common/cxxqt_type.h>
 
-namespace rust::cxxqtlib1 {
-template<typename T>
-class CxxQtThread;
-}
-
 namespace cxx_qt::my_object {
 class MyObject;
 using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cxx-qt-common/cxxqt_locking.h>
-#include <memory>
+#include <cxx-qt-common/cxxqt_type.h>
 
 namespace rust::cxxqtlib1 {
 template<typename T>
@@ -18,6 +18,7 @@ using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;
 namespace cxx_qt::my_object {
 class MyObject
   : public QObject
+  , public ::rust::cxxqtlib1::CxxQtType<MyObjectRust>
   , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
@@ -26,9 +27,6 @@ public:
   ~MyObject();
 
 public:
-  MyObjectRust const& unsafeRust() const;
-  MyObjectRust& unsafeRustMut();
-
   void cppMethod() const;
   Q_INVOKABLE void invokable() const;
   Q_INVOKABLE void invokableMutable();
@@ -66,7 +64,6 @@ private:
     ::cxx_qt::my_object::cxx_qt_my_object::CxxQtConstructorArguments1&& args);
 
 private:
-  ::rust::Box<MyObjectRust> m_rustObj;
   ::std::shared_ptr<::rust::cxxqtlib1::CxxQtGuardedPointer<MyObject>>
     m_cxxQtThreadObj;
 };

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -59,6 +59,7 @@ MyObject::MyObject(QObject* parent)
   : QStringListModel(parent)
   , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
       ::cxx_qt::multi_object::cxx_qt_my_object::createRs())
+  , ::rust::cxxqtlib1::CxxQtLocking()
 {
 }
 

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -70,14 +70,7 @@ MyObject::readyConnect(::rust::Fn<void(MyObject&)> func,
 MyObject::MyObject(QObject* parent)
   : QStringListModel(parent)
   , m_rustObj(::cxx_qt::multi_object::cxx_qt_my_object::createRs())
-  , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
 {
-}
-
-::std::lock_guard<::std::recursive_mutex>
-MyObject::unsafeRustLock() const
-{
-  return ::std::lock_guard<::std::recursive_mutex>(*m_rustObjMutex);
 }
 
 } // namespace cxx_qt::multi_object

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -4,18 +4,6 @@ namespace cxx_qt::multi_object {
 
 MyObject::~MyObject() {}
 
-MyObjectRust const&
-MyObject::unsafeRust() const
-{
-  return *m_rustObj;
-}
-
-MyObjectRust&
-MyObject::unsafeRustMut()
-{
-  return *m_rustObj;
-}
-
 ::std::int32_t const&
 MyObject::getPropertyName() const
 {
@@ -69,7 +57,8 @@ MyObject::readyConnect(::rust::Fn<void(MyObject&)> func,
 
 MyObject::MyObject(QObject* parent)
   : QStringListModel(parent)
-  , m_rustObj(::cxx_qt::multi_object::cxx_qt_my_object::createRs())
+  , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
+      ::cxx_qt::multi_object::cxx_qt_my_object::createRs())
 {
 }
 
@@ -78,18 +67,6 @@ MyObject::MyObject(QObject* parent)
 namespace cxx_qt::multi_object {
 
 SecondObject::~SecondObject() {}
-
-SecondObjectRust const&
-SecondObject::unsafeRust() const
-{
-  return *m_rustObj;
-}
-
-SecondObjectRust&
-SecondObject::unsafeRustMut()
-{
-  return *m_rustObj;
-}
 
 ::std::int32_t const&
 SecondObject::getPropertyName() const
@@ -138,7 +115,8 @@ SecondObject::readyConnect(::rust::Fn<void(SecondObject&)> func,
 
 SecondObject::SecondObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(::cxx_qt::multi_object::cxx_qt_second_object::createRs())
+  , ::rust::cxxqtlib1::CxxQtType<SecondObjectRust>(
+      ::cxx_qt::multi_object::cxx_qt_second_object::createRs())
 {
 }
 

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -2,8 +2,6 @@
 
 namespace cxx_qt::multi_object {
 
-MyObject::~MyObject() {}
-
 ::std::int32_t const&
 MyObject::getPropertyName() const
 {
@@ -66,8 +64,6 @@ MyObject::MyObject(QObject* parent)
 } // namespace cxx_qt::multi_object
 
 namespace cxx_qt::multi_object {
-
-SecondObject::~SecondObject() {}
 
 ::std::int32_t const&
 SecondObject::getPropertyName() const

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -26,7 +26,7 @@ class MyObject
                setPropertyName NOTIFY propertyNameChanged)
 
 public:
-  ~MyObject();
+  virtual ~MyObject() = default;
 
 public:
   ::std::int32_t const& getPropertyName() const;
@@ -63,7 +63,7 @@ class SecondObject
                setPropertyName NOTIFY propertyNameChanged)
 
 public:
-  ~SecondObject();
+  virtual ~SecondObject() = default;
 
 public:
   ::std::int32_t const& getPropertyName() const;

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cxx-qt-common/cxxqt_locking.h>
-#include <memory>
+#include <cxx-qt-common/cxxqt_type.h>
 
 namespace rust::cxxqtlib1 {
 template<typename T>
@@ -23,6 +23,7 @@ class SecondObject;
 namespace cxx_qt::multi_object {
 class MyObject
   : public QStringListModel
+  , public ::rust::cxxqtlib1::CxxQtType<MyObjectRust>
   , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
@@ -33,9 +34,6 @@ public:
   ~MyObject();
 
 public:
-  MyObjectRust const& unsafeRust() const;
-  MyObjectRust& unsafeRustMut();
-
   ::std::int32_t const& getPropertyName() const;
   Q_SLOT void setPropertyName(::std::int32_t const& value);
   Q_SIGNAL void propertyNameChanged();
@@ -52,9 +50,6 @@ private:
   ::std::int32_t const& getPropertyNameWrapper() const noexcept;
   void setPropertyNameWrapper(::std::int32_t value) noexcept;
   void invokableNameWrapper() noexcept;
-
-private:
-  ::rust::Box<MyObjectRust> m_rustObj;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,
@@ -64,7 +59,9 @@ static_assert(::std::is_base_of<QObject, MyObject>::value,
 Q_DECLARE_METATYPE(cxx_qt::multi_object::MyObject*)
 
 namespace cxx_qt::multi_object {
-class SecondObject : public QObject
+class SecondObject
+  : public QObject
+  , public ::rust::cxxqtlib1::CxxQtType<SecondObjectRust>
 {
   Q_OBJECT
   Q_PROPERTY(::std::int32_t propertyName READ getPropertyName WRITE
@@ -74,9 +71,6 @@ public:
   ~SecondObject();
 
 public:
-  SecondObjectRust const& unsafeRust() const;
-  SecondObjectRust& unsafeRustMut();
-
   ::std::int32_t const& getPropertyName() const;
   Q_SLOT void setPropertyName(::std::int32_t const& value);
   Q_SIGNAL void propertyNameChanged();
@@ -93,9 +87,6 @@ private:
   ::std::int32_t const& getPropertyNameWrapper() const noexcept;
   void setPropertyNameWrapper(::std::int32_t value) noexcept;
   void invokableNameWrapper() noexcept;
-
-private:
-  ::rust::Box<SecondObjectRust> m_rustObj;
 };
 
 static_assert(::std::is_base_of<QObject, SecondObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <cxx-qt-common/cxxqt_locking.h>
 #include <memory>
-#include <mutex>
 
 namespace rust::cxxqtlib1 {
 template<typename T>
@@ -21,7 +21,9 @@ class SecondObject;
 #include "cxx-qt-gen/multi_object.cxx.h"
 
 namespace cxx_qt::multi_object {
-class MyObject : public QStringListModel
+class MyObject
+  : public QStringListModel
+  , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
   Q_PROPERTY(::std::int32_t propertyName READ getPropertyName WRITE
@@ -50,12 +52,9 @@ private:
   ::std::int32_t const& getPropertyNameWrapper() const noexcept;
   void setPropertyNameWrapper(::std::int32_t value) noexcept;
   void invokableNameWrapper() noexcept;
-  [[nodiscard]] ::std::lock_guard<::std::recursive_mutex> unsafeRustLock()
-    const;
 
 private:
   ::rust::Box<MyObjectRust> m_rustObj;
-  ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -3,11 +3,6 @@
 #include <cxx-qt-common/cxxqt_locking.h>
 #include <cxx-qt-common/cxxqt_type.h>
 
-namespace rust::cxxqtlib1 {
-template<typename T>
-class CxxQtThread;
-}
-
 namespace cxx_qt::multi_object {
 class MyObject;
 

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -66,6 +66,7 @@ MyObject::MyObject(QObject* parent)
   : QObject(parent)
   , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
       ::cxx_qt::my_object::cxx_qt_my_object::createRs())
+  , ::rust::cxxqtlib1::CxxQtLocking()
 {
 }
 

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -2,8 +2,6 @@
 
 namespace cxx_qt::my_object {
 
-MyObject::~MyObject() {}
-
 ::std::int32_t const&
 MyObject::getPrimitive() const
 {

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -77,14 +77,7 @@ MyObject::trivialChangedConnect(::rust::Fn<void(MyObject&)> func,
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
   , m_rustObj(::cxx_qt::my_object::cxx_qt_my_object::createRs())
-  , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
 {
-}
-
-::std::lock_guard<::std::recursive_mutex>
-MyObject::unsafeRustLock() const
-{
-  return ::std::lock_guard<::std::recursive_mutex>(*m_rustObjMutex);
 }
 
 } // namespace cxx_qt::my_object

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -4,18 +4,6 @@ namespace cxx_qt::my_object {
 
 MyObject::~MyObject() {}
 
-MyObjectRust const&
-MyObject::unsafeRust() const
-{
-  return *m_rustObj;
-}
-
-MyObjectRust&
-MyObject::unsafeRustMut()
-{
-  return *m_rustObj;
-}
-
 ::std::int32_t const&
 MyObject::getPrimitive() const
 {
@@ -76,7 +64,8 @@ MyObject::trivialChangedConnect(::rust::Fn<void(MyObject&)> func,
 
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(::cxx_qt::my_object::cxx_qt_my_object::createRs())
+  , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
+      ::cxx_qt::my_object::cxx_qt_my_object::createRs())
 {
 }
 

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -23,7 +23,7 @@ class MyObject
     QPoint trivial READ getTrivial WRITE setTrivial NOTIFY trivialChanged)
 
 public:
-  ~MyObject();
+  virtual ~MyObject() = default;
 
 public:
   ::std::int32_t const& getPrimitive() const;

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -3,11 +3,6 @@
 #include <cxx-qt-common/cxxqt_locking.h>
 #include <cxx-qt-common/cxxqt_type.h>
 
-namespace rust::cxxqtlib1 {
-template<typename T>
-class CxxQtThread;
-}
-
 namespace cxx_qt::my_object {
 class MyObject;
 

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cxx-qt-common/cxxqt_locking.h>
-#include <memory>
+#include <cxx-qt-common/cxxqt_type.h>
 
 namespace rust::cxxqtlib1 {
 template<typename T>
@@ -18,6 +18,7 @@ class MyObject;
 namespace cxx_qt::my_object {
 class MyObject
   : public QObject
+  , public ::rust::cxxqtlib1::CxxQtType<MyObjectRust>
   , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
@@ -30,9 +31,6 @@ public:
   ~MyObject();
 
 public:
-  MyObjectRust const& unsafeRust() const;
-  MyObjectRust& unsafeRustMut();
-
   ::std::int32_t const& getPrimitive() const;
   Q_SLOT void setPrimitive(::std::int32_t const& value);
   QPoint const& getTrivial() const;
@@ -52,9 +50,6 @@ private:
   void setPrimitiveWrapper(::std::int32_t value) noexcept;
   QPoint const& getTrivialWrapper() const noexcept;
   void setTrivialWrapper(QPoint value) noexcept;
-
-private:
-  ::rust::Box<MyObjectRust> m_rustObj;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <cxx-qt-common/cxxqt_locking.h>
 #include <memory>
-#include <mutex>
 
 namespace rust::cxxqtlib1 {
 template<typename T>
@@ -16,7 +16,9 @@ class MyObject;
 #include "cxx-qt-gen/ffi.cxx.h"
 
 namespace cxx_qt::my_object {
-class MyObject : public QObject
+class MyObject
+  : public QObject
+  , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
   Q_PROPERTY(::std::int32_t primitive READ getPrimitive WRITE setPrimitive
@@ -50,12 +52,9 @@ private:
   void setPrimitiveWrapper(::std::int32_t value) noexcept;
   QPoint const& getTrivialWrapper() const noexcept;
   void setTrivialWrapper(QPoint value) noexcept;
-  [[nodiscard]] ::std::lock_guard<::std::recursive_mutex> unsafeRustLock()
-    const;
 
 private:
   ::rust::Box<MyObjectRust> m_rustObj;
-  ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -82,6 +82,7 @@ MyObject::MyObject(QObject* parent)
   : QObject(parent)
   , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
       ::cxx_qt::my_object::cxx_qt_my_object::createRs())
+  , ::rust::cxxqtlib1::CxxQtLocking()
 {
 }
 

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -2,8 +2,6 @@
 
 namespace cxx_qt::my_object {
 
-MyObject::~MyObject() {}
-
 void
 MyObject::invokable()
 {

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -4,18 +4,6 @@ namespace cxx_qt::my_object {
 
 MyObject::~MyObject() {}
 
-MyObjectRust const&
-MyObject::unsafeRust() const
-{
-  return *m_rustObj;
-}
-
-MyObjectRust&
-MyObject::unsafeRustMut()
-{
-  return *m_rustObj;
-}
-
 void
 MyObject::invokable()
 {
@@ -92,7 +80,8 @@ MyObject::newDataConnect(::rust::Fn<void(MyObject&,
 
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
-  , m_rustObj(::cxx_qt::my_object::cxx_qt_my_object::createRs())
+  , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
+      ::cxx_qt::my_object::cxx_qt_my_object::createRs())
 {
 }
 

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -93,14 +93,7 @@ MyObject::newDataConnect(::rust::Fn<void(MyObject&,
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
   , m_rustObj(::cxx_qt::my_object::cxx_qt_my_object::createRs())
-  , m_rustObjMutex(::std::make_shared<::std::recursive_mutex>())
 {
-}
-
-::std::lock_guard<::std::recursive_mutex>
-MyObject::unsafeRustLock() const
-{
-  return ::std::lock_guard<::std::recursive_mutex>(*m_rustObjMutex);
 }
 
 } // namespace cxx_qt::my_object

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cxx-qt-common/cxxqt_locking.h>
-#include <memory>
+#include <cxx-qt-common/cxxqt_type.h>
 
 namespace rust::cxxqtlib1 {
 template<typename T>
@@ -18,6 +18,7 @@ class MyObject;
 namespace cxx_qt::my_object {
 class MyObject
   : public QObject
+  , public ::rust::cxxqtlib1::CxxQtType<MyObjectRust>
   , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
@@ -26,9 +27,6 @@ public:
   ~MyObject();
 
 public:
-  MyObjectRust const& unsafeRust() const;
-  MyObjectRust& unsafeRustMut();
-
   Q_INVOKABLE void invokable();
   Q_SIGNAL void ready();
   ::QMetaObject::Connection readyConnect(::rust::Fn<void(MyObject&)> func,
@@ -55,9 +53,6 @@ public:
 
 private:
   void invokableWrapper() noexcept;
-
-private:
-  ::rust::Box<MyObjectRust> m_rustObj;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <cxx-qt-common/cxxqt_locking.h>
 #include <memory>
-#include <mutex>
 
 namespace rust::cxxqtlib1 {
 template<typename T>
@@ -16,7 +16,9 @@ class MyObject;
 #include "cxx-qt-gen/ffi.cxx.h"
 
 namespace cxx_qt::my_object {
-class MyObject : public QObject
+class MyObject
+  : public QObject
+  , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
 
@@ -53,12 +55,9 @@ public:
 
 private:
   void invokableWrapper() noexcept;
-  [[nodiscard]] ::std::lock_guard<::std::recursive_mutex> unsafeRustLock()
-    const;
 
 private:
   ::rust::Box<MyObjectRust> m_rustObj;
-  ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -3,11 +3,6 @@
 #include <cxx-qt-common/cxxqt_locking.h>
 #include <cxx-qt-common/cxxqt_type.h>
 
-namespace rust::cxxqtlib1 {
-template<typename T>
-class CxxQtThread;
-}
-
 namespace cxx_qt::my_object {
 class MyObject;
 

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -19,7 +19,7 @@ class MyObject
   Q_OBJECT
 
 public:
-  ~MyObject();
+  virtual ~MyObject() = default;
 
 public:
   Q_INVOKABLE void invokable();


### PR DESCRIPTION
These mixins in the C++ side then match the traits we have on the Rust side.

This then means as a next phase we can have `MaybeLockGuard<T>` which can lock a given type if it derives from `CxxQtLocking` or do nothing if it doesn't. Which then means we can always put that in the code generation simplifying that further. Which then means for connection generation for signals of external types (like `QPushButton`) we don't need to have different generation for if it's a `CxxQtLocking` object or not :tada:  (expect this in further pull requests).

Related to #577 