### PR TITLE
github: always use same cache rather than creating new ones

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     # Keep in sync with manual-book.yml
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Install mdbook and mdbook-linkcheck from binaries
       run: |
         mkdir mdbook
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.36/mdbook-v0.4.36-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
         curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/latest/download/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -o mdbook-linkcheck.zip
         unzip mdbook-linkcheck.zip -d mdbook-linkcheck/

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -198,7 +198,7 @@ jobs:
           ${{ matrix.cargo_dir }}/bin/sccache${{ matrix.exe_suffix }}
           ${{ matrix.cargo_dir }}/bin/mdbook${{ matrix.exe_suffix }}
           ${{ matrix.cargo_dir }}/bin/mdbook-linkcheck${{ matrix.exe_suffix }}
-        key: ${{ matrix.os }}_sccache-0.4.1_mdbook-0.4.28_mdbook-linkcheck-0.7.7
+        key: ${{ matrix.os }}_sccache-0.7.6_mdbook-0.4.36_mdbook-linkcheck-0.7.7
     - name: "Build Rust tools"
       if: steps.rust-tools-cache.outputs.cache-hit != 'true'
       run: cargo install --locked sccache mdbook mdbook-linkcheck

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -201,7 +201,10 @@ jobs:
         key: ${{ matrix.os }}_sccache-0.7.6_mdbook-0.4.36_mdbook-linkcheck-0.7.7
     - name: "Build Rust tools"
       if: steps.rust-tools-cache.outputs.cache-hit != 'true'
-      run: cargo install --locked sccache mdbook mdbook-linkcheck
+      # Do not build with storage backends enabled, we only need local
+      run: |
+        cargo install --no-default-features sccache
+        cargo install mdbook mdbook-linkcheck
 
     - name: "Compiler cache"
       # Always cache and save all branches

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -169,9 +169,10 @@ jobs:
         # Match the deployment target that Qt was built with via vcpkg, otherwise the following error occurs
         # ld: warning: object file (LIB) was built for newer macOS version (12.7) than being linked (12.0)
         MACOSX_DEPLOYMENT_TARGET: 12.7
-        # sccache is around 250-350M in size for a normal build
-        # set the cache size to double of this to leave some headroom
-        # but don't expand too large as we cache old data and cause cache evictions
+        # sccache is around 180-300M in size for a normal build
+        # With GitHub caches we have a 10 GB limit / 6 conditions = 1666 MB
+        # Allow a larger cache size so that code in branches can be cached
+        # but still leave room for the tools cache
         SCCACHE_CACHE_SIZE: 600M
 
     steps:
@@ -190,7 +191,7 @@ jobs:
       run: rustup component add clippy rustfmt
 
     - name: "Rust tools cache"
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-tools-cache
       with:
         path: |
@@ -203,13 +204,14 @@ jobs:
       run: cargo install --locked sccache mdbook mdbook-linkcheck
 
     - name: "Compiler cache"
-      uses: actions/cache@v3
+      # Always cache and save all branches
+      # otherwise if we only restore here and only save the main branch
+      # we don't update the cache until something reaches main which
+      # causes an eviction of the cache if the cache isn't accessed for 1 week
+      uses: actions/cache@v4
       with:
         path: ${{ matrix.compiler_cache_path }}
-        key: ${{ matrix.name }}-${{ github.head_ref }}-${{ github.run_number }}
-        restore-keys: |
-          ${{ matrix.name }}-${{ github.head_ref }}
-          ${{ matrix.name }}
+        key: ${{ matrix.name }}_compiler_cache
 
     - name: "[Ubuntu] Install dependencies"
       if: runner.os == 'Linux'

--- a/.github/workflows/manual-book.yml
+++ b/.github/workflows/manual-book.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     # Keep in sync with book.yml
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Install mdbook and mdbook-linkcheck from binaries
       run: |
         mkdir mdbook
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.36/mdbook-v0.4.36-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
         curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/latest/download/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -o mdbook-linkcheck.zip
         unzip mdbook-linkcheck.zip -d mdbook-linkcheck/


### PR DESCRIPTION
Before we had the problem that we tried to always restore the same cache but only save it when a commit reached `main`, this had the problem that if nothing reached `main` the cache would expire after 1 week.

Instead always save the cache, this will cause the cache to have some items from branches, but is probably still more beneficial and allows us to avoid evictions.