### PR TITLE
Refactor: Use naming::Name in QObjectNames struct

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/cxxqttype.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/cxxqttype.rs
@@ -3,10 +3,10 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::generator::{cpp::qobject::GeneratedCppQObjectBlocks, naming::qobject::QObjectName};
+use crate::generator::{cpp::qobject::GeneratedCppQObjectBlocks, naming::qobject::QObjectNames};
 use syn::Result;
 
-pub fn generate(qobject_idents: &QObjectName) -> Result<GeneratedCppQObjectBlocks> {
+pub fn generate(qobject_idents: &QObjectNames) -> Result<GeneratedCppQObjectBlocks> {
     let mut result = GeneratedCppQObjectBlocks::default();
 
     let rust_struct = qobject_idents.rust_struct.cxx_qualified();

--- a/crates/cxx-qt-gen/src/generator/cpp/cxxqttype.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/cxxqttype.rs
@@ -9,7 +9,7 @@ use syn::Result;
 pub fn generate(qobject_idents: &QObjectName) -> Result<GeneratedCppQObjectBlocks> {
     let mut result = GeneratedCppQObjectBlocks::default();
 
-    let rust_ident = qobject_idents.rust_struct.cpp.to_string();
+    let rust_struct = qobject_idents.rust_struct.cxx_qualified();
 
     result
         .includes
@@ -17,7 +17,7 @@ pub fn generate(qobject_idents: &QObjectName) -> Result<GeneratedCppQObjectBlock
 
     result
         .base_classes
-        .push(format!("::rust::cxxqt1::CxxQtType<{rust_ident}>"));
+        .push(format!("::rust::cxxqt1::CxxQtType<{rust_struct}>"));
 
     Ok(result)
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/externcxxqt.rs
@@ -29,7 +29,8 @@ pub fn generate(
     for block in blocks {
         for signal in &block.signals {
             let mut block = GeneratedCppExternCxxQtBlocks::default();
-            let data = generate_cpp_signal(signal, &signal.qobject_ident, type_names)?;
+            let qobject_name = type_names.lookup(&signal.qobject_ident)?;
+            let data = generate_cpp_signal(signal, qobject_name, type_names)?;
             block.includes = data.includes;
             // Ensure that we include MaybeLockGuard<T> that is used in multiple places
             block

--- a/crates/cxx-qt-gen/src/generator/cpp/method.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/method.rs
@@ -26,7 +26,7 @@ pub fn generate_cpp_methods(
     type_names: &TypeNames,
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut generated = GeneratedCppQObjectBlocks::default();
-    let qobject_ident = qobject_idents.cpp_class.cpp.to_string();
+    let qobject_ident = qobject_idents.name.cxx_unqualified();
     for invokable in invokables {
         let idents = QMethodName::from(invokable);
         let return_cxx_ty = syn_type_to_cpp_return_type(&invokable.method.sig.output, type_names)?;

--- a/crates/cxx-qt-gen/src/generator/cpp/method.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/method.rs
@@ -9,7 +9,7 @@ use crate::{
             fragment::{CppFragment, CppNamedType},
             qobject::GeneratedCppQObjectBlocks,
         },
-        naming::{method::QMethodName, qobject::QObjectName},
+        naming::{method::QMethodName, qobject::QObjectNames},
     },
     naming::cpp::{
         syn_return_type_to_cpp_except, syn_type_to_cpp_return_type, syn_type_to_cpp_type,
@@ -22,7 +22,7 @@ use syn::{spanned::Spanned, Error, FnArg, Pat, PatIdent, PatType, Result};
 
 pub fn generate_cpp_methods(
     invokables: &Vec<ParsedMethod>,
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
     type_names: &TypeNames,
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut generated = GeneratedCppQObjectBlocks::default();

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -5,7 +5,7 @@
 
 use crate::generator::{
     cpp::{qobject::GeneratedCppQObjectBlocks, signal::generate_cpp_signals},
-    naming::{property::QPropertyName, qobject::QObjectName},
+    naming::{property::QPropertyName, qobject::QObjectNames},
 };
 use crate::{
     naming::cpp::syn_type_to_cpp_type, naming::TypeNames, parser::property::ParsedQProperty,
@@ -19,7 +19,7 @@ mod signal;
 
 pub fn generate_cpp_properties(
     properties: &Vec<ParsedQProperty>,
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
     type_names: &TypeNames,
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut generated = GeneratedCppQObjectBlocks::default();

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -24,7 +24,7 @@ pub fn generate_cpp_properties(
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut generated = GeneratedCppQObjectBlocks::default();
     let mut signals = vec![];
-    let qobject_ident = qobject_idents.cpp_class.cpp.to_string();
+    let qobject_ident = qobject_idents.name.cxx_unqualified();
 
     for property in properties {
         // Cache the idents as they are used in multiple places

--- a/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
@@ -6,11 +6,11 @@
 use syn::ForeignItemFn;
 
 use crate::{
-    generator::naming::{property::QPropertyName, qobject::QObjectName},
+    generator::naming::{property::QPropertyName, qobject::QObjectNames},
     parser::signals::ParsedSignal,
 };
 
-pub fn generate(idents: &QPropertyName, qobject_idents: &QObjectName) -> ParsedSignal {
+pub fn generate(idents: &QPropertyName, qobject_idents: &QObjectNames) -> ParsedSignal {
     // We build our signal in the generation phase as we need to use the naming
     // structs to build the signal name
     let cpp_class_rust = &qobject_idents.name.rust_unqualified();

--- a/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
@@ -13,7 +13,7 @@ use crate::{
 pub fn generate(idents: &QPropertyName, qobject_idents: &QObjectName) -> ParsedSignal {
     // We build our signal in the generation phase as we need to use the naming
     // structs to build the signal name
-    let cpp_class_rust = &qobject_idents.cpp_class.rust;
+    let cpp_class_rust = &qobject_idents.name.rust_unqualified();
     let notify_cpp = &idents.notify.cpp;
     let notify_rust_str = idents.notify.rust.to_string();
     let method: ForeignItemFn = syn::parse_quote! {
@@ -24,6 +24,6 @@ pub fn generate(idents: &QPropertyName, qobject_idents: &QObjectName) -> ParsedS
     ParsedSignal::from_property_method(
         method,
         idents.notify.clone(),
-        qobject_idents.cpp_class.rust.clone(),
+        qobject_idents.name.rust_unqualified().clone(),
     )
 }

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -104,7 +104,7 @@ impl GeneratedCppQObject {
         let qobject = structured_qobject.declaration;
 
         // Create the base object
-        let qobject_idents = QObjectName::from(qobject);
+        let qobject_idents = QObjectName::from_qobject(qobject, type_names)?;
         let namespace_idents = NamespaceName::from(qobject);
         let mut generated = GeneratedCppQObject {
             name: qobject.name.clone(),

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -10,7 +10,7 @@ use crate::{
             method::generate_cpp_methods, property::generate_cpp_properties, qenum,
             signal::generate_cpp_signals, threading,
         },
-        naming::{namespace::NamespaceName, qobject::QObjectName},
+        naming::{namespace::NamespaceName, qobject::QObjectNames},
         structuring::StructuredQObject,
     },
     naming::Name,
@@ -104,7 +104,7 @@ impl GeneratedCppQObject {
         let qobject = structured_qobject.declaration;
 
         // Create the base object
-        let qobject_idents = QObjectName::from_qobject(qobject, type_names)?;
+        let qobject_idents = QObjectNames::from_qobject(qobject, type_names)?;
         let namespace_idents = NamespaceName::from(qobject);
         let mut generated = GeneratedCppQObject {
             name: qobject.name.clone(),

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -7,7 +7,7 @@ use crate::{
     generator::{
         cpp::{fragment::CppFragment, qobject::GeneratedCppQObjectBlocks},
         naming::{
-            qobject::QObjectName,
+            qobject::QObjectNames,
             signals::{QSignalHelperName, QSignalName},
         },
     },
@@ -191,7 +191,7 @@ pub fn generate_cpp_signal(
 
 pub fn generate_cpp_signals(
     signals: &Vec<ParsedSignal>,
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
     type_names: &TypeNames,
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut generated = GeneratedCppQObjectBlocks::default();

--- a/crates/cxx-qt-gen/src/generator/cpp/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/threading.rs
@@ -5,12 +5,12 @@
 
 use crate::generator::{
     cpp::{fragment::CppFragment, qobject::GeneratedCppQObjectBlocks},
-    naming::qobject::QObjectName,
+    naming::qobject::QObjectNames,
 };
 use indoc::formatdoc;
 use syn::Result;
 
-pub fn generate(qobject_idents: &QObjectName) -> Result<(String, GeneratedCppQObjectBlocks)> {
+pub fn generate(qobject_idents: &QObjectNames) -> Result<(String, GeneratedCppQObjectBlocks)> {
     let mut result = GeneratedCppQObjectBlocks::default();
 
     let cpp_class = &qobject_idents.name.cxx_unqualified();

--- a/crates/cxx-qt-gen/src/generator/cpp/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/threading.rs
@@ -13,7 +13,7 @@ use syn::Result;
 pub fn generate(qobject_idents: &QObjectName) -> Result<(String, GeneratedCppQObjectBlocks)> {
     let mut result = GeneratedCppQObjectBlocks::default();
 
-    let cpp_class = &qobject_idents.cpp_class.cpp;
+    let cpp_class = &qobject_idents.name.cxx_unqualified();
     let cxx_qt_thread_ident = &qobject_idents.cxx_qt_thread_class;
 
     result.forward_declares.push(format!(

--- a/crates/cxx-qt-gen/src/generator/naming/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/qobject.rs
@@ -11,7 +11,7 @@ use quote::format_ident;
 use syn::{Ident, Result};
 
 /// Names for parts of a Q_OBJECT
-pub struct QObjectName {
+pub struct QObjectNames {
     /// The name of the QObject itself.
     pub name: Name,
     /// The name of the inner Rust struct
@@ -22,11 +22,13 @@ pub struct QObjectName {
     pub cxx_qt_thread_queued_fn_struct: Ident,
 }
 
-impl QObjectName {
+impl QObjectNames {
+    /// For a given QObject, create the names associated with it for generation.
     pub fn from_qobject(qobject: &ParsedQObject, type_names: &TypeNames) -> Result<Self> {
         Self::from_name_and_ident(&qobject.name, &qobject.rust_type, type_names)
     }
 
+    /// From the QObject name and Rust struct ident, create the names needed for generation.
     pub fn from_name_and_ident(
         qobject_name: &Name,
         ident_right: &Ident,
@@ -78,14 +80,14 @@ pub mod tests {
 
     use crate::parser::qobject::tests::create_parsed_qobject;
 
-    pub fn create_qobjectname() -> QObjectName {
-        QObjectName::from_qobject(&create_parsed_qobject(), &TypeNames::mock()).unwrap()
+    pub fn create_qobjectname() -> QObjectNames {
+        QObjectNames::from_qobject(&create_parsed_qobject(), &TypeNames::mock()).unwrap()
     }
 
     #[test]
     fn test_parsed_property() {
         let names =
-            QObjectName::from_qobject(&create_parsed_qobject(), &TypeNames::mock()).unwrap();
+            QObjectNames::from_qobject(&create_parsed_qobject(), &TypeNames::mock()).unwrap();
         assert_eq!(names.name.cxx_unqualified(), "MyObject");
         assert_eq!(names.name.rust_unqualified(), &format_ident!("MyObject"));
         assert_eq!(names.rust_struct.cxx_unqualified(), "MyObjectRust");

--- a/crates/cxx-qt-gen/src/generator/naming/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/qobject.rs
@@ -2,56 +2,54 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use crate::{generator::naming::CombinedIdent, naming::Name, parser::qobject::ParsedQObject};
+use crate::{
+    naming::{Name, TypeNames},
+    parser::qobject::ParsedQObject,
+};
 use convert_case::{Case, Casing};
 use quote::format_ident;
-use syn::Ident;
+use syn::{Ident, Result};
 
 /// Names for parts of a Q_OBJECT
 pub struct QObjectName {
-    // Store the ident so that cxx_qt_thread_method can use it later
-    ident: Ident,
-    /// The name of the C++ class
-    pub cpp_class: CombinedIdent,
-    /// The name of the Rust struct
-    pub rust_struct: CombinedIdent,
+    /// The name of the QObject itself.
+    pub name: Name,
+    /// The name of the inner Rust struct
+    pub rust_struct: Name,
     /// The name of the CxxQtThread
     pub cxx_qt_thread_class: Ident,
     /// The name of the Rust closure wrapper to be passed in to CxxQtThread
     pub cxx_qt_thread_queued_fn_struct: Ident,
 }
 
-impl From<&ParsedQObject> for QObjectName {
-    fn from(qobject: &ParsedQObject) -> Self {
-        Self::from_name_and_ident(&qobject.name, qobject.rust_type.clone())
-    }
-}
-
 impl QObjectName {
-    pub fn from_name_and_ident(qobject_name: &Name, ident_right: Ident) -> Self {
-        Self {
-            cpp_class: CombinedIdent {
-                cpp: format_ident!("{}", qobject_name.cxx_unqualified()),
-                rust: qobject_name.rust_unqualified().clone(),
-            },
-            rust_struct: CombinedIdent::from_ident(ident_right),
+    pub fn from_qobject(qobject: &ParsedQObject, type_names: &TypeNames) -> Result<Self> {
+        Self::from_name_and_ident(&qobject.name, &qobject.rust_type, type_names)
+    }
+
+    pub fn from_name_and_ident(
+        qobject_name: &Name,
+        ident_right: &Ident,
+        type_names: &TypeNames,
+    ) -> Result<Self> {
+        Ok(Self {
+            name: qobject_name.clone(),
+            rust_struct: type_names.lookup(ident_right)?.clone(),
             cxx_qt_thread_class: cxx_qt_thread_class_from_ident(qobject_name.rust_unqualified()),
             cxx_qt_thread_queued_fn_struct: cxx_qt_thread_queued_fn_struct_from_ident(
                 qobject_name.rust_unqualified(),
             ),
-            ident: qobject_name.rust_unqualified().clone(),
-        }
+        })
     }
 
     // Only for mocking in tests
     #[cfg(test)]
     pub fn from_idents(ident_left: Ident, ident_right: Ident) -> Self {
         Self {
-            cpp_class: CombinedIdent::from_ident(ident_left.clone()),
-            rust_struct: CombinedIdent::from_ident(ident_right),
+            name: Name::mock(&ident_left.to_string()),
+            rust_struct: Name::mock(&ident_right.to_string()),
             cxx_qt_thread_class: cxx_qt_thread_class_from_ident(&ident_left),
             cxx_qt_thread_queued_fn_struct: cxx_qt_thread_queued_fn_struct_from_ident(&ident_left),
-            ident: ident_left,
         }
     }
 
@@ -59,7 +57,7 @@ impl QObjectName {
     pub fn cxx_qt_thread_method(&self, suffix: &str) -> Ident {
         format_ident!(
             "cxx_qt_ffi_{ident}_{suffix}",
-            ident = self.ident.to_string().to_case(Case::Snake)
+            ident = self.name.cxx_unqualified().to_case(Case::Snake)
         )
     }
 }
@@ -74,16 +72,6 @@ fn cxx_qt_thread_queued_fn_struct_from_ident(ident: &Ident) -> Ident {
     format_ident!("{ident}CxxQtThreadQueuedFn")
 }
 
-impl CombinedIdent {
-    /// For a given ident generate the Rust and C++ names
-    fn from_ident(ident: Ident) -> Self {
-        Self {
-            cpp: ident.clone(),
-            rust: ident,
-        }
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -91,16 +79,20 @@ pub mod tests {
     use crate::parser::qobject::tests::create_parsed_qobject;
 
     pub fn create_qobjectname() -> QObjectName {
-        QObjectName::from(&create_parsed_qobject())
+        QObjectName::from_qobject(&create_parsed_qobject(), &TypeNames::mock()).unwrap()
     }
 
     #[test]
     fn test_parsed_property() {
-        let names = QObjectName::from(&create_parsed_qobject());
-        assert_eq!(names.cpp_class.cpp, format_ident!("MyObject"));
-        assert_eq!(names.cpp_class.rust, format_ident!("MyObject"));
-        assert_eq!(names.rust_struct.cpp, format_ident!("MyObjectRust"));
-        assert_eq!(names.rust_struct.rust, format_ident!("MyObjectRust"));
+        let names =
+            QObjectName::from_qobject(&create_parsed_qobject(), &TypeNames::mock()).unwrap();
+        assert_eq!(names.name.cxx_unqualified(), "MyObject");
+        assert_eq!(names.name.rust_unqualified(), &format_ident!("MyObject"));
+        assert_eq!(names.rust_struct.cxx_unqualified(), "MyObjectRust");
+        assert_eq!(
+            names.rust_struct.rust_unqualified(),
+            &format_ident!("MyObjectRust")
+        );
         assert_eq!(
             names.cxx_qt_thread_class,
             format_ident!("MyObjectCxxQtThread")

--- a/crates/cxx-qt-gen/src/generator/naming/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/signals.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::parser::signals::ParsedSignal;
-use crate::{generator::naming::CombinedIdent, naming::TypeNames};
+use crate::{generator::naming::CombinedIdent, naming::Name};
 use convert_case::{Case, Casing};
 use quote::format_ident;
 use syn::{Ident, Result};
@@ -52,12 +52,9 @@ pub struct QSignalHelperName {
 }
 
 impl QSignalHelperName {
-    pub fn new(
-        idents: &QSignalName,
-        qobject_ident: &Ident,
-        type_names: &TypeNames,
-    ) -> Result<Self> {
+    pub fn new(idents: &QSignalName, qobject_name: &Name) -> Result<Self> {
         let signal_ident = &idents.name.cpp;
+        let qobject_ident = qobject_name.rust_unqualified().to_string();
         let handler_alias = format_ident!("{qobject_ident}CxxQtSignalHandler{signal_ident}");
         let namespace = {
             // This namespace will take the form of:
@@ -71,10 +68,10 @@ impl QSignalHelperName {
             //
             // See the comment on TypeNames::cxx_qualified for why fully qualifying is
             // unfortunately not possible.
-            let qobject_namespace = type_names.namespace(qobject_ident)?;
+            let qobject_namespace = qobject_name.namespace();
             let namespace: Vec<_> = qobject_namespace
                 .into_iter()
-                .chain(vec!["rust::cxxqtgen1".to_owned()])
+                .chain(vec!["rust::cxxqtgen1"])
                 .collect();
 
             namespace.join("::")

--- a/crates/cxx-qt-gen/src/generator/rust/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/constructor.rs
@@ -63,7 +63,7 @@ fn generate_default_constructor(
     qobject_idents: &QObjectName,
     namespace: &NamespaceName,
 ) -> GeneratedRustFragment {
-    let rust_struct_ident = &qobject_idents.rust_struct.rust;
+    let rust_struct_ident = qobject_idents.rust_struct.rust_unqualified();
 
     let create_rs_ident = format_ident!(
         "create_rs_{object_name}",
@@ -189,12 +189,12 @@ pub fn generate(
     let mut result = GeneratedRustFragment::default();
     let namespace_internals = &namespace.internal;
 
-    let qobject_name = &qobject_idents.cpp_class.cpp;
-    let qobject_name_rust = &qobject_idents.cpp_class.rust;
+    let qobject_name = qobject_idents.name.cxx_unqualified();
+    let qobject_name_rust = qobject_idents.name.rust_unqualified();
     let qobject_name_rust_qualified = type_names.rust_qualified(qobject_name_rust)?;
     let qobject_name_snake = qobject_name.to_string().to_case(Case::Snake);
 
-    let rust_struct_name_rust = &qobject_idents.rust_struct.rust;
+    let rust_struct_name_rust = qobject_idents.rust_struct.rust_unqualified();
 
     for (index, constructor) in constructors.iter().enumerate() {
         let lifetime = constructor.lifetime.as_ref().map(|lifetime| {

--- a/crates/cxx-qt-gen/src/generator/rust/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/constructor.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     generator::{
-        naming::{namespace::NamespaceName, qobject::QObjectName, CombinedIdent},
+        naming::{namespace::NamespaceName, qobject::QObjectNames, CombinedIdent},
         rust::fragment::GeneratedRustFragment,
     },
     naming::rust::{syn_type_cxx_bridge_to_qualified, syn_type_is_cxx_bridge_unsafe},
@@ -60,7 +60,7 @@ fn argument_members(args: &[Type]) -> Vec<TokenStream> {
 }
 
 fn generate_default_constructor(
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
     namespace: &NamespaceName,
 ) -> GeneratedRustFragment {
     let rust_struct_ident = qobject_idents.rust_struct.rust_unqualified();
@@ -177,7 +177,7 @@ fn unsafe_if(condition: bool) -> Option<TokenStream> {
 
 pub fn generate(
     constructors: &[Constructor],
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
     namespace: &NamespaceName,
     type_names: &TypeNames,
     module_ident: &Ident,
@@ -456,8 +456,8 @@ mod tests {
         }
     }
 
-    fn mock_name() -> QObjectName {
-        QObjectName::from_idents(format_ident!("MyObject"), format_ident!("MyObjectRust"))
+    fn mock_name() -> QObjectNames {
+        QObjectNames::from_idents(format_ident!("MyObject"), format_ident!("MyObjectRust"))
     }
 
     fn mock_namespace() -> NamespaceName {

--- a/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
@@ -18,8 +18,8 @@ pub fn generate(
 ) -> Result<GeneratedRustFragment> {
     let mut blocks = GeneratedRustFragment::default();
 
-    let cpp_struct_ident = &qobject_ident.cpp_class.rust;
-    let rust_struct_ident = &qobject_ident.rust_struct.rust;
+    let cpp_struct_ident = &qobject_ident.name.rust_unqualified();
+    let rust_struct_ident = &qobject_ident.rust_struct.rust_unqualified();
     let qualified_impl = type_names.rust_qualified(cpp_struct_ident)?;
 
     let fragment = RustFragmentPair {
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn test_generate_rust_cxxqttype() {
         let qobject = create_parsed_qobject();
-        let qobject_idents = QObjectName::from(&qobject);
+        let qobject_idents = QObjectName::from_qobject(&qobject, &TypeNames::mock()).unwrap();
 
         let generated = generate(&qobject_idents, &TypeNames::mock()).unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
-    generator::{naming::qobject::QObjectName, rust::fragment::GeneratedRustFragment},
+    generator::{naming::qobject::QObjectNames, rust::fragment::GeneratedRustFragment},
     naming::TypeNames,
 };
 use quote::quote;
@@ -13,7 +13,7 @@ use syn::Result;
 use super::fragment::RustFragmentPair;
 
 pub fn generate(
-    qobject_ident: &QObjectName,
+    qobject_ident: &QObjectNames,
     type_names: &TypeNames,
 ) -> Result<GeneratedRustFragment> {
     let mut blocks = GeneratedRustFragment::default();
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn test_generate_rust_cxxqttype() {
         let qobject = create_parsed_qobject();
-        let qobject_idents = QObjectName::from_qobject(&qobject, &TypeNames::mock()).unwrap();
+        let qobject_idents = QObjectNames::from_qobject(&qobject, &TypeNames::mock()).unwrap();
 
         let generated = generate(&qobject_idents, &TypeNames::mock()).unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
@@ -41,7 +41,7 @@ impl GeneratedRustFragment {
 
         // Build the signals
         for signal in &extern_cxxqt_block.signals {
-            let qobject_name = &signal.qobject_ident;
+            let qobject_name = type_names.lookup(&signal.qobject_ident)?;
 
             generated.append(&mut generate_rust_signal(
                 signal,

--- a/crates/cxx-qt-gen/src/generator/rust/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/inherit.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
-    generator::{naming::qobject::QObjectName, rust::fragment::GeneratedRustFragment},
+    generator::{naming::qobject::QObjectNames, rust::fragment::GeneratedRustFragment},
     parser::inherit::ParsedInheritedMethod,
 };
 use proc_macro2::TokenStream;
@@ -12,7 +12,7 @@ use quote::{quote, quote_spanned};
 use syn::{spanned::Spanned, Item, Result};
 
 pub fn generate(
-    qobject_ident: &QObjectName,
+    qobject_ident: &QObjectNames,
     methods: &[ParsedInheritedMethod],
 ) -> Result<GeneratedRustFragment> {
     let mut blocks = GeneratedRustFragment::default();

--- a/crates/cxx-qt-gen/src/generator/rust/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/inherit.rs
@@ -16,7 +16,7 @@ pub fn generate(
     methods: &[ParsedInheritedMethod],
 ) -> Result<GeneratedRustFragment> {
     let mut blocks = GeneratedRustFragment::default();
-    let qobject_name = &qobject_ident.cpp_class.rust;
+    let qobject_name = qobject_ident.name.rust_unqualified();
 
     let mut bridges = methods
         .iter()

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     generator::{
-        naming::{method::QMethodName, qobject::QObjectName},
+        naming::{method::QMethodName, qobject::QObjectNames},
         rust::fragment::{GeneratedRustFragment, RustFragmentPair},
     },
     parser::method::ParsedMethod,
@@ -16,7 +16,7 @@ use syn::{spanned::Spanned, Result};
 
 pub fn generate_rust_methods(
     invokables: &Vec<ParsedMethod>,
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
 ) -> Result<GeneratedRustFragment> {
     let mut generated = GeneratedRustFragment::default();
     let cpp_class_name_rust = &qobject_idents.name.rust_unqualified();

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -19,7 +19,7 @@ pub fn generate_rust_methods(
     qobject_idents: &QObjectName,
 ) -> Result<GeneratedRustFragment> {
     let mut generated = GeneratedRustFragment::default();
-    let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
+    let cpp_class_name_rust = &qobject_idents.name.rust_unqualified();
 
     for invokable in invokables {
         let idents = QMethodName::from(invokable);

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     generator::{
-        naming::{property::QPropertyName, qobject::QObjectName},
+        naming::{property::QPropertyName, qobject::QObjectNames},
         rust::fragment::RustFragmentPair,
     },
     naming::rust::syn_type_cxx_bridge_to_qualified,
@@ -16,7 +16,7 @@ use syn::{Result, Type};
 
 pub fn generate(
     idents: &QPropertyName,
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
     cxx_ty: &Type,
     type_names: &TypeNames,
 ) -> Result<RustFragmentPair> {

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -20,7 +20,7 @@ pub fn generate(
     cxx_ty: &Type,
     type_names: &TypeNames,
 ) -> Result<RustFragmentPair> {
-    let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
+    let cpp_class_name_rust = &qobject_idents.name.rust_unqualified();
     let getter_wrapper_cpp = idents.getter_wrapper.cpp.to_string();
     let getter_rust = &idents.getter.rust;
     let ident = &idents.name.rust;

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -9,7 +9,7 @@ pub mod signal;
 
 use crate::{
     generator::{
-        naming::{property::QPropertyName, qobject::QObjectName},
+        naming::{property::QPropertyName, qobject::QObjectNames},
         rust::fragment::GeneratedRustFragment,
     },
     naming::TypeNames,
@@ -21,7 +21,7 @@ use super::signals::generate_rust_signals;
 
 pub fn generate_rust_properties(
     properties: &Vec<ParsedQProperty>,
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
     type_names: &TypeNames,
     module_ident: &Ident,
 ) -> Result<GeneratedRustFragment> {

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     generator::{
-        naming::{property::QPropertyName, qobject::QObjectName},
+        naming::{property::QPropertyName, qobject::QObjectNames},
         rust::fragment::RustFragmentPair,
     },
     naming::rust::{syn_type_cxx_bridge_to_qualified, syn_type_is_cxx_bridge_unsafe},
@@ -16,7 +16,7 @@ use syn::{Result, Type};
 
 pub fn generate(
     idents: &QPropertyName,
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
     cxx_ty: &Type,
     type_names: &TypeNames,
 ) -> Result<RustFragmentPair> {

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -20,7 +20,7 @@ pub fn generate(
     cxx_ty: &Type,
     type_names: &TypeNames,
 ) -> Result<RustFragmentPair> {
-    let cpp_class_name_rust = &qobject_idents.cpp_class.rust;
+    let cpp_class_name_rust = &qobject_idents.name.rust_unqualified();
     let setter_wrapper_cpp = idents.setter_wrapper.cpp.to_string();
     let setter_rust = &idents.setter.rust;
     let ident = &idents.name.rust;

--- a/crates/cxx-qt-gen/src/generator/rust/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/signal.rs
@@ -13,7 +13,7 @@ use crate::{
 pub fn generate(idents: &QPropertyName, qobject_idents: &QObjectName) -> ParsedSignal {
     // We build our signal in the generation phase as we need to use the naming
     // structs to build the signal name
-    let cpp_class_rust = &qobject_idents.cpp_class.rust;
+    let cpp_class_rust = &qobject_idents.name.rust_unqualified();
     let notify_rust = &idents.notify.rust;
     let notify_cpp_str = &idents.notify.cpp.to_string();
     let method: ForeignItemFn = syn::parse_quote! {
@@ -24,6 +24,6 @@ pub fn generate(idents: &QPropertyName, qobject_idents: &QObjectName) -> ParsedS
     ParsedSignal::from_property_method(
         method,
         idents.notify.clone(),
-        qobject_idents.cpp_class.rust.clone(),
+        qobject_idents.name.rust_unqualified().clone(),
     )
 }

--- a/crates/cxx-qt-gen/src/generator/rust/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/signal.rs
@@ -6,11 +6,11 @@
 use syn::ForeignItemFn;
 
 use crate::{
-    generator::naming::{property::QPropertyName, qobject::QObjectName},
+    generator::naming::{property::QPropertyName, qobject::QObjectNames},
     parser::signals::ParsedSignal,
 };
 
-pub fn generate(idents: &QPropertyName, qobject_idents: &QObjectName) -> ParsedSignal {
+pub fn generate(idents: &QPropertyName, qobject_idents: &QObjectNames) -> ParsedSignal {
     // We build our signal in the generation phase as we need to use the naming
     // structs to build the signal name
     let cpp_class_rust = &qobject_idents.name.rust_unqualified();

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     generator::{
-        naming::{namespace::NamespaceName, qobject::QObjectName},
+        naming::{namespace::NamespaceName, qobject::QObjectNames},
         rust::{
             constructor, cxxqttype,
             fragment::{GeneratedRustFragment, RustFragmentPair},
@@ -29,7 +29,7 @@ impl GeneratedRustFragment {
         module_ident: &Ident,
     ) -> Result<Self> {
         // Create the base object
-        let qobject_idents = QObjectName::from_qobject(qobject, type_names)?;
+        let qobject_idents = QObjectNames::from_qobject(qobject, type_names)?;
         let namespace_idents = NamespaceName::from(qobject);
         let mut generated = Self::default();
 
@@ -115,7 +115,7 @@ impl GeneratedRustFragment {
 
 /// Generate the C++ and Rust CXX definitions for the QObject
 fn generate_qobject_definitions(
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
     namespace: &str,
 ) -> Result<GeneratedRustFragment> {
     let mut generated = GeneratedRustFragment::default();

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -6,7 +6,7 @@
 use crate::{
     generator::{
         naming::{
-            qobject::QObjectName,
+            qobject::QObjectNames,
             signals::{QSignalHelperName, QSignalName},
         },
         rust::fragment::{GeneratedRustFragment, RustFragmentPair},
@@ -207,7 +207,7 @@ pub fn generate_rust_signal(
 
 pub fn generate_rust_signals(
     signals: &Vec<ParsedSignal>,
-    qobject_idents: &QObjectName,
+    qobject_idents: &QObjectNames,
     type_names: &TypeNames,
     module_ident: &Ident,
 ) -> Result<GeneratedRustFragment> {

--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -7,7 +7,7 @@ use crate::{
     generator::{
         naming::{
             namespace::{namespace_combine_ident, NamespaceName},
-            qobject::QObjectName,
+            qobject::QObjectNames,
         },
         rust::fragment::GeneratedRustFragment,
     },
@@ -19,7 +19,7 @@ use syn::{Ident, Result};
 use super::fragment::RustFragmentPair;
 
 pub fn generate(
-    qobject_ident: &QObjectName,
+    qobject_ident: &QObjectNames,
     namespace_ident: &NamespaceName,
     type_names: &TypeNames,
     module_ident: &Ident,
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn test_generate_rust_threading() {
         let qobject = create_parsed_qobject();
-        let qobject_idents = QObjectName::from_qobject(&qobject, &TypeNames::mock()).unwrap();
+        let qobject_idents = QObjectNames::from_qobject(&qobject, &TypeNames::mock()).unwrap();
         let namespace_ident = NamespaceName::from(&qobject);
 
         let generated = generate(

--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -26,7 +26,7 @@ pub fn generate(
 ) -> Result<GeneratedRustFragment> {
     let mut blocks = GeneratedRustFragment::default();
 
-    let cpp_struct_ident = &qobject_ident.cpp_class.rust;
+    let cpp_struct_ident = qobject_ident.name.rust_unqualified();
     let cxx_qt_thread_ident = &qobject_ident.cxx_qt_thread_class;
     let cxx_qt_thread_queued_fn_ident = &qobject_ident.cxx_qt_thread_queued_fn_struct;
     let cxx_qt_thread_queue_fn = qobject_ident.cxx_qt_thread_method("queue_boxed_fn");
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn test_generate_rust_threading() {
         let qobject = create_parsed_qobject();
-        let qobject_idents = QObjectName::from(&qobject);
+        let qobject_idents = QObjectName::from_qobject(&qobject, &TypeNames::mock()).unwrap();
         let namespace_ident = NamespaceName::from(&qobject);
 
         let generated = generate(

--- a/crates/cxx-qt-gen/src/naming/name.rs
+++ b/crates/cxx-qt-gen/src/naming/name.rs
@@ -109,6 +109,17 @@ impl Name {
         &self.rust
     }
 
+    /// Get the qualified name of this type in Rust, including its source module.
+    pub fn rust_qualified(&self) -> Path {
+        if let Some(module) = &self.module {
+            let mut qualified_ident = module.clone();
+            qualified_ident.segments.push(self.rust.clone().into());
+            qualified_ident
+        } else {
+            Path::from(self.rust.clone())
+        }
+    }
+
     /// Set the namespace to the given value.
     ///
     /// Returns the previous value of the namespace.

--- a/crates/cxx-qt-gen/src/naming/type_names.rs
+++ b/crates/cxx-qt-gen/src/naming/type_names.rs
@@ -322,15 +322,7 @@ impl TypeNames {
     /// Note that this only handles types that are declared inside this bridge.
     /// E.g. UniquePtr -> cxx::UniquePtr isn't handled here.
     pub fn rust_qualified(&self, ident: &Ident) -> Result<Path> {
-        self.lookup(ident).map(|name| {
-            if let Some(module) = &name.module {
-                let mut qualified_ident = module.clone();
-                qualified_ident.segments.push(name.rust.clone().into());
-                qualified_ident
-            } else {
-                Path::from(name.rust.clone())
-            }
-        })
+        self.lookup(ident).map(Name::rust_qualified)
     }
 
     fn duplicate_type(&self, ident: &Ident) -> Error {


### PR DESCRIPTION
Part of #939 

Depends on #952 