### PR TITLE
fix: Remove dev-dependencies on cxx-qt-lib

### DIFF
--- a/crates/cxx-qt-macro/Cargo.toml
+++ b/crates/cxx-qt-macro/Cargo.toml
@@ -24,5 +24,4 @@ syn.workspace = true
 
 [dev-dependencies]
 cxx.workspace = true
-cxx-qt-lib.workspace = true
 cxx-qt.workspace = true

--- a/crates/cxx-qt/Cargo.toml
+++ b/crates/cxx-qt/Cargo.toml
@@ -28,4 +28,3 @@ qt-build-utils.workspace = true
 
 [dev-dependencies]
 cxx.workspace = true
-cxx-qt-lib.workspace = true


### PR DESCRIPTION
This was causing a duplicate build of cxx-qt-lib, which caused the file locking issues we observed in CI.

This should also speed up the CI run for cargo_test, as it's not building -lib twice now.

However, this doesn't yet solve the inherent issue that Cargo may run build scripts of different configurations in parallel. So this remains a TODO!