### PR TITLE
refactor: Use Name for C++ QObject generation

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -100,7 +100,7 @@ mod tests {
         let cpp = GeneratedCppBlocks::from(&parser).unwrap();
         assert_eq!(cpp.cxx_file_stem, "ffi");
         assert_eq!(cpp.qobjects.len(), 1);
-        assert_eq!(cpp.qobjects[0].namespace, "");
+        assert_eq!(cpp.qobjects[0].name.namespace(), None);
     }
 
     #[test]
@@ -119,7 +119,7 @@ mod tests {
         let cpp = GeneratedCppBlocks::from(&parser).unwrap();
         assert_eq!(cpp.cxx_file_stem, "my_object");
         assert_eq!(cpp.qobjects.len(), 1);
-        assert_eq!(&cpp.qobjects[0].namespace, "");
+        assert_eq!(cpp.qobjects[0].name.namespace(), None);
     }
 
     #[test]
@@ -136,6 +136,6 @@ mod tests {
         let parser = Parser::from(module).unwrap();
 
         let cpp = GeneratedCppBlocks::from(&parser).unwrap();
-        assert_eq!(cpp.qobjects[0].namespace, "cxx_qt");
+        assert_eq!(cpp.qobjects[0].name.namespace(), Some("cxx_qt"));
     }
 }

--- a/crates/cxx-qt-gen/src/naming/name.rs
+++ b/crates/cxx-qt-gen/src/naming/name.rs
@@ -150,4 +150,24 @@ impl Name {
             cxx_name
         }
     }
+
+    #[cfg(test)]
+    pub fn mock(ident: &str) -> Self {
+        Self {
+            rust: format_ident!("{ident}"),
+            cxx: None,
+            module: Some(Path::from(format_ident!("qobject"))),
+            namespace: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn mock_namespaced(ident: &str, namespace: &str) -> Self {
+        Self {
+            rust: format_ident!("{ident}"),
+            cxx: None,
+            module: Some(Path::from(format_ident!("qobject"))),
+            namespace: Some(namespace.to_owned()),
+        }
+    }
 }

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -220,13 +220,20 @@ mod tests {
         assert_eq!(parser.passthrough_module.content.unwrap().1.len(), 0);
         assert_eq!(parser.cxx_qt_data.namespace, Some("cxx_qt".to_owned()));
         assert_eq!(parser.cxx_qt_data.qobjects.len(), 1);
-        assert_eq!(parser.type_names.num_types(), 17);
+        assert_eq!(parser.type_names.num_types(), 18);
         assert_eq!(
             parser
                 .type_names
                 .rust_qualified(&format_ident!("MyObject"))
                 .unwrap(),
             parse_quote! { ffi::MyObject }
+        );
+        assert_eq!(
+            parser
+                .type_names
+                .rust_qualified(&format_ident!("MyObjectRust"))
+                .unwrap(),
+            parse_quote! { ffi::MyObjectRust }
         );
     }
 
@@ -316,7 +323,7 @@ mod tests {
             }
         };
         let parser = Parser::from(module).unwrap();
-        assert_eq!(parser.type_names.num_types(), 19);
+        assert_eq!(parser.type_names.num_types(), 22);
         assert_eq!(
             parser
                 .type_names
@@ -340,6 +347,28 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             "extern_namespace"
+        );
+
+        assert_eq!(
+            parser
+                .type_names
+                .namespace(&format_ident!("MyObjectARust"))
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            parser
+                .type_names
+                .namespace(&format_ident!("MyObjectBRust"))
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            parser
+                .type_names
+                .namespace(&format_ident!("MyObjectCRust"))
+                .unwrap(),
+            None
         );
     }
 }

--- a/crates/cxx-qt-gen/src/writer/cpp/source.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/source.rs
@@ -30,7 +30,7 @@ fn qobjects_source(generated: &GeneratedCppBlocks) -> Vec<String> {
                 .filter_map(pair_as_source)
                 .collect::<Vec<String>>()
                 .join("\n");
-            let namespaced = namespaced(&qobject.namespace, &methods);
+            let namespaced = namespaced(qobject.name.namespace().unwrap_or_default(), &methods);
 
             qobject
                 .blocks


### PR DESCRIPTION
Part of #939 