### PR TITLE
Refactor to use Structuring for methods and signals

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/method.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/method.rs
@@ -21,13 +21,13 @@ use indoc::formatdoc;
 use syn::{spanned::Spanned, Error, FnArg, Pat, PatIdent, PatType, Result};
 
 pub fn generate_cpp_methods(
-    invokables: &Vec<ParsedMethod>,
+    invokables: &Vec<&ParsedMethod>,
     qobject_idents: &QObjectNames,
     type_names: &TypeNames,
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut generated = GeneratedCppQObjectBlocks::default();
     let qobject_ident = qobject_idents.name.cxx_unqualified();
-    for invokable in invokables {
+    for &invokable in invokables {
         let idents = QMethodName::try_from(invokable)?;
         let return_cxx_ty = syn_type_to_cpp_return_type(&invokable.method.sig.output, type_names)?;
 
@@ -274,7 +274,12 @@ mod tests {
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("QColor", None, None, None);
 
-        let generated = generate_cpp_methods(&invokables, &qobject_idents, &type_names).unwrap();
+        let generated = generate_cpp_methods(
+            &invokables.iter().map(|method| method).collect(),
+            &qobject_idents,
+            &type_names,
+        )
+        .unwrap();
 
         // methods
         assert_eq!(generated.methods.len(), 5);
@@ -450,7 +455,12 @@ mod tests {
         type_names.mock_insert("A", None, Some("A1"), None);
         type_names.mock_insert("B", None, Some("B2"), None);
 
-        let generated = generate_cpp_methods(&invokables, &qobject_idents, &type_names).unwrap();
+        let generated = generate_cpp_methods(
+            &invokables.iter().map(|method| method).collect(),
+            &qobject_idents,
+            &type_names,
+        )
+        .unwrap();
 
         // methods
         assert_eq!(generated.methods.len(), 1);

--- a/crates/cxx-qt-gen/src/generator/cpp/method.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/method.rs
@@ -274,12 +274,9 @@ mod tests {
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("QColor", None, None, None);
 
-        let generated = generate_cpp_methods(
-            &invokables.iter().map(|method| method).collect(),
-            &qobject_idents,
-            &type_names,
-        )
-        .unwrap();
+        let generated =
+            generate_cpp_methods(&invokables.iter().collect(), &qobject_idents, &type_names)
+                .unwrap();
 
         // methods
         assert_eq!(generated.methods.len(), 5);
@@ -433,10 +430,11 @@ mod tests {
 
     #[test]
     fn test_generate_cpp_invokables_mapped_cxx_name() {
-        let method: ForeignItemFn =
+        let method_declaration: ForeignItemFn =
             parse_quote! { fn trivial_invokable(self: &MyObject, param: A) -> B; };
-        let invokables = vec![ParsedMethod {
-            method: method.clone(),
+
+        let method = ParsedMethod {
+            method: method_declaration.clone(),
             qobject_ident: format_ident!("MyObject"),
             mutable: false,
             safe: true,
@@ -446,21 +444,22 @@ mod tests {
             }],
             specifiers: HashSet::new(),
             is_qinvokable: true,
-            name: Name::from_rust_ident_and_attrs(&method.sig.ident, &method.attrs, None, None)
-                .unwrap(),
-        }];
+            name: Name::from_rust_ident_and_attrs(
+                &method_declaration.sig.ident,
+                &method_declaration.attrs,
+                None,
+                None,
+            )
+            .unwrap(),
+        };
+        let invokables = vec![&method];
         let qobject_idents = create_qobjectname();
 
         let mut type_names = TypeNames::default();
         type_names.mock_insert("A", None, Some("A1"), None);
         type_names.mock_insert("B", None, Some("B2"), None);
 
-        let generated = generate_cpp_methods(
-            &invokables.iter().map(|method| method).collect(),
-            &qobject_idents,
-            &type_names,
-        )
-        .unwrap();
+        let generated = generate_cpp_methods(&invokables, &qobject_idents, &type_names).unwrap();
 
         // methods
         assert_eq!(generated.methods.len(), 1);

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -57,7 +57,7 @@ pub fn generate_cpp_properties(
     }
 
     generated.append(&mut generate_cpp_signals(
-        &signals,
+        &signals.iter().map(|signal| signal).collect(), // Converting Vec<ParsedSignal> to Vec<&ParsedSignal>
         qobject_idents,
         type_names,
     )?);

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -57,7 +57,7 @@ pub fn generate_cpp_properties(
     }
 
     generated.append(&mut generate_cpp_signals(
-        &signals.iter().collect(), // Converting Vec<ParsedSignal> to Vec<&ParsedSignal>
+        &signals.iter().collect(),
         qobject_idents,
         type_names,
     )?);

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -57,7 +57,7 @@ pub fn generate_cpp_properties(
     }
 
     generated.append(&mut generate_cpp_signals(
-        &signals.iter().map(|signal| signal).collect(), // Converting Vec<ParsedSignal> to Vec<&ParsedSignal>
+        &signals.iter().collect(), // Converting Vec<ParsedSignal> to Vec<&ParsedSignal>
         qobject_idents,
         type_names,
     )?);

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -145,12 +145,12 @@ impl GeneratedCppQObject {
             type_names,
         )?);
         generated.blocks.append(&mut generate_cpp_methods(
-            &qobject.methods,
+            &structured_qobject.methods,
             &qobject_idents,
             type_names,
         )?);
         generated.blocks.append(&mut generate_cpp_signals(
-            &qobject.signals,
+            &structured_qobject.signals,
             &qobject_idents,
             type_names,
         )?);

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_generate_cpp_signals() {
-        let signals = vec![ParsedSignal {
+        let signal = ParsedSignal {
             method: parse_quote! {
                 fn data_changed(self: Pin<&mut MyObject>, trivial: i32, opaque: UniquePtr<QColor>);
             },
@@ -242,17 +242,13 @@ mod tests {
             safe: true,
             inherit: false,
             private: false,
-        }];
+        };
+        let signals = vec![&signal];
         let qobject_idents = create_qobjectname();
 
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("QColor", None, None, None);
-        let generated = generate_cpp_signals(
-            &signals.iter().map(|signal| signal).collect(),
-            &qobject_idents,
-            &type_names,
-        )
-        .unwrap();
+        let generated = generate_cpp_signals(&signals, &qobject_idents, &type_names).unwrap();
 
         assert_eq!(generated.methods.len(), 1);
         let header = if let CppFragment::Header(header) = &generated.methods[0] {
@@ -330,7 +326,7 @@ mod tests {
 
     #[test]
     fn test_generate_cpp_signals_mapped_cxx_name() {
-        let signals = vec![ParsedSignal {
+        let signal = ParsedSignal {
             method: parse_quote! {
                 fn data_changed(self: Pin<&mut MyObject>, mapped: A);
             },
@@ -344,18 +340,14 @@ mod tests {
             safe: true,
             inherit: false,
             private: false,
-        }];
+        };
+        let signals = vec![&signal];
         let qobject_idents = create_qobjectname();
 
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("A", None, Some("A1"), None);
 
-        let generated = generate_cpp_signals(
-            &signals.iter().map(|signal| signal).collect(),
-            &qobject_idents,
-            &type_names,
-        )
-        .unwrap();
+        let generated = generate_cpp_signals(&signals, &qobject_idents, &type_names).unwrap();
 
         assert_eq!(generated.methods.len(), 1);
         let header = if let CppFragment::Header(header) = &generated.methods[0] {
@@ -430,7 +422,7 @@ mod tests {
 
     #[test]
     fn test_generate_cpp_signals_existing_cxx_name() {
-        let signals = vec![ParsedSignal {
+        let signal = ParsedSignal {
             method: parse_quote! {
                 #[cxx_name = "baseName"]
                 fn existing_signal(self: Pin<&mut MyObject>);
@@ -442,14 +434,11 @@ mod tests {
             safe: true,
             inherit: true,
             private: false,
-        }];
+        };
+        let signals = vec![&signal];
         let qobject_idents = create_qobjectname();
-        let generated = generate_cpp_signals(
-            &signals.iter().map(|signal| signal).collect(),
-            &qobject_idents,
-            &TypeNames::mock(),
-        )
-        .unwrap();
+        let generated =
+            generate_cpp_signals(&signals, &qobject_idents, &TypeNames::mock()).unwrap();
 
         assert_eq!(generated.methods.len(), 0);
         assert_eq!(generated.fragments.len(), 1);

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -190,13 +190,13 @@ pub fn generate_cpp_signal(
 }
 
 pub fn generate_cpp_signals(
-    signals: &Vec<ParsedSignal>,
+    signals: &Vec<&ParsedSignal>,
     qobject_idents: &QObjectNames,
     type_names: &TypeNames,
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut generated = GeneratedCppQObjectBlocks::default();
 
-    for signal in signals {
+    for &signal in signals {
         let mut block = GeneratedCppQObjectBlocks::default();
         let data = generate_cpp_signal(signal, &qobject_idents.name, type_names)?;
         block.includes = data.includes;
@@ -247,7 +247,12 @@ mod tests {
 
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("QColor", None, None, None);
-        let generated = generate_cpp_signals(&signals, &qobject_idents, &type_names).unwrap();
+        let generated = generate_cpp_signals(
+            &signals.iter().map(|signal| signal).collect(),
+            &qobject_idents,
+            &type_names,
+        )
+        .unwrap();
 
         assert_eq!(generated.methods.len(), 1);
         let header = if let CppFragment::Header(header) = &generated.methods[0] {
@@ -345,7 +350,12 @@ mod tests {
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("A", None, Some("A1"), None);
 
-        let generated = generate_cpp_signals(&signals, &qobject_idents, &type_names).unwrap();
+        let generated = generate_cpp_signals(
+            &signals.iter().map(|signal| signal).collect(),
+            &qobject_idents,
+            &type_names,
+        )
+        .unwrap();
 
         assert_eq!(generated.methods.len(), 1);
         let header = if let CppFragment::Header(header) = &generated.methods[0] {
@@ -434,8 +444,12 @@ mod tests {
             private: false,
         }];
         let qobject_idents = create_qobjectname();
-        let generated =
-            generate_cpp_signals(&signals, &qobject_idents, &TypeNames::mock()).unwrap();
+        let generated = generate_cpp_signals(
+            &signals.iter().map(|signal| signal).collect(),
+            &qobject_idents,
+            &TypeNames::mock(),
+        )
+        .unwrap();
 
         assert_eq!(generated.methods.len(), 0);
         assert_eq!(generated.fragments.len(), 1);

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -15,13 +15,13 @@ use quote::{quote, quote_spanned};
 use syn::{spanned::Spanned, Result};
 
 pub fn generate_rust_methods(
-    invokables: &Vec<ParsedMethod>,
+    invokables: &Vec<&ParsedMethod>,
     qobject_idents: &QObjectNames,
 ) -> Result<GeneratedRustFragment> {
     let mut generated = GeneratedRustFragment::default();
     let cpp_class_name_rust = &qobject_idents.name.rust_unqualified();
 
-    for invokable in invokables {
+    for &invokable in invokables {
         let idents = QMethodName::try_from(invokable)?;
         let wrapper_ident_cpp = idents.wrapper.cxx_unqualified();
         let invokable_ident_rust = &idents.name.rust_unqualified();
@@ -181,7 +181,11 @@ mod tests {
         ];
         let qobject_idents = create_qobjectname();
 
-        let generated = generate_rust_methods(&invokables, &qobject_idents).unwrap();
+        let generated = generate_rust_methods(
+            &invokables.iter().map(|method| method).collect(),
+            &qobject_idents,
+        )
+        .unwrap();
 
         assert_eq!(generated.cxx_mod_contents.len(), 4);
         assert_eq!(generated.cxx_qt_mod_contents.len(), 0);

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -181,11 +181,8 @@ mod tests {
         ];
         let qobject_idents = create_qobjectname();
 
-        let generated = generate_rust_methods(
-            &invokables.iter().map(|method| method).collect(),
-            &qobject_idents,
-        )
-        .unwrap();
+        let generated =
+            generate_rust_methods(&invokables.iter().collect(), &qobject_idents).unwrap();
 
         assert_eq!(generated.cxx_mod_contents.len(), 4);
         assert_eq!(generated.cxx_qt_mod_contents.len(), 0);

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -16,6 +16,7 @@ pub mod signals;
 pub mod threading;
 
 use crate::generator::rust::fragment::GeneratedRustFragment;
+use crate::generator::structuring;
 use crate::parser::Parser;
 use crate::writer;
 use quote::quote;
@@ -36,12 +37,13 @@ pub struct GeneratedRustBlocks {
 impl GeneratedRustBlocks {
     /// Create a [GeneratedRustBlocks] from the given [Parser] object
     pub fn from(parser: &Parser) -> Result<GeneratedRustBlocks> {
+        let structures = structuring::Structures::new(&parser.cxx_qt_data)?;
+
         let mut fragments = vec![];
         fragments.extend(
-            parser
-                .cxx_qt_data
+            structures
                 .qobjects
-                .values()
+                .iter()
                 .map(|qobject| {
                     GeneratedRustFragment::from_qobject(
                         qobject,

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -55,7 +55,7 @@ pub fn generate_rust_properties(
     }
 
     generated.append(&mut generate_rust_signals(
-        &signals.iter().collect(), // Converts Vec<T> to Vec<&T>
+        &signals.iter().collect(),
         qobject_idents,
         type_names,
         module_ident,

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -55,7 +55,7 @@ pub fn generate_rust_properties(
     }
 
     generated.append(&mut generate_rust_signals(
-        &signals,
+        &signals.iter().map(|signal| signal).collect(),
         qobject_idents,
         type_names,
         module_ident,

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -55,7 +55,7 @@ pub fn generate_rust_properties(
     }
 
     generated.append(&mut generate_rust_signals(
-        &signals.iter().map(|signal| signal).collect(),
+        &signals.iter().collect(), // Converts Vec<T> to Vec<&T>
         qobject_idents,
         type_names,
         module_ident,

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::generator::structuring::StructuredQObject;
 use crate::{
     generator::{
         naming::{namespace::NamespaceName, qobject::QObjectNames},
@@ -25,10 +26,11 @@ use syn::{Ident, Result};
 impl GeneratedRustFragment {
     // Might need to be refactored to use a StructuredQObject instead (confirm with Leon)
     pub fn from_qobject(
-        qobject: &ParsedQObject,
+        structured_qobject: &StructuredQObject,
         type_names: &TypeNames,
         module_ident: &Ident,
     ) -> Result<Self> {
+        let qobject = structured_qobject.declaration;
         // Create the base object
         let qobject_idents = QObjectNames::from_qobject(qobject, type_names)?;
         let namespace_idents = NamespaceName::from(qobject);
@@ -47,7 +49,7 @@ impl GeneratedRustFragment {
             module_ident,
         )?);
         generated.append(&mut generate_rust_methods(
-            &qobject.methods,
+            &structured_qobject.methods,
             &qobject_idents,
         )?);
         generated.append(&mut inherit::generate(

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -18,7 +18,6 @@ use crate::{
         },
     },
     naming::TypeNames,
-    parser::qobject::ParsedQObject,
 };
 use quote::quote;
 use syn::{Ident, Result};

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -200,7 +200,7 @@ mod tests {
         let structures = Structures::new(&parser.cxx_qt_data).unwrap();
 
         let rust = GeneratedRustFragment::from_qobject(
-            &structures.qobjects[0],
+            &structures.qobjects.get(0).unwrap(),
             &parser.type_names,
             &format_ident!("ffi"),
         )

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -57,7 +57,7 @@ impl GeneratedRustFragment {
             &qobject.inherited_methods,
         )?);
         generated.append(&mut generate_rust_signals(
-            &qobject.signals,
+            &structured_qobject.signals,
             &qobject_idents,
             type_names,
             module_ident,
@@ -178,6 +178,7 @@ fn generate_qobject_definitions(
 mod tests {
     use super::*;
 
+    use crate::generator::structuring::Structures;
     use crate::parser::Parser;
     use crate::tests::assert_tokens_eq;
     use quote::format_ident;
@@ -197,9 +198,10 @@ mod tests {
             }
         };
         let parser = Parser::from(module).unwrap();
+        let structures = Structures::new(&parser.cxx_qt_data).unwrap();
 
         let rust = GeneratedRustFragment::from_qobject(
-            parser.cxx_qt_data.qobjects.values().next().unwrap(),
+            &structures.qobjects[0],
             &parser.type_names,
             &format_ident!("ffi"),
         )

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -204,7 +204,7 @@ pub fn generate_rust_signal(
 }
 
 pub fn generate_rust_signals(
-    signals: &Vec<ParsedSignal>,
+    signals: &Vec<&ParsedSignal>,
     qobject_idents: &QObjectNames,
     type_names: &TypeNames,
     module_ident: &Ident,
@@ -214,7 +214,8 @@ pub fn generate_rust_signals(
     // Create the methods for the other signals
     for signal in signals {
         let signal = {
-            let mut signal = signal.clone();
+            // Hacky fix, this block should be removed when naming fixes are in place
+            let mut signal = (*signal).clone();
 
             // Inject a cxx_name if there isn't any custom naming as we automatically rename RustQt signals
             if attribute_find_path(&signal.method.attrs, &["cxx_name"]).is_none()
@@ -269,7 +270,7 @@ mod tests {
         let qobject_idents = create_qobjectname();
 
         let generated = generate_rust_signals(
-            &vec![qsignal],
+            &vec![&qsignal],
             &qobject_idents,
             &TypeNames::mock(),
             &format_ident!("ffi"),
@@ -431,7 +432,7 @@ mod tests {
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("QColor", None, None, None);
         let generated = generate_rust_signals(
-            &vec![qsignal],
+            &vec![&qsignal],
             &qobject_idents,
             &type_names,
             &format_ident!("ffi"),
@@ -590,7 +591,7 @@ mod tests {
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("T", None, None, None);
         let generated = generate_rust_signals(
-            &vec![qsignal],
+            &vec![&qsignal],
             &qobject_idents,
             &type_names,
             &format_ident!("ffi"),
@@ -742,7 +743,7 @@ mod tests {
         let qobject_idents = create_qobjectname();
 
         let generated = generate_rust_signals(
-            &vec![qsignal],
+            &vec![&qsignal],
             &qobject_idents,
             &TypeNames::mock(),
             &format_ident!("ffi"),


### PR DESCRIPTION
The generators and tests should now be using StructuredQObject and its fields, methods and signals, in place of ParsedQobject and it's fields of the same name, this includes:

- Rewriting some of the generate functions in order to accept &Vec<&T> where they used to accept &Vec<T> and all the use of these to follow that
- Rewriting the rust generators to accept StructuredQObject instead of ParsedQObject
- Rewriting the generator functions to push methods from StructuredQObject 