### PR TITLE
Add QtQuickControls module to cxx-qt-lib, expose QQuickStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CxxQtThread` is now marked as `Sync` so that it can be used by reference
 - Add cxx-qt-lib-extras crate which contains: `QCommandLineOption`, `QCommandLineParser`, `QElapsedTimer`, `QApplication`
 - Serde support for `QString` (requires "serde" feature on cxx-qt-lib)
+- A new QuickControls module, which exposes `QQuickStyle`. This module is enabled by default and is behind the `qt_quickcontrols` feature.
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,10 +124,10 @@ add_compile_definitions(
 # QMAKE environment variable is needed by qt-build-utils to ensure that Cargo
 # uses the same installation of Qt as CMake does.
 if(NOT USE_QT5)
-    find_package(Qt6 COMPONENTS Core Gui Test)
+    find_package(Qt6 COMPONENTS Core Gui Test QuickControls2)
 endif()
 if(NOT Qt6_FOUND)
-    find_package(Qt5 5.15 COMPONENTS Core Gui Test REQUIRED)
+    find_package(Qt5 5.15 COMPONENTS Core Gui Test QuickControls2 REQUIRED)
 endif()
 
 if (NOT Qt5_FOUND)

--- a/crates/cxx-qt-lib-headers/Cargo.toml
+++ b/crates/cxx-qt-lib-headers/Cargo.toml
@@ -15,6 +15,7 @@ repository.workspace = true
 default = []
 qt_gui = []
 qt_qml = []
+qt_quickcontrols = []
 
 [dependencies]
 cxx-qt-build.workspace = true

--- a/crates/cxx-qt-lib-headers/include/quickcontrols/qquickstyle.h
+++ b/crates/cxx-qt-lib-headers/include/quickcontrols/qquickstyle.h
@@ -1,0 +1,30 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Joshua Goins <joshua.goins@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+#pragma once
+
+#ifdef CXX_QT_QUICKCONTROLS_FEATURE
+
+#include <memory>
+
+#include <QtQuickControls2/QQuickStyle>
+
+namespace rust {
+namespace cxxqtlib1 {
+
+QString
+qquickstyleName();
+
+void
+qquickstyleSetFallbackStyle(const QString& style);
+
+void
+qquickstyleSetStyle(const QString& style);
+
+}
+}
+
+#endif

--- a/crates/cxx-qt-lib-headers/src/lib.rs
+++ b/crates/cxx-qt-lib-headers/src/lib.rs
@@ -100,6 +100,11 @@ pub fn build_opts() -> cxx_qt_build::CxxQtBuildersOpts {
         ),
         #[cfg(feature = "qt_qml")]
         (include_str!("../include/qml/qqmlengine.h"), "qqmlengine.h"),
+        #[cfg(feature = "qt_quickcontrols")]
+        (
+            include_str!("../include/quickcontrols/qquickstyle.h"),
+            "qquickstyle.h",
+        ),
         (include_str!("../include/common.h"), "common.h"),
     ] {
         opts = opts.header(file_contents, "cxx-qt-lib", file_name);
@@ -113,6 +118,13 @@ pub fn build_opts() -> cxx_qt_build::CxxQtBuildersOpts {
     #[cfg(feature = "qt_qml")]
     {
         opts = opts.define("CXX_QT_QML_FEATURE").qt_module("Qml");
+    }
+
+    #[cfg(feature = "qt_quickcontrols")]
+    {
+        opts = opts
+            .define("CXX_QT_QUICKCONTROLS_FEATURE")
+            .qt_module("QuickControls2");
     }
 
     opts

--- a/crates/cxx-qt-lib/Cargo.toml
+++ b/crates/cxx-qt-lib/Cargo.toml
@@ -29,13 +29,14 @@ cxx-qt-build.workspace = true
 cxx-qt-lib-headers.workspace = true
 
 [features]
-default = ["qt_gui", "qt_qml"]
+default = ["qt_gui", "qt_qml", "qt_quickcontrols"]
 bytes = ["dep:bytes"]
 chrono = ["dep:chrono"]
 http = ["dep:http"]
 rgb = ["dep:rgb"]
 qt_gui = ["cxx-qt-lib-headers/qt_gui"]
 qt_qml = ["cxx-qt-lib-headers/qt_qml"]
+qt_quickcontrols = ["cxx-qt-lib-headers/qt_quickcontrols"]
 time = ["dep:time"]
 url = ["dep:url"]
 serde = ["dep:serde"]

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -8,6 +8,7 @@ use cxx_qt_build::CxxQtBuilder;
 fn main() {
     let feature_qt_gui_enabled = std::env::var("CARGO_FEATURE_QT_GUI").is_ok();
     let feature_qt_qml_enabled = std::env::var("CARGO_FEATURE_QT_QML").is_ok();
+    let feature_qt_quickcontrols_enabled = std::env::var("CARGO_FEATURE_QT_QUICKCONTROLS").is_ok();
     let emscripten_targeted = match std::env::var("CARGO_CFG_TARGET_OS") {
         Ok(val) => val == "emscripten",
         Err(_) => false,
@@ -159,6 +160,10 @@ fn main() {
         rust_bridges.extend(["qml/qqmlapplicationengine", "qml/qqmlengine"]);
     }
 
+    if feature_qt_quickcontrols_enabled {
+        rust_bridges.extend(["quickcontrols/qquickstyle"]);
+    }
+
     if !emscripten_targeted {
         rust_bridges.extend([
             "core/qdatetime",
@@ -218,6 +223,10 @@ fn main() {
 
     if feature_qt_qml_enabled {
         cpp_files.extend(["qml/qqmlapplicationengine", "qml/qqmlengine"]);
+    }
+
+    if feature_qt_quickcontrols_enabled {
+        cpp_files.extend(["quickcontrols/qquickstyle"]);
     }
 
     if !emscripten_targeted {

--- a/crates/cxx-qt-lib/src/lib.rs
+++ b/crates/cxx-qt-lib/src/lib.rs
@@ -20,3 +20,8 @@ pub use crate::gui::*;
 mod qml;
 #[cfg(feature = "qt_qml")]
 pub use crate::qml::*;
+
+#[cfg(feature = "qt_quickcontrols")]
+mod quickcontrols;
+#[cfg(feature = "qt_quickcontrols")]
+pub use crate::quickcontrols::*;

--- a/crates/cxx-qt-lib/src/quickcontrols/mod.rs
+++ b/crates/cxx-qt-lib/src/quickcontrols/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Joshua Goins <joshua.goins@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+mod qquickstyle;
+pub use qquickstyle::QQuickStyle;

--- a/crates/cxx-qt-lib/src/quickcontrols/qquickstyle.cpp
+++ b/crates/cxx-qt-lib/src/quickcontrols/qquickstyle.cpp
@@ -1,0 +1,32 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Joshua Goins <joshua.goins@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#include "cxx-qt-lib/qquickstyle.h"
+
+namespace rust {
+namespace cxxqtlib1 {
+
+QString
+qquickstyleName()
+{
+  return QQuickStyle::name();
+}
+
+void
+qquickstyleSetFallbackStyle(const QString& style)
+{
+  QQuickStyle::setFallbackStyle(style);
+}
+
+void
+qquickstyleSetStyle(const QString& style)
+{
+  QQuickStyle::setStyle(style);
+}
+
+}
+}

--- a/crates/cxx-qt-lib/src/quickcontrols/qquickstyle.rs
+++ b/crates/cxx-qt-lib/src/quickcontrols/qquickstyle.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Joshua Goins <joshua.goins@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cxx_qt::bridge(cxx_file_stem = "qquickstyle")]
+mod ffi {
+    unsafe extern "C++Qt" {
+        include!("cxx-qt-lib/qquickstyle.h");
+        #[qobject]
+        type QQuickStyle;
+
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
+    }
+
+    #[namespace = "rust::cxxqtlib1"]
+    unsafe extern "C++" {
+        #[doc(hidden)]
+        #[rust_name = "qquickstyle_name"]
+        fn qquickstyleName() -> QString;
+
+        #[doc(hidden)]
+        #[rust_name = "qquickstyle_set_fallback_style"]
+        fn qquickstyleSetFallbackStyle(style: &QString);
+
+        #[doc(hidden)]
+        #[rust_name = "qquickstyle_set_style"]
+        fn qquickstyleSetStyle(style: &QString);
+    }
+}
+
+use crate::QString;
+pub use ffi::QQuickStyle;
+
+impl QQuickStyle {
+    pub fn name() -> QString {
+        ffi::qquickstyle_name()
+    }
+
+    pub fn set_fallback_style(style: &QString) {
+        ffi::qquickstyle_set_fallback_style(style)
+    }
+
+    pub fn set_style(style: &QString) {
+        ffi::qquickstyle_set_style(style)
+    }
+}

--- a/tests/basic_cxx_only/CMakeLists.txt
+++ b/tests/basic_cxx_only/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${CRATE} INTERFACE
     Qt::Core
     Qt::Gui
     Qt::Qml
+    Qt::QuickControls2
 )
 
 add_executable(${APP_NAME}

--- a/tests/basic_cxx_qt/CMakeLists.txt
+++ b/tests/basic_cxx_qt/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${CRATE} INTERFACE
     Qt::Core
     Qt::Gui
     Qt::Qml
+    Qt::QuickControls2
 )
 
 add_executable(${APP_NAME} cpp/main.cpp)

--- a/tests/qt_types_standalone/CMakeLists.txt
+++ b/tests/qt_types_standalone/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${CRATE} INTERFACE
     Qt::Core
     Qt::Gui
     Qt::Qml
+    Qt::QuickControls2
 )
 
 add_executable(${APP_NAME}


### PR DESCRIPTION
This is used to control which Quick Controls style is used in the application. This is part of the Quick Controls API and requires the QuickControls2 Qt module, so it's separated into another folder in cxx-qt-lib.

Example:

```rust
QQuickStyle::setStyle(&QString::from("Basic"));
QQuickStyle::setFallbackStyle(&QString::from("Material"));
println!("Style name: {}", QQuickStyle::name());
```

This is a pretty common pattern in KDE applications, and a pretty low-hanging fruit.