### PR TITLE
Make rust_mut() API convenient by implicit as_mut

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/cxxqttype.rs
@@ -57,7 +57,7 @@ pub fn generate(
                         self.cxx_qt_ffi_rust()
                     }
 
-                    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+                    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
                         self.cxx_qt_ffi_rust_mut()
                     }
                 }
@@ -139,7 +139,7 @@ mod tests {
                         self.cxx_qt_ffi_rust()
                     }
 
-                    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+                    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
                         self.cxx_qt_ffi_rust_mut()
                     }
                 }

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -85,7 +85,7 @@ impl cxx_qt::CxxQtType for inheritance::MyObject {
     fn rust(&self) -> &Self::Rust {
         self.cxx_qt_ffi_rust()
     }
-    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -348,7 +348,7 @@ impl cxx_qt::CxxQtType for ffi::MyObject {
     fn rust(&self) -> &Self::Rust {
         self.cxx_qt_ffi_rust()
     }
-    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -562,7 +562,7 @@ impl cxx_qt::CxxQtType for ffi::MyObject {
     fn rust(&self) -> &Self::Rust {
         self.cxx_qt_ffi_rust()
     }
-    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         self.cxx_qt_ffi_rust_mut()
     }
 }
@@ -582,7 +582,7 @@ impl cxx_qt::CxxQtType for ffi::MyRustName {
     fn rust(&self) -> &Self::Rust {
         self.cxx_qt_ffi_rust()
     }
-    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         self.cxx_qt_ffi_rust_mut()
     }
 }
@@ -745,7 +745,7 @@ impl cxx_qt::CxxQtType for ffi::SecondObject {
     fn rust(&self) -> &Self::Rust {
         self.cxx_qt_ffi_rust()
     }
-    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -301,7 +301,7 @@ impl cxx_qt::CxxQtType for ffi::MyObject {
     fn rust(&self) -> &Self::Rust {
         self.cxx_qt_ffi_rust()
     }
-    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs
@@ -145,7 +145,7 @@ impl cxx_qt::CxxQtType for ffi::MyObject {
     fn rust(&self) -> &Self::Rust {
         self.cxx_qt_ffi_rust()
     }
-    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         self.cxx_qt_ffi_rust_mut()
     }
 }
@@ -165,7 +165,7 @@ impl cxx_qt::CxxQtType for ffi::MyRenamedObject {
     fn rust(&self) -> &Self::Rust {
         self.cxx_qt_ffi_rust()
     }
-    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -434,7 +434,7 @@ impl cxx_qt::CxxQtType for ffi::MyObject {
     fn rust(&self) -> &Self::Rust {
         self.cxx_qt_ffi_rust()
     }
-    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
+    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         self.cxx_qt_ffi_rust_mut()
     }
 }

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -41,7 +41,13 @@ pub trait CxxQtType {
     fn rust(&self) -> &Self::Rust;
 
     /// Retrieve a mutable reference to the Rust struct backing this C++ object
-    fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust>;
+    fn rust_mut_consuming(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust>;
+
+    /// Convenience method: Retrieve a mutable reference to the Rust struct backing this C++ object without having to
+    /// call `Pin::as_mut` first.
+    fn rust_mut<'a>(self: &'a mut core::pin::Pin<&mut Self>) -> core::pin::Pin<&'a mut Self::Rust> {
+        self.as_mut().rust_mut_consuming()
+    }
 }
 
 /// Types which implement the `Locking` trait are guarded from concurrent access in C++ (the default in CXX-Qt).

--- a/examples/demo_threading/rust/src/lib.rs
+++ b/examples/demo_threading/rust/src/lib.rs
@@ -146,12 +146,12 @@ impl cxx_qt::Constructor<()> for qobject::EnergyUsage {
         let sensors_changed = Arc::new(AtomicBool::new(false));
 
         // Make relevent clones so that we can pass them to the threads
-        let accumulator_sensors = Arc::clone(&self.as_mut().rust_mut().sensors_map);
+        let accumulator_sensors = Arc::clone(&self.rust_mut().sensors_map);
         let accumulator_sensors_changed = Arc::clone(&sensors_changed);
         let accumulator_qt_thread = self.qt_thread();
-        let sensors = Arc::clone(&self.as_mut().rust_mut().sensors_map);
+        let sensors = Arc::clone(&self.rust_mut().sensors_map);
         let sensors_qt_thread = self.qt_thread();
-        let timeout_sensors = Arc::clone(&self.as_mut().rust_mut().sensors_map);
+        let timeout_sensors = Arc::clone(&self.rust_mut().sensors_map);
         let timeout_network_tx = network_tx.clone();
 
         // Start our threads

--- a/examples/qml_features/rust/src/containers.rs
+++ b/examples/qml_features/rust/src/containers.rs
@@ -100,7 +100,7 @@ impl qobject::RustContainers {
     pub fn reset(mut self: Pin<&mut Self>) {
         // Update the private rust fields via the rust_mut
         {
-            let mut rust_mut = self.as_mut().rust_mut();
+            let mut rust_mut = self.rust_mut();
             rust_mut.hash = QHash::<QHashPair_QString_QVariant>::default();
             rust_mut.list = QList::<i32>::default();
             rust_mut.set = QSet::<i32>::default();
@@ -115,28 +115,28 @@ impl qobject::RustContainers {
 
     /// Append the given number to the vector container
     pub fn append_vector(mut self: Pin<&mut Self>, value: i32) {
-        self.as_mut().rust_mut().vector.append(value);
+        self.rust_mut().vector.append(value);
 
         self.update_strings();
     }
 
     /// Append the given number to the list container
     pub fn append_list(mut self: Pin<&mut Self>, value: i32) {
-        self.as_mut().rust_mut().list.append(value);
+        self.rust_mut().list.append(value);
 
         self.update_strings();
     }
 
     /// Insert the given number into the set container
     pub fn insert_set(mut self: Pin<&mut Self>, value: i32) {
-        self.as_mut().rust_mut().set.insert(value);
+        self.rust_mut().set.insert(value);
 
         self.update_strings();
     }
 
     /// Insert the given string and variant to the hash container
     pub fn insert_hash(mut self: Pin<&mut Self>, key: QString, value: QVariant) {
-        self.as_mut().rust_mut().hash.insert(key, value);
+        self.rust_mut().hash.insert(key, value);
 
         self.update_strings();
     }
@@ -144,7 +144,7 @@ impl qobject::RustContainers {
     /// Insert the given string and variant to the map container
     pub fn insert_map(mut self: Pin<&mut Self>, key: QString, value: QVariant) {
         // Note: map is a Q_PROPERTY so ensure we manually trigger changed
-        self.as_mut().rust_mut().map.insert(key, value);
+        self.rust_mut().map.insert(key, value);
         self.as_mut().map_changed();
 
         self.update_strings();

--- a/examples/qml_features/rust/src/custom_base_class.rs
+++ b/examples/qml_features/rust/src/custom_base_class.rs
@@ -233,7 +233,7 @@ impl qobject::CustomBaseClass {
     pub fn add_on_thread_delayed(mut self: Pin<&mut Self>, mut counter: i32, delay_ms: u64) {
         let qt_thread = self.qt_thread();
 
-        self.as_mut().rust_mut().pending_adds += counter;
+        self.rust_mut().pending_adds += counter;
         self.as_mut().set_state(qobject::State::Running);
 
         std::thread::spawn(move || {
@@ -248,7 +248,7 @@ impl qobject::CustomBaseClass {
                 qt_thread
                     .queue(|mut this| {
                         this.as_mut().add_cpp_context();
-                        this.as_mut().rust_mut().pending_adds -= 1;
+                        this.rust_mut().pending_adds -= 1;
                         if this.pending_adds == 0 {
                             this.set_state(qobject::State::Idle);
                         }
@@ -270,7 +270,7 @@ impl qobject::CustomBaseClass {
             self.as_mut()
                 .begin_insert_rows(&QModelIndex::default(), count as i32, count as i32);
             let id = self.id;
-            self.as_mut().rust_mut().id = id + 1;
+            self.rust_mut().id = id + 1;
             self.as_mut()
                 .rust_mut()
                 .vector
@@ -286,8 +286,8 @@ impl qobject::CustomBaseClass {
     pub fn clear(mut self: Pin<&mut Self>) {
         unsafe {
             self.as_mut().begin_reset_model();
-            self.as_mut().rust_mut().id = 0;
-            self.as_mut().rust_mut().vector.clear();
+            self.rust_mut().id = 0;
+            self.rust_mut().vector.clear();
             self.as_mut().end_reset_model();
         }
     }
@@ -297,7 +297,7 @@ impl qobject::CustomBaseClass {
 impl qobject::CustomBaseClass {
     /// Multiply the number in the row with the given index by the given factor
     pub fn multiply(mut self: Pin<&mut Self>, index: i32, factor: f64) {
-        if let Some((_, value)) = self.as_mut().rust_mut().vector.get_mut(index as usize) {
+        if let Some((_, value)) = self.rust_mut().vector.get_mut(index as usize) {
             *value *= factor;
 
             // Emit dataChanged for the index and value role
@@ -318,7 +318,7 @@ impl qobject::CustomBaseClass {
         unsafe {
             self.as_mut()
                 .begin_remove_rows(&QModelIndex::default(), index, index);
-            self.as_mut().rust_mut().vector.remove(index as usize);
+            self.rust_mut().vector.remove(index as usize);
             self.as_mut().end_remove_rows();
         }
     }

--- a/examples/qml_features/rust/src/invokables.rs
+++ b/examples/qml_features/rust/src/invokables.rs
@@ -132,7 +132,7 @@ impl qobject::RustInvokables {
 impl qobject::RustInvokables {
     /// Mutable C++ context method that helps to store the color
     fn store_helper(mut self: Pin<&mut Self>, red: f32, green: f32, blue: f32) {
-        let mut rust_mut = self.as_mut().rust_mut();
+        let mut rust_mut = self.rust_mut();
         rust_mut.red = red;
         rust_mut.green = green;
         rust_mut.blue = blue;

--- a/examples/qml_features/rust/src/properties.rs
+++ b/examples/qml_features/rust/src/properties.rs
@@ -95,7 +95,7 @@ impl qobject::RustProperties {
 
             // We are directly modifying the Rust struct to avoid creating an extra QUrl.
             // So we need to manually call the notify signal for the property ourselves.
-            std::mem::swap(&mut self.as_mut().rust_mut().connected_url, &mut url);
+            std::mem::swap(&mut self.rust_mut().connected_url, &mut url);
             self.as_mut().connected_url_changed();
 
             // Then we can store the old url without having to temporarily store it

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -122,7 +122,7 @@ impl cxx_qt::Initialize for qobject::RustSignals {
                             ConnectionType::QueuedConnection,
                         ),
                     ];
-                    qobject.as_mut().rust_mut().connections = Some(connections);
+                    qobject.rust_mut().connections = Some(connections);
                     // ANCHOR_END: book_signals_connect
                 }
             } else {
@@ -130,7 +130,7 @@ impl cxx_qt::Initialize for qobject::RustSignals {
                 // ANCHOR: book_signals_disconnect
                 // By making connections None, we trigger a drop on the connections
                 // this then causes disconnections
-                qobject.as_mut().rust_mut().connections = None;
+                qobject.rust_mut().connections = None;
                 // ANCHOR_END: book_signals_disconnect
             }
         })

--- a/examples/qml_minimal/rust/src/cxxqt_object.rs
+++ b/examples/qml_minimal/rust/src/cxxqt_object.rs
@@ -48,6 +48,7 @@ pub mod qobject {
 
 // ANCHOR: book_use
 use core::pin::Pin;
+use cxx_qt::CxxQtType;
 use cxx_qt_lib::QString;
 // ANCHOR_END: book_use
 


### PR DESCRIPTION
I just talked with Andy about this and he inspired me to take another crack at removing all the `as_mut()` calls.

So this is an idea of how to make this work.
However, it's very much non-standard and may be confusing, as it only drops the as_mut() requirement for `rust_mut()` and nothing else.

Maybe this is not worth it, but an idea we can play with.