### PR TITLE
Enable verbose ctest output

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -283,19 +283,15 @@ jobs:
         -S . -B build
       working-directory: ${{ matrix.workspace }}
       env:
-        RUSTC_WRAPPER: sccache
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
     - name: "Build"
       run: cmake --build build --config Release --parallel ${{ matrix.cores }}
       working-directory: ${{ matrix.workspace }}
-      env:
-        RUSTC_WRAPPER: sccache
     - name: "Test"
       run: ctest ${{ matrix.ctest_args }} -C Release -T test -VV
       working-directory: ${{ matrix.workspace }}/build
       env:
-        RUSTC_WRAPPER: sccache
         QT_QPA_PLATFORM: ${{ matrix.qt_qpa_platform }}
         QT_SELECT: qt${{ matrix.qt_version }}
 

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -288,6 +288,10 @@ jobs:
     - name: "Build"
       run: cmake --build build --config Release --parallel ${{ matrix.cores }}
       working-directory: ${{ matrix.workspace }}
+
+    - name: "Print intermediate compiler cache statistics"
+      run: sccache --show-stats
+
     - name: "Test"
       run: ctest ${{ matrix.ctest_args }} -C Release -T test -VV
       working-directory: ${{ matrix.workspace }}/build
@@ -295,7 +299,7 @@ jobs:
         QT_QPA_PLATFORM: ${{ matrix.qt_qpa_platform }}
         QT_SELECT: qt${{ matrix.qt_version }}
 
-    - name: "Print compiler cache statistics"
+    - name: "Print final compiler cache statistics"
       run: sccache --show-stats
 
     - name: Upload GitHub Actions artifacts of vcpkg logs

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -292,7 +292,7 @@ jobs:
       env:
         RUSTC_WRAPPER: sccache
     - name: "Test"
-      run: ctest ${{ matrix.ctest_args }} -C Release -T test --output-on-failure --parallel ${{ matrix.cores }}
+      run: ctest ${{ matrix.ctest_args }} -C Release -T test -VV
       working-directory: ${{ matrix.workspace }}/build
       env:
         RUSTC_WRAPPER: sccache


### PR DESCRIPTION
This could help investigate why CTest is slow on Windows