### PR TITLE
cxx-qt-lib: fix incorrect cmp order

### DIFF
--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -364,7 +364,7 @@ impl PartialOrd for QDateTime {
 
 impl Ord for QDateTime {
     fn cmp(&self, other: &Self) -> Ordering {
-        0.cmp(&ffi::qdatetime_cmp(self, other))
+        ffi::qdatetime_cmp(self, other).cmp(&0)
     }
 }
 
@@ -487,6 +487,30 @@ impl TryFrom<QDateTime> for time::PrimitiveDateTime {
 unsafe impl ExternType for QDateTime {
     type Id = type_id!("QDateTime");
     type Kind = cxx::kind::Trivial;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_ordering() {
+        let qdatetime_a = QDateTime::from_date_and_time_time_zone(
+            &QDate::new(2023, 1, 1),
+            &QTime::new(1, 1, 1, 1),
+            &ffi::QTimeZone::utc(),
+        );
+        let qdatetime_b = QDateTime::from_date_and_time_time_zone(
+            &QDate::new(2023, 2, 2),
+            &QTime::new(2, 2, 2, 2),
+            &ffi::QTimeZone::utc(),
+        );
+
+        assert!(qdatetime_a < qdatetime_b);
+        assert_eq!(qdatetime_a.cmp(&qdatetime_b), Ordering::Less);
+        assert_eq!(qdatetime_b.cmp(&qdatetime_a), Ordering::Greater);
+        assert_eq!(qdatetime_a.cmp(&qdatetime_a), Ordering::Equal);
+    }
 }
 
 #[cfg(test)]

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -220,7 +220,7 @@ impl PartialOrd for QString {
 
 impl Ord for QString {
     fn cmp(&self, other: &Self) -> Ordering {
-        0.cmp(&ffi::qstring_cmp(self, other))
+        ffi::qstring_cmp(self, other).cmp(&0)
     }
 }
 
@@ -291,7 +291,7 @@ impl QString {
     /// Lexically compares this string with the other string and
     /// returns if this string is less than, equal to, or greater than the other string.
     pub fn compare(&self, other: &QString, cs: ffi::CaseSensitivity) -> Ordering {
-        0.cmp(&self.compare_i32(other, cs))
+        self.compare_i32(other, cs).cmp(&0)
     }
 
     /// Returns the index position of the first occurrence of the string str in this string,
@@ -380,4 +380,33 @@ impl QString {
 unsafe impl ExternType for QString {
     type Id = type_id!("QString");
     type Kind = cxx::kind::Trivial;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_ordering() {
+        let qstring_a = QString::from("a");
+        let qstring_b = QString::from("b");
+
+        assert!(qstring_a < qstring_b);
+        assert_eq!(qstring_a.cmp(&qstring_b), Ordering::Less);
+        assert_eq!(qstring_b.cmp(&qstring_a), Ordering::Greater);
+        assert_eq!(qstring_a.cmp(&qstring_a), Ordering::Equal);
+
+        assert_eq!(
+            qstring_a.compare(&qstring_b, crate::CaseSensitivity::CaseInsensitive),
+            Ordering::Less
+        );
+        assert_eq!(
+            qstring_b.compare(&qstring_a, crate::CaseSensitivity::CaseInsensitive),
+            Ordering::Greater
+        );
+        assert_eq!(
+            qstring_a.compare(&qstring_a, crate::CaseSensitivity::CaseInsensitive),
+            Ordering::Equal
+        );
+    }
 }


### PR DESCRIPTION
This meant that QString and QDateTime had reversed Ord results.