### PR TITLE
cxx-qt-gen: support private signals on the extern "C++Qt"

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -209,6 +209,7 @@ mod tests {
             },
             safe: true,
             inherit: false,
+            private: false,
         }];
         let qobject_idents = create_qobjectname();
 
@@ -272,6 +273,7 @@ mod tests {
             },
             safe: true,
             inherit: false,
+            private: false,
         }];
         let qobject_idents = create_qobjectname();
 
@@ -334,6 +336,7 @@ mod tests {
             },
             safe: true,
             inherit: true,
+            private: false,
         }];
         let qobject_idents = create_qobjectname();
 
@@ -382,6 +385,7 @@ mod tests {
             },
             safe: true,
             inherit: false,
+            private: false,
         };
 
         let generated = generate_cpp_free_signal(&signal, &ParsedCxxMappings::default()).unwrap();
@@ -436,6 +440,7 @@ mod tests {
             },
             safe: true,
             inherit: false,
+            private: false,
         };
 
         let mut cxx_mappings = ParsedCxxMappings::default();

--- a/crates/cxx-qt-gen/src/generator/naming/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/signals.rs
@@ -61,6 +61,7 @@ mod tests {
             },
             safe: true,
             inherit: false,
+            private: false,
         };
 
         let names = QSignalName::from(&qsignal);
@@ -90,6 +91,7 @@ mod tests {
             },
             safe: true,
             inherit: false,
+            private: false,
         };
 
         let names = QSignalName::from(&qsignal);


### PR DESCRIPTION
Related to #661

Requires #662 