### PR TITLE
Add support for #[qenum] associated with a QObject

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -11,6 +11,7 @@ pub mod inherit;
 pub mod locking;
 pub mod method;
 pub mod property;
+pub mod qenum;
 pub mod qobject;
 pub mod signal;
 pub mod threading;

--- a/crates/cxx-qt-gen/src/generator/cpp/qenum.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qenum.rs
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use indoc::formatdoc;
+use syn::Result;
+
+use crate::{
+    generator::utils::cpp::Indent,
+    parser::{mappings::ParsedCxxMappings, qenum::ParsedQEnum},
+};
+
+use super::qobject::GeneratedCppQObjectBlocks;
+
+pub fn generate(
+    qenums: &[ParsedQEnum],
+    cxx_mappings: &ParsedCxxMappings,
+) -> Result<GeneratedCppQObjectBlocks> {
+    let mut generated = GeneratedCppQObjectBlocks::default();
+
+    for qenum in qenums {
+        let enum_name = &qenum.ident.to_string();
+
+        let mut qualified_name = cxx_mappings.cxx(enum_name);
+        // TODO: this is a workaround for cxx_mappings.cxx not always returning a fully-qualified
+        // identifier.
+        // Once https://github.com/KDAB/cxx-qt/issues/619 is fixed, this can be removed.
+        if !qualified_name.starts_with("::") {
+            qualified_name.insert_str(0, "::");
+        }
+
+        let enum_values = qenum
+            .variants
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",\n");
+
+        generated.includes.insert("#include <cstdint>".to_string());
+        let enum_definition = formatdoc! { r#"
+            enum class {enum_name} : ::std::int32_t {{
+            {enum_values}
+            }};
+        "#, enum_values = enum_values.indented(2) };
+        generated.forward_declares.push(enum_definition.clone());
+        generated.metaobjects.push(formatdoc! {r#"
+            #ifdef Q_MOC_RUN
+            {enum_definition}
+              Q_ENUM({enum_name})
+            #else
+              using {enum_name} = {qualified_name};
+              Q_ENUM({enum_name})
+            #endif
+        "#, enum_definition = enum_definition.indented(2) });
+    }
+
+    Ok(generated)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_eq;
+
+    use super::*;
+    use indoc::indoc;
+    use pretty_assertions::assert_str_eq;
+    use syn::parse_quote;
+
+    #[test]
+    fn generates() {
+        let qenums = [ParsedQEnum::parse(parse_quote! {
+            enum MyEnum {
+                A, B, C
+            }
+        })
+        .unwrap()];
+
+        let generated = generate(&qenums, &ParsedCxxMappings::default()).unwrap();
+        assert_eq!(generated.includes.len(), 1);
+        assert!(generated.includes.contains("#include <cstdint>"));
+        assert_eq!(generated.metaobjects.len(), 1);
+        assert_str_eq!(
+            indoc! {r#"
+                #ifdef Q_MOC_RUN
+                  enum class MyEnum : ::std::int32_t {
+                    A,
+                    B,
+                    C
+                  };
+                  Q_ENUM(MyEnum)
+                #else
+                  using MyEnum = ::MyEnum;
+                  Q_ENUM(MyEnum)
+                #endif
+            "#},
+            generated.metaobjects[0],
+        );
+        assert_eq!(generated.forward_declares.len(), 1);
+        assert_str_eq!(
+            indoc! { r#"
+                enum class MyEnum : ::std::int32_t {
+                  A,
+                  B,
+                  C
+                };
+            "# },
+            generated.forward_declares[0],
+        );
+    }
+}

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -6,7 +6,7 @@
 use crate::generator::{
     cpp::{
         constructor, cxxqttype, fragment::CppFragment, inherit, locking,
-        method::generate_cpp_methods, property::generate_cpp_properties,
+        method::generate_cpp_methods, property::generate_cpp_properties, qenum,
         signal::generate_cpp_signals, threading,
     },
     naming::{namespace::NamespaceName, qobject::QObjectName},
@@ -134,6 +134,9 @@ impl GeneratedCppQObject {
             &qobject.base_class,
             cxx_mappings,
         )?);
+        generated
+            .blocks
+            .append(&mut qenum::generate(&qobject.qenums, cxx_mappings)?);
 
         let mut class_initializers = vec![];
 

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -9,6 +9,7 @@ pub mod fragment;
 pub mod inherit;
 pub mod method;
 pub mod property;
+pub mod qenum;
 pub mod qobject;
 pub mod signals;
 pub mod threading;

--- a/crates/cxx-qt-gen/src/generator/rust/qenum.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qenum.rs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{generator::rust::qobject::GeneratedRustQObject, parser::qenum::ParsedQEnum};
+use syn::parse_quote;
+
+pub fn generate(qenums: &[ParsedQEnum]) -> GeneratedRustQObject {
+    let mut result = GeneratedRustQObject::default();
+    for qenum in qenums {
+        let qenum_item = &qenum.item;
+        let qenum_ident = &qenum.ident;
+        result.append(&mut GeneratedRustQObject {
+            cxx_mod_contents: vec![
+                parse_quote! {
+                    #[repr(i32)]
+                    #qenum_item
+                },
+                parse_quote! {
+                    extern "C++" {
+                        type #qenum_ident;
+                    }
+                },
+            ],
+            ..Default::default()
+        });
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::assert_tokens_eq;
+    use quote::quote;
+    use syn::parse_quote;
+
+    use super::*;
+
+    #[test]
+    fn generates() {
+        let qenums = vec![ParsedQEnum::parse(parse_quote! {
+            /// Doc comment
+            enum MyEnum {
+                /// Document Variant1
+                Variant1,
+                /// Document Variant2
+                Variant2,
+            }
+        })
+        .unwrap()];
+
+        let generated = generate(&qenums);
+        assert_eq!(generated.cxx_mod_contents.len(), 2);
+        assert_tokens_eq(
+            &generated.cxx_mod_contents[0],
+            quote! {
+                #[repr(i32)]
+                #[doc = r" Doc comment"]
+                enum MyEnum {
+                    #[doc = r" Document Variant1"]
+                    Variant1,
+                    #[doc = r" Document Variant2"]
+                    Variant2,
+                }
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_mod_contents[1],
+            quote! {
+                extern "C++" {
+                    type MyEnum;
+                }
+            },
+        )
+    }
+}

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -20,6 +20,8 @@ use crate::{
 use quote::quote;
 use syn::{Ident, ImplItem, Item, Path, Result};
 
+use super::qenum;
+
 #[derive(Default)]
 pub struct GeneratedRustQObject {
     /// Module for the CXX bridge
@@ -73,6 +75,7 @@ impl GeneratedRustQObject {
             &qobject_idents,
             qualified_mappings,
         )?);
+        generated.append(&mut qenum::generate(&qobject.qenums));
 
         // If this type is a singleton then we need to add an include
         if let Some(qml_metadata) = &qobject.qml_metadata {

--- a/crates/cxx-qt-gen/src/generator/utils/cpp.rs
+++ b/crates/cxx-qt-gen/src/generator/utils/cpp.rs
@@ -292,8 +292,27 @@ fn possible_built_in_template_base(ty: &str) -> Option<&str> {
     }
 }
 
+/// A trait to allow indenting multi-line string
+/// This is specifically useful when using formatdoc! with a multi-line string argument.
+/// As the formatdoc! formatting doesn't support indenting multi-line arguments, we can indent
+/// those ourselves.
+pub(crate) trait Indent {
+    fn indented(&self, indent: usize) -> String;
+}
+
+impl Indent for str {
+    fn indented(&self, indent: usize) -> String {
+        self.lines()
+            .map(|line| " ".repeat(indent) + line)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use indoc::{formatdoc, indoc};
+    use pretty_assertions::assert_str_eq;
     use syn::parse_quote;
 
     use super::*;
@@ -693,6 +712,28 @@ mod tests {
         assert_eq!(
             syn_type_to_cpp_return_type(&ty, &ParsedCxxMappings::default()).unwrap(),
             None
+        );
+    }
+
+    #[test]
+    fn indent_string() {
+        let multiline_string = indoc! { r#"
+            A,
+            B,
+        "#};
+
+        assert_str_eq!(
+            formatdoc! { r#"
+                enum Test {{
+                {multiline_string}
+                }}
+            "#, multiline_string = multiline_string.indented(2) },
+            indoc! { r#"
+                enum Test {
+                  A,
+                  B,
+                }
+            "#}
         );
     }
 }

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -211,4 +211,9 @@ mod tests {
     fn generates_inheritance() {
         test_code_generation!("inheritance");
     }
+
+    #[test]
+    fn generates_qenum() {
+        test_code_generation!("qenum");
+    }
 }

--- a/crates/cxx-qt-gen/src/parser/mappings.rs
+++ b/crates/cxx-qt-gen/src/parser/mappings.rs
@@ -10,7 +10,7 @@ use syn::{spanned::Spanned, Attribute, Ident, Path, Result};
 
 use crate::syntax::{attribute::attribute_find_path, expr::expr_to_string, path::path_from_idents};
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ParsedCxxMappings {
     /// Map of the cxx_name of any types defined in CXX extern blocks
     ///

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -11,6 +11,7 @@ pub mod mappings;
 pub mod method;
 pub mod parameter;
 pub mod property;
+pub mod qenum;
 pub mod qobject;
 pub mod signals;
 

--- a/crates/cxx-qt-gen/src/parser/qenum.rs
+++ b/crates/cxx-qt-gen/src/parser/qenum.rs
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use quote::ToTokens;
+use syn::{Ident, ItemEnum, Result, Variant};
+
+use crate::syntax::path::path_compare_str;
+
+pub struct ParsedQEnum {
+    /// The ident of the QEnum
+    pub ident: Ident,
+    /// the values of the QEnum
+    pub variants: Vec<Ident>,
+    /// The original enum item
+    pub item: ItemEnum,
+}
+
+impl ParsedQEnum {
+    fn parse_variant(variant: &Variant) -> Result<Ident> {
+        fn err(spanned: &impl ToTokens, message: &str) -> Result<Ident> {
+            Err(syn::Error::new_spanned(spanned, message))
+        }
+
+        if !variant.fields.is_empty() {
+            return err(variant, "QEnum variants cannot have fields");
+        }
+        if let Some(attr) = variant
+            .attrs
+            .iter()
+            .find(|attr| !path_compare_str(attr.path(), &["doc"]))
+        {
+            return err(
+                attr,
+                "QEnum variants can only have #[doc=\"...\"] attributes",
+            );
+        }
+        if let Some(discriminant) = variant.discriminant.as_ref() {
+            return err(
+                &discriminant.1,
+                "QEnum variants with explicit values are not supported (yet)",
+            );
+        }
+
+        Ok(variant.ident.clone())
+    }
+
+    pub fn parse(qenum: ItemEnum) -> Result<Self> {
+        if qenum.variants.is_empty() {
+            return Err(syn::Error::new_spanned(
+                qenum,
+                "QEnum must have at least one variant",
+            ));
+        }
+
+        // TODO: Add support for `namespace`, `cxx_name` and `rust_name` attributes.
+        if let Some(attr) = qenum
+            .attrs
+            .iter()
+            .find(|attr| !path_compare_str(attr.path(), &["doc"]))
+        {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "Additional attributes are not allowed on #[qenum] enums",
+            ));
+        }
+
+        let variants = qenum
+            .variants
+            .iter()
+            .map(Self::parse_variant)
+            .collect::<Result<_>>()?;
+
+        Ok(Self {
+            ident: qenum.ident.clone(),
+            variants,
+            item: qenum,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn parse() {
+        let qenum: ItemEnum = parse_quote! {
+            /// My doc comment
+            enum MyEnum {
+                /// Variant1 doc comment
+                Variant1,
+                /// Variant2 doc comment
+                Variant2,
+            }
+        };
+
+        let parsed = ParsedQEnum::parse(qenum).unwrap();
+        assert_eq!(parsed.ident, "MyEnum");
+
+        assert_eq!(
+            *parsed
+                .variants
+                .iter()
+                .map(Ident::to_string)
+                .collect::<Vec<_>>(),
+            ["Variant1", "Variant2"],
+        )
+    }
+
+    macro_rules! assert_parse_error {
+        ($( $input:tt )*) => {
+            let qenum: ItemEnum = parse_quote! { $($input)* };
+            assert!(ParsedQEnum::parse(qenum).is_err());
+        }
+    }
+
+    #[test]
+    fn parse_errors() {
+        assert_parse_error! {
+            // No variants
+            enum MyEnum {}
+        }
+        assert_parse_error! {
+            // Unkown attributes
+            #[any_attribute]
+            enum MyEnum { A }
+        }
+        assert_parse_error! {
+            // Repr is not allowed either
+            #[repr(u32)]
+            enum MyEnum { A }
+        }
+        assert_parse_error! {
+            // Fields are not allowed
+            enum MyEnum {
+                A { field: i32 }
+            }
+        }
+        assert_parse_error! {
+            // Fields are not allowed
+            enum MyEnum {
+                A(i32)
+            }
+        }
+        assert_parse_error! {
+            // Attributes on variants are not allowed
+            enum MyEnum {
+                #[any_attribute]
+                A
+            }
+        }
+
+        // TODO: allow discriminants
+        assert_parse_error! {
+            enum MyEnum {
+                A = 1
+            }
+        }
+    }
+}

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -6,7 +6,7 @@
 use crate::{
     parser::{
         constructor::Constructor, inherit::ParsedInheritedMethod, method::ParsedMethod,
-        property::ParsedQProperty, signals::ParsedSignal,
+        property::ParsedQProperty, qenum::ParsedQEnum, signals::ParsedSignal,
     },
     syntax::{
         attribute::attribute_take_path, expr::expr_to_string, foreignmod::ForeignTypeIdentAlias,
@@ -37,6 +37,8 @@ pub struct ParsedQObject {
     pub namespace: String,
     /// Representation of the Q_SIGNALS for the QObject
     pub signals: Vec<ParsedSignal>,
+    /// The Q_ENUM enums associated with this QObject
+    pub qenums: Vec<ParsedQEnum>,
     /// List of methods that need to be implemented on the C++ object in Rust
     ///
     /// These could also be exposed as Q_INVOKABLE on the C++ object
@@ -94,6 +96,7 @@ impl TryFrom<&ForeignTypeIdentAlias> for ParsedQObject {
             qobject_ty,
             namespace,
             signals: vec![],
+            qenums: vec![],
             methods: vec![],
             inherited_methods: vec![],
             passthrough_impl_items: vec![],

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -74,9 +74,9 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
             class {ident} : {base_classes}
             {{
               Q_OBJECT
+            public:
               {metaobjects}
 
-            public:
               virtual ~{ident}() = default;
 
             {public_methods}

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -300,10 +300,10 @@ mod tests {
         class MyObject : public QStringListModel
         {
           Q_OBJECT
+        public:
           Q_PROPERTY(int count READ count WRITE setCount NOTIFY countChanged)
           Q_PROPERTY(bool longPropertyNameThatWrapsInClangFormat READ getToggle WRITE setToggle NOTIFY toggleChanged)
 
-        public:
           virtual ~MyObject() = default;
 
         public:
@@ -354,9 +354,9 @@ mod tests {
         class FirstObject : public QStringListModel
         {
           Q_OBJECT
+        public:
           Q_PROPERTY(int longPropertyNameThatWrapsInClangFormat READ count WRITE setCount NOTIFY countChanged)
 
-        public:
           virtual ~FirstObject() = default;
 
         public:
@@ -376,9 +376,9 @@ mod tests {
         class SecondObject : public QStringListModel
         {
           Q_OBJECT
+        public:
           Q_PROPERTY(int count READ count WRITE setCount NOTIFY countChanged)
 
-        public:
           virtual ~SecondObject() = default;
 
         public:
@@ -418,10 +418,10 @@ mod tests {
         class MyObject : public QStringListModel
         {
           Q_OBJECT
+        public:
           Q_PROPERTY(int count READ count WRITE setCount NOTIFY countChanged)
           Q_PROPERTY(bool longPropertyNameThatWrapsInClangFormat READ getToggle WRITE setToggle NOTIFY toggleChanged)
 
-        public:
           virtual ~MyObject() = default;
 
         public:

--- a/crates/cxx-qt-gen/test_inputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_inputs/qenum.rs
@@ -1,0 +1,23 @@
+#[cxx_qt::bridge(namespace = "cxx_qt::my_object")]
+mod ffi {
+    #[qenum(MyObject)]
+    enum MyEnum {
+        A,
+    }
+
+    #[qenum(MyObject)]
+    enum MyOtherEnum {
+        X,
+        Y,
+        Z,
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[derive(Default)]
+        type MyObject = super::MyObjectRust;
+
+        #[qinvokable]
+        fn my_invokable(self: &MyObject, qenum: MyEnum, other_qenum: MyOtherEnum);
+    }
+}

--- a/crates/cxx-qt-gen/test_inputs/qenum.rs.license
+++ b/crates/cxx-qt-gen/test_inputs/qenum.rs.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -14,7 +14,6 @@ class MyObject
   , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
-
 public:
   virtual ~MyObject() = default;
 

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -18,7 +18,6 @@ class MyObject
   , public ::rust::cxxqtlib1::CxxQtThreading<MyObject>
 {
   Q_OBJECT
-
 public:
   virtual ~MyObject() = default;
 

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -49,10 +49,10 @@ class MyObject
   , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
+public:
   Q_PROPERTY(::std::int32_t propertyName READ getPropertyName WRITE
                setPropertyName NOTIFY propertyNameChanged)
 
-public:
   virtual ~MyObject() = default;
 
 public:
@@ -86,10 +86,10 @@ class SecondObject
   , public ::rust::cxxqtlib1::CxxQtType<SecondObjectRust>
 {
   Q_OBJECT
+public:
   Q_PROPERTY(::std::int32_t propertyName READ getPropertyName WRITE
                setPropertyName NOTIFY propertyNameChanged)
 
-public:
   virtual ~SecondObject() = default;
 
 public:

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -18,12 +18,12 @@ class MyObject
   , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
+public:
   Q_PROPERTY(::std::int32_t primitive READ getPrimitive WRITE setPrimitive
                NOTIFY primitiveChanged)
   Q_PROPERTY(
     QPoint trivial READ getTrivial WRITE setTrivial NOTIFY trivialChanged)
 
-public:
   virtual ~MyObject() = default;
 
 public:

--- a/crates/cxx-qt-gen/test_outputs/qenum.cpp
+++ b/crates/cxx-qt-gen/test_outputs/qenum.cpp
@@ -1,0 +1,21 @@
+#include "cxx-qt-gen/ffi.cxxqt.h"
+
+namespace cxx_qt::my_object {
+
+void
+MyObject::myInvokable(::cxx_qt::my_object::MyEnum qenum,
+                      ::cxx_qt::my_object::MyOtherEnum other_qenum) const
+{
+  const ::rust::cxxqtlib1::MaybeLockGuard<MyObject> guard(*this);
+  myInvokableWrapper(qenum, other_qenum);
+}
+
+MyObject::MyObject(QObject* parent)
+  : QObject(parent)
+  , ::rust::cxxqtlib1::CxxQtType<MyObjectRust>(
+      ::cxx_qt::my_object::cxx_qt_my_object::createRs())
+  , ::rust::cxxqtlib1::CxxQtLocking()
+{
+}
+
+} // namespace cxx_qt::my_object

--- a/crates/cxx-qt-gen/test_outputs/qenum.cpp.license
+++ b/crates/cxx-qt-gen/test_outputs/qenum.cpp.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+

--- a/crates/cxx-qt-gen/test_outputs/qenum.h
+++ b/crates/cxx-qt-gen/test_outputs/qenum.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstdint>
+#include <cxx-qt-common/cxxqt_locking.h>
+#include <cxx-qt-common/cxxqt_maybelockguard.h>
+#include <cxx-qt-common/cxxqt_type.h>
+
+namespace cxx_qt::my_object {
+class MyObject;
+enum class MyEnum : ::std::int32_t
+{
+  A
+};
+
+enum class MyOtherEnum : ::std::int32_t
+{
+  X,
+  Y,
+  Z
+};
+
+} // namespace cxx_qt::my_object
+
+#include "cxx-qt-gen/ffi.cxx.h"
+
+namespace cxx_qt::my_object {
+class MyObject
+  : public QObject
+  , public ::rust::cxxqtlib1::CxxQtType<MyObjectRust>
+  , public ::rust::cxxqtlib1::CxxQtLocking
+{
+  Q_OBJECT
+public:
+#ifdef Q_MOC_RUN
+  enum class MyEnum : ::std::int32_t{ A };
+  Q_ENUM(MyEnum)
+#else
+  using MyEnum = ::cxx_qt::my_object::MyEnum;
+  Q_ENUM(MyEnum)
+#endif
+
+#ifdef Q_MOC_RUN
+  enum class MyOtherEnum : ::std::int32_t{ X, Y, Z };
+  Q_ENUM(MyOtherEnum)
+#else
+  using MyOtherEnum = ::cxx_qt::my_object::MyOtherEnum;
+  Q_ENUM(MyOtherEnum)
+#endif
+
+  virtual ~MyObject() = default;
+
+public:
+  Q_INVOKABLE void myInvokable(
+    ::cxx_qt::my_object::MyEnum qenum,
+    ::cxx_qt::my_object::MyOtherEnum other_qenum) const;
+  explicit MyObject(QObject* parent = nullptr);
+
+private:
+  void myInvokableWrapper(
+    ::cxx_qt::my_object::MyEnum qenum,
+    ::cxx_qt::my_object::MyOtherEnum other_qenum) const noexcept;
+};
+
+static_assert(::std::is_base_of<QObject, MyObject>::value,
+              "MyObject must inherit from QObject");
+} // namespace cxx_qt::my_object
+
+Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)

--- a/crates/cxx-qt-gen/test_outputs/qenum.h.license
+++ b/crates/cxx-qt-gen/test_outputs/qenum.h.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs
@@ -1,0 +1,87 @@
+#[cxx::bridge(namespace = "cxx_qt::my_object")]
+mod ffi {
+    unsafe extern "C++" {
+        include ! (< QtCore / QObject >);
+        include!("cxx-qt-lib/qt.h");
+        #[doc(hidden)]
+        #[namespace = "Qt"]
+        #[rust_name = "CxxQtConnectionType"]
+        type ConnectionType = cxx_qt_lib::ConnectionType;
+        include!("cxx-qt-lib/qmetaobjectconnection.h");
+        #[doc(hidden)]
+        #[namespace = "rust::cxxqtlib1"]
+        #[rust_name = "CxxQtQMetaObjectConnection"]
+        type QMetaObjectConnection = cxx_qt_lib::QMetaObjectConnection;
+    }
+    unsafe extern "C++" {
+        include!("cxx-qt-gen/ffi.cxxqt.h");
+    }
+    unsafe extern "C++" {
+        #[doc = "The C++ type for the QObject "]
+        #[doc = "MyObjectRust"]
+        #[doc = "\n"]
+        #[doc = "Use this type when referring to the QObject as a pointer"]
+        #[doc = "\n"]
+        #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
+        type MyObject;
+    }
+    extern "Rust" {
+        type MyObjectRust;
+    }
+    extern "Rust" {
+        #[doc(hidden)]
+        #[cxx_name = "myInvokableWrapper"]
+        fn my_invokable(self: &MyObject, qenum: MyEnum, other_qenum: MyOtherEnum);
+    }
+    #[repr(i32)]
+    enum MyEnum {
+        A,
+    }
+    extern "C++" {
+        type MyEnum;
+    }
+    #[repr(i32)]
+    enum MyOtherEnum {
+        X,
+        Y,
+        Z,
+    }
+    extern "C++" {
+        type MyOtherEnum;
+    }
+    extern "Rust" {
+        #[cxx_name = "createRs"]
+        #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
+        fn create_rs_my_object_rust() -> Box<MyObjectRust>;
+    }
+    unsafe extern "C++" {
+        #[cxx_name = "unsafeRust"]
+        #[doc(hidden)]
+        fn cxx_qt_ffi_rust(self: &MyObject) -> &MyObjectRust;
+    }
+    unsafe extern "C++" {
+        #[cxx_name = "unsafeRustMut"]
+        #[doc(hidden)]
+        fn cxx_qt_ffi_rust_mut(self: Pin<&mut MyObject>) -> Pin<&mut MyObjectRust>;
+    }
+}
+impl cxx_qt::Locking for ffi::MyObject {}
+#[doc(hidden)]
+pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
+    std::boxed::Box::new(core::default::Default::default())
+}
+impl core::ops::Deref for ffi::MyObject {
+    type Target = MyObjectRust;
+    fn deref(&self) -> &Self::Target {
+        self.cxx_qt_ffi_rust()
+    }
+}
+impl cxx_qt::CxxQtType for ffi::MyObject {
+    type Rust = MyObjectRust;
+    fn rust(&self) -> &Self::Rust {
+        self.cxx_qt_ffi_rust()
+    }
+    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+        self.cxx_qt_ffi_rust_mut()
+    }
+}

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs.license
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -18,7 +18,6 @@ class MyObject
   , public ::rust::cxxqtlib1::CxxQtLocking
 {
   Q_OBJECT
-
 public:
   virtual ~MyObject() = default;
 

--- a/examples/qml_features/qml/pages/CustomBaseClassPage.qml
+++ b/examples/qml_features/qml/pages/CustomBaseClassPage.qml
@@ -57,6 +57,7 @@ Page {
     }
 
     ScrollView {
+        id: scrollView
         anchors.fill: parent
         clip: true
         ScrollBar.vertical.policy: ScrollBar.vertical.size === 1.0 ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
@@ -75,5 +76,14 @@ Page {
                 onClicked: ListView.view.currentIndex = index
             }
         }
+    }
+
+    BusyIndicator {
+        anchors {
+            right: scrollView.right
+            bottom: scrollView.bottom
+            margins: 15
+        }
+        running: customBaseClass.state === CustomBaseClass.Running
     }
 }

--- a/examples/qml_features/tests/tst_custom_base_class.qml
+++ b/examples/qml_features/tests/tst_custom_base_class.qml
@@ -82,4 +82,28 @@ TestCase {
         compare(instantiator.count, 1);
         compare(dataChangedSpy.count, 1);
     }
+
+    function test_roles_qenum() {
+        compare(CustomBaseClass.Id, 0);
+        compare(CustomBaseClass.Value, 1);
+
+        const model = createTemporaryObject(componentCustomBaseClass, null, {});
+
+        model.add();
+        compare(model.data(model.index(0, 0), CustomBaseClass.Id), 0);
+        compare(model.data(model.index(0, 0), CustomBaseClass.Value), 0);
+
+        model.add();
+        compare(model.data(model.index(1, 0), CustomBaseClass.Id), 1);
+        compare(model.data(model.index(1, 0), CustomBaseClass.Value), 1.0 / 3.0);
+
+        compare(model.state, CustomBaseClass.Idle);
+        model.addOnThreadDelayed(1, 0 /*ms*/);
+        // This shouldn't cause a flaky test, as the `addOnThread` cannot reset the
+        // state to `Idle` until the Event-Loop of this thread is available again.
+        // Which should only be after this thread has finished.
+        compare(model.state, CustomBaseClass.Running);
+        // Return to the event loop now to give the background thread a chance to reset the "state" again.
+        tryCompare(model, "state", CustomBaseClass.Idle);
+    }
 }


### PR DESCRIPTION
This is the initial support for #34.

It only supports `Q_ENUM` within a given `Q_OBJECT` class. `Q_ENUM_NS` is not (yet) supported.
Documentation will be added in a follow-up commit.