### PR TITLE
refactor: Free namespacing on associated QEnum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File name is used for CXX bridges rather than module name to match upstream
 - `#[qobject]` attribute is now optional on types in `extern "RustQt"`
 - `#[qobject]` attribute is now required on types in `extern "C++Qt"`
+- `#[qenum]`s now resolve their namespace independently from their associated QObject
 
 ### Removed
 

--- a/crates/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -56,7 +56,6 @@ impl GeneratedCppBlocks {
                 .cxx_qt_data
                 .qenums
                 .iter()
-                .filter(|parsed_qenum| parsed_qenum.qobject.is_none())
                 .map(|parsed_qenum| qenum::generate_declaration(parsed_qenum, &mut includes)),
         );
         Ok(GeneratedCppBlocks {

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -162,7 +162,7 @@ impl GeneratedCppQObject {
             &qobject.base_class,
             type_names,
         )?);
-        generated.blocks.append(&mut qenum::generate(
+        generated.blocks.append(&mut qenum::generate_on_qobject(
             structured_qobject.qenums.iter().cloned(),
         )?);
 

--- a/crates/cxx-qt-gen/src/generator/rust/qenum.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qenum.rs
@@ -15,13 +15,6 @@ pub fn generate_cxx_mod_contents(qenums: &[ParsedQEnum]) -> Vec<Item> {
             let qenum_ident = &qenum.name.rust_unqualified();
             let namespace = &qenum.name.namespace();
 
-            // If the QEnum has a namespace inherited from its QObject, it won't have the
-            // `#[namespace=...]` attribute, so we need to inject it.
-            let shared_namespace = if namespace.is_some() && qenum.qobject.is_some() {
-                quote! { #[namespace = #namespace] }
-            } else {
-                quote! {}
-            };
             let cxx_namespace = if namespace.is_none() {
                 quote! {}
             } else {
@@ -31,7 +24,6 @@ pub fn generate_cxx_mod_contents(qenums: &[ParsedQEnum]) -> Vec<Item> {
                 parse_quote_spanned! {
                     qenum.item.span() =>
                     #[repr(i32)]
-                    #shared_namespace
                     #qenum_item
                 },
                 parse_quote_spanned! {

--- a/crates/cxx-qt-gen/src/generator/structuring/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/structuring/mod.rs
@@ -16,13 +16,7 @@ pub mod qobject;
 pub use qobject::StructuredQObject;
 
 use crate::parser::cxxqtdata::ParsedCxxQtData;
-use syn::{Error, Ident, Result};
-
-/// The naming phase may already associate QEnums with QObjects.
-/// In this case, we want to use the same error message, as in this module.
-pub(crate) fn error_unknown_qobject(ident: &Ident) -> Error {
-    Error::new_spanned(ident, format!("Unknown QObject: {ident}"))
-}
+use syn::{Error, Result};
 
 /// The list of all structures that could be associated from the parsed data.
 /// Most importantly, this includes the list of qobjects.
@@ -52,7 +46,10 @@ impl<'a> Structures<'a> {
                 {
                     qobject.qenums.push(qenum);
                 } else {
-                    return Err(error_unknown_qobject(qobject_ident));
+                    return Err(Error::new_spanned(
+                        qobject_ident,
+                        format!("Unknown QObject: {qobject_ident}"),
+                    ));
                 }
             }
         }

--- a/crates/cxx-qt-gen/src/parser/qenum.rs
+++ b/crates/cxx-qt-gen/src/parser/qenum.rs
@@ -61,12 +61,6 @@ impl ParsedQEnum {
             ));
         }
 
-        // If we have a QObject, we can't have a namespace, so also do not inherit one.
-        let parent_namespace = if qobject.is_some() {
-            None
-        } else {
-            parent_namespace
-        };
         let name =
             Name::from_ident_and_attrs(&qenum.ident, &qenum.attrs, parent_namespace, module)?;
 
@@ -227,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_inherit_namespace_and_qobject() {
+    fn parse_qobject_and_qenum_namespace_are_independent() {
         let qenum: ItemEnum = parse_quote! {
             enum MyEnum {
                 A,
@@ -237,7 +231,7 @@ mod tests {
         let qobject = Some(format_ident!("MyObject"));
         let parsed =
             ParsedQEnum::parse(qenum, qobject.clone(), parent_namespace, &mock_module()).unwrap();
-        assert!(parsed.name.namespace().is_none());
+        assert_eq!(parsed.name.namespace(), Some("my_namespace"));
         assert_eq!(parsed.qobject, qobject);
     }
 }

--- a/crates/cxx-qt-gen/test_inputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_inputs/qenum.rs
@@ -5,7 +5,9 @@ mod ffi {
         A,
     }
 
+    // Associated QEnums can be namespaced independently
     #[qenum(MyObject)]
+    #[namespace = "my_namespace"]
     enum MyOtherEnum {
         X,
         Y,

--- a/crates/cxx-qt-gen/test_outputs/qenum.cpp
+++ b/crates/cxx-qt-gen/test_outputs/qenum.cpp
@@ -3,7 +3,7 @@
 namespace cxx_qt::my_object {
 void
 MyObject::myInvokable(cxx_qt::my_object::MyEnum qenum,
-                      cxx_qt::my_object::MyOtherEnum other_qenum) const
+                      my_namespace::MyOtherEnum other_qenum) const
 {
   const ::rust::cxxqt1::MaybeLockGuard<MyObject> guard(*this);
   myInvokableWrapper(qenum, other_qenum);

--- a/crates/cxx-qt-gen/test_outputs/qenum.h
+++ b/crates/cxx-qt-gen/test_outputs/qenum.h
@@ -9,28 +9,11 @@
 
 namespace cxx_qt::my_object {
 class MyObject;
-enum class MyEnum : ::std::int32_t
-{
-  A
-};
-
-enum class MyOtherEnum : ::std::int32_t
-{
-  X,
-  Y,
-  Z
-};
 
 } // namespace cxx_qt::my_object
 
 namespace cxx_qt::my_object {
 class CxxName;
-enum class MyRenamedEnum : ::std::int32_t
-{
-  A,
-  B,
-  C
-};
 
 } // namespace cxx_qt::my_object
 
@@ -42,6 +25,22 @@ QML_ELEMENT
 namespace other_namespace {
 Q_NAMESPACE
 } // namespace other_namespace
+
+namespace cxx_qt::my_object {
+enum class MyEnum : ::std::int32_t
+{
+  A
+};
+} // namespace cxx_qt::my_object
+
+namespace my_namespace {
+enum class MyOtherEnum : ::std::int32_t
+{
+  X,
+  Y,
+  Z
+};
+} // namespace my_namespace
 
 namespace cxx_qt::my_object {
 Q_NAMESPACE
@@ -63,6 +62,15 @@ enum class MyOtherNamespacedEnum : ::std::int32_t
 };
 Q_ENUM_NS(MyOtherNamespacedEnum)
 } // namespace other_namespace
+
+namespace cxx_qt::my_object {
+enum class MyRenamedEnum : ::std::int32_t
+{
+  A,
+  B,
+  C
+};
+} // namespace cxx_qt::my_object
 
 #include "cxx-qt-gen/ffi.cxx.h"
 
@@ -86,22 +94,20 @@ public:
   enum class MyOtherEnum : ::std::int32_t{ X, Y, Z };
   Q_ENUM(MyOtherEnum)
 #else
-  using MyOtherEnum = ::cxx_qt::my_object::MyOtherEnum;
+  using MyOtherEnum = ::my_namespace::MyOtherEnum;
   Q_ENUM(MyOtherEnum)
 #endif
 
   virtual ~MyObject() = default;
 
 public:
-  Q_INVOKABLE void myInvokable(
-    cxx_qt::my_object::MyEnum qenum,
-    cxx_qt::my_object::MyOtherEnum other_qenum) const;
+  Q_INVOKABLE void myInvokable(cxx_qt::my_object::MyEnum qenum,
+                               my_namespace::MyOtherEnum other_qenum) const;
   explicit MyObject(QObject* parent = nullptr);
 
 private:
-  void myInvokableWrapper(
-    cxx_qt::my_object::MyEnum qenum,
-    cxx_qt::my_object::MyOtherEnum other_qenum) const noexcept;
+  void myInvokableWrapper(cxx_qt::my_object::MyEnum qenum,
+                          my_namespace::MyOtherEnum other_qenum) const noexcept;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs
@@ -13,7 +13,6 @@ mod ffi {
         type QMetaObjectConnection = cxx_qt::QMetaObjectConnection;
     }
     #[repr(i32)]
-    #[namespace = "cxx_qt::my_object"]
     enum MyEnum {
         A,
     }
@@ -22,14 +21,14 @@ mod ffi {
         type MyEnum;
     }
     #[repr(i32)]
-    #[namespace = "cxx_qt::my_object"]
+    #[namespace = "my_namespace"]
     enum MyOtherEnum {
         X,
         Y,
         Z,
     }
     extern "C++" {
-        #[namespace = "cxx_qt::my_object"]
+        #[namespace = "my_namespace"]
         type MyOtherEnum;
     }
     #[repr(i32)]
@@ -53,7 +52,6 @@ mod ffi {
         type MyOtherNamespacedEnum;
     }
     #[repr(i32)]
-    #[namespace = "cxx_qt::my_object"]
     enum MyRenamedEnum {
         A,
         B,


### PR DESCRIPTION
There is really no reason the QEnum must inherit the QObject namespace.
Even makes our code generation a lot simpler.

Closes #945