### PR TITLE
Add qobject_header_include() to add support for moc -I<path>

### DIFF
--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -287,6 +287,7 @@ fn panic_duplicate_file_and_qml_module(
 pub struct CxxQtBuilder {
     rust_sources: Vec<PathBuf>,
     qobject_headers: Vec<PathBuf>,
+    qobject_header_includes: Vec<PathBuf>,
     qrc_files: Vec<PathBuf>,
     qt_modules: HashSet<String>,
     qml_modules: Vec<OwningQmlModule>,
@@ -305,6 +306,7 @@ impl CxxQtBuilder {
         Self {
             rust_sources: vec![],
             qobject_headers: vec![],
+            qobject_header_includes: vec![],
             qrc_files: vec![],
             qt_modules,
             qml_modules: vec![],
@@ -414,6 +416,13 @@ impl CxxQtBuilder {
         let path = path.as_ref();
         self.qobject_headers.push(path.to_owned());
         println!("cargo:rerun-if-changed={}", path.display());
+        self
+    }
+
+    /// Specify additional include paths when running the moc compiler (qobject_header).
+    pub fn qobject_header_include(mut self, path: impl AsRef<Path>) -> Self {
+        let path = path.as_ref();
+        self.qobject_header_includes.push(path.to_owned());
         self
     }
 
@@ -534,7 +543,7 @@ impl CxxQtBuilder {
 
         // Run moc on C++ headers with Q_OBJECT macro
         for qobject_header in self.qobject_headers {
-            let moc_products = qtbuild.moc(&qobject_header, None);
+            let moc_products = qtbuild.moc(&qobject_header, None, &self.qobject_header_includes);
             self.cc_builder.file(moc_products.cpp);
         }
 
@@ -552,7 +561,7 @@ impl CxxQtBuilder {
                 if let (Some(qobject), Some(qobject_header)) = (files.qobject, files.qobject_header)
                 {
                     self.cc_builder.file(&qobject);
-                    let moc_products = qtbuild.moc(qobject_header, Some(&qml_module.uri));
+                    let moc_products = qtbuild.moc(qobject_header, Some(&qml_module.uri), &vec![]);
                     self.cc_builder.file(moc_products.cpp);
                     qml_metatypes_json.push(moc_products.metatypes_json);
                 }

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -531,7 +531,8 @@ impl QtBuild {
     /// as well as the path to the generated metatypes.json file, which can be passed to [register_qml_module](Self::register_qml_module).
     ///
     /// * uri - Should be passed if the input_file is part of a QML module
-    pub fn moc(&mut self, input_file: impl AsRef<Path>, uri: Option<&str>) -> MocProducts {
+    /// * include_paths - Additional include paths to pass to moc
+    pub fn moc(&mut self, input_file: impl AsRef<Path>, uri: Option<&str>, include_paths: &Vec<PathBuf>) -> MocProducts {
         if self.moc_executable.is_none() {
             self.moc_executable = Some(self.get_qt_tool("moc").expect("Could not find moc"));
         }
@@ -546,7 +547,12 @@ impl QtBuild {
         let metatypes_json_path = PathBuf::from(&format!("{}.json", output_path.display()));
 
         let mut include_args = String::new();
+        // Qt includes
         for include_path in self.include_paths() {
+            include_args += &format!("-I {} ", include_path.display());
+        }
+        // User includes
+        for include_path in include_paths {
             include_args += &format!("-I {} ", include_path.display());
         }
 
@@ -824,7 +830,7 @@ public:
 "#
             )
             .unwrap();
-            self.moc(&qml_plugin_cpp_path, Some(uri));
+            self.moc(&qml_plugin_cpp_path, Some(uri), &vec![]);
 
             // Generate file to load static QQmlExtensionPlugin
             let mut qml_plugin_init = File::create(&qml_plugin_init_path).unwrap();


### PR DESCRIPTION
POC, probably not the best way to do this, but it was the simplest.

- Needed when the moc compiler does not have all the necessary files present in the cwd.
- Fixes #679 