### PR TITLE
Add is_alive method to CxxQtThread

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -263,6 +263,11 @@ mod tests {
                     }
 
                     #[doc(hidden)]
+                    fn is_destroyed(cxx_qt_thread: &qobject::MyObjectCxxQtThread) -> bool {
+                        qobject::cxx_qt_ffi_my_object_cxx_qt_thread_is_destroyed(cxx_qt_thread)
+                    }
+
+                    #[doc(hidden)]
                     fn queue<F>(cxx_qt_thread: &qobject::MyObjectCxxQtThread, f: F) -> std::result::Result<(), cxx::Exception>
                     where
                         F: FnOnce(core::pin::Pin<&mut qobject::MyObject>),

--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -230,6 +230,12 @@ mod tests {
                     #[cxx_name = "cxxQtThreadDrop"]
                     #[namespace = "rust::cxxqt1"]
                     fn cxx_qt_ffi_my_object_cxx_qt_thread_drop(cxx_qt_thread: &mut MyObjectCxxQtThread);
+
+                    #[doc(hidden)]
+                    #[cxx_name = "cxxQtThreadIsDestroyed"]
+                    #[namespace = "rust::cxxqt1"]
+                    fn cxx_qt_ffi_my_object_cxx_qt_thread_is_destroyed(cxx_qt_thread: &MyObjectCxxQtThread)
+                        -> bool;
                 }
             },
         );

--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -42,6 +42,10 @@ pub fn generate(
         .into_cxx_parts();
     let (thread_fn_name, thread_fn_attrs, thread_fn_qualified) =
         qobject_names.cxx_qt_ffi_method("qtThread").into_cxx_parts();
+    let (thread_is_destroyed_name, thread_is_destroyed_attrs, thread_is_destroyed_qualified) =
+        qobject_names
+            .cxx_qt_ffi_method("cxxQtThreadIsDestroyed")
+            .into_cxx_parts();
 
     let namespace_internals = &namespace_ident.internal;
     let cxx_qt_thread_ident_type_id_str =
@@ -85,6 +89,10 @@ pub fn generate(
                     #[doc(hidden)]
                     #(#thread_drop_attrs)*
                     fn #thread_drop_name(cxx_qt_thread: &mut #cxx_qt_thread_ident);
+
+                    #[doc(hidden)]
+                    #(#thread_is_destroyed_attrs)*
+                    fn #thread_is_destroyed_name(cxx_qt_thread: &#cxx_qt_thread_ident) -> bool;
                 }
             },
             quote! {
@@ -103,6 +111,12 @@ pub fn generate(
                     fn qt_thread(&self) -> #module_ident::#cxx_qt_thread_ident
                     {
                         #thread_fn_qualified(self)
+                    }
+
+                    #[doc(hidden)]
+                    fn is_destroyed(cxx_qt_thread: &#module_ident::#cxx_qt_thread_ident) -> bool
+                    {
+                        #thread_is_destroyed_qualified(cxx_qt_thread)
                     }
 
                     #[doc(hidden)]

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -135,6 +135,12 @@ mod ffi {
         #[cxx_name = "cxxQtThreadDrop"]
         #[namespace = "rust::cxxqt1"]
         fn cxx_qt_ffi_my_object_cxx_qt_thread_drop(cxx_qt_thread: &mut MyObjectCxxQtThread);
+        #[doc(hidden)]
+        #[cxx_name = "cxxQtThreadIsDestroyed"]
+        #[namespace = "rust::cxxqt1"]
+        fn cxx_qt_ffi_my_object_cxx_qt_thread_is_destroyed(
+            cxx_qt_thread: &MyObjectCxxQtThread,
+        ) -> bool;
     }
     extern "Rust" {
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
@@ -249,6 +255,10 @@ impl cxx_qt::Threading for ffi::MyObject {
     type ThreadingTypeId = cxx::type_id!("cxx_qt::my_object::MyObjectCxxQtThread");
     fn qt_thread(&self) -> ffi::MyObjectCxxQtThread {
         ffi::cxx_qt_ffi_my_object_qt_thread(self)
+    }
+    #[doc(hidden)]
+    fn is_destroyed(cxx_qt_thread: &ffi::MyObjectCxxQtThread) -> bool {
+        ffi::cxx_qt_ffi_my_object_cxx_qt_thread_is_destroyed(cxx_qt_thread)
     }
     #[doc(hidden)]
     fn queue<F>(

--- a/crates/cxx-qt/include/thread.h
+++ b/crates/cxx-qt/include/thread.h
@@ -45,6 +45,12 @@ public:
   CxxQtThread(const CxxQtThread<T>& other) = default;
   CxxQtThread(CxxQtThread<T>&& other) = default;
 
+  bool isDestroyed() const
+  {
+    const auto guard = ::std::shared_lock(m_obj->mutex);
+    return m_obj->ptr == nullptr;
+  }
+
   template<typename A>
   void queue(::rust::Fn<void(T& self, ::rust::Box<A> arg)> func,
              ::rust::Box<A> arg) const
@@ -105,6 +111,13 @@ cxxQtThreadQueue(const CxxQtThread<T>& cxxQtThread,
                  ::rust::Box<A> arg)
 {
   cxxQtThread.queue(::std::move(func), ::std::move(arg));
+}
+
+template<typename T>
+bool
+cxxQtThreadIsDestroyed(const CxxQtThread<T>& cxxQtThread)
+{
+  return cxxQtThread.isDestroyed();
 }
 
 } // namespace cxxqt1

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -106,6 +106,9 @@ pub trait Threading: Sized {
     fn qt_thread(&self) -> CxxQtThread<Self>;
 
     #[doc(hidden)]
+    fn is_destroyed(cxx_qt_thread: &CxxQtThread<Self>) -> bool;
+
+    #[doc(hidden)]
     fn queue<F>(cxx_qt_thread: &CxxQtThread<Self>, f: F) -> Result<(), cxx::Exception>
     where
         F: FnOnce(core::pin::Pin<&mut Self>),

--- a/crates/cxx-qt/src/threading.rs
+++ b/crates/cxx-qt/src/threading.rs
@@ -90,9 +90,9 @@ where
     /// be destroyed after the check but before the `queue` call.
     ///
     /// For example:
-    /// ```rust
+    /// ```rust,ignore
     /// if !thread.is_destroyed() {
-    ///     thread.queue(...).unwrap();
+    ///     thread.queue(/*...*/).unwrap();
     /// }
     /// ```
     /// In this scenario, the `QObject` might be destroyed between the
@@ -105,9 +105,9 @@ where
     /// However, `is_destroyed()` can still be useful in scenarios where you
     /// need to control loops or perform cleanup operations based on the
     /// destruction status of the `QObject`. For instance:
-    /// ```rust
+    /// ```rust,ignore
     /// while !thread.is_destroyed() {
-    ///     thread.queue(...).ok();
+    ///     thread.queue(/*...*/).ok();
     /// }
     /// ```
     pub fn is_destroyed(&self) -> bool {

--- a/crates/cxx-qt/src/threading.rs
+++ b/crates/cxx-qt/src/threading.rs
@@ -80,4 +80,37 @@ where
     {
         T::queue(self, f)
     }
+
+    /// Checks whether the associated `QObject` has been destroyed.
+    ///
+    /// This method only confirms if the `QObject` has already been destroyed.
+    /// It does not guarantee that the `QObject` remains alive for any
+    /// subsequent operations. There is a potential race condition when using
+    /// `is_destroyed()` before calling `queue`. Specifically, the `QObject` may
+    /// be destroyed after the check but before the `queue` call.
+    ///
+    /// For example:
+    /// ```rust
+    /// if !thread.is_destroyed() {
+    ///     thread.queue(...).unwrap();
+    /// }
+    /// ```
+    /// In this scenario, the `QObject` might be destroyed between the
+    /// `is_destroyed` check and the `queue` invocation, resulting in a panic.
+    ///
+    /// To handle such cases safely, it is recommended to call `queue(...).ok()`
+    /// directly without checking `is_destroyed()`. This approach allows you to
+    /// handle the potential failure gracefully without risking a panic.
+    ///
+    /// However, `is_destroyed()` can still be useful in scenarios where you
+    /// need to control loops or perform cleanup operations based on the
+    /// destruction status of the `QObject`. For instance:
+    /// ```rust
+    /// while !thread.is_destroyed() {
+    ///     thread.queue(...).ok();
+    /// }
+    /// ```
+    pub fn is_destroyed(&self) -> bool {
+        T::is_destroyed(self)
+    }
 }


### PR DESCRIPTION
When combining async Rust channels and QT objects, it's really easy to end up in a situation where a message is received on the channel after the `QObject` has already been destroyed, causing `CxxQtThread::queue` to throw an exception. This PR introduces an `is_alive()` function to check the handle if it's been invalidated.

- Implement is_alive method in C++ CxxQtThread class
- Add is_alive to Rust Threading trait
- Generate FFI bindings for is_alive in cxx-qt-gen
- Expose is_alive as a public method on CxxQtThread in Rust
- Update documentation for Threading trait and CxxQtThread