### PR TITLE
Use new QT_NO_CONTEXTLESS_CONNECT variable in qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ if(NOT Qt6_FOUND)
     find_package(Qt5 5.15 COMPONENTS Core Gui Test REQUIRED)
 endif()
 
+if (NOT Qt5_FOUND)
+    add_definitions(-DQT_NO_CONTEXTLESS_CONNECT)
+endif()
 
 if(UNIX AND NOT APPLE)
     if (Qt5_FOUND)


### PR DESCRIPTION
Defining the macro before including any Qt header will disable the overload of QObject::connect that does not take a receiver/context argument.