### PR TITLE
cxx-qt-build: set minimum macOS version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,4 +60,4 @@ serde_json = "1.0"
 # Use a patched version of cc-rs that respects the rustc wrapper
 # This should greatly speed up CI builds!
 [patch.crates-io]
-cc = { git = "https://github.com/LeonMatthesKDAB/cc-rs.git", branch="respect-rustc-wrapper" }
+cc = { git = "https://github.com/Be-ing/cc-rs.git", branch="apple_deployment_target_api" }

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -510,6 +510,11 @@ impl CxxQtBuilder {
             builder.flag_if_supported("-std=c++17");
             // MinGW requires big-obj otherwise debug builds fail
             builder.flag_if_supported("-Wa,-mbig-obj");
+            // macOS
+            // We need
+            //   - std::filesystem::path from 10.15
+            //   - std::shared_mutex from 10.12
+            builder.apple_deployment_target(&"10.5");
             // Enable Qt Gui in C++ if the feature is enabled
             #[cfg(feature = "qt_gui")]
             builder.define("CXX_QT_GUI_FEATURE", None);

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -289,6 +289,11 @@ fn main() {
     builder.flag_if_supported("/bigobj");
     // GCC + Clang
     builder.flag_if_supported("-std=c++17");
+    // macOS
+    // We need
+    //   - std::filesystem::path from 10.15
+    //   - std::shared_mutex from 10.12
+    builder.apple_deployment_target(&"10.15");
     // MinGW requires big-obj otherwise debug builds fail
     builder.flag_if_supported("-Wa,-mbig-obj");
 


### PR DESCRIPTION
to override cc's default which is too low for CXX-Qt. Setting the MACOSX_DEPLOYMENT_TARGET environment variable in CI is fine, but that doesn't solve the problem for downstream users.

relies on a pending PR for cc https://github.com/rust-lang/cc-rs/pull/938
