### PR TITLE
Remove "defined as struct" warning

### DIFF
--- a/crates/cxx-qt-gen/include/cxxqt_locking.h
+++ b/crates/cxx-qt-gen/include/cxxqt_locking.h
@@ -32,7 +32,7 @@ protected:
 
   // Friend MaybeLockGuard so that it can use unsafeRustLock()
   template<typename T, typename D>
-  friend class MaybeLockGuard;
+  friend struct MaybeLockGuard;
 };
 
 }


### PR DESCRIPTION
Removed the following warning:

```
warning: /Users/michael/projects/qml_minimal_copy/build/cxxqt/qml-minimal/cxx-qt-common/cxxqt_maybelockguard.h:21:1: warning: 'MaybeLockGuard' defined as a struct template here but previously declared as a class template; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
warning: struct MaybeLockGuard
warning: ^
warning: /Users/michael/projects/qml_minimal_copy/build/cxxqt/qml-minimal/cxx-qt-common/cxxqt_locking.h:35:10: note: did you mean struct here?
warning:   friend class MaybeLockGuard;
warning:          ^~~~~
warning:          struct
```