### PR TITLE
qt-build-utils: use QML module name in .qrc file name

### DIFF
--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -636,7 +636,7 @@ prefer :/qt/qml/{qml_uri_dirs}/
         }
 
         // Generate .qrc file and run rcc on it
-        let qrc_path = format!("{qml_module_dir}/qml_module_resources.qrc");
+        let qrc_path = format!("{qml_module_dir}/qml_module_resources_{qml_uri_underscores}.qrc");
         {
             fn qrc_file_line(file_path: &impl AsRef<Path>) -> String {
                 let path_display = file_path.as_ref().display();


### PR DESCRIPTION
This is required to link together multiple QML modules in one project without duplicate symbol errors. This fixes the link error in #598.