### PR TITLE
cxx-qt-lib: fix new clippy warning for PartialOrd and Ord impls

### DIFF
--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -358,13 +358,13 @@ impl Eq for QDateTime {}
 
 impl PartialOrd for QDateTime {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        0.partial_cmp(&ffi::qdatetime_cmp(self, other))
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for QDateTime {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        0.cmp(&ffi::qdatetime_cmp(self, other))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -214,13 +214,13 @@ impl Eq for QString {}
 
 impl PartialOrd for QString {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        0.partial_cmp(&ffi::qstring_cmp(self, other))
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for QString {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        0.cmp(&ffi::qstring_cmp(self, other))
     }
 }
 


### PR DESCRIPTION
incorrect implementation of `partial_cmp` on an `Ord` type