### PR TITLE
cxx-qt-gen: add missing noexcept to SignalHandler deconstructor

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -209,7 +209,7 @@ mod tests {
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
             namespace rust::cxxqtlib1 {
             template <>
-            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamstrivialPropertyChanged *>::~SignalHandler()
+            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamstrivialPropertyChanged *>::~SignalHandler() noexcept
             {
                 if (data[0] == nullptr && data[1] == nullptr)
                 {
@@ -270,7 +270,7 @@ mod tests {
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
             namespace rust::cxxqtlib1 {
             template <>
-            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamsopaquePropertyChanged *>::~SignalHandler()
+            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamsopaquePropertyChanged *>::~SignalHandler() noexcept
             {
                 if (data[0] == nullptr && data[1] == nullptr)
                 {
@@ -439,7 +439,7 @@ mod tests {
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
             namespace rust::cxxqtlib1 {
             template <>
-            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamsmappedPropertyChanged *>::~SignalHandler()
+            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamsmappedPropertyChanged *>::~SignalHandler() noexcept
             {
                 if (data[0] == nullptr && data[1] == nullptr)
                 {

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -150,7 +150,7 @@ pub fn generate_cpp_signal(
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
             namespace rust::cxxqtlib1 {{
             template <>
-            {signal_handler_type}::~SignalHandler()
+            {signal_handler_type}::~SignalHandler() noexcept
             {{
                 if (data[0] == nullptr && data[1] == nullptr)
                 {{
@@ -290,7 +290,7 @@ mod tests {
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
             namespace rust::cxxqtlib1 {
             template <>
-            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamsdataChanged *>::~SignalHandler()
+            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamsdataChanged *>::~SignalHandler() noexcept
             {
                 if (data[0] == nullptr && data[1] == nullptr)
                 {
@@ -390,7 +390,7 @@ mod tests {
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
             namespace rust::cxxqtlib1 {
             template <>
-            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamsdataChanged *>::~SignalHandler()
+            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamsdataChanged *>::~SignalHandler() noexcept
             {
                 if (data[0] == nullptr && data[1] == nullptr)
                 {
@@ -478,7 +478,7 @@ mod tests {
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
             namespace rust::cxxqtlib1 {
             template <>
-            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamsbaseName *>::~SignalHandler()
+            SignalHandler<::rust::cxxqtgen1::MyObjectCxxQtSignalParamsbaseName *>::~SignalHandler() noexcept
             {
                 if (data[0] == nullptr && data[1] == nullptr)
                 {
@@ -570,7 +570,7 @@ mod tests {
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
             namespace rust::cxxqtlib1 {
             template <>
-            SignalHandler<::rust::cxxqtgen1::ObjRustCxxQtSignalParamssignalRustName *>::~SignalHandler()
+            SignalHandler<::rust::cxxqtgen1::ObjRustCxxQtSignalParamssignalRustName *>::~SignalHandler() noexcept
             {
                 if (data[0] == nullptr && data[1] == nullptr)
                 {
@@ -666,7 +666,7 @@ mod tests {
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
             namespace rust::cxxqtlib1 {
             template <>
-            SignalHandler<::rust::cxxqtgen1::mynamespace::ObjRustCxxQtSignalParamssignalCxxName *>::~SignalHandler()
+            SignalHandler<::rust::cxxqtgen1::mynamespace::ObjRustCxxQtSignalParamssignalCxxName *>::~SignalHandler() noexcept
             {
                 if (data[0] == nullptr && data[1] == nullptr)
                 {

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.cpp
@@ -4,8 +4,8 @@
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
 namespace rust::cxxqtlib1 {
 template<>
-SignalHandler<
-  ::rust::cxxqtgen1::QPushButtonCxxQtSignalParamsclicked*>::~SignalHandler()
+SignalHandler<::rust::cxxqtgen1::QPushButtonCxxQtSignalParamsclicked*>::
+  ~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;
@@ -59,8 +59,9 @@ QPushButton_clickedConnect(
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
 namespace rust::cxxqtlib1 {
 template<>
-SignalHandler<::rust::cxxqtgen1::mynamespace::
-                ExternObjectCxxQtSignalParamsdataReady*>::~SignalHandler()
+SignalHandler<
+  ::rust::cxxqtgen1::mynamespace::ExternObjectCxxQtSignalParamsdataReady*>::
+  ~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;
@@ -117,8 +118,9 @@ ExternObject_dataReadyConnect(
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
 namespace rust::cxxqtlib1 {
 template<>
-SignalHandler<::rust::cxxqtgen1::mynamespace::
-                ExternObjectCxxQtSignalParamserrorOccurred*>::~SignalHandler()
+SignalHandler<
+  ::rust::cxxqtgen1::mynamespace::ExternObjectCxxQtSignalParamserrorOccurred*>::
+  ~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;
@@ -175,8 +177,9 @@ ExternObject_errorOccurredConnect(
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
 namespace rust::cxxqtlib1 {
 template<>
-SignalHandler<::rust::cxxqtgen1::cxx_qt::multi_object::
-                MyObjectCxxQtSignalParamspropertyNameChanged*>::~SignalHandler()
+SignalHandler<
+  ::rust::cxxqtgen1::cxx_qt::multi_object::
+    MyObjectCxxQtSignalParamspropertyNameChanged*>::~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;
@@ -234,7 +237,7 @@ MyObject_propertyNameChangedConnect(
 namespace rust::cxxqtlib1 {
 template<>
 SignalHandler<::rust::cxxqtgen1::cxx_qt::multi_object::
-                MyObjectCxxQtSignalParamsready*>::~SignalHandler()
+                MyObjectCxxQtSignalParamsready*>::~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;
@@ -321,9 +324,9 @@ MyObject::MyObject(QObject* parent)
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
 namespace rust::cxxqtlib1 {
 template<>
-SignalHandler<
-  ::rust::cxxqtgen1::second_object::
-    SecondObjectCxxQtSignalParamspropertyNameChanged*>::~SignalHandler()
+SignalHandler<::rust::cxxqtgen1::second_object::
+                SecondObjectCxxQtSignalParamspropertyNameChanged*>::
+  ~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;
@@ -380,7 +383,7 @@ SecondObject_propertyNameChangedConnect(
 namespace rust::cxxqtlib1 {
 template<>
 SignalHandler<::rust::cxxqtgen1::second_object::
-                SecondObjectCxxQtSignalParamsready*>::~SignalHandler()
+                SecondObjectCxxQtSignalParamsready*>::~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -4,8 +4,9 @@
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
 namespace rust::cxxqtlib1 {
 template<>
-SignalHandler<::rust::cxxqtgen1::cxx_qt::my_object::
-                MyObjectCxxQtSignalParamsprimitiveChanged*>::~SignalHandler()
+SignalHandler<
+  ::rust::cxxqtgen1::cxx_qt::my_object::
+    MyObjectCxxQtSignalParamsprimitiveChanged*>::~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;
@@ -61,8 +62,9 @@ MyObject_primitiveChangedConnect(
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
 namespace rust::cxxqtlib1 {
 template<>
-SignalHandler<::rust::cxxqtgen1::cxx_qt::my_object::
-                MyObjectCxxQtSignalParamstrivialChanged*>::~SignalHandler()
+SignalHandler<
+  ::rust::cxxqtgen1::cxx_qt::my_object::
+    MyObjectCxxQtSignalParamstrivialChanged*>::~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;

--- a/crates/cxx-qt-gen/test_outputs/signals.cpp
+++ b/crates/cxx-qt-gen/test_outputs/signals.cpp
@@ -5,7 +5,7 @@
 namespace rust::cxxqtlib1 {
 template<>
 SignalHandler<::rust::cxxqtgen1::cxx_qt::my_object::
-                QTimerCxxQtSignalParamstimeout*>::~SignalHandler()
+                QTimerCxxQtSignalParamstimeout*>::~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;
@@ -63,7 +63,7 @@ QTimer_timeoutConnect(
 namespace rust::cxxqtlib1 {
 template<>
 SignalHandler<::rust::cxxqtgen1::cxx_qt::my_object::
-                MyObjectCxxQtSignalParamsready*>::~SignalHandler()
+                MyObjectCxxQtSignalParamsready*>::~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;
@@ -120,8 +120,9 @@ MyObject_readyConnect(
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
 namespace rust::cxxqtlib1 {
 template<>
-SignalHandler<::rust::cxxqtgen1::cxx_qt::my_object::
-                MyObjectCxxQtSignalParamsdataChanged*>::~SignalHandler()
+SignalHandler<
+  ::rust::cxxqtgen1::cxx_qt::my_object::MyObjectCxxQtSignalParamsdataChanged*>::
+  ~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;
@@ -200,7 +201,7 @@ MyObject_dataChangedConnect(
 namespace rust::cxxqtlib1 {
 template<>
 SignalHandler<::rust::cxxqtgen1::cxx_qt::my_object::
-                MyObjectCxxQtSignalParamsnewData*>::~SignalHandler()
+                MyObjectCxxQtSignalParamsnewData*>::~SignalHandler() noexcept
 {
   if (data[0] == nullptr && data[1] == nullptr) {
     return;


### PR DESCRIPTION
This fixes warnings in CI from macOS using clang.