### PR TITLE
CI: Split up cargo test

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -291,9 +291,17 @@ jobs:
       working-directory: ${{ matrix.workspace }}
       env:
         RUSTC_WRAPPER: sccache
-    - name: "Test"
+    - name: "CTest"
       run: ctest ${{ matrix.ctest_args }} -C Release -T test --output-on-failure --parallel ${{ matrix.cores }}
       working-directory: ${{ matrix.workspace }}/build
+      env:
+        RUSTC_WRAPPER: sccache
+        QT_QPA_PLATFORM: ${{ matrix.qt_qpa_platform }}
+        QT_SELECT: qt${{ matrix.qt_version }}
+
+    - name: "Cargo test"
+      run: cargo test --release --all-features --target-dir ${{ matrix.workspace }}/build/cargo/build
+      working-directory: ${{ matrix.workspace }}
       env:
         RUSTC_WRAPPER: sccache
         QT_QPA_PLATFORM: ${{ matrix.qt_qpa_platform }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,8 +213,7 @@ endif()
 # from the main build.
 set(CARGO_TARGET_DIR "${CMAKE_BINARY_DIR}/${BUILD_DIR}/cargo/build")
 
-# Add CMake tests for `cargo test/clippy/fmt/doc`.
-add_test(NAME cargo_tests COMMAND cargo test --release --all-features --target-dir ${CARGO_TARGET_DIR})
+# Add CMake tests for `clippy/doc`.
 add_test(NAME cargo_doc COMMAND cargo doc --release --all-features --target-dir ${CARGO_TARGET_DIR})
 add_test(NAME cargo_clippy COMMAND cargo clippy --release --all-features --target-dir ${CARGO_TARGET_DIR} -- -D warnings)
 
@@ -222,9 +221,6 @@ if(CMAKE_RUSTC_WRAPPER)
     list(APPEND CARGO_ENV "RUSTC_WRAPPER=set:${CMAKE_RUSTC_WRAPPER}")
 endif()
 
-set_tests_properties(cargo_tests cargo_clippy PROPERTIES
-    ENVIRONMENT_MODIFICATION "${CARGO_ENV}"
-)
 set_tests_properties(cargo_doc PROPERTIES
     ENVIRONMENT_MODIFICATION "${CARGO_ENV};RUSTDOCFLAGS=set:--deny=warnings"
 )


### PR DESCRIPTION
This should help investigate why Windows build is taking so long, even with caching.