### PR TITLE
cxx-qt-gen: add MaybeLockGuard which can optionally lock

### DIFF
--- a/crates/cxx-qt-gen/include/cxxqt_locking.h
+++ b/crates/cxx-qt-gen/include/cxxqt_locking.h
@@ -29,6 +29,10 @@ protected:
   }
 
   ::std::shared_ptr<::std::recursive_mutex> m_rustObjMutex;
+
+  // Friend MaybeLockGuard so that it can use unsafeRustLock()
+  template<typename T, typename D>
+  friend class MaybeLockGuard;
 };
 
 }

--- a/crates/cxx-qt-gen/include/cxxqt_maybelockguard.h
+++ b/crates/cxx-qt-gen/include/cxxqt_maybelockguard.h
@@ -1,0 +1,40 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#pragma once
+
+#include <cxx-qt-common/cxxqt_locking.h>
+#include <memory>
+#include <mutex>
+#include <type_traits>
+
+namespace rust::cxxqtlib1 {
+
+// An empty implementation of MaybeLockGuard
+//
+// This means for types that do not implement CxxQtLocking we do nothing
+template<typename T, typename Derived = void>
+struct MaybeLockGuard
+{
+  MaybeLockGuard(const T&) {}
+};
+
+// Create a lock guard for types that implement CxxQtLocking
+template<typename T>
+struct MaybeLockGuard<T,
+                      ::std::enable_if_t<::std::is_base_of_v<CxxQtLocking, T>>>
+{
+  MaybeLockGuard(const CxxQtLocking& locking)
+    : m_lock(locking.unsafeRustLock())
+  {
+  }
+
+private:
+  ::std::lock_guard<::std::recursive_mutex> m_lock;
+};
+
+}

--- a/crates/cxx-qt-gen/src/generator/cpp/method.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/method.rs
@@ -26,7 +26,7 @@ pub fn generate_cpp_methods(
     invokables: &Vec<ParsedMethod>,
     qobject_idents: &QObjectName,
     cxx_mappings: &ParsedCxxMappings,
-    lock_guard: Option<&str>,
+    lock_guard: &str,
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut generated = GeneratedCppQObjectBlocks::default();
     let qobject_ident = qobject_idents.cpp_class.cpp.to_string();
@@ -117,7 +117,7 @@ pub fn generate_cpp_methods(
                     {return_cxx_ty}
                     {qobject_ident}::{ident}({parameter_types}){is_const}
                     {{
-                        {rust_obj_guard}
+                        {lock_guard}
                         {body};
                     }}
                     "#,
@@ -130,7 +130,6 @@ pub fn generate_cpp_methods(
                 is_const = is_const,
                 parameter_types = parameter_types,
                 qobject_ident = qobject_ident,
-                rust_obj_guard = lock_guard.unwrap_or_default(),
                 body = if return_cxx_ty.is_some() {
                     format!("return {body}", body = body)
                 } else {
@@ -241,7 +240,7 @@ mod tests {
             &invokables,
             &qobject_idents,
             &ParsedCxxMappings::default(),
-            Some("// ::std::lock_guard"),
+            "// ::std::lock_guard",
         )
         .unwrap();
 
@@ -423,7 +422,7 @@ mod tests {
             &invokables,
             &qobject_idents,
             &cxx_mappings,
-            Some("// ::std::lock_guard"),
+            "// ::std::lock_guard",
         )
         .unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/cpp/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/getter.rs
@@ -10,7 +10,7 @@ pub fn generate(
     idents: &QPropertyName,
     qobject_ident: &str,
     cxx_ty: &str,
-    lock_guard: Option<&str>,
+    lock_guard: &str,
 ) -> CppFragment {
     CppFragment::Pair {
         header: format!(
@@ -23,7 +23,7 @@ pub fn generate(
             {return_cxx_ty} const&
             {qobject_ident}::{ident_getter}() const
             {{
-                {rust_obj_guard}
+                {lock_guard}
                 return {ident_getter_wrapper}();
             }}
             "#,
@@ -31,7 +31,6 @@ pub fn generate(
             ident_getter = idents.getter.cpp.to_string(),
             ident_getter_wrapper = idents.getter_wrapper.cpp.to_string(),
             qobject_ident = qobject_ident,
-            rust_obj_guard = lock_guard.unwrap_or_default(),
         ),
     }
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -20,7 +20,7 @@ pub fn generate_cpp_properties(
     properties: &Vec<ParsedQProperty>,
     qobject_idents: &QObjectName,
     cxx_mappings: &ParsedCxxMappings,
-    lock_guard: Option<&str>,
+    lock_guard: &str,
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut generated = GeneratedCppQObjectBlocks::default();
     let mut signals = vec![];
@@ -92,7 +92,7 @@ mod tests {
             &properties,
             &qobject_idents,
             &ParsedCxxMappings::default(),
-            Some("// ::std::lock_guard"),
+            "// ::std::lock_guard",
         )
         .unwrap();
 
@@ -310,7 +310,7 @@ mod tests {
             &properties,
             &qobject_idents,
             &cxx_mapping,
-            Some("// ::std::lock_guard"),
+            "// ::std::lock_guard",
         )
         .unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/cpp/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/setter.rs
@@ -10,7 +10,7 @@ pub fn generate(
     idents: &QPropertyName,
     qobject_ident: &str,
     cxx_ty: &str,
-    lock_guard: Option<&str>,
+    lock_guard: &str,
 ) -> CppFragment {
     CppFragment::Pair {
         header: format!(
@@ -23,7 +23,7 @@ pub fn generate(
             void
             {qobject_ident}::{ident_setter}({cxx_ty} const& value)
             {{
-                {rust_obj_guard}
+                {lock_guard}
                 {ident_setter_wrapper}(value);
             }}
             "#,
@@ -31,7 +31,6 @@ pub fn generate(
             ident_setter = idents.setter.cpp,
             ident_setter_wrapper = idents.setter_wrapper.cpp.to_string(),
             qobject_ident = qobject_ident,
-            rust_obj_guard = lock_guard.unwrap_or_default(),
         },
     }
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -18,7 +18,7 @@ pub fn generate_cpp_signals(
     signals: &Vec<ParsedSignal>,
     qobject_idents: &QObjectName,
     cxx_mappings: &ParsedCxxMappings,
-    lock_guard: Option<&str>,
+    lock_guard: &str,
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut generated = GeneratedCppQObjectBlocks::default();
     let qobject_ident = qobject_idents.cpp_class.cpp.to_string();
@@ -73,7 +73,7 @@ pub fn generate_cpp_signals(
                             &{qobject_ident}::{signal_ident},
                             this,
                             [&, func = ::std::move(func)]({parameters_cpp}) {{
-                              {rust_obj_guard}
+                              {lock_guard}
                               func({parameter_values});
                             }}, type);
                 }}
@@ -82,7 +82,6 @@ pub fn generate_cpp_signals(
                 parameters_cpp = parameter_types_cpp.join(", "),
                 parameters_rust = parameter_types_rust.join(", "),
                 parameter_values = parameter_values_connection.join(", "),
-                rust_obj_guard = lock_guard.unwrap_or_default(),
             },
         });
     }
@@ -132,7 +131,7 @@ mod tests {
             &signals,
             &qobject_idents,
             &ParsedCxxMappings::default(),
-            Some("// ::std::lock_guard"),
+            "// ::std::lock_guard",
         )
         .unwrap();
 
@@ -204,7 +203,7 @@ mod tests {
             &signals,
             &qobject_idents,
             &cxx_mappings,
-            Some("// ::std::lock_guard"),
+            "// ::std::lock_guard",
         )
         .unwrap();
 
@@ -266,7 +265,7 @@ mod tests {
             &signals,
             &qobject_idents,
             &ParsedCxxMappings::default(),
-            Some("// ::std::lock_guard"),
+            "// ::std::lock_guard",
         )
         .unwrap();
 

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -28,6 +28,10 @@ pub fn write_headers(directory: impl AsRef<Path>) {
             include_str!("../include/cxxqt_locking.h"),
             "cxxqt_locking.h",
         ),
+        (
+            include_str!("../include/cxxqt_maybelockguard.h"),
+            "cxxqt_maybelockguard.h",
+        ),
         (include_str!("../include/cxxqt_thread.h"), "cxxqt_thread.h"),
         (
             include_str!("../include/cxxqt_threading.h"),

--- a/crates/cxx-qt-gen/test_outputs/inheritance.cpp
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.cpp
@@ -3,14 +3,14 @@
 QVariant
 MyObject::data(QModelIndex const& _index, ::std::int32_t _role) const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   return dataWrapper(_index, _role);
 }
 
 bool
 MyObject::hasChildren(QModelIndex const& _parent) const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   return hasChildrenWrapper(_parent);
 }
 

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cxx-qt-common/cxxqt_locking.h>
+#include <cxx-qt-common/cxxqt_maybelockguard.h>
 #include <cxx-qt-common/cxxqt_type.h>
 
 class MyObject;

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -5,21 +5,21 @@ namespace cxx_qt::my_object {
 void
 MyObject::cppMethod() const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   cppMethodWrapper();
 }
 
 void
 MyObject::invokable() const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   invokableWrapper();
 }
 
 void
 MyObject::invokableMutable()
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   invokableMutableWrapper();
 }
 
@@ -28,56 +28,56 @@ MyObject::invokableParameters(QColor const& opaque,
                               QPoint const& trivial,
                               ::std::int32_t primitive) const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   invokableParametersWrapper(opaque, trivial, primitive);
 }
 
 ::std::unique_ptr<Opaque>
 MyObject::invokableReturnOpaque()
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   return invokableReturnOpaqueWrapper();
 }
 
 QPoint
 MyObject::invokableReturnTrivial()
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   return invokableReturnTrivialWrapper();
 }
 
 void
 MyObject::invokableFinal() const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   invokableFinalWrapper();
 }
 
 void
 MyObject::invokableOverride() const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   invokableOverrideWrapper();
 }
 
 void
 MyObject::invokableVirtual() const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   invokableVirtualWrapper();
 }
 
 void
 MyObject::invokableResultTuple() const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   invokableResultTupleWrapper();
 }
 
 ::rust::String
 MyObject::invokableResultType() const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   return invokableResultTypeWrapper();
 }
 

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cxx-qt-common/cxxqt_maybelockguard.h>
 #include <cxx-qt-common/cxxqt_threading.h>
 #include <cxx-qt-common/cxxqt_type.h>
 

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -5,14 +5,14 @@ namespace cxx_qt::multi_object {
 ::std::int32_t const&
 MyObject::getPropertyName() const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   return getPropertyNameWrapper();
 }
 
 void
 MyObject::setPropertyName(::std::int32_t const& value)
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   setPropertyNameWrapper(value);
 }
 
@@ -25,7 +25,7 @@ MyObject::propertyNameChangedConnect(::rust::Fn<void(MyObject&)> func,
     &MyObject::propertyNameChanged,
     this,
     [&, func = ::std::move(func)]() {
-      const auto guard = unsafeRustLock();
+      const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
       func(*this);
     },
     type);
@@ -34,7 +34,7 @@ MyObject::propertyNameChangedConnect(::rust::Fn<void(MyObject&)> func,
 void
 MyObject::invokableName()
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   invokableNameWrapper();
 }
 
@@ -47,7 +47,7 @@ MyObject::readyConnect(::rust::Fn<void(MyObject&)> func,
     &MyObject::ready,
     this,
     [&, func = ::std::move(func)]() {
-      const auto guard = unsafeRustLock();
+      const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
       func(*this);
     },
     type);
@@ -68,14 +68,14 @@ namespace cxx_qt::multi_object {
 ::std::int32_t const&
 SecondObject::getPropertyName() const
 {
-
+  const ::rust::cxxqtlib1::MaybeLockGuard<SecondObject> guard(*this);
   return getPropertyNameWrapper();
 }
 
 void
 SecondObject::setPropertyName(::std::int32_t const& value)
 {
-
+  const ::rust::cxxqtlib1::MaybeLockGuard<SecondObject> guard(*this);
   setPropertyNameWrapper(value);
 }
 
@@ -87,14 +87,17 @@ SecondObject::propertyNameChangedConnect(::rust::Fn<void(SecondObject&)> func,
     this,
     &SecondObject::propertyNameChanged,
     this,
-    [&, func = ::std::move(func)]() { func(*this); },
+    [&, func = ::std::move(func)]() {
+      const ::rust::cxxqtlib1::MaybeLockGuard<SecondObject> guard(*this);
+      func(*this);
+    },
     type);
 }
 
 void
 SecondObject::invokableName()
 {
-
+  const ::rust::cxxqtlib1::MaybeLockGuard<SecondObject> guard(*this);
   invokableNameWrapper();
 }
 
@@ -106,7 +109,10 @@ SecondObject::readyConnect(::rust::Fn<void(SecondObject&)> func,
     this,
     &SecondObject::ready,
     this,
-    [&, func = ::std::move(func)]() { func(*this); },
+    [&, func = ::std::move(func)]() {
+      const ::rust::cxxqtlib1::MaybeLockGuard<SecondObject> guard(*this);
+      func(*this);
+    },
     type);
 }
 

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cxx-qt-common/cxxqt_locking.h>
+#include <cxx-qt-common/cxxqt_maybelockguard.h>
 #include <cxx-qt-common/cxxqt_type.h>
 
 namespace cxx_qt::multi_object {

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -5,28 +5,28 @@ namespace cxx_qt::my_object {
 ::std::int32_t const&
 MyObject::getPrimitive() const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   return getPrimitiveWrapper();
 }
 
 void
 MyObject::setPrimitive(::std::int32_t const& value)
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   setPrimitiveWrapper(value);
 }
 
 QPoint const&
 MyObject::getTrivial() const
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   return getTrivialWrapper();
 }
 
 void
 MyObject::setTrivial(QPoint const& value)
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   setTrivialWrapper(value);
 }
 
@@ -39,7 +39,7 @@ MyObject::primitiveChangedConnect(::rust::Fn<void(MyObject&)> func,
     &MyObject::primitiveChanged,
     this,
     [&, func = ::std::move(func)]() {
-      const auto guard = unsafeRustLock();
+      const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
       func(*this);
     },
     type);
@@ -54,7 +54,7 @@ MyObject::trivialChangedConnect(::rust::Fn<void(MyObject&)> func,
     &MyObject::trivialChanged,
     this,
     [&, func = ::std::move(func)]() {
-      const auto guard = unsafeRustLock();
+      const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
       func(*this);
     },
     type);

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cxx-qt-common/cxxqt_locking.h>
+#include <cxx-qt-common/cxxqt_maybelockguard.h>
 #include <cxx-qt-common/cxxqt_type.h>
 
 namespace cxx_qt::my_object {

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -5,7 +5,7 @@ namespace cxx_qt::my_object {
 void
 MyObject::invokable()
 {
-  const auto guard = unsafeRustLock();
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
   invokableWrapper();
 }
 
@@ -18,7 +18,7 @@ MyObject::readyConnect(::rust::Fn<void(MyObject&)> func,
     &MyObject::ready,
     this,
     [&, func = ::std::move(func)]() {
-      const auto guard = unsafeRustLock();
+      const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
       func(*this);
     },
     type);
@@ -40,7 +40,7 @@ MyObject::dataChangedConnect(::rust::Fn<void(MyObject&,
                                   ::std::unique_ptr<Opaque> second,
                                   QPoint third,
                                   QPoint const& fourth) {
-      const auto guard = unsafeRustLock();
+      const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
       func(*this,
            ::std::move(first),
            ::std::move(second),
@@ -66,7 +66,7 @@ MyObject::newDataConnect(::rust::Fn<void(MyObject&,
                                   ::std::unique_ptr<Opaque> second,
                                   QPoint third,
                                   QPoint const& fourth) {
-      const auto guard = unsafeRustLock();
+      const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
       func(*this,
            ::std::move(first),
            ::std::move(second),

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cxx-qt-common/cxxqt_locking.h>
+#include <cxx-qt-common/cxxqt_maybelockguard.h>
 #include <cxx-qt-common/cxxqt_type.h>
 
 namespace cxx_qt::my_object {


### PR DESCRIPTION
This means that all places where we need to lock can use this
and not have to worry if the type actually implements locking
or not. As MaybeLockGuard detects if the type has the
CxxQtLocking mixin.
    
This then simplifies connections later with extern C++ types
like QPushButton.
    
Related to #577

Requires #648 