### PR TITLE
cxx-qt-gen: allow for optional #[qobject] macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cxx-qt-gen` now does not generate code requiring `cxx-qt-lib`, this allows for `cxx-qt-lib` to be optional
 - `cxx-qt-lib` headers must be given to `cxx-qt-build` with `.with_opts(cxx_qt_lib_headers::build_opts())`
 - File name is used for CXX bridges rather than module name to match upstream
+- `#[qobject]` attribute is now optional on types in `extern "RustQt"`
 
 ### Fixed
 

--- a/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
@@ -22,6 +22,9 @@ pub fn generate(
 
     for method in inherited_methods {
         let return_type = syn_type_to_cpp_return_type(&method.method.sig.output, type_names)?;
+        // Note that no qobject macro with no base class is an error
+        //
+        // So a default of QObject is fine here
         let base_class = base_class.as_deref().unwrap_or("QObject");
 
         result.methods.push(CppFragment::Header(formatdoc! {

--- a/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
+++ b/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
@@ -80,27 +80,44 @@ impl ParsedCxxQtData {
                                     syn::parse2(tokens.clone())?;
 
                                 // Check this type is tagged with a #[qobject]
-                                if attribute_take_path(&mut foreign_alias.attrs, &["qobject"])
-                                    .is_some()
+                                let has_qobject_macro =
+                                    attribute_take_path(&mut foreign_alias.attrs, &["qobject"])
+                                        .is_some();
+
+                                // Load the QObject
+                                let mut qobject = ParsedQObject::try_from(&foreign_alias)?;
+                                qobject.has_qobject_macro = has_qobject_macro;
+
+                                // Ensure that the base class attribute is not empty, as this is not valid in both cases
+                                // - when there is a qobject macro it is not valid
+                                // - when there is not a qobject macro it is not valid
+                                if qobject
+                                    .base_class
+                                    .as_ref()
+                                    .is_some_and(|base| base.is_empty())
                                 {
-                                    // Load the QObject
-                                    let mut qobject = ParsedQObject::try_from(&foreign_alias)?;
-
-                                    // Inject the bridge namespace if the qobject one is empty
-                                    if qobject.namespace.is_empty() && namespace.is_some() {
-                                        qobject.namespace = namespace.clone().unwrap();
-                                    }
-
-                                    // Note that we assume a compiler error will occur later
-                                    // if you had two structs with the same name
-                                    self.qobjects
-                                        .insert(foreign_alias.ident_left.clone(), qobject);
-                                } else {
                                     return Err(Error::new(
                                         foreign_item.span(),
-                                        "type A = super::B must be tagged with #[qobject]",
+                                        "The #[base] attribute cannot be empty",
                                     ));
                                 }
+
+                                // Ensure that if there is no qobject macro that a base class is specificed
+                                //
+                                // Note this assumes the check above
+                                if !qobject.has_qobject_macro && qobject.base_class.is_none() {
+                                    return Err(Error::new(foreign_item.span(), "A type without a #[qobject] attribute must specify a #[base] attribute"));
+                                }
+
+                                // Inject the bridge namespace if the qobject one is empty
+                                if qobject.namespace.is_empty() && namespace.is_some() {
+                                    qobject.namespace = namespace.clone().unwrap();
+                                }
+
+                                // Note that we assume a compiler error will occur later
+                                // if you had two structs with the same name
+                                self.qobjects
+                                    .insert(foreign_alias.ident_left.clone(), qobject);
                             }
                             // Const Macro, Type are unsupported in extern "RustQt" for now
                             _others => {
@@ -316,6 +333,13 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(cxx_qt_data.qobjects.len(), 1);
         assert!(cxx_qt_data.qobjects.contains_key(&qobject_ident()));
+        assert!(
+            cxx_qt_data
+                .qobjects
+                .get(&qobject_ident())
+                .unwrap()
+                .has_qobject_macro
+        );
     }
 
     #[test]
@@ -380,7 +404,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_qobjects_no_qobject() {
+    fn test_find_qobjects_no_qobject_no_base() {
         let mut cxx_qt_data = ParsedCxxQtData::new(format_ident!("ffi"), None);
 
         let module: ItemMod = parse_quote! {
@@ -393,6 +417,39 @@ mod tests {
         };
         let result = cxx_qt_data.find_qobject_types(&module.content.unwrap().1);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_find_qobjects_no_qobject_with_base() {
+        let mut cxx_qt_data = ParsedCxxQtData::new(format_ident!("ffi"), None);
+
+        let module: ItemMod = parse_quote! {
+            mod module {
+                extern "RustQt" {
+                    #[base = "OtherBase"]
+                    type Other = super::OtherRust;
+                    #[base = "MyObjectBase"]
+                    type MyObject = super::MyObjectRust;
+                }
+            }
+        };
+        let result = cxx_qt_data.find_qobject_types(&module.content.unwrap().1);
+        assert!(result.is_ok());
+        assert_eq!(cxx_qt_data.qobjects.len(), 2);
+        assert!(
+            !cxx_qt_data
+                .qobjects
+                .get(&format_ident!("Other"))
+                .unwrap()
+                .has_qobject_macro
+        );
+        assert!(
+            !cxx_qt_data
+                .qobjects
+                .get(&format_ident!("MyObject"))
+                .unwrap()
+                .has_qobject_macro
+        );
     }
 
     #[test]

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -57,6 +57,8 @@ pub struct ParsedQObject {
     pub locking: bool,
     /// Whether threading has been enabled for this QObject
     pub threading: bool,
+    /// Whether this type has a #[qobject] / Q_OBJECT macro
+    pub has_qobject_macro: bool,
 }
 
 impl TryFrom<&ForeignTypeIdentAlias> for ParsedQObject {
@@ -97,6 +99,7 @@ impl TryFrom<&ForeignTypeIdentAlias> for ParsedQObject {
             qml_metadata,
             locking: true,
             threading: false,
+            has_qobject_macro: false,
         })
     }
 }

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -62,6 +62,7 @@ mod tests {
                     rust_ident: "MyObjectRust".to_owned(),
                     namespace: "cxx_qt::my_object".to_owned(),
                     namespace_internals: "cxx_qt::my_object::cxx_qt_my_object".to_owned(),
+                    has_qobject_macro: true,
                     blocks: GeneratedCppQObjectBlocks {
                         base_classes: vec!["QStringListModel".to_owned()],
                         includes: {
@@ -185,6 +186,7 @@ mod tests {
                     rust_ident: "FirstObjectRust".to_owned(),
                     namespace: "cxx_qt".to_owned(),
                     namespace_internals: "cxx_qt::cxx_qt_first_object".to_owned(),
+                    has_qobject_macro: true,
                     blocks: GeneratedCppQObjectBlocks {
                         base_classes: vec!["QStringListModel".to_owned()],
                         includes: {
@@ -228,6 +230,7 @@ mod tests {
                     rust_ident: "SecondObjectRust".to_owned(),
                     namespace: "cxx_qt".to_owned(),
                     namespace_internals: "cxx_qt::cxx_qt_second_object".to_owned(),
+                    has_qobject_macro: true,
                     blocks: GeneratedCppQObjectBlocks {
                         base_classes: vec!["QStringListModel".to_owned()],
                         includes: {


### PR DESCRIPTION
This allows for using CXX-Qt helpers with normal C++ classes, eg #[inherit] and #[cxx_override] etc.