### PR TITLE
fix: Use QT_QPA_PLATFORM=offscreen in tests

### DIFF
--- a/examples/qml_features/CMakeLists.txt
+++ b/examples/qml_features/CMakeLists.txt
@@ -77,6 +77,15 @@ if(BUILD_TESTING)
         NAME ${APP_TEST_NAME}
         COMMAND ${TEST_CMD}
     )
+    # Unfortunately due to the static linking in our CI on macOS we can't load the
+    # offscreen plugin, so just leave it at the default.
+    if (NOT APPLE)
+        set_tests_properties(${APP_TEST_NAME} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+    endif()
+    # RUNTIME_ENV comes from the CMakeLists.txt at the root of this repository.
+    set_tests_properties(
+        ${APP_TEST_NAME} PROPERTIES ENVIRONMENT_MODIFICATION "${RUNTIME_ENV}"
+    )
 
     if (COMMAND add_valgrind_test)
         add_valgrind_test(
@@ -85,9 +94,4 @@ if(BUILD_TESTING)
     else()
         MESSAGE(STATUS "add_valgrind_test is defined in the top level of CXX-Qt. It will not executed")
     endif()
-
-    # RUNTIME_ENV comes from the CMakeLists.txt at the root of this repository.
-    set_tests_properties(
-        ${APP_TEST_NAME} PROPERTIES ENVIRONMENT_MODIFICATION "${RUNTIME_ENV}"
-    )
 endif()

--- a/examples/qml_minimal/CMakeLists.txt
+++ b/examples/qml_minimal/CMakeLists.txt
@@ -88,12 +88,18 @@ if(BUILD_TESTING)
             NAME ${APP_TEST_NAME}
             COMMAND ${TEST_CMD}
         )
-
+        # Unfortunately due to the static linking in our CI on macOS we can't load the
+        # offscreen plugin, so just leave it at the default.
+        if (NOT APPLE)
+            set_tests_properties(${APP_TEST_NAME} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+        endif()
         # RUNTIME_ENV comes from the CMakeLists.txt at the root of this repository.
         set_tests_properties(
-            ${APP_NAME}_${TEST_NAME}_test PROPERTIES ENVIRONMENT_MODIFICATION
-                                                    "${RUNTIME_ENV}"
+            ${APP_NAME}_${TEST_NAME}_test
+            PROPERTIES
+            ENVIRONMENT_MODIFICATION "${RUNTIME_ENV}"
         )
+
         if (COMMAND add_valgrind_test)
             add_valgrind_test(
                 ${APP_TEST_NAME} "${TEST_CMD}" ${CMAKE_CURRENT_BINARY_DIR}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,8 +15,19 @@ function(add_acceptance_tests TEST_NAME)
     set(CPP_TEST_NAME ${NAME_WITH_PREFIX}_cpp_tests)
     add_test(NAME ${CPP_TEST_NAME} COMMAND $<TARGET_FILE:${TARGET_NAME}>)
 
+    # Unfortunately due to the static linking in our CI we can't load the
+    # offscreen plugin, so just leave it at the default.
+    if (NOT APPLE)
+       set_tests_properties(
+          ${CPP_TEST_NAME}
+          PROPERTIES
+          ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+          )
+    endif()
     set_tests_properties(
-        ${CPP_TEST_NAME} PROPERTIES ENVIRONMENT_MODIFICATION "${RUNTIME_ENV}"
+       ${CPP_TEST_NAME}
+       PROPERTIES
+       ENVIRONMENT_MODIFICATION "${RUNTIME_ENV}"
     )
 
     if (NOT WIN32)


### PR DESCRIPTION
This avoids windows popping up when running the tests for qml_features and qml_minimal.