### PR TITLE
CI: markdown-lint

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -32,6 +32,14 @@ jobs:
       - run: rustup component add rustfmt
       - run: cargo fmt --all --check --verbose
 
+  markdown_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v14
+        with:
+          globs: 'book/**/*.md'
+
   build:
     # Run after pre checks
     needs: [clang_format, license_check, rust_format_check]

--- a/book/.markdownlint.json
+++ b/book/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "MD033": false,
+    "MD013": false,
+    "MD028": false,
+    "MD014": false
+}

--- a/book/.markdownlint.json
+++ b/book/.markdownlint.json
@@ -1,6 +1,0 @@
-{
-    "MD033": false,
-    "MD013": false,
-    "MD028": false,
-    "MD014": false
-}

--- a/book/.markdownlint.jsonc
+++ b/book/.markdownlint.jsonc
@@ -1,0 +1,13 @@
+/*
+SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+SPDX-FileContributor: Matt Aber <matt.aber@kdab.com>
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+*/
+
+{
+    "MD033": false,
+    "MD013": false,
+    "MD028": false,
+    "MD014": false
+}


### PR DESCRIPTION
only lints in book for now, the rules may have to be different for changelog & readme or they may need to be edited to conform or just have comments turning certain rules off

resolves #800 