### PR TITLE
Refactor syn_type_to_cpp_type

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/externcxxqt.rs
@@ -84,12 +84,7 @@ mod tests {
         })
         .unwrap()];
         let mut type_names = TypeNames::default();
-        type_names
-            .cxx_names
-            .insert("ObjRust".to_owned(), "ObjCpp".to_owned());
-        type_names
-            .namespaces
-            .insert("ObjRust".to_owned(), "mynamespace".to_owned());
+        type_names.insert("ObjRust", None, Some("ObjCpp"), Some("mynamespace"));
 
         let generated = generate(&blocks, &type_names).unwrap();
         assert_eq!(generated.len(), 1);

--- a/crates/cxx-qt-gen/src/generator/cpp/method.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/method.rs
@@ -400,8 +400,8 @@ mod tests {
         let qobject_idents = create_qobjectname();
 
         let mut type_names = TypeNames::default();
-        type_names.cxx_names.insert("A".to_owned(), "A1".to_owned());
-        type_names.cxx_names.insert("B".to_owned(), "B2".to_owned());
+        type_names.insert("A", None, Some("A1"), None);
+        type_names.insert("B", None, Some("B2"), None);
 
         let generated = generate_cpp_methods(&invokables, &qobject_idents, &type_names).unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -360,7 +360,7 @@ mod tests {
         let qobject_idents = create_qobjectname();
 
         let mut type_names = TypeNames::default();
-        type_names.cxx_names.insert("A".to_owned(), "A1".to_owned());
+        type_names.insert("A", None, Some("A1"), None);
 
         let generated = generate_cpp_properties(&properties, &qobject_idents, &type_names).unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/cpp/qenum.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qenum.rs
@@ -59,8 +59,8 @@ pub fn generate(
     for qenum in qenums {
         let enum_name = &qenum.ident.to_string();
 
-        let mut qualified_name = type_names.cxx(enum_name);
-        // TODO: this is a workaround for type_names.cxx not always returning a fully-qualified
+        let mut qualified_name = type_names.cxx_qualified(enum_name);
+        // TODO: this is a workaround for type_names.cxx_qualified not always returning a fully-qualified
         // identifier.
         // Once https://github.com/KDAB/cxx-qt/issues/619 is fixed, this can be removed.
         if !qualified_name.starts_with("::") {

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -351,7 +351,7 @@ mod tests {
         let qobject_idents = create_qobjectname();
 
         let mut type_names = TypeNames::default();
-        type_names.cxx_names.insert("A".to_owned(), "A1".to_owned());
+        type_names.insert("A", None, Some("A1"), None);
 
         let generated = generate_cpp_signals(&signals, &qobject_idents, &type_names).unwrap();
 
@@ -622,12 +622,7 @@ mod tests {
         };
 
         let mut type_names = TypeNames::default();
-        type_names
-            .cxx_names
-            .insert("ObjRust".to_owned(), "ObjCpp".to_owned());
-        type_names
-            .namespaces
-            .insert("ObjRust".to_owned(), "mynamespace".to_owned());
+        type_names.insert("ObjRust", None, Some("ObjCpp"), Some("mynamespace"));
 
         let generated = generate_cpp_signal(&signal, &signal.qobject_ident, &type_names).unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -65,7 +65,7 @@ fn parameter_types_and_values(
     let parameter_named_types = parameter_named_types_with_self.join(", ");
 
     // Insert the extra argument into the closure
-    let self_ty = type_names.cxx(self_ty);
+    let self_ty = type_names.cxx_qualified(self_ty);
     parameter_named_types_with_self.insert(0, format!("{self_ty}& self"));
     parameter_types_with_self.insert(0, format!("{self_ty}&"));
     parameter_values_with_self.insert(0, "self".to_owned());
@@ -92,7 +92,7 @@ pub fn generate_cpp_signal(
 
     // Build a namespace that includes any namespace for the T
     let qobject_ident_str = qobject_ident.to_string();
-    let qobject_ident_namespaced = type_names.cxx(&qobject_ident_str);
+    let qobject_ident_namespaced = type_names.cxx_qualified(&qobject_ident_str);
 
     // Prepare the idents
     let idents = QSignalName::from(signal);

--- a/crates/cxx-qt-gen/src/generator/naming/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/signals.rs
@@ -56,8 +56,8 @@ impl QSignalHelperName {
         let signal_ident = &idents.name.cpp;
         let handler_alias = format_ident!("{qobject_ident}CxxQtSignalHandler{signal_ident}");
         let namespace = {
-            let mut namespace = vec!["rust::cxxqtgen1"];
-            if let Some(qobject_namespace) = type_names.namespaces.get(&qobject_ident.to_string()) {
+            let mut namespace = vec!["rust::cxxqtgen1".to_owned()];
+            if let Some(qobject_namespace) = type_names.namespace(&qobject_ident.to_string()) {
                 namespace.push(qobject_namespace);
             }
 

--- a/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
@@ -3,27 +3,24 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::BTreeMap;
-
-use crate::generator::{
-    naming::qobject::QObjectName, rust::fragment::GeneratedRustFragment,
-    utils::rust::syn_ident_cxx_bridge_to_qualified_impl,
+use crate::{
+    generator::{naming::qobject::QObjectName, rust::fragment::GeneratedRustFragment},
+    parser::naming::TypeNames,
 };
 use quote::quote;
-use syn::{Ident, Path, Result};
+use syn::Result;
 
 use super::fragment::RustFragmentPair;
 
 pub fn generate(
     qobject_ident: &QObjectName,
-    qualified_mappings: &BTreeMap<Ident, Path>,
+    type_names: &TypeNames,
 ) -> Result<GeneratedRustFragment> {
     let mut blocks = GeneratedRustFragment::default();
 
     let cpp_struct_ident = &qobject_ident.cpp_class.rust;
     let rust_struct_ident = &qobject_ident.rust_struct.rust;
-    let qualified_impl =
-        syn_ident_cxx_bridge_to_qualified_impl(cpp_struct_ident, qualified_mappings);
+    let qualified_impl = type_names.rust_qualified(cpp_struct_ident);
 
     let fragment = RustFragmentPair {
         cxx_bridge: vec![
@@ -91,7 +88,7 @@ mod tests {
         let qobject = create_parsed_qobject();
         let qobject_idents = QObjectName::from(&qobject);
 
-        let generated = generate(&qobject_idents, &BTreeMap::<Ident, Path>::default()).unwrap();
+        let generated = generate(&qobject_idents, &TypeNames::default()).unwrap();
 
         assert_eq!(generated.cxx_mod_contents.len(), 2);
         assert_eq!(generated.cxx_qt_mod_contents.len(), 2);

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -3,29 +3,30 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::generator::{
-    naming::{property::QPropertyName, qobject::QObjectName},
-    rust::fragment::RustFragmentPair,
-    utils::rust::{syn_ident_cxx_bridge_to_qualified_impl, syn_type_cxx_bridge_to_qualified},
+use crate::{
+    generator::{
+        naming::{property::QPropertyName, qobject::QObjectName},
+        rust::fragment::RustFragmentPair,
+        utils::rust::syn_type_cxx_bridge_to_qualified,
+    },
+    parser::naming::TypeNames,
 };
 use quote::quote;
-use std::collections::BTreeMap;
-use syn::{Ident, Path, Type};
+use syn::Type;
 
 pub fn generate(
     idents: &QPropertyName,
     qobject_idents: &QObjectName,
     cxx_ty: &Type,
-    qualified_mappings: &BTreeMap<Ident, Path>,
+    type_names: &TypeNames,
 ) -> RustFragmentPair {
     let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
     let getter_wrapper_cpp = idents.getter_wrapper.cpp.to_string();
     let getter_rust = &idents.getter.rust;
     let ident = &idents.name.rust;
     let ident_str = ident.to_string();
-    let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, qualified_mappings);
-    let qualified_impl =
-        syn_ident_cxx_bridge_to_qualified_impl(cpp_class_name_rust, qualified_mappings);
+    let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, type_names);
+    let qualified_impl = type_names.rust_qualified(cpp_class_name_rust);
 
     RustFragmentPair {
         cxx_bridge: vec![quote! {

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -31,7 +31,7 @@ pub fn generate_rust_properties(
         let idents = QPropertyName::from(property);
 
         // Getters
-        let getter = getter::generate(&idents, qobject_idents, &property.ty, &type_names.qualified);
+        let getter = getter::generate(&idents, qobject_idents, &property.ty, type_names);
         generated
             .cxx_mod_contents
             .append(&mut getter.cxx_bridge_as_items()?);
@@ -40,7 +40,7 @@ pub fn generate_rust_properties(
             .append(&mut getter.implementation_as_items()?);
 
         // Setters
-        let setter = setter::generate(&idents, qobject_idents, &property.ty, &type_names.qualified);
+        let setter = setter::generate(&idents, qobject_idents, &property.ty, type_names);
         generated
             .cxx_mod_contents
             .append(&mut setter.cxx_bridge_as_items()?);

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -3,23 +3,22 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::generator::{
-    naming::{property::QPropertyName, qobject::QObjectName},
-    rust::fragment::RustFragmentPair,
-    utils::rust::{
-        syn_ident_cxx_bridge_to_qualified_impl, syn_type_cxx_bridge_to_qualified,
-        syn_type_is_cxx_bridge_unsafe,
+use crate::{
+    generator::{
+        naming::{property::QPropertyName, qobject::QObjectName},
+        rust::fragment::RustFragmentPair,
+        utils::rust::{syn_type_cxx_bridge_to_qualified, syn_type_is_cxx_bridge_unsafe},
     },
+    parser::naming::TypeNames,
 };
 use quote::quote;
-use std::collections::BTreeMap;
-use syn::{Ident, Path, Type};
+use syn::Type;
 
 pub fn generate(
     idents: &QPropertyName,
     qobject_idents: &QObjectName,
     cxx_ty: &Type,
-    qualified_mappings: &BTreeMap<Ident, Path>,
+    type_names: &TypeNames,
 ) -> RustFragmentPair {
     let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
     let setter_wrapper_cpp = idents.setter_wrapper.cpp.to_string();
@@ -27,9 +26,8 @@ pub fn generate(
     let ident = &idents.name.rust;
     let ident_str = ident.to_string();
     let notify_ident = &idents.notify.rust;
-    let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, qualified_mappings);
-    let qualified_impl =
-        syn_ident_cxx_bridge_to_qualified_impl(cpp_class_name_rust, qualified_mappings);
+    let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, type_names);
+    let qualified_impl = type_names.rust_qualified(cpp_class_name_rust);
 
     // Determine if unsafe is required due to an unsafe type
     let has_unsafe = if syn_type_is_cxx_bridge_unsafe(cxx_ty) {

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -15,7 +15,6 @@ use crate::{
             signals::generate_rust_signals,
             threading,
         },
-        utils::rust::syn_ident_cxx_bridge_to_qualified_impl,
     },
     parser::{naming::TypeNames, qobject::ParsedQObject},
 };
@@ -85,7 +84,7 @@ impl GeneratedRustFragment {
             generated.append(&mut threading::generate(
                 &qobject_idents,
                 &namespace_idents,
-                &type_names.qualified,
+                type_names,
                 module_ident,
             )?);
         }
@@ -95,10 +94,7 @@ impl GeneratedRustFragment {
         // This could be implemented using an auto trait in the future once stable
         // https://doc.rust-lang.org/beta/unstable-book/language-features/auto-traits.html
         if qobject.locking {
-            let qualified_impl = syn_ident_cxx_bridge_to_qualified_impl(
-                &qobject_idents.cpp_class.rust,
-                &type_names.qualified,
-            );
+            let qualified_impl = type_names.rust_qualified(&qobject_idents.cpp_class.rust);
             generated.cxx_qt_mod_contents.push(syn::parse_quote! {
                 impl cxx_qt::Locking for #qualified_impl {}
             });
@@ -108,14 +104,11 @@ impl GeneratedRustFragment {
             &qobject.constructors,
             &qobject_idents,
             &namespace_idents,
-            &type_names.qualified,
+            type_names,
             module_ident,
         )?);
 
-        generated.append(&mut cxxqttype::generate(
-            &qobject_idents,
-            &type_names.qualified,
-        )?);
+        generated.append(&mut cxxqttype::generate(&qobject_idents, type_names)?);
 
         Ok(generated)
     }

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -10,7 +10,7 @@ use crate::{
             signals::{QSignalHelperName, QSignalName},
         },
         rust::fragment::{GeneratedRustFragment, RustFragmentPair},
-        utils::rust::{syn_ident_cxx_bridge_to_qualified_impl, syn_type_cxx_bridge_to_qualified},
+        utils::rust::syn_type_cxx_bridge_to_qualified,
     },
     parser::{naming::TypeNames, signals::ParsedSignal},
     syntax::attribute::attribute_find_path,
@@ -51,8 +51,7 @@ pub fn generate_rust_signal(
         .cloned()
         .map(|mut parameter| {
             if let FnArg::Typed(pat_type) = &mut parameter {
-                *pat_type.ty =
-                    syn_type_cxx_bridge_to_qualified(&pat_type.ty, &type_names.qualified);
+                *pat_type.ty = syn_type_cxx_bridge_to_qualified(&pat_type.ty, type_names);
             }
             parameter
         })
@@ -66,9 +65,7 @@ pub fn generate_rust_signal(
         .iter()
         .cloned()
         .map(|parameter| match parameter {
-            FnArg::Typed(pat_type) => {
-                syn_type_cxx_bridge_to_qualified(&pat_type.ty, &type_names.qualified)
-            }
+            FnArg::Typed(pat_type) => syn_type_cxx_bridge_to_qualified(&pat_type.ty, type_names),
             _ => unreachable!("should only have typed no receiver"),
         })
         .collect();
@@ -78,10 +75,8 @@ pub fn generate_rust_signal(
     } else {
         parse_quote! { &#qobject_name }
     };
-    let self_type_qualified =
-        syn_type_cxx_bridge_to_qualified(&self_type_cxx, &type_names.qualified);
-    let qualified_impl =
-        syn_ident_cxx_bridge_to_qualified_impl(qobject_name, &type_names.qualified);
+    let self_type_qualified = syn_type_cxx_bridge_to_qualified(&self_type_cxx, type_names);
+    let qualified_impl = type_names.rust_qualified(qobject_name);
 
     let mut unsafe_block = None;
     let mut unsafe_call = Some(quote! { unsafe });

--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -3,25 +3,25 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::BTreeMap;
-
-use crate::generator::{
-    naming::{
-        namespace::{namespace_combine_ident, NamespaceName},
-        qobject::QObjectName,
+use crate::{
+    generator::{
+        naming::{
+            namespace::{namespace_combine_ident, NamespaceName},
+            qobject::QObjectName,
+        },
+        rust::fragment::GeneratedRustFragment,
     },
-    rust::fragment::GeneratedRustFragment,
-    utils::rust::syn_ident_cxx_bridge_to_qualified_impl,
+    parser::naming::TypeNames,
 };
 use quote::quote;
-use syn::{Ident, Path, Result};
+use syn::{Ident, Result};
 
 use super::fragment::RustFragmentPair;
 
 pub fn generate(
     qobject_ident: &QObjectName,
     namespace_ident: &NamespaceName,
-    qualified_mappings: &BTreeMap<Ident, Path>,
+    type_names: &TypeNames,
     module_ident: &Ident,
 ) -> Result<GeneratedRustFragment> {
     let mut blocks = GeneratedRustFragment::default();
@@ -35,8 +35,7 @@ pub fn generate(
     let namespace_internals = &namespace_ident.internal;
     let cxx_qt_thread_ident_type_id_str =
         namespace_combine_ident(&namespace_ident.namespace, cxx_qt_thread_ident);
-    let qualified_impl =
-        syn_ident_cxx_bridge_to_qualified_impl(cpp_struct_ident, qualified_mappings);
+    let qualified_impl = type_names.rust_qualified(cpp_struct_ident);
 
     let fragment = RustFragmentPair {
         cxx_bridge: vec![
@@ -156,6 +155,7 @@ pub fn generate(
 mod tests {
     use super::*;
 
+    use crate::parser::naming::TypeNames;
     use crate::tests::assert_tokens_eq;
 
     use crate::parser::qobject::tests::create_parsed_qobject;
@@ -171,7 +171,7 @@ mod tests {
         let generated = generate(
             &qobject_idents,
             &namespace_ident,
-            &BTreeMap::<Ident, Path>::default(),
+            &TypeNames::default(),
             &format_ident!("ffi"),
         )
         .unwrap();

--- a/crates/cxx-qt-gen/src/generator/utils/cpp.rs
+++ b/crates/cxx-qt-gen/src/generator/utils/cpp.rs
@@ -382,7 +382,7 @@ mod tests {
     fn test_syn_type_to_cpp_type_mapped() {
         let ty = parse_quote! { A };
         let mut type_names = TypeNames::default();
-        type_names.cxx_names.insert("A".to_owned(), "A1".to_owned());
+        type_names.insert("A", None, Some("A1"), None);
         assert_eq!(syn_type_to_cpp_type(&ty, &type_names).unwrap(), "A1");
     }
 
@@ -390,10 +390,7 @@ mod tests {
     fn test_syn_type_to_cpp_type_mapped_with_namespace() {
         let ty = parse_quote! { A };
         let mut type_names = TypeNames::default();
-        type_names.cxx_names.insert("A".to_owned(), "A1".to_owned());
-        type_names
-            .namespaces
-            .insert("A".to_owned(), "N1".to_owned());
+        type_names.insert("A", None, Some("A1"), Some("N1"));
         assert_eq!(syn_type_to_cpp_type(&ty, &type_names).unwrap(), "::N1::A1");
     }
 

--- a/crates/cxx-qt-gen/src/generator/utils/cpp.rs
+++ b/crates/cxx-qt-gen/src/generator/utils/cpp.rs
@@ -127,7 +127,7 @@ pub(crate) fn syn_type_to_cpp_type(ty: &Type, type_names: &TypeNames) -> Result<
                 }
 
                 // Use the CXX mapped name
-                Ok(type_names.cxx(first))
+                Ok(type_names.cxx_qualified(first))
             } else {
                 Ok(ty_strings.join("::"))
             }
@@ -232,7 +232,7 @@ fn path_segment_to_string(segment: &PathSegment, type_names: &TypeNames) -> Resu
         ident = if let Some(built_in) = possible_built_in_template_base(&ident) {
             built_in.to_owned()
         } else {
-            type_names.cxx(&ident)
+            type_names.cxx_qualified(&ident)
         };
     }
 

--- a/crates/cxx-qt-gen/src/generator/utils/cpp.rs
+++ b/crates/cxx-qt-gen/src/generator/utils/cpp.rs
@@ -330,166 +330,52 @@ mod tests {
         assert_eq!(syn_return_type_to_cpp_except(&ty), "noexcept");
     }
 
-    #[test]
-    fn test_syn_type_to_cpp_type_built_in_one_part() {
-        let ty = parse_quote! { i32 };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::std::int32_t"
-        );
+    macro_rules! test_syn_types_to_cpp_types {
+        [$($input_type:tt => $output_type:literal),*] => {
+            $(
+            assert_eq!(
+                syn_type_to_cpp_type(&parse_quote! $input_type, &TypeNames::default()).unwrap(),
+                $output_type);
+            )*
+        }
     }
 
     #[test]
-    fn test_syn_type_to_cpp_type_unknown_one_part() {
-        let ty = parse_quote! { QPoint };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "QPoint"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_ref_const_one_part() {
-        let ty = parse_quote! { &QPoint };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "QPoint const&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_ref_mut_one_part() {
-        let ty = parse_quote! { &mut QPoint };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "QPoint&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_ref_const_ptr_mut_one_part() {
-        let ty = parse_quote! { &*mut T };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "T* const&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_ref_const_ptr_const_one_part() {
-        let ty = parse_quote! { &*const T };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "const T* const&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_ref_mut_ptr_mut_one_part() {
-        let ty = parse_quote! { &mut *mut T };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "T*&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_ref_mut_ptr_const_one_part() {
-        let ty = parse_quote! { &mut *const T };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "const T*&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_ptr_mut_one_part() {
-        let ty = parse_quote! { *mut T };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "T*"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_ptr_const_one_part() {
-        let ty = parse_quote! { *const T };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "const T*"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_templated_built_in() {
-        let ty = parse_quote! { Vec<f64> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::rust::Vec<double>"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_templated_unknown() {
-        let ty = parse_quote! { UniquePtr<QColor> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::std::unique_ptr<QColor>"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_templated_built_in_ref_const() {
-        let ty = parse_quote! { &Vec<f64> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::rust::Vec<double> const&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_templated_built_in_ptr_mut() {
-        let ty = parse_quote! { &Vec<*mut T> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::rust::Vec<T*> const&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_templated_built_in_ptr_const() {
-        let ty = parse_quote! { &Vec<*const T> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::rust::Vec<const T*> const&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_templated_unknown_ref_mut() {
-        let ty = parse_quote! { &mut UniquePtr<QColor> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::std::unique_ptr<QColor>&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_templated_unknown_ptr_mut() {
-        let ty = parse_quote! { &mut UniquePtr<*mut T> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::std::unique_ptr<T*>&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_templated_unknown_ptr_const() {
-        let ty = parse_quote! { &mut UniquePtr<*const T> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::std::unique_ptr<const T*>&"
-        );
+    fn test_syn_type_to_cpp_type() {
+        test_syn_types_to_cpp_types! [
+            { i32 } => "::std::int32_t",
+            { () } => "void",
+            { fn() } => "::rust::Fn<void, ()>",
+            { fn(i32, i32) -> bool } => "::rust::Fn<bool, (::std::int32_t, ::std::int32_t)>",
+            { [i32; 10] } => "::std::array<::std::int32_t, 10>",
+            { Vec<&str> } => "::rust::Vec<::rust::Str>",
+            { &str } => "::rust::Str",
+            { &mut [i32] } => "::rust::Slice<::std::int32_t>",
+            { &[i32] } => "::rust::Slice<::std::int32_t const>",
+            { Pin<&mut UniquePtr<T>> } => "::std::unique_ptr<T>&",
+            { Pin<&UniquePtr<T>> } => "::std::unique_ptr<T> const&",
+            { Pin<UniquePtr<T>> } => "::std::unique_ptr<T>",
+            { Pin<&mut T> } => "T&",
+            { Pin<&T> } => "T const&",
+            { Pin<T> } => "T",
+            { &mut UniquePtr<*const T> } => "::std::unique_ptr<const T*>&",
+            { &mut UniquePtr<*mut T> } => "::std::unique_ptr<T*>&",
+            { &mut UniquePtr<QColor> } => "::std::unique_ptr<QColor>&",
+            { &Vec<*const T> } => "::rust::Vec<const T*> const&",
+            { &Vec<*mut T> } => "::rust::Vec<T*> const&",
+            { &Vec<f64> } => "::rust::Vec<double> const&",
+            { UniquePtr<QColor> } => "::std::unique_ptr<QColor>",
+            { Vec<f64> } => "::rust::Vec<double>",
+            { *const T } => "const T*",
+            { *mut T } => "T*",
+            { &mut *const T } => "const T*&",
+            { &mut *mut T } => "T*&",
+            { &*const T } => "const T* const&",
+            { &*mut T } => "T* const&",
+            { &mut QPoint } => "QPoint&",
+            { &QPoint } => "QPoint const&",
+            { QPoint} => "QPoint"
+        ];
     }
 
     #[test]
@@ -512,105 +398,6 @@ mod tests {
     }
 
     #[test]
-    fn test_syn_type_to_cpp_type_pin() {
-        let ty = parse_quote! { Pin<T> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "T"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_pin_ref() {
-        let ty = parse_quote! { Pin<&T> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "T const&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_pin_ref_mut() {
-        let ty = parse_quote! { Pin<&mut T> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "T&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_pin_template() {
-        let ty = parse_quote! { Pin<UniquePtr<T>> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::std::unique_ptr<T>"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_pin_template_ref() {
-        let ty = parse_quote! { Pin<&UniquePtr<T>> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::std::unique_ptr<T> const&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_pin_template_ref_mut() {
-        let ty = parse_quote! { Pin<&mut UniquePtr<T>> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::std::unique_ptr<T>&"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_slice() {
-        let ty = parse_quote! { &[i32] };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::rust::Slice<::std::int32_t const>"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_slice_mut() {
-        let ty = parse_quote! { &mut [i32] };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::rust::Slice<::std::int32_t>"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_str() {
-        let ty = parse_quote! { &str };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::rust::Str"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_str_template() {
-        let ty = parse_quote! { Vec<&str> };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::rust::Vec<::rust::Str>"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_array() {
-        let ty = parse_quote! { [i32; 10] };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::std::array<::std::int32_t, 10>"
-        );
-    }
-
-    #[test]
     fn test_syn_type_to_cpp_type_array_length_zero() {
         let ty = parse_quote! { [i32; 0] };
         assert!(syn_type_to_cpp_type(&ty, &TypeNames::default()).is_err());
@@ -620,33 +407,6 @@ mod tests {
     fn test_syn_type_to_cpp_type_array_length_invalid() {
         let ty = parse_quote! { [i32; String] };
         assert!(syn_type_to_cpp_type(&ty, &TypeNames::default()).is_err());
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_fn() {
-        let ty = parse_quote! { fn(i32, i32) -> bool };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::rust::Fn<bool, (::std::int32_t, ::std::int32_t)>"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_fn_void() {
-        let ty = parse_quote! { fn() };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "::rust::Fn<void, ()>"
-        );
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_tuple_empty() {
-        let ty = parse_quote! { () };
-        assert_eq!(
-            syn_type_to_cpp_type(&ty, &TypeNames::default()).unwrap(),
-            "void"
-        );
     }
 
     #[test]

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -203,14 +203,10 @@ mod tests {
         assert_eq!(parser.passthrough_module.content.unwrap().1.len(), 0);
         assert_eq!(parser.cxx_qt_data.namespace, "cxx_qt");
         assert_eq!(parser.cxx_qt_data.qobjects.len(), 1);
-        assert_eq!(parser.type_names.qualified.len(), 1);
+        assert_eq!(parser.type_names.num_types(), 1);
         assert_eq!(
-            parser
-                .type_names
-                .qualified
-                .get(&format_ident!("MyObject"))
-                .unwrap(),
-            &parse_quote! { ffi::MyObject }
+            parser.type_names.rust_qualified(&format_ident!("MyObject")),
+            parse_quote! { ffi::MyObject }
         );
     }
 
@@ -300,17 +296,17 @@ mod tests {
             }
         };
         let parser = Parser::from(module).unwrap();
-        assert_eq!(parser.type_names.namespaces.len(), 3);
+        assert_eq!(parser.type_names.num_types(), 3);
         assert_eq!(
-            parser.type_names.namespaces.get("MyObjectA").unwrap(),
+            parser.type_names.namespace("MyObjectA").unwrap(),
             "bridge_namespace"
         );
         assert_eq!(
-            parser.type_names.namespaces.get("MyObjectB").unwrap(),
+            parser.type_names.namespace("MyObjectB").unwrap(),
             "type_namespace"
         );
         assert_eq!(
-            parser.type_names.namespaces.get("MyObjectC").unwrap(),
+            parser.type_names.namespace("MyObjectC").unwrap(),
             "extern_namespace"
         );
     }

--- a/crates/cxx-qt-gen/src/parser/naming.rs
+++ b/crates/cxx-qt-gen/src/parser/naming.rs
@@ -218,8 +218,8 @@ impl TypeNames {
     ///
     /// Eg MyObject -> ffi::MyObject
     ///
-    /// Note that this does not handle CXX types such as UniquePtr -> cxx::UniquePtr.
-    /// This is just for resolving impl T {} -> impl module::T {}
+    /// Note that this only handles types that are declared inside this bridge.
+    /// E.g. UniquePtr -> cxx::UniquePtr isn't handled here.
     pub fn rust_qualified(&self, ident: &Ident) -> syn::Path {
         if let Some(qualified_path) = self.qualified.get(ident) {
             qualified_path.clone()

--- a/crates/cxx-qt-gen/src/parser/naming.rs
+++ b/crates/cxx-qt-gen/src/parser/naming.rs
@@ -191,7 +191,7 @@ impl TypeNames {
     }
 
     /// For a given rust ident return the CXX name with its namespace
-    pub fn cxx(&self, ident: &str) -> String {
+    pub fn cxx_qualified(&self, ident: &str) -> String {
         // Check if there is a cxx_name or namespace to handle
         let cxx_name = self
             .cxx_names
@@ -483,9 +483,9 @@ mod tests {
 
         assert_eq!(type_names.num_types(), 3);
 
-        assert_eq!(type_names.cxx("A"), "::type_namespace::B");
-        assert_eq!(type_names.cxx("C"), "::extern_namespace::D");
-        assert_eq!(type_names.cxx("E"), "::bridge_namespace::E");
+        assert_eq!(type_names.cxx_qualified("A"), "::type_namespace::B");
+        assert_eq!(type_names.cxx_qualified("C"), "::extern_namespace::D");
+        assert_eq!(type_names.cxx_qualified("E"), "::bridge_namespace::E");
 
         assert_eq!(type_names.namespace("A").unwrap(), "type_namespace");
         assert_eq!(type_names.namespace("C").unwrap(), "extern_namespace");


### PR DESCRIPTION
This should be a responsibility of the TypeNames struct in the future.