### PR TITLE
Backports for 0.6.1

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -176,6 +176,16 @@ jobs:
     - name: "[Ubuntu] Install reuse"
       if: runner.os == 'Linux'
       run: pip3 install reuse
+
+    # FIXME: Workaround until meson supports Python 3.12+ in vcpkg
+    # for now force Python 3.11
+    # https://github.com/microsoft/vcpkg/issues/35332
+    - name: "[macOS] Force python 3.11 for vcpkg"
+      if: runner.os == 'macOS'
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
     - name: "[macOS] Install dependencies"
       if: runner.os == 'macOS'
       # FIXME: clang-format-14 causes formatting differences if it is selected by brew

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -55,8 +55,8 @@ jobs:
                 libxkbcommon-dev
             workspace: /home/runner/cxx-qt
 
-          - name: macOS 11 (clang) Qt5
-            os: macos-11
+          - name: macOS 12 (clang) Qt5
+            os: macos-12
             qt_version: 5
             # FIXME: qmltestrunner fails to import QtQuick module
             # https://github.com/KDAB/cxx-qt/issues/110
@@ -72,8 +72,8 @@ jobs:
             workspace: /Users/runner/cxx-qt
             cc: clang
             cxx: clang++
-          - name: macOS 11 (clang) Qt6
-            os: macos-11
+          - name: macOS 12 (clang) Qt6
+            os: macos-12
             qt_version: 6
             # FIXME: qmltestrunner fails to import QtQuick module
             # https://github.com/KDAB/cxx-qt/issues/110

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -113,6 +113,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}
     env:
+        # Match the deployment target that Qt was built with via vcpkg, otherwise the following error occurs
+        # ld: warning: object file (LIB) was built for newer macOS version (12.7) than being linked (12.0)
+        MACOSX_DEPLOYMENT_TARGET: 12.7
         # sccache is around 250-350M in size for a normal build
         # set the cache size to double of this to leave some headroom
         # but don't expand too large as we cache old data and cause cache evictions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.6.0...HEAD)
+## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.6.1...HEAD)
+
+## [0.6.1](https://github.com/KDAB/cxx-qt/compare/v0.6.0...v0.6.1) - 2024-04-19
 
 ### Fixed
 
 - Missing include for `MaybeLockGuard` when using only `extern "C++Qt"` signals
+- Fix build issues with Qt 6.7
+- Improve handling of Apple frameworks with Qt
+- Run qmlcachegen only when required
+- Support for building with no Rust or C++ files in the builder script
 
 ## [0.6.0](https://github.com/KDAB/cxx-qt/compare/v0.5.3...v0.6.0) - 2023-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.6.0...HEAD)
 
+### Fixed
+
+- Missing include for `MaybeLockGuard` when using only `extern "C++Qt"` signals
+
 ## [0.6.0](https://github.com/KDAB/cxx-qt/compare/v0.5.3...v0.6.0) - 2023-11-17
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ cxx-qt-lib = { path = "crates/cxx-qt-lib" }
 cxx-qt-lib-headers = { path = "crates/cxx-qt-lib-headers", version = "0.6.0" }
 qt-build-utils = { path = "crates/qt-build-utils", version = "0.6.0" }
 
-cc = { version = "1.0.79", features = ["parallel"] }
+cc = { version = "1.0.89", features = ["parallel"] }
 # Ensure that the example comments are kept in sync
 # ./examples/cargo_without_cmake/Cargo.toml
 # ./examples/qml_minimal/rust/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,18 +27,18 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/KDAB/cxx-qt/"
-version = "0.6.0"
+version = "0.6.1"
 
 # Note a version needs to be specified on dependencies of packages
 # we publish, otherwise crates.io complains as it doesn't know the version.
 [workspace.dependencies]
 cxx-qt = { path = "crates/cxx-qt" }
-cxx-qt-macro = { path = "crates/cxx-qt-macro", version = "0.6.0" }
+cxx-qt-macro = { path = "crates/cxx-qt-macro", version = "0.6.1" }
 cxx-qt-build = { path = "crates/cxx-qt-build" }
-cxx-qt-gen = { path = "crates/cxx-qt-gen", version = "0.6.0" }
+cxx-qt-gen = { path = "crates/cxx-qt-gen", version = "0.6.1" }
 cxx-qt-lib = { path = "crates/cxx-qt-lib" }
-cxx-qt-lib-headers = { path = "crates/cxx-qt-lib-headers", version = "0.6.0" }
-qt-build-utils = { path = "crates/qt-build-utils", version = "0.6.0" }
+cxx-qt-lib-headers = { path = "crates/cxx-qt-lib-headers", version = "0.6.1" }
+qt-build-utils = { path = "crates/qt-build-utils", version = "0.6.1" }
 
 cc = { version = "1.0.89", features = ["parallel"] }
 # Ensure that the example comments are kept in sync

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -632,6 +632,11 @@ impl CxxQtBuilder {
         if cc_builder_whole_archive_files_added {
             cc_builder_whole_archive.compile("qt-static-initializers");
         }
-        self.cc_builder.compile(lib_name);
+
+        // Only compile if we have added files to the builder
+        // otherwise we end up with no static library but ask cargo to link to it which causes an error
+        if self.cc_builder.get_files().count() > 0 {
+            self.cc_builder.compile(lib_name);
+        }
     }
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/externcxxqt.rs
@@ -32,6 +32,10 @@ pub fn generate(
             let mut block = GeneratedCppExternCxxQtBlocks::default();
             let data = generate_cpp_signal(signal, &signal.qobject_ident, cxx_mappings)?;
             block.includes = data.includes;
+            // Ensure that we include MaybeLockGuard<T> that is used in multiple places
+            block
+                .includes
+                .insert("#include <cxx-qt-common/cxxqt_maybelockguard.h>".to_owned());
             block.forward_declares = data.forward_declares;
             block.fragments = data.fragments;
             debug_assert!(data.methods.is_empty());

--- a/crates/cxx-qt-gen/src/syntax/mod.rs
+++ b/crates/cxx-qt-gen/src/syntax/mod.rs
@@ -13,5 +13,5 @@ mod qtitem;
 pub mod safety;
 pub mod types;
 
-pub use qtfile::{parse_qt_file, CxxQtFile};
+pub use qtfile::parse_qt_file;
 pub use qtitem::CxxQtItem;

--- a/crates/cxx-qt-lib-headers/include/core/qdatetime.h
+++ b/crates/cxx-qt-lib-headers/include/core/qdatetime.h
@@ -67,6 +67,7 @@ qdatetimeTimeZone(const QDateTime& datetime);
 qdatetimeToMSecsSinceEpoch(const QDateTime& datetime);
 ::std::int64_t
 qdatetimeToSecsSinceEpoch(const QDateTime& datetime);
-
+void
+qdatetimeSetTimeZone(QDateTime& datetime, const QTimeZone& timeZone);
 }
 }

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -271,7 +271,6 @@ fn main() {
     builder.flag_if_supported("/Zc:__cplusplus");
     builder.flag_if_supported("/permissive-");
     builder.flag_if_supported("/bigobj");
-
     // GCC + Clang
     builder.flag_if_supported("-std=c++17");
     // MinGW requires big-obj otherwise debug builds fail

--- a/crates/cxx-qt-lib/src/core/qdatetime.cpp
+++ b/crates/cxx-qt-lib/src/core/qdatetime.cpp
@@ -145,5 +145,16 @@ qdatetimeToSecsSinceEpoch(const QDateTime& datetime)
   return static_cast<::std::int64_t>(datetime.toSecsSinceEpoch());
 }
 
+void
+qdatetimeSetTimeZone(QDateTime& datetime, const QTimeZone& timeZone)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+  datetime.setTimeZone(timeZone,
+                       QDateTime::TransitionResolution::LegacyBehavior);
+#else
+  datetime.setTimeZone(timeZone);
+#endif
+}
+
 }
 }

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -63,10 +63,6 @@ mod ffi {
         #[rust_name = "set_time_spec"]
         fn setTimeSpec(self: &mut QDateTime, spec: TimeSpec);
 
-        /// Sets the time zone used in this datetime to toZone. The datetime will refer to a different point in time.
-        #[rust_name = "set_time_zone"]
-        fn setTimeZone(self: &mut QDateTime, time_zone: &QTimeZone);
-
         /// Returns the time part of the datetime.
         fn time(self: &QDateTime) -> QTime;
 
@@ -162,6 +158,8 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qdatetime_to_secs_since_epoch"]
         fn qdatetimeToSecsSinceEpoch(datetime: &QDateTime) -> i64;
+        #[rust_name = "qdatetime_settimezone"]
+        fn qdatetimeSetTimeZone(datetime: &mut QDateTime, time_zone: &QTimeZone);
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -208,6 +206,11 @@ pub struct QDateTime {
 }
 
 impl QDateTime {
+    /// Sets the time zone used in this datetime to toZone. The datetime will refer to a different point in time.
+    pub fn set_time_zone(&mut self, time_zone: &ffi::QTimeZone) {
+        ffi::qdatetime_settimezone(self, time_zone)
+    }
+
     /// Returns a QDateTime object containing a datetime ndays days later than the datetime of this object (or earlier if ndays is negative).
     pub fn add_days(&self, ndays: i64) -> Self {
         ffi::qdatetime_add_days(self, ndays)

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -402,6 +402,21 @@ impl QtBuild {
         println!("cargo:rustc-link-search={lib_path}");
 
         let target = env::var("TARGET");
+
+        // Add the QT_INSTALL_LIBS as a framework link search path as well
+        //
+        // Note that leaving the kind empty should default to all,
+        // but this doesn't appear to find frameworks in all situations
+        // https://github.com/KDAB/cxx-qt/issues/885
+        //
+        // Note this doesn't have an adverse affect running all the time
+        // as it appears that all rustc-link-search are added
+        if let Ok(target) = &target {
+            if target.contains("apple") {
+                println!("cargo:rustc-link-search=framework={lib_path}");
+            }
+        }
+
         let prefix = match &target {
             Ok(target) => {
                 if target.contains("windows") {

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -64,10 +64,21 @@ fn command_help_output(command: &str) -> std::io::Result<std::process::Output> {
 /// If you are using a C++ build system such as CMake to do the final link of the executable, you do
 /// not need to call this function.
 ///
+/// With Apple devices we set -fapple-link-rtlib as we build with -nodefaultlibs
+/// otherwise we cannot user helpers from the compiler runtime in Qt
+///
 /// This does nothing on non-Unix platforms.
 pub fn setup_linker() {
     if env::var("CARGO_CFG_UNIX").is_err() {
         return;
+    }
+
+    if let Ok(vendor) = env::var("CARGO_CFG_TARGET_VENDOR") {
+        if vendor == "apple" {
+            // Tell clang link to clang_rt as we build with -nodefaultlibs
+            // otherwise we cannot use helpers from the compiler runtime in Qt
+            println!("cargo:rustc-link-arg=-fapple-link-rtlib");
+        }
     }
 
     let flags = env::var("CARGO_ENCODED_RUSTFLAGS").unwrap();
@@ -401,14 +412,6 @@ impl QtBuild {
             }
             Err(_) => "lib",
         };
-
-        if let Ok(target) = &target {
-            if target.contains("apple") {
-                // Tell clang link to clang_rt as we build with -nodefaultlibs
-                // otherwise we cannot use helpers from the compiler in Qt
-                println!("cargo:rustc-link-arg=-fapple-link-rtlib");
-            }
-        }
 
         for qt_module in &self.qt_modules {
             let framework = match &target {

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -402,6 +402,14 @@ impl QtBuild {
             Err(_) => "lib",
         };
 
+        if let Ok(target) = &target {
+            if target.contains("apple") {
+                // Tell clang link to clang_rt as we build with -nodefaultlibs
+                // otherwise we cannot use helpers from the compiler in Qt
+                println!("cargo:rustc-link-arg=-fapple-link-rtlib");
+            }
+        }
+
         for qt_module in &self.qt_modules {
             let framework = match &target {
                 Ok(target) => {

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -750,22 +750,25 @@ prefer :/qt/qml/{qml_uri_dirs}/
                 qmlcachegen_loader.clone(),
             ];
 
-            let cmd = Command::new(qmlcachegen_executable)
-                .args(
-                    common_args
-                        .iter()
-                        .chain(&specific_args)
-                        .chain(&qml_file_qrc_paths),
-                )
-                .output()
-                .unwrap_or_else(|_| panic!("qmlcachegen failed for QML module {uri}"));
-            if !cmd.status.success() {
-                panic!(
-                    "qmlcachegen failed for QML module {uri}:\n{}",
-                    String::from_utf8_lossy(&cmd.stderr)
-                );
+            // If there are no QML files there is nothing for qmlcachegen to run with
+            if !qml_files.is_empty() {
+                let cmd = Command::new(qmlcachegen_executable)
+                    .args(
+                        common_args
+                            .iter()
+                            .chain(&specific_args)
+                            .chain(&qml_file_qrc_paths),
+                    )
+                    .output()
+                    .unwrap_or_else(|_| panic!("qmlcachegen failed for QML module {uri}"));
+                if !cmd.status.success() {
+                    panic!(
+                        "qmlcachegen failed for QML module {uri}:\n{}",
+                        String::from_utf8_lossy(&cmd.stderr)
+                    );
+                }
+                qmlcachegen_file_paths.push(PathBuf::from(&qmlcachegen_loader));
             }
-            qmlcachegen_file_paths.push(PathBuf::from(&qmlcachegen_loader));
         }
 
         // Run qmltyperegistrar

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -694,7 +694,7 @@ prefer :/qt/qml/{qml_uri_dirs}/
             std::fs::create_dir_all(&qmlcachegen_dir)
                 .expect("Could not create qmlcachegen directory for QML module");
 
-            let common_args = vec![
+            let common_args = [
                 "-i".to_string(),
                 qmldir_file_path.to_string(),
                 "--resource".to_string(),

--- a/examples/cargo_without_cmake/CMakeLists.txt
+++ b/examples/cargo_without_cmake/CMakeLists.txt
@@ -27,7 +27,7 @@ if(NOT Corrosion_FOUND)
     FetchContent_Declare(
         Corrosion
         GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.4.2
+        GIT_TAG v0.4.5
     )
 
     FetchContent_MakeAvailable(Corrosion)

--- a/examples/demo_threading/CMakeLists.txt
+++ b/examples/demo_threading/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT Corrosion_FOUND)
     FetchContent_Declare(
         Corrosion
         GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.4.2
+        GIT_TAG v0.4.5
     )
 
     FetchContent_MakeAvailable(Corrosion)

--- a/examples/qml_features/CMakeLists.txt
+++ b/examples/qml_features/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT Corrosion_FOUND)
     FetchContent_Declare(
         Corrosion
         GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.4.2
+        GIT_TAG v0.4.5
     )
 
     FetchContent_MakeAvailable(Corrosion)

--- a/examples/qml_minimal/CMakeLists.txt
+++ b/examples/qml_minimal/CMakeLists.txt
@@ -43,7 +43,7 @@ if(NOT Corrosion_FOUND)
     FetchContent_Declare(
         Corrosion
         GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.4.2
+        GIT_TAG v0.4.5
     )
 
     FetchContent_MakeAvailable(Corrosion)


### PR DESCRIPTION
So far this is
- abdd6893 (fix corrosion build failure)
- bc12e66e (fix clippy warnings)
- 295f761a (move to macOS12)
- f62c1013 (use newer vcpkg)
- a5f923f9 (fix Python version with macOS)
- a47e7f16 (match macOS version)
- 55befe12 (improve apple linking to clang_rt)
- 1342bf43 (improve apple linking to clang_rt)
- 07f880a7 (run QML cachegen when required)
- d8770614 (add missing include)
- 188e562a (Qt 6.7 fix)
- 46061ff5 (fix unused import)
- fad7084d (fix clippy warnings)
- 25bd6fce5af399b114b39d03d545073bd508ba58 (allow builds with no files)
- 25a553d8c9357ed02aaa0cded59a351105ead91e (apple framework improvements)
- 8b809e8b4102fdac0690161bf3264ff65864432e (cc bump to 1.0.89 for get_files)

Further commits

- [x] ~Must_use fix from #930 ?~ (must_use was in the right place in 0.6.x)