### PR TITLE
Refactor to remove method fields in ParsedQObject

### DIFF
--- a/crates/cxx-qt-gen/src/generator/structuring/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/structuring/mod.rs
@@ -89,6 +89,28 @@ mod tests {
     use syn::{parse_quote, ItemMod};
 
     #[test]
+    fn test_structuring_unknown_qobject() {
+        let module: ItemMod = parse_quote! {
+            #[cxx_qt::bridge]
+            mod ffi {
+                extern "RustQt" {
+                    #[qobject]
+                    type MyObject = super::MyObjectRust;
+                }
+
+                unsafe extern "RustQt" {
+                    #[qsignal]
+                    fn ready(self: Pin<&mut UnknownObject>);
+                }
+            }
+        };
+        let parser = Parser::from(module).unwrap();
+        let structures = Structures::new(&parser.cxx_qt_data);
+
+        assert!(structures.is_err());
+    }
+
+    #[test]
     fn test_structures() {
         let module: ItemMod = parse_quote! {
             #[cxx_qt::bridge]

--- a/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
+++ b/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
@@ -210,14 +210,8 @@ impl ParsedCxxQtData {
             if let ForeignItem::Fn(mut foreign_fn) = item {
                 // Test if the function is a signal
                 if attribute_take_path(&mut foreign_fn.attrs, &["qsignal"]).is_some() {
-                    let parsed_signal_method = ParsedSignal::parse(foreign_fn.clone(), safe_call)?;
-
-                    let parsed_signal_method_self = ParsedSignal::parse(foreign_fn, safe_call)?;
-                    self.signals.push(parsed_signal_method_self);
-
-                    self.with_qobject(&parsed_signal_method.qobject_ident)?
-                        .signals
-                        .push(parsed_signal_method);
+                    let parsed_signal_method = ParsedSignal::parse(foreign_fn, safe_call)?;
+                    self.signals.push(parsed_signal_method);
 
                     // Test if the function is an inheritance method
                     //
@@ -231,14 +225,8 @@ impl ParsedCxxQtData {
                         .push(parsed_inherited_method);
                     // Remaining methods are either C++ methods or invokables
                 } else {
-                    let parsed_method = ParsedMethod::parse(foreign_fn.clone(), safe_call)?;
-
-                    let parsed_method_self = ParsedMethod::parse(foreign_fn, safe_call)?;
-                    self.methods.push(parsed_method_self);
-
-                    self.with_qobject(&parsed_method.qobject_ident)?
-                        .methods
-                        .push(parsed_method);
+                    let parsed_method = ParsedMethod::parse(foreign_fn, safe_call)?;
+                    self.methods.push(parsed_method);
                 }
             }
         }
@@ -653,19 +641,6 @@ mod tests {
         );
         assert!(!signals[0].inherit);
         assert!(signals[1].inherit);
-    }
-
-    #[test]
-    fn test_parse_qsignals_unknown_obj() {
-        let mut cxxqtdata = create_parsed_cxx_qt_data();
-        let block: Item = parse_quote! {
-            unsafe extern "RustQt" {
-                #[qsignal]
-                fn ready(self: Pin<&mut UnknownObj>);
-            }
-        };
-        let parsed_block = cxxqtdata.parse_cxx_qt_item(block);
-        assert!(parsed_block.is_err());
     }
 
     #[test]

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -268,26 +268,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parser_from_error() {
-        let module: ItemMod = parse_quote! {
-            #[cxx_qt::bridge]
-            mod ffi {
-                extern "RustQt" {
-                    #[qobject]
-                    type MyObject = super::MyObjectRust;
-                }
-
-                unsafe extern "RustQt" {
-                    #[qsignal]
-                    fn ready(self: Pin<&mut UnknownObject>);
-                }
-            }
-        };
-        let parser = Parser::from(module);
-        assert!(parser.is_err());
-    }
-
-    #[test]
     fn test_parser_from_error_no_attribute() {
         let module: ItemMod = parse_quote! {
             mod ffi {

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -5,10 +5,7 @@
 
 use crate::{
     naming::Name,
-    parser::{
-        constructor::Constructor, inherit::ParsedInheritedMethod, method::ParsedMethod,
-        property::ParsedQProperty, signals::ParsedSignal,
-    },
+    parser::{constructor::Constructor, inherit::ParsedInheritedMethod, property::ParsedQProperty},
     syntax::{
         attribute::attribute_take_path, expr::expr_to_string, foreignmod::ForeignTypeIdentAlias,
         path::path_compare_str,
@@ -35,12 +32,6 @@ pub struct ParsedQObject {
     pub name: Name,
     /// The ident of the inner type of the QObject
     pub rust_type: Ident,
-    /// Representation of the Q_SIGNALS for the QObject
-    pub signals: Vec<ParsedSignal>,
-    /// List of methods that need to be implemented on the C++ object in Rust
-    ///
-    /// These could also be exposed as Q_INVOKABLE on the C++ object
-    pub methods: Vec<ParsedMethod>,
     /// List of inherited methods
     pub inherited_methods: Vec<ParsedInheritedMethod>,
     /// Any user-defined constructors
@@ -95,8 +86,6 @@ impl ParsedQObject {
             declaration,
             name,
             rust_type: inner,
-            signals: vec![],
-            methods: vec![],
             inherited_methods: vec![],
             constructors: vec![],
             properties,


### PR DESCRIPTION
Remove the now unused method and signals fields from ParsedQObject since they are now created inside StructuredQObject instead, and update a few tests