### PR TITLE
demo_threading: remove dependency on random

### DIFF
--- a/examples/demo_threading/rust/Cargo.toml
+++ b/examples/demo_threading/rust/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3"
 futures-timer = "3.0"
 serde.workspace = true
 serde_json.workspace = true
-uuid = { version = "1.2", features = ["serde", "v4"] }
+uuid = { version = "1.2", features = ["serde"] }
 
 [build-dependencies]
 cxx-qt-build.workspace = true


### PR DESCRIPTION
We do not need the feature v4 as we only read uuids not generate.