### PR TITLE
cxx-qt-lib: fix Q{Core,Gui}Application setOrganizationName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl cxx_qt::trait for qobject::T` inside the bridge is now `impl cxx_qt::trait for T`
 - `qobject::T` as the self parameter in the bridge is now `T`
 - `#[cxx_override]`, `#[cxx_final]`, `#[cxx_virtual]` are now independant attributes rather than embedded in `#[qinvokable]`
+- Use `set_organization_name` instead of `q{core,gui}application_set_organization_name` in cxx-qt-lib
 
 ### Fixed
 

--- a/crates/cxx-qt-lib/src/core/qcoreapplication.rs
+++ b/crates/cxx-qt-lib/src/core/qcoreapplication.rs
@@ -160,7 +160,7 @@ impl QCoreApplication {
     }
 
     /// Sets the Internet domain of the organization that wrote this application
-    pub fn qcoreapplication_set_organization_domain(self: Pin<&mut Self>, domain: &QString) {
+    pub fn set_organization_domain(self: Pin<&mut Self>, domain: &QString) {
         ffi::qcoreapplication_set_organization_domain(self, domain);
     }
 

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.rs
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.rs
@@ -164,7 +164,7 @@ impl QGuiApplication {
     }
 
     /// Sets the Internet domain of the organization that wrote this application
-    pub fn qguiapplication_set_organization_domain(self: Pin<&mut Self>, domain: &QString) {
+    pub fn set_organization_domain(self: Pin<&mut Self>, domain: &QString) {
         ffi::qguiapplication_set_organization_domain(self, domain);
     }
 


### PR DESCRIPTION
This should be set_organization_name rather than
q{core,gui}application_set_organization_name.

Closes #652