### PR TITLE
fix: Qrc test data

### DIFF
--- a/examples/qml_features/tests/tst_qrc.qml
+++ b/examples/qml_features/tests/tst_qrc.qml
@@ -28,6 +28,8 @@ TestCase {
         return [
             {
                 tag: "valid", source: "qrc:/images/red.png", status: Image.Ready,
+            },
+            {
                 tag: "invalid", source: "qrc:/images/invalid.png", status: Image.Error,
             }
         ]


### PR DESCRIPTION
This was accidentally only running the data from the "invalid" test case, as JS was merging everything into a single object, instead of two objects in an array.