### PR TITLE
Refactor ParsedSignal to remove old code

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
@@ -5,6 +5,7 @@
 
 use syn::ForeignItemFn;
 
+use crate::syntax::attribute::attribute_take_path;
 use crate::{
     generator::naming::{
         property::{NameState, QPropertyNames},
@@ -20,16 +21,22 @@ pub fn generate(idents: &QPropertyNames, qobject_idents: &QObjectNames) -> Optio
         let cpp_class_rust = &qobject_idents.name.rust_unqualified();
         let notify_cpp = notify.cxx_unqualified();
         let notify_rust = notify.rust_unqualified();
-        let method: ForeignItemFn = syn::parse_quote! {
+        let mut method: ForeignItemFn = syn::parse_quote! {
             #[doc = "Notify for the Q_PROPERTY"]
             #[cxx_name = #notify_cpp]
             fn #notify_rust(self: Pin<&mut #cpp_class_rust>);
         };
 
+        let mut docs = vec![];
+        while let Some(doc) = attribute_take_path(&mut method.attrs, &["doc"]) {
+            docs.push(doc);
+        }
+
         Some(ParsedSignal::from_property_method(
             method,
             notify.clone(),
             qobject_idents.name.rust_unqualified().clone(),
+            docs,
         ))
     } else {
         None

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -242,6 +242,7 @@ mod tests {
             safe: true,
             inherit: false,
             private: false,
+            docs: vec![],
         };
         let signals = vec![&signal];
         let qobject_idents = create_qobjectname();
@@ -340,6 +341,7 @@ mod tests {
             safe: true,
             inherit: false,
             private: false,
+            docs: vec![],
         };
         let signals = vec![&signal];
         let qobject_idents = create_qobjectname();
@@ -434,6 +436,7 @@ mod tests {
             safe: true,
             inherit: true,
             private: false,
+            docs: vec![],
         };
         let signals = vec![&signal];
         let qobject_idents = create_qobjectname();
@@ -519,6 +522,7 @@ mod tests {
             safe: true,
             inherit: true,
             private: false,
+            docs: vec![],
         };
 
         let mut type_names = TypeNames::default();
@@ -608,6 +612,7 @@ mod tests {
             safe: true,
             inherit: true,
             private: false,
+            docs: vec![],
         };
 
         let mut type_names = TypeNames::default();

--- a/crates/cxx-qt-gen/src/generator/naming/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/signals.rs
@@ -118,6 +118,7 @@ mod tests {
             safe: true,
             inherit: false,
             private: false,
+            docs: vec![],
         };
 
         let names = QSignalNames::from(&qsignal);
@@ -148,6 +149,7 @@ mod tests {
             safe: true,
             inherit: false,
             private: false,
+            docs: vec![],
         };
 
         let names = QSignalNames::from(&qsignal);

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -276,8 +276,8 @@ mod tests {
             &generated.cxx_mod_contents[6],
             parse_quote! {
                 unsafe extern "C++" {
-                    #[doc = "Notify for the Q_PROPERTY"]
                     #[cxx_name = "trivialPropertyChanged"]
+                    #[doc = "Notify for the Q_PROPERTY"]
                     fn trivial_property_changed(self: Pin<&mut MyObject>);
                 }
             },
@@ -401,8 +401,8 @@ mod tests {
             &generated.cxx_mod_contents[9],
             parse_quote! {
                 unsafe extern "C++" {
-                    #[doc = "Notify for the Q_PROPERTY"]
                     #[cxx_name = "opaquePropertyChanged"]
+                    #[doc = "Notify for the Q_PROPERTY"]
                     fn opaque_property_changed(self: Pin<&mut MyObject>);
                 }
             },
@@ -526,8 +526,8 @@ mod tests {
             &generated.cxx_mod_contents[12],
             parse_quote! {
                 unsafe extern "C++" {
-                    #[doc = "Notify for the Q_PROPERTY"]
                     #[cxx_name = "unsafePropertyChanged"]
+                    #[doc = "Notify for the Q_PROPERTY"]
                     fn unsafe_property_changed(self: Pin<&mut MyObject>);
                 }
             },

--- a/crates/cxx-qt-gen/src/generator/rust/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/signal.rs
@@ -5,6 +5,7 @@
 
 use syn::ForeignItemFn;
 
+use crate::syntax::attribute::attribute_take_path;
 use crate::{
     generator::naming::{
         property::{NameState, QPropertyNames},
@@ -21,16 +22,22 @@ pub fn generate(idents: &QPropertyNames, qobject_idents: &QObjectNames) -> Optio
         let notify_rust = notify.rust_unqualified();
         let notify_cpp_str = notify.cxx_unqualified();
 
-        let method: ForeignItemFn = syn::parse_quote! {
+        let mut method: ForeignItemFn = syn::parse_quote! {
             #[doc = "Notify for the Q_PROPERTY"]
             #[cxx_name = #notify_cpp_str]
             fn #notify_rust(self: Pin<&mut #cpp_class_rust>);
         };
 
+        let mut docs = vec![];
+        while let Some(doc) = attribute_take_path(&mut method.attrs, &["doc"]) {
+            docs.push(doc);
+        }
+
         Some(ParsedSignal::from_property_method(
             method,
             notify.clone(),
             qobject_idents.name.rust_unqualified().clone(),
+            docs,
         ))
     } else {
         None

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -91,8 +91,8 @@ pub mod ffi {
         fn set_property_name(self: Pin<&mut MyObject>, value: i32);
     }
     unsafe extern "C++" {
-        #[doc = "Notify for the Q_PROPERTY"]
         #[cxx_name = "propertyNameChanged"]
+        #[doc = "Notify for the Q_PROPERTY"]
         fn property_name_changed(self: Pin<&mut MyObject>);
     }
     unsafe extern "C++" {
@@ -224,8 +224,8 @@ pub mod ffi {
         fn set_property_name(self: Pin<&mut SecondObject>, value: i32);
     }
     unsafe extern "C++" {
-        #[doc = "Notify for the Q_PROPERTY"]
         #[cxx_name = "propertyNameChanged"]
+        #[doc = "Notify for the Q_PROPERTY"]
         fn property_name_changed(self: Pin<&mut SecondObject>);
     }
     unsafe extern "C++" {
@@ -262,7 +262,6 @@ pub mod ffi {
         fn invokable_name(self: Pin<&mut SecondObject>);
     }
     unsafe extern "C++" {
-        #[my_attribute]
         #[cxx_name = "ready"]
         fn ready(self: Pin<&mut SecondObject>);
     }
@@ -313,6 +312,7 @@ pub mod ffi {
         type ExternObject;
     }
     unsafe extern "C++" {
+        #[cxx_name = "clicked"]
         fn clicked(self: Pin<&mut QPushButton>, checked: bool);
     }
     unsafe extern "C++" {
@@ -372,8 +372,8 @@ pub mod ffi {
         );
     }
     unsafe extern "C++" {
-        #[rust_name = "error_occurred"]
-        fn errorOccurred(self: Pin<&mut ExternObject>);
+        #[cxx_name = "errorOccurred"]
+        fn error_occurred(self: Pin<&mut ExternObject>);
     }
     unsafe extern "C++" {
         #[doc(hidden)]

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -90,8 +90,8 @@ mod ffi {
         fn set_final_prop(self: Pin<&mut MyObject>, value: i32);
     }
     unsafe extern "C++" {
-        #[doc = "Notify for the Q_PROPERTY"]
         #[cxx_name = "primitiveChanged"]
+        #[doc = "Notify for the Q_PROPERTY"]
         fn primitive_changed(self: Pin<&mut MyObject>);
     }
     unsafe extern "C++" {
@@ -122,8 +122,8 @@ mod ffi {
         );
     }
     unsafe extern "C++" {
-        #[doc = "Notify for the Q_PROPERTY"]
         #[cxx_name = "trivialChanged"]
+        #[doc = "Notify for the Q_PROPERTY"]
         fn trivial_changed(self: Pin<&mut MyObject>);
     }
     unsafe extern "C++" {
@@ -154,8 +154,8 @@ mod ffi {
         );
     }
     unsafe extern "C++" {
-        #[doc = "Notify for the Q_PROPERTY"]
         #[cxx_name = "customFunctionPropChanged"]
+        #[doc = "Notify for the Q_PROPERTY"]
         fn custom_function_prop_changed(self: Pin<&mut MyObject>);
     }
     unsafe extern "C++" {


### PR DESCRIPTION
Removes some old code in ParsedSignal creation for adding cxx_name, as this is now handled by Name. Refactored from just using the ForeignItemFn that was passed, to custom building the token stream like is done for ParsedMethod, including docs passthrough and cxx_names on all signals

- Update tests with new order for doc and cxx_name
- Update test_outputs for new attribute parsing
- Add doc field to ParsedSignal for passthrough
- Update tests to ignore unknown attributes like #[my_attribute]
- Update from_property_method of ParsedSignal to accept docs