### PR TITLE
signals: use #[must_use] when returning a QMetaObjectConnectionGuard

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -287,7 +287,6 @@ mod tests {
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    #[must_use]
                     #[rust_name = "MyObject_connect_trivial_property_changed"]
                     fn MyObject_trivialPropertyChangedConnect(self_value: Pin<&mut MyObject>, signal_handler: MyObjectCxxQtSignalHandlertrivialPropertyChanged, conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
                 }
@@ -413,7 +412,6 @@ mod tests {
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    #[must_use]
                     #[rust_name = "MyObject_connect_opaque_property_changed"]
                     fn MyObject_opaquePropertyChangedConnect(self_value: Pin<&mut MyObject>, signal_handler: MyObjectCxxQtSignalHandleropaquePropertyChanged, conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
                 }
@@ -539,7 +537,6 @@ mod tests {
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    #[must_use]
                     #[rust_name = "MyObject_connect_unsafe_property_changed"]
                     fn MyObject_unsafePropertyChangedConnect(self_value: Pin<&mut MyObject>, signal_handler: MyObjectCxxQtSignalHandlerunsafePropertyChanged, conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
                 }

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -111,7 +111,6 @@ pub fn generate_rust_signal(
 
             #[doc(hidden)]
             #[namespace = #namespace_str]
-            #[must_use]
             #[rust_name = #free_connect_ident_rust_str]
             fn #free_connect_ident_cpp(self_value: #self_type_cxx, signal_handler: #signal_handler_alias, conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
         }
@@ -304,7 +303,6 @@ mod tests {
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    #[must_use]
                     #[rust_name = "MyObject_connect_ready"]
                     fn MyObject_readyConnect(self_value: Pin<&mut MyObject>, signal_handler: MyObjectCxxQtSignalHandlerready, conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
                 }
@@ -471,7 +469,6 @@ mod tests {
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    #[must_use]
                     #[rust_name = "MyObject_connect_data_changed"]
                     fn MyObject_dataChangedConnect(self_value: Pin<&mut MyObject>, signal_handler: MyObjectCxxQtSignalHandlerdataChanged, conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
                 }
@@ -632,7 +629,6 @@ mod tests {
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    #[must_use]
                     #[rust_name = "MyObject_connect_unsafe_signal"]
                     fn MyObject_unsafeSignalConnect(self_value: Pin<&mut MyObject>, signal_handler: MyObjectCxxQtSignalHandlerunsafeSignal, conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
                 }
@@ -789,7 +785,6 @@ mod tests {
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    #[must_use]
                     #[rust_name = "MyObject_connect_existing_signal"]
                     fn MyObject_baseNameConnect(self_value: Pin<&mut MyObject>, signal_handler: MyObjectCxxQtSignalHandlerbaseName, conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
                 }
@@ -941,7 +936,6 @@ mod tests {
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    #[must_use]
                     #[rust_name = "MyObject_connect_ready"]
                     fn MyObject_readyConnect(self_value: Pin<&mut MyObject>, signal_handler: MyObjectCxxQtSignalHandlerready, conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
                 }
@@ -1085,7 +1079,6 @@ mod tests {
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    #[must_use]
                     #[rust_name = "MyObject_connect_ready"]
                     fn MyObject_readyConnect(self_value: Pin<&mut MyObject>, signal_handler: MyObjectCxxQtSignalHandlerready, conn_type: CxxQtConnectionType) -> CxxQtQMetaObjectConnection;
                 }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -104,7 +104,6 @@ pub mod ffi {
             >;
         #[doc(hidden)]
         #[namespace = "cxx_qt::multi_object::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "MyObject_connect_property_name_changed"]
         fn MyObject_propertyNameChangedConnect(
             self_value: Pin<&mut MyObject>,
@@ -140,7 +139,6 @@ pub mod ffi {
             cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosureready>;
         #[doc(hidden)]
         #[namespace = "cxx_qt::multi_object::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "MyObject_connect_ready"]
         fn MyObject_readyConnect(
             self_value: Pin<&mut MyObject>,
@@ -208,7 +206,6 @@ pub mod ffi {
             >;
         #[doc(hidden)]
         #[namespace = "second_object::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "SecondObject_connect_property_name_changed"]
         fn SecondObject_propertyNameChangedConnect(
             self_value: Pin<&mut SecondObject>,
@@ -245,7 +242,6 @@ pub mod ffi {
             cxx_qt::signalhandler::CxxQtSignalHandler<super::SecondObjectCxxQtSignalClosureready>;
         #[doc(hidden)]
         #[namespace = "second_object::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "SecondObject_connect_ready"]
         fn SecondObject_readyConnect(
             self_value: Pin<&mut SecondObject>,
@@ -295,7 +291,6 @@ pub mod ffi {
             cxx_qt::signalhandler::CxxQtSignalHandler<super::QPushButtonCxxQtSignalClosureclicked>;
         #[doc(hidden)]
         #[namespace = "rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "QPushButton_connect_clicked"]
         fn QPushButton_clickedConnect(
             self_value: Pin<&mut QPushButton>,
@@ -326,7 +321,6 @@ pub mod ffi {
         >;
         #[doc(hidden)]
         #[namespace = "mynamespace::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "ExternObject_connect_data_ready"]
         fn ExternObject_dataReadyConnect(
             self_value: Pin<&mut ExternObject>,
@@ -359,7 +353,6 @@ pub mod ffi {
             >;
         #[doc(hidden)]
         #[namespace = "mynamespace::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "ExternObject_connect_error_occurred"]
         fn ExternObject_errorOccurredConnect(
             self_value: Pin<&mut ExternObject>,

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -62,7 +62,6 @@ mod ffi {
         >;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "MyObject_connect_primitive_changed"]
         fn MyObject_primitiveChangedConnect(
             self_value: Pin<&mut MyObject>,
@@ -95,7 +94,6 @@ mod ffi {
         >;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "MyObject_connect_trivial_changed"]
         fn MyObject_trivialChangedConnect(
             self_value: Pin<&mut MyObject>,

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -50,7 +50,6 @@ mod ffi {
             cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosureready>;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "MyObject_connect_ready"]
         fn MyObject_readyConnect(
             self_value: Pin<&mut MyObject>,
@@ -85,7 +84,6 @@ mod ffi {
             cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosuredataChanged>;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "MyObject_connect_data_changed"]
         fn MyObject_dataChangedConnect(
             self_value: Pin<&mut MyObject>,
@@ -124,7 +122,6 @@ mod ffi {
             cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosurenewData>;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "MyObject_connect_base_class_new_data"]
         fn MyObject_newDataConnect(
             self_value: Pin<&mut MyObject>,
@@ -173,7 +170,6 @@ mod ffi {
             cxx_qt::signalhandler::CxxQtSignalHandler<super::QTimerCxxQtSignalClosuretimeout>;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        #[must_use]
         #[rust_name = "QTimer_connect_timeout"]
         fn QTimer_timeoutConnect(
             self_value: Pin<&mut QTimer>,

--- a/crates/cxx-qt/src/connectionguard.rs
+++ b/crates/cxx-qt/src/connectionguard.rs
@@ -11,7 +11,8 @@ use crate::QMetaObjectConnection;
 ///
 /// Note that when this struct is dropped the connection is disconnected.
 /// So to keep a connection active either hold onto the struct for the duration
-/// that the connection should be active or call `release`.
+/// that the connection should be active or call `release`, hence the `#[must_use]`.
+#[must_use]
 pub struct QMetaObjectConnectionGuard {
     connection: QMetaObjectConnection,
 }

--- a/examples/cargo_without_cmake/src/main.rs
+++ b/examples/cargo_without_cmake/src/main.rs
@@ -30,9 +30,12 @@ fn main() {
 
     if let Some(engine) = engine.as_mut() {
         // Listen to a signal from the QML Engine
-        engine.as_qqmlengine().on_quit(|_| {
-            println!("QML Quit!");
-        });
+        engine
+            .as_qqmlengine()
+            .on_quit(|_| {
+                println!("QML Quit!");
+            })
+            .release();
     }
 
     // Start the app


### PR DESCRIPTION
Before we used to return a QMetaObjectConnection which used to disconnection now we have two types, so ensure #[must_use] is in the right place.

Closes #930 