### PR TITLE
Fix namespace generation of QObjects

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/constructor.rs
@@ -142,6 +142,7 @@ mod tests {
         GeneratedCppQObject {
             ident: "MyObject".to_string(),
             rust_ident: "MyObjectRust".to_string(),
+            namespace: "".to_string(),
             namespace_internals: "rust".to_string(),
             blocks: GeneratedCppQObjectBlocks::default(),
         }

--- a/crates/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -25,8 +25,6 @@ use syn::Result;
 pub struct GeneratedCppBlocks {
     /// Stem of the CXX header to include
     pub cxx_file_stem: String,
-    /// Ident of the common namespace of the QObjects
-    pub namespace: String,
     /// Generated QObjects
     pub qobjects: Vec<GeneratedCppQObject>,
     /// Generated extern C++Qt blocks
@@ -37,7 +35,6 @@ impl GeneratedCppBlocks {
     pub fn from(parser: &Parser) -> Result<GeneratedCppBlocks> {
         Ok(GeneratedCppBlocks {
             cxx_file_stem: parser.cxx_file_stem.clone(),
-            namespace: parser.cxx_qt_data.namespace.clone(),
             qobjects: parser
                 .cxx_qt_data
                 .qobjects
@@ -74,8 +71,8 @@ mod tests {
 
         let cpp = GeneratedCppBlocks::from(&parser).unwrap();
         assert_eq!(cpp.cxx_file_stem, "ffi");
-        assert_eq!(cpp.namespace, "");
         assert_eq!(cpp.qobjects.len(), 1);
+        assert_eq!(cpp.qobjects[0].namespace, "");
     }
 
     #[test]
@@ -93,8 +90,8 @@ mod tests {
 
         let cpp = GeneratedCppBlocks::from(&parser).unwrap();
         assert_eq!(cpp.cxx_file_stem, "my_object");
-        assert_eq!(cpp.namespace, "");
         assert_eq!(cpp.qobjects.len(), 1);
+        assert_eq!(&cpp.qobjects[0].namespace, "");
     }
 
     #[test]
@@ -111,6 +108,6 @@ mod tests {
         let parser = Parser::from(module).unwrap();
 
         let cpp = GeneratedCppBlocks::from(&parser).unwrap();
-        assert_eq!(cpp.namespace, "cxx_qt");
+        assert_eq!(cpp.qobjects[0].namespace, "cxx_qt");
     }
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -73,6 +73,9 @@ pub struct GeneratedCppQObject {
     pub ident: String,
     /// Ident of the Rust object
     pub rust_ident: String,
+    /// Ident of the QObject namespace
+    /// If one isn't specified on the QObject, it's the same as the module.
+    pub namespace: String,
     /// Ident of the namespace for CXX-Qt internals of the QObject
     pub namespace_internals: String,
     /// The blocks of the QObject
@@ -91,6 +94,7 @@ impl GeneratedCppQObject {
         let mut generated = GeneratedCppQObject {
             ident: cpp_class.clone(),
             rust_ident: qobject_idents.rust_struct.cpp.to_string(),
+            namespace: qobject.namespace.clone(),
             namespace_internals: namespace_idents.internal,
             blocks: GeneratedCppQObjectBlocks::from(qobject),
         };

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -50,7 +50,10 @@ impl GeneratedRustQObject {
             cxx_qt_mod_contents: qobject.others.clone(),
         };
 
-        generated.append(&mut generate_qobject_definitions(&qobject_idents)?);
+        generated.append(&mut generate_qobject_definitions(
+            &qobject_idents,
+            &namespace_idents.namespace,
+        )?);
 
         // Generate methods for the properties, invokables, signals
         generated.append(&mut generate_rust_properties(
@@ -160,11 +163,20 @@ pub fn generate_passthrough_impl(
 }
 
 /// Generate the C++ and Rust CXX definitions for the QObject
-fn generate_qobject_definitions(qobject_idents: &QObjectName) -> Result<GeneratedRustQObject> {
+fn generate_qobject_definitions(
+    qobject_idents: &QObjectName,
+    namespace: &str,
+) -> Result<GeneratedRustQObject> {
     let mut generated = GeneratedRustQObject::default();
     let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
     let rust_struct_name_rust = &qobject_idents.rust_struct.rust;
     let rust_struct_name_rust_str = rust_struct_name_rust.to_string();
+    let namespace = if !namespace.is_empty() {
+        Some(quote! { #[namespace=#namespace] })
+    } else {
+        None
+    };
+
     let fragment = RustFragmentPair {
         cxx_bridge: vec![
             quote! {
@@ -175,6 +187,7 @@ fn generate_qobject_definitions(qobject_idents: &QObjectName) -> Result<Generate
                     #[doc = "Use this type when referring to the QObject as a pointer"]
                     #[doc = "\n"]
                     #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
+                    #namespace
                     type #cpp_class_name_rust;
                 }
             },
@@ -235,6 +248,7 @@ mod tests {
                     #[doc = "Use this type when referring to the QObject as a pointer"]
                     #[doc = "\n"]
                     #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
+                    #[namespace = "cxx_qt"]
                     type MyObject;
                 }
             },

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -51,12 +51,12 @@ mod tests {
     pub fn create_generated_cpp() -> GeneratedCppBlocks {
         GeneratedCppBlocks {
             cxx_file_stem: "cxx_file_stem".to_owned(),
-            namespace: "cxx_qt::my_object".to_owned(),
             extern_cxx_qt: vec![],
             qobjects: vec![
                 GeneratedCppQObject {
                     ident: "MyObject".to_owned(),
                     rust_ident: "MyObjectRust".to_owned(),
+                    namespace: "cxx_qt::my_object".to_owned(),
                     namespace_internals: "cxx_qt::my_object::cxx_qt_my_object".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
                         forward_declares: vec![],
@@ -172,12 +172,12 @@ mod tests {
     pub fn create_generated_cpp_multi_qobjects() -> GeneratedCppBlocks {
         GeneratedCppBlocks {
             cxx_file_stem: "cxx_file_stem".to_owned(),
-            namespace: "cxx_qt".to_owned(),
             extern_cxx_qt: vec![],
             qobjects: vec![
                 GeneratedCppQObject {
                     ident: "FirstObject".to_owned(),
                     rust_ident: "FirstObjectRust".to_owned(),
+                    namespace: "cxx_qt".to_owned(),
                     namespace_internals: "cxx_qt::cxx_qt_first_object".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
                         forward_declares: vec![],
@@ -221,6 +221,7 @@ mod tests {
                 GeneratedCppQObject {
                     ident: "SecondObject".to_owned(),
                     rust_ident: "SecondObjectRust".to_owned(),
+                    namespace: "cxx_qt".to_owned(),
                     namespace_internals: "cxx_qt::cxx_qt_second_object".to_owned(),
                     blocks: GeneratedCppQObjectBlocks {
                         forward_declares: vec![],
@@ -276,7 +277,7 @@ mod tests {
     /// Helper to create a GeneratedCppBlocks with no namespace for testing
     pub fn create_generated_cpp_no_namespace() -> GeneratedCppBlocks {
         let mut generated = create_generated_cpp();
-        generated.namespace = "".to_owned();
+        generated.qobjects[0].namespace = "".to_owned();
         generated.qobjects[0].namespace_internals = "cxx_qt_my_object".to_owned();
         generated
     }

--- a/crates/cxx-qt-gen/src/writer/cpp/source.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/source.rs
@@ -18,9 +18,8 @@ fn pair_as_source(pair: &CppFragment) -> Option<String> {
 
 /// For a given GeneratedCppBlocks write the implementations
 fn qobjects_source(generated: &GeneratedCppBlocks) -> Vec<String> {
-    let (namespace_start, namespace_end) = namespace_start_and_end(&generated.namespace);
-
     generated.qobjects.iter().map(|qobject| {
+        let (namespace_start, namespace_end) = namespace_start_and_end(&qobject.namespace);
         formatdoc! { r#"
             {namespace_start}
 

--- a/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
@@ -116,6 +116,7 @@ pub mod ffi {
 
     extern "RustQt" {
         #[qobject]
+        #[namespace = "second_object"]
         #[qproperty(i32, property_name)]
         type SecondObject = super::SecondObjectRust;
     }

--- a/crates/cxx-qt-gen/test_outputs/invokables.cpp
+++ b/crates/cxx-qt-gen/test_outputs/invokables.cpp
@@ -1,7 +1,6 @@
 #include "cxx-qt-gen/ffi.cxxqt.h"
 
 namespace cxx_qt::my_object {
-
 void
 MyObject::cppMethod() const
 {

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -7,6 +7,7 @@
 namespace cxx_qt::my_object {
 class MyObject;
 using MyObjectCxxQtThread = ::rust::cxxqtlib1::CxxQtThread<MyObject>;
+
 } // namespace cxx_qt::my_object
 
 #include "cxx-qt-gen/ffi.cxx.h"

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -32,6 +32,7 @@ mod ffi {
         #[doc = "Use this type when referring to the QObject as a pointer"]
         #[doc = "\n"]
         #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
+        #[namespace = "cxx_qt::my_object"]
         type MyObject;
     }
     extern "Rust" {

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -124,7 +124,7 @@ MyObject::MyObject(QObject* parent)
 
 } // namespace cxx_qt::multi_object
 
-namespace cxx_qt::multi_object {
+namespace second_object {
 
 ::std::int32_t const&
 SecondObject::getPropertyName() const
@@ -180,8 +180,8 @@ SecondObject::readyConnect(::rust::Fn<void(SecondObject&)> func,
 SecondObject::SecondObject(QObject* parent)
   : QObject(parent)
   , ::rust::cxxqtlib1::CxxQtType<SecondObjectRust>(
-      ::cxx_qt::multi_object::cxx_qt_second_object::createRs())
+      ::second_object::cxx_qt_second_object::createRs())
 {
 }
 
-} // namespace cxx_qt::multi_object
+} // namespace second_object

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -62,7 +62,6 @@ ExternObject_errorOccurredConnect(
 } // namespace rust::cxxqtgen1::externcxxqt::mynamespace
 
 namespace cxx_qt::multi_object {
-
 ::std::int32_t const&
 MyObject::getPropertyName() const
 {
@@ -125,7 +124,6 @@ MyObject::MyObject(QObject* parent)
 } // namespace cxx_qt::multi_object
 
 namespace second_object {
-
 ::std::int32_t const&
 SecondObject::getPropertyName() const
 {

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -9,10 +9,10 @@ class MyObject;
 
 } // namespace cxx_qt::multi_object
 
-namespace cxx_qt::multi_object {
+namespace second_object {
 class SecondObject;
 
-} // namespace cxx_qt::multi_object
+} // namespace second_object
 
 #include "cxx-qt-gen/multi_object.cxx.h"
 
@@ -80,7 +80,7 @@ static_assert(::std::is_base_of<QObject, MyObject>::value,
 
 Q_DECLARE_METATYPE(cxx_qt::multi_object::MyObject*)
 
-namespace cxx_qt::multi_object {
+namespace second_object {
 class SecondObject
   : public QObject
   , public ::rust::cxxqtlib1::CxxQtType<SecondObjectRust>
@@ -113,6 +113,6 @@ private:
 
 static_assert(::std::is_base_of<QObject, SecondObject>::value,
               "SecondObject must inherit from QObject");
-} // namespace cxx_qt::multi_object
+} // namespace second_object
 
-Q_DECLARE_METATYPE(cxx_qt::multi_object::SecondObject*)
+Q_DECLARE_METATYPE(second_object::SecondObject*)

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -68,6 +68,7 @@ pub mod ffi {
         #[doc = "Use this type when referring to the QObject as a pointer"]
         #[doc = "\n"]
         #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
+        #[namespace = "cxx_qt::multi_object"]
         type MyObject;
     }
     extern "Rust" {
@@ -141,6 +142,7 @@ pub mod ffi {
         #[doc = "Use this type when referring to the QObject as a pointer"]
         #[doc = "\n"]
         #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
+        #[namespace = "second_object"]
         type SecondObject;
     }
     extern "Rust" {
@@ -195,7 +197,7 @@ pub mod ffi {
     }
     extern "Rust" {
         #[cxx_name = "createRs"]
-        #[namespace = "cxx_qt::multi_object::cxx_qt_second_object"]
+        #[namespace = "second_object::cxx_qt_second_object"]
         fn create_rs_second_object_rust() -> Box<SecondObjectRust>;
     }
     unsafe extern "C++" {

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -1,7 +1,6 @@
 #include "cxx-qt-gen/ffi.cxxqt.h"
 
 namespace cxx_qt::my_object {
-
 ::std::int32_t const&
 MyObject::getPrimitive() const
 {

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -28,6 +28,7 @@ mod ffi {
         #[doc = "Use this type when referring to the QObject as a pointer"]
         #[doc = "\n"]
         #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
+        #[namespace = "cxx_qt::my_object"]
         type MyObject;
     }
     extern "Rust" {

--- a/crates/cxx-qt-gen/test_outputs/qenum.cpp
+++ b/crates/cxx-qt-gen/test_outputs/qenum.cpp
@@ -1,7 +1,6 @@
 #include "cxx-qt-gen/ffi.cxxqt.h"
 
 namespace cxx_qt::my_object {
-
 void
 MyObject::myInvokable(::cxx_qt::my_object::MyEnum qenum,
                       ::cxx_qt::my_object::MyOtherEnum other_qenum) const

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs
@@ -23,6 +23,7 @@ mod ffi {
         #[doc = "Use this type when referring to the QObject as a pointer"]
         #[doc = "\n"]
         #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
+        #[namespace = "cxx_qt::my_object"]
         type MyObject;
     }
     extern "Rust" {

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -1,7 +1,6 @@
 #include "cxx-qt-gen/ffi.cxxqt.h"
 
 namespace cxx_qt::my_object {
-
 void
 MyObject::invokable()
 {

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -28,6 +28,7 @@ mod ffi {
         #[doc = "Use this type when referring to the QObject as a pointer"]
         #[doc = "\n"]
         #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/qobject/generated-qobject.html>"]
+        #[namespace = "cxx_qt::my_object"]
         type MyObject;
     }
     extern "Rust" {


### PR DESCRIPTION
Previously, specifying a `#[namespace="..."]` directly on a QObject didn't correctly overwrite the bridge namespace.