### PR TITLE
Wrapper for QModelIndex::internalId

### DIFF
--- a/crates/cxx-qt-lib-headers/include/core/qmodelindex.h
+++ b/crates/cxx-qt-lib-headers/include/core/qmodelindex.h
@@ -6,4 +6,15 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #pragma once
 
+#include <cinttypes>
+
 #include <QtCore/QModelIndex>
+
+namespace rust {
+namespace cxxqtlib1 {
+
+::std::size_t
+qmodelindexInternalId(const QModelIndex& index);
+
+}
+}

--- a/crates/cxx-qt-lib/src/core/qmodelindex.cpp
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.cpp
@@ -17,3 +17,14 @@ assert_alignment_and_size(QModelIndex,
                             sizeof(::std::size_t));
 
 static_assert(::std::is_trivially_copyable<QModelIndex>::value);
+
+namespace rust {
+namespace cxxqtlib1 {
+
+::std::size_t
+qmodelindexInternalId(const QModelIndex& index) {
+  return index.internalId();
+}
+
+}
+}

--- a/crates/cxx-qt-lib/src/core/qmodelindex.cpp
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.cpp
@@ -22,7 +22,8 @@ namespace rust {
 namespace cxxqtlib1 {
 
 ::std::size_t
-qmodelindexInternalId(const QModelIndex& index) {
+qmodelindexInternalId(const QModelIndex& index)
+{
   return index.internalId();
 }
 

--- a/crates/cxx-qt-lib/src/core/qmodelindex.cpp
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.cpp
@@ -24,7 +24,8 @@ namespace cxxqtlib1 {
 ::std::size_t
 qmodelindexInternalId(const QModelIndex& index)
 {
-  return index.internalId();
+  // TODO: need to add support for quintptr
+  return static_cast<::std::size_t>(index.internalId());
 }
 
 }

--- a/crates/cxx-qt-lib/src/core/qmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.rs
@@ -67,6 +67,9 @@ pub struct QModelIndex {
 }
 
 impl QModelIndex {
+    /// Returns a `usize` used by the model to associate the index with the internal data structure.
+    //
+    // TODO: need to add support for quintptr
     pub fn internal_id(&self) -> usize {
         ffi::qmodelindex_internal_id(self)
     }

--- a/crates/cxx-qt-lib/src/core/qmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.rs
@@ -49,6 +49,10 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qmodelindex_to_qstring"]
         fn toQString(value: &QModelIndex) -> QString;
+
+        #[doc(hidden)]
+        #[rust_name = "qmodelindex_internal_id"]
+        fn qmodelindexInternalId(index: &QModelIndex) -> usize;
     }
 }
 
@@ -60,6 +64,12 @@ pub struct QModelIndex {
     _c: MaybeUninit<i32>,
     _i: MaybeUninit<usize>,
     _m: MaybeUninit<usize>,
+}
+
+impl QModelIndex {
+    pub fn internal_id(&self) -> usize {
+        ffi::qmodelindex_internal_id(self)
+    }
 }
 
 impl Default for QModelIndex {


### PR DESCRIPTION
Implementation of QModelIndex::internalId for #719 using a wrapper function.
The direct solution 

        #[rust_name = "internalId"]
        fn internal_id(self: &QModelIndex) -> usize;

didn't compile. There was a type mismatch between ::std::size_t (unsigned long) and quintptr (unsigned long long) on my system (Apple Silicon, stable-aarch64-apple-darwin).

This PR enables trees via QAbstractItemModel.