### PR TITLE
build: use .std("c++17") instead of flag_if_supported

### DIFF
--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -534,13 +534,11 @@ impl CxxQtBuilder {
         for builder in [&mut self.cc_builder, &mut cc_builder_whole_archive] {
             // Note, ensure our settings stay in sync across cxx-qt, cxx-qt-build, and cxx-qt-lib
             builder.cpp(true);
+            builder.std("c++17");
             // MSVC
-            builder.flag_if_supported("/std:c++17");
             builder.flag_if_supported("/Zc:__cplusplus");
             builder.flag_if_supported("/permissive-");
             builder.flag_if_supported("/bigobj");
-            // GCC + Clang
-            builder.flag_if_supported("-std=c++17");
             // MinGW requires big-obj otherwise debug builds fail
             builder.flag_if_supported("-Wa,-mbig-obj");
 

--- a/crates/cxx-qt/build.rs
+++ b/crates/cxx-qt/build.rs
@@ -52,13 +52,11 @@ fn main() {
 
     // Note, ensure our settings stay in sync across cxx-qt, cxx-qt-build, and cxx-qt-lib
     builder.cpp(true);
+    builder.std("c++17");
     // MSVC
-    builder.flag_if_supported("/std:c++17");
     builder.flag_if_supported("/Zc:__cplusplus");
     builder.flag_if_supported("/permissive-");
     builder.flag_if_supported("/bigobj");
-    // GCC + Clang
-    builder.flag_if_supported("-std=c++17");
     // MinGW requires big-obj otherwise debug builds fail
     builder.flag_if_supported("-Wa,-mbig-obj");
 


### PR DESCRIPTION
This then works in a common way with MSVC and GCC/Clang etc