### PR TITLE
cxx-qt-gen: more generic helpers for namespaces and signals

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -195,12 +195,13 @@ mod tests {
             MyObject::trivialPropertyChangedConnect(::rust::Fn<void(MyObject&)> func, ::Qt::ConnectionType type)
             {
                 return ::QObject::connect(this,
-                        &MyObject::trivialPropertyChanged,
-                        this,
-                        [&, func = ::std::move(func)]() {
-                          const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
-                          func(*this);
-                        }, type);
+                    &MyObject::trivialPropertyChanged,
+                    this,
+                    [&, func = ::std::move(func)]() {
+                        const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
+                        func(*this);
+                    },
+                    type);
             }
             "#}
         );
@@ -228,12 +229,13 @@ mod tests {
             MyObject::opaquePropertyChangedConnect(::rust::Fn<void(MyObject&)> func, ::Qt::ConnectionType type)
             {
                 return ::QObject::connect(this,
-                        &MyObject::opaquePropertyChanged,
-                        this,
-                        [&, func = ::std::move(func)]() {
-                          const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
-                          func(*this);
-                        }, type);
+                    &MyObject::opaquePropertyChanged,
+                    this,
+                    [&, func = ::std::move(func)]() {
+                        const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
+                        func(*this);
+                    },
+                    type);
             }
             "#}
         );
@@ -361,12 +363,13 @@ mod tests {
             MyObject::mappedPropertyChangedConnect(::rust::Fn<void(MyObject&)> func, ::Qt::ConnectionType type)
             {
                 return ::QObject::connect(this,
-                        &MyObject::mappedPropertyChanged,
-                        this,
-                        [&, func = ::std::move(func)]() {
-                          const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
-                          func(*this);
-                        }, type);
+                    &MyObject::mappedPropertyChanged,
+                    this,
+                    [&, func = ::std::move(func)]() {
+                        const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
+                        func(*this);
+                    },
+                    type);
             }
             "#}
         );

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeSet;
 
 use crate::generator::cpp::{fragment::CppFragment, GeneratedCppBlocks};
-use crate::writer::cpp::namespace_pair;
+use crate::writer::cpp::namespace_start_and_end;
 use indoc::formatdoc;
 
 /// Extract the header from a given CppFragment
@@ -43,7 +43,7 @@ fn create_block(block: &str, items: &[String]) -> String {
 //
 // Note that this is needed incase ObjectA refers to ObjectB in it's class
 fn forward_declare(generated: &GeneratedCppBlocks) -> Vec<String> {
-    let (namespace_start, namespace_end) = namespace_pair(generated);
+    let (namespace_start, namespace_end) = namespace_start_and_end(&generated.namespace);
 
     generated
         .qobjects
@@ -66,7 +66,7 @@ fn forward_declare(generated: &GeneratedCppBlocks) -> Vec<String> {
 
 /// For a given GeneratedCppBlocks write the classes
 fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
-    let (namespace_start, namespace_end) = namespace_pair(generated);
+    let (namespace_start, namespace_end) = namespace_start_and_end(&generated.namespace);
 
     generated.qobjects.iter().map(|qobject| {
         formatdoc! { r#"

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -12,21 +12,15 @@ use header::write_cpp_header;
 use source::write_cpp_source;
 
 /// For a given GeneratedCppBlocks write the namespace pair
-pub fn namespace_pair(generated: &GeneratedCppBlocks) -> (String, String) {
-    let namespace_start = if generated.namespace.is_empty() {
-        "".to_owned()
+pub fn namespace_start_and_end(namespace: &str) -> (String, String) {
+    if namespace.is_empty() {
+        ("".to_owned(), "".to_owned())
     } else {
-        format!("namespace {namespace} {{", namespace = generated.namespace)
-    };
-    let namespace_end = if generated.namespace.is_empty() {
-        "".to_owned()
-    } else {
-        format!(
-            "}} // namespace {namespace}",
-            namespace = generated.namespace
+        (
+            format!("namespace {namespace} {{"),
+            format!("}} // namespace {namespace}"),
         )
-    };
-    (namespace_start, namespace_end)
+    }
 }
 
 /// For a given GeneratedCppBlocks write this into a C++ header and source pair

--- a/crates/cxx-qt-gen/src/writer/cpp/source.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/source.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::generator::cpp::{fragment::CppFragment, GeneratedCppBlocks};
-use crate::writer::cpp::namespace_pair;
+use crate::writer::cpp::namespace_start_and_end;
 use indoc::formatdoc;
 
 /// Extract the source from a given CppFragment
@@ -18,7 +18,7 @@ fn pair_as_source(pair: &CppFragment) -> Option<String> {
 
 /// For a given GeneratedCppBlocks write the implementations
 fn qobjects_source(generated: &GeneratedCppBlocks) -> Vec<String> {
-    let (namespace_start, namespace_end) = namespace_pair(generated);
+    let (namespace_start, namespace_end) = namespace_start_and_end(&generated.namespace);
 
     generated.qobjects.iter().map(|qobject| {
         formatdoc! { r#"


### PR DESCRIPTION
This helps us with signal generation for extern "C++Qt" blocks later.

Related to #577