### PR TITLE
Introduce method lookup into NameState so that cxx_names can be used

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -89,9 +89,9 @@ mod tests {
 
         let qobject_idents = create_qobjectname();
 
-        let obj = ParsedQObject::mock_parsed_qobject();
+        let obj = ParsedQObject::mock();
 
-        let structured_qobject = StructuredQObject::mock_structured_qobject(&obj);
+        let structured_qobject = StructuredQObject::mock(&obj);
 
         let type_names = TypeNames::mock();
         generate_cpp_properties(
@@ -145,8 +145,6 @@ mod tests {
             struct MyStruct;
         };
 
-        // let generated = setup_generated(&mut input).unwrap();
-
         let property = ParsedQProperty::parse(input.attrs.remove(0)).unwrap();
 
         let properties = vec![property];
@@ -157,14 +155,14 @@ mod tests {
         let parser = Parser::from(module).unwrap();
         let structures = Structures::new(&parser.cxx_qt_data).unwrap();
 
-        let structured_qobject = structures.qobjects.get(0).unwrap();
+        let structured_qobject = structures.qobjects.first().unwrap();
 
         let type_names = TypeNames::mock();
         let generated = generate_cpp_properties(
             &properties,
             &qobject_idents,
             &type_names,
-            &structured_qobject,
+            structured_qobject,
         )
         .unwrap();
 
@@ -203,8 +201,6 @@ mod tests {
             struct MyStruct;
         };
 
-        // let generated = setup_generated(&mut input).unwrap();
-
         let property = ParsedQProperty::parse(input.attrs.remove(0)).unwrap();
 
         let properties = vec![property];
@@ -216,14 +212,14 @@ mod tests {
         let parser = Parser::from(module).unwrap();
         let structures = Structures::new(&parser.cxx_qt_data).unwrap();
 
-        let structured_qobject = structures.qobjects.get(0).unwrap();
+        let structured_qobject = structures.qobjects.first().unwrap();
 
         let type_names = TypeNames::mock();
         let generated = generate_cpp_properties(
             &properties,
             &qobject_idents,
             &type_names,
-            &structured_qobject,
+            structured_qobject,
         )
         .unwrap();
 
@@ -266,9 +262,9 @@ mod tests {
 
         let qobject_idents = create_qobjectname();
 
-        let obj = ParsedQObject::mock_parsed_qobject();
+        let obj = ParsedQObject::mock();
 
-        let structured_qobject = StructuredQObject::mock_structured_qobject(&obj);
+        let structured_qobject = StructuredQObject::mock(&obj);
 
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("QColor", None, None, None);
@@ -559,9 +555,9 @@ mod tests {
         }];
         let qobject_idents = create_qobjectname();
 
-        let obj = ParsedQObject::mock_parsed_qobject();
+        let obj = ParsedQObject::mock();
 
-        let structured_qobject = StructuredQObject::mock_structured_qobject(&obj);
+        let structured_qobject = StructuredQObject::mock(&obj);
 
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("A", None, Some("A1"), None);

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -102,6 +102,42 @@ mod tests {
         )
     }
 
+    // Might be a cleaner way than using functions but not sure a const / static is possible due to parse_quote!()
+    fn mock_module_custom_setter() -> ItemMod {
+        parse_quote! {
+            #[cxx_qt::bridge]
+            mod ffi {
+                extern "RustQt" {
+                    #[qobject]
+                    type MyObject = super::MyObjectRust;
+                }
+
+                unsafe extern "RustQt" {
+                    fn mySetter(self: Pin<&mut MyObject>, value: i32);
+                }
+            }
+        }
+    }
+
+    fn mock_module_custom_setter_and_reset() -> ItemMod {
+        parse_quote! {
+            #[cxx_qt::bridge]
+            mod ffi {
+                extern "RustQt" {
+                    #[qobject]
+                    type MyObject = super::MyObjectRust;
+                }
+
+                unsafe extern "RustQt" {
+                    fn mySetter(self: Pin<&mut MyObject>, value: i32);
+
+                    fn my_resetter(self: Pin<&mut MyObject>);
+
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_custom_setter() {
         let mut input: ItemStruct = parse_quote! {
@@ -117,20 +153,7 @@ mod tests {
 
         let qobject_idents = create_qobjectname();
 
-        // Prototyping, this test need properly rewriting
-        let module: ItemMod = parse_quote! {
-            #[cxx_qt::bridge]
-            mod ffi {
-                extern "RustQt" {
-                    #[qobject]
-                    type MyObject = super::MyObjectRust;
-                }
-
-                unsafe extern "RustQt" {
-                    fn mySetter(self: Pin<&mut MyObject>, value: i32);
-                }
-            }
-        };
+        let module = mock_module_custom_setter();
         let parser = Parser::from(module).unwrap();
         let structures = Structures::new(&parser.cxx_qt_data).unwrap();
 
@@ -189,22 +212,7 @@ mod tests {
         let qobject_idents = create_qobjectname();
 
         // Prototyping, this test need properly rewriting
-        let module: ItemMod = parse_quote! {
-            #[cxx_qt::bridge]
-            mod ffi {
-                extern "RustQt" {
-                    #[qobject]
-                    type MyObject = super::MyObjectRust;
-                }
-
-                unsafe extern "RustQt" {
-                    fn mySetter(self: Pin<&mut MyObject>, value: i32);
-
-                    fn my_resetter(self: Pin<&mut MyObject>);
-
-                }
-            }
-        };
+        let module = mock_module_custom_setter_and_reset();
         let parser = Parser::from(module).unwrap();
         let structures = Structures::new(&parser.cxx_qt_data).unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -30,7 +30,7 @@ pub fn generate_cpp_properties(
 
     for property in properties {
         // Cache the idents as they are used in multiple places
-        let idents = QPropertyNames::from_property(property, structured_qobject);
+        let idents = QPropertyNames::try_from_property(property, structured_qobject)?;
         let cxx_ty = syn_type_to_cpp_type(&property.ty, type_names)?;
 
         generated

--- a/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/mod.rs
@@ -75,9 +75,7 @@ mod tests {
 
     use crate::generator::naming::qobject::tests::create_qobjectname;
     use crate::generator::structuring::Structures;
-    use crate::naming::Name;
     use crate::parser::qobject::ParsedQObject;
-    use crate::syntax::foreignmod::ForeignTypeIdentAlias;
     use crate::{CppFragment, Parser};
     use indoc::indoc;
     use pretty_assertions::assert_str_eq;
@@ -91,27 +89,9 @@ mod tests {
 
         let qobject_idents = create_qobjectname();
 
-        // PROTO for mocking only (these need to be replaced by parsing a real module in order to pick up methods)
-        // This should also include a new test or two, as this new code should ensure that custom methods passed actually exist
-        let obj = ParsedQObject {
-            base_class: None,
-            name: Name::new(format_ident!("my_property")),
-            rust_type: format_ident!("i32"),
-            inherited_methods: vec![],
-            constructors: vec![],
-            properties: vec![],
-            qml_metadata: None,
-            locking: false,
-            threading: false,
-            has_qobject_macro: false,
-            declaration: ForeignTypeIdentAlias {
-                attrs: vec![],
-                ident_left: format_ident!("MyObject"),
-                ident_right: format_ident!("MyObjectRust"),
-            },
-        };
+        let obj = ParsedQObject::mock_parsed_qobject();
 
-        let structured_qobject = StructuredQObject::from_qobject(&obj);
+        let structured_qobject = StructuredQObject::mock_structured_qobject(&obj);
 
         let type_names = TypeNames::mock();
         generate_cpp_properties(
@@ -278,26 +258,9 @@ mod tests {
 
         let qobject_idents = create_qobjectname();
 
-        // PROTO mocking only
-        let obj = ParsedQObject {
-            base_class: None,
-            name: Name::new(format_ident!("my_property")),
-            rust_type: format_ident!("i32"),
-            inherited_methods: vec![],
-            constructors: vec![],
-            properties: vec![],
-            qml_metadata: None,
-            locking: false,
-            threading: false,
-            has_qobject_macro: false,
-            declaration: ForeignTypeIdentAlias {
-                attrs: vec![],
-                ident_left: format_ident!("MyObject"),
-                ident_right: format_ident!("MyObjectRust"),
-            },
-        };
+        let obj = ParsedQObject::mock_parsed_qobject();
 
-        let structured_qobject = StructuredQObject::from_qobject(&obj);
+        let structured_qobject = StructuredQObject::mock_structured_qobject(&obj);
 
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("QColor", None, None, None);
@@ -588,26 +551,9 @@ mod tests {
         }];
         let qobject_idents = create_qobjectname();
 
-        // PROTO mocking only
-        let obj = ParsedQObject {
-            base_class: None,
-            name: Name::new(format_ident!("my_property")),
-            rust_type: format_ident!("i32"),
-            inherited_methods: vec![],
-            constructors: vec![],
-            properties: vec![],
-            qml_metadata: None,
-            locking: false,
-            threading: false,
-            has_qobject_macro: false,
-            declaration: ForeignTypeIdentAlias {
-                attrs: vec![],
-                ident_left: format_ident!("MyObject"),
-                ident_right: format_ident!("MyObjectRust"),
-            },
-        };
+        let obj = ParsedQObject::mock_parsed_qobject();
 
-        let structured_qobject = StructuredQObject::from_qobject(&obj);
+        let structured_qobject = StructuredQObject::mock_structured_qobject(&obj);
 
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("A", None, Some("A1"), None);

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -143,6 +143,7 @@ impl GeneratedCppQObject {
             &qobject.properties,
             &qobject_idents,
             type_names,
+            structured_qobject,
         )?);
         generated.blocks.append(&mut generate_cpp_methods(
             &structured_qobject.methods,

--- a/crates/cxx-qt-gen/src/generator/naming/property.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/property.rs
@@ -162,7 +162,6 @@ pub mod tests {
     use super::*;
     use crate::parser::property::QPropertyFlags;
     use crate::parser::qobject::ParsedQObject;
-    use crate::syntax::foreignmod::ForeignTypeIdentAlias;
 
     pub fn create_i32_qpropertyname() -> QPropertyNames {
         let ty: syn::Type = parse_quote! { i32 };
@@ -171,26 +170,10 @@ pub mod tests {
             ty,
             flags: QPropertyFlags::default(),
         };
-        // PROTO, only for allowing code to compile
-        let obj = ParsedQObject {
-            base_class: None,
-            name: Name::new(format_ident!("my_property")),
-            rust_type: format_ident!("i32"),
-            inherited_methods: vec![],
-            constructors: vec![],
-            properties: vec![],
-            qml_metadata: None,
-            locking: false,
-            threading: false,
-            has_qobject_macro: false,
-            declaration: ForeignTypeIdentAlias {
-                attrs: vec![],
-                ident_left: format_ident!("MyObject"),
-                ident_right: format_ident!("MyObjectRust"),
-            },
-        };
 
-        let structured_qobject = StructuredQObject::from_qobject(&obj);
+        let obj = ParsedQObject::mock_parsed_qobject();
+
+        let structured_qobject = StructuredQObject::mock_structured_qobject(&obj);
         QPropertyNames::try_from_property(&property, &structured_qobject)
             .expect("Failed to create QPropertyNames")
     }

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -69,10 +69,8 @@ pub fn generate_rust_properties(
 mod tests {
     use super::*;
 
-    use crate::naming::Name;
     use crate::parser::property::QPropertyFlags;
     use crate::parser::qobject::ParsedQObject;
-    use crate::syntax::foreignmod::ForeignTypeIdentAlias;
     use crate::{generator::naming::qobject::tests::create_qobjectname, tests::assert_tokens_eq};
     use quote::format_ident;
     use syn::parse_quote;
@@ -98,26 +96,9 @@ mod tests {
         ];
         let qobject_idents = create_qobjectname();
 
-        // PROTO mocking only
-        let obj = ParsedQObject {
-            base_class: None,
-            name: Name::new(format_ident!("my_property")),
-            rust_type: format_ident!("i32"),
-            inherited_methods: vec![],
-            constructors: vec![],
-            properties: vec![],
-            qml_metadata: None,
-            locking: false,
-            threading: false,
-            has_qobject_macro: false,
-            declaration: ForeignTypeIdentAlias {
-                attrs: vec![],
-                ident_left: format_ident!("MyObject"),
-                ident_right: format_ident!("MyObjectRust"),
-            },
-        };
+        let obj = ParsedQObject::mock_parsed_qobject();
 
-        let structured_qobject = StructuredQObject::from_qobject(&obj);
+        let structured_qobject = StructuredQObject::mock_structured_qobject(&obj);
 
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("T", None, None, None);

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -7,6 +7,8 @@ pub mod getter;
 pub mod setter;
 pub mod signal;
 
+use super::signals::generate_rust_signals;
+use crate::generator::structuring::StructuredQObject;
 use crate::{
     generator::{
         naming::{property::QPropertyNames, qobject::QObjectNames},
@@ -17,19 +19,18 @@ use crate::{
 };
 use syn::{Ident, Result};
 
-use super::signals::generate_rust_signals;
-
 pub fn generate_rust_properties(
     properties: &Vec<ParsedQProperty>,
     qobject_idents: &QObjectNames,
     type_names: &TypeNames,
     module_ident: &Ident,
+    structured_qobject: &StructuredQObject,
 ) -> Result<GeneratedRustFragment> {
     let mut generated = GeneratedRustFragment::default();
     let mut signals = vec![];
 
     for property in properties {
-        let idents = QPropertyNames::from(property);
+        let idents = QPropertyNames::from_property(property, structured_qobject);
 
         if let Some(getter) = getter::generate(&idents, qobject_idents, &property.ty, type_names)? {
             generated
@@ -68,7 +69,10 @@ pub fn generate_rust_properties(
 mod tests {
     use super::*;
 
+    use crate::naming::Name;
     use crate::parser::property::QPropertyFlags;
+    use crate::parser::qobject::ParsedQObject;
+    use crate::syntax::foreignmod::ForeignTypeIdentAlias;
     use crate::{generator::naming::qobject::tests::create_qobjectname, tests::assert_tokens_eq};
     use quote::format_ident;
     use syn::parse_quote;
@@ -94,6 +98,27 @@ mod tests {
         ];
         let qobject_idents = create_qobjectname();
 
+        // PROTO mocking only
+        let obj = ParsedQObject {
+            base_class: None,
+            name: Name::new(format_ident!("my_property")),
+            rust_type: format_ident!("i32"),
+            inherited_methods: vec![],
+            constructors: vec![],
+            properties: vec![],
+            qml_metadata: None,
+            locking: false,
+            threading: false,
+            has_qobject_macro: false,
+            declaration: ForeignTypeIdentAlias {
+                attrs: vec![],
+                ident_left: format_ident!("MyObject"),
+                ident_right: format_ident!("MyObjectRust"),
+            },
+        };
+
+        let structured_qobject = StructuredQObject::from_qobject(&obj);
+
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("T", None, None, None);
         type_names.mock_insert("QColor", None, None, None);
@@ -102,6 +127,7 @@ mod tests {
             &qobject_idents,
             &type_names,
             &format_ident!("ffi"),
+            &structured_qobject,
         )
         .unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -30,7 +30,7 @@ pub fn generate_rust_properties(
     let mut signals = vec![];
 
     for property in properties {
-        let idents = QPropertyNames::from_property(property, structured_qobject);
+        let idents = QPropertyNames::try_from_property(property, structured_qobject)?;
 
         if let Some(getter) = getter::generate(&idents, qobject_idents, &property.ty, type_names)? {
             generated

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -96,9 +96,9 @@ mod tests {
         ];
         let qobject_idents = create_qobjectname();
 
-        let obj = ParsedQObject::mock_parsed_qobject();
+        let obj = ParsedQObject::mock();
 
-        let structured_qobject = StructuredQObject::mock_structured_qobject(&obj);
+        let structured_qobject = StructuredQObject::mock(&obj);
 
         let mut type_names = TypeNames::mock();
         type_names.mock_insert("T", None, None, None);

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -46,6 +46,7 @@ impl GeneratedRustFragment {
             &qobject_idents,
             type_names,
             module_ident,
+            structured_qobject,
         )?);
         generated.append(&mut generate_rust_methods(
             &structured_qobject.methods,

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -201,7 +201,7 @@ mod tests {
         let structures = Structures::new(&parser.cxx_qt_data).unwrap();
 
         let rust = GeneratedRustFragment::from_qobject(
-            &structures.qobjects.get(0).unwrap(),
+            structures.qobjects.first().unwrap(),
             &parser.type_names,
             &format_ident!("ffi"),
         )

--- a/crates/cxx-qt-gen/src/generator/structuring/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/structuring/qobject.rs
@@ -9,6 +9,7 @@ use crate::parser::inherit::ParsedInheritedMethod;
 use crate::parser::signals::ParsedSignal;
 use crate::parser::{qenum::ParsedQEnum, qobject::ParsedQObject};
 use proc_macro2::Ident;
+use syn::{Error, Result};
 
 /// The StructuredQObject contains the parsed QObject and all members.
 /// This includes QEnums, QSignals, methods, etc.
@@ -36,21 +37,19 @@ impl<'a> StructuredQObject<'a> {
         }
     }
 
-    pub fn method_lookup(&self, id: &Ident) -> Name {
-        println!("Doing method lookup for Ident: {:?}", id);
-        println!(
-            "Method names: {:?}",
-            self.methods
-                .iter()
-                .map(|method| method.name.clone())
-                .collect::<Vec<_>>()
-        );
+    pub fn method_lookup(&self, id: &Ident) -> Result<Name> {
         let method = self
             .methods
             .iter()
-            .find(|method| method.name.rust_unqualified() == id)
-            .expect("Method not found");
+            .find(|method| method.name.rust_unqualified() == id);
 
-        method.name.clone()
+        if let Some(method) = method {
+            Ok(method.name.clone())
+        } else {
+            Err(Error::new_spanned(
+                id,
+                format!("Method with name '{id}' not found!"),
+            ))
+        }
     }
 }

--- a/crates/cxx-qt-gen/src/generator/structuring/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/structuring/qobject.rs
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::inherit::ParsedInheritedMethod;
+use crate::naming::Name;
 use crate::parser::method::ParsedMethod;
+use crate::parser::inherit::ParsedInheritedMethod;
 use crate::parser::signals::ParsedSignal;
 use crate::parser::{qenum::ParsedQEnum, qobject::ParsedQObject};
 use proc_macro2::Ident;
@@ -33,5 +34,23 @@ impl<'a> StructuredQObject<'a> {
             inherited_methods: vec![],
             signals: vec![],
         }
+    }
+
+    pub fn method_lookup(&self, id: &Ident) -> Name {
+        println!("Doing method lookup for Ident: {:?}", id);
+        println!(
+            "Method names: {:?}",
+            self.methods
+                .iter()
+                .map(|method| method.name.clone())
+                .collect::<Vec<_>>()
+        );
+        let method = self
+            .methods
+            .iter()
+            .find(|method| method.name.rust_unqualified() == id)
+            .expect("Method not found");
+
+        method.name.clone()
     }
 }

--- a/crates/cxx-qt-gen/src/generator/structuring/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/structuring/qobject.rs
@@ -52,4 +52,9 @@ impl<'a> StructuredQObject<'a> {
             ))
         }
     }
+
+    #[cfg(test)]
+    pub fn mock_structured_qobject(obj: &'a ParsedQObject) -> Self {
+        Self::from_qobject(&obj)
+    }
 }

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -11,6 +11,9 @@ use crate::{
         path::path_compare_str,
     },
 };
+#[cfg(test)]
+use quote::format_ident;
+
 use syn::{Attribute, Error, Ident, ItemImpl, Meta, Result};
 
 /// Metadata for registering QML element
@@ -20,7 +23,6 @@ pub struct QmlElementMetadata {
     pub uncreatable: bool,
     pub singleton: bool,
 }
-
 /// A representation of a QObject within a CXX-Qt [syn::ItemMod]
 ///
 /// This has initial splitting of [syn::Item]'s into relevant blocks, other phases will
@@ -54,6 +56,27 @@ pub struct ParsedQObject {
 }
 
 impl ParsedQObject {
+    #[cfg(test)]
+    pub fn mock_parsed_qobject() -> Self {
+        ParsedQObject {
+            base_class: None,
+            name: Name::new(format_ident!("my_property")),
+            rust_type: format_ident!("i32"),
+            inherited_methods: vec![],
+            constructors: vec![],
+            properties: vec![],
+            qml_metadata: None,
+            locking: false,
+            threading: false,
+            has_qobject_macro: false,
+            declaration: ForeignTypeIdentAlias {
+                attrs: vec![],
+                ident_left: format_ident!("MyObject"),
+                ident_right: format_ident!("MyObjectRust"),
+            },
+        }
+    }
+
     /// Parse a ForeignTypeIdentAlias into a [ParsedQObject] with the index of the #[qobject] specified
     pub fn parse(
         mut declaration: ForeignTypeIdentAlias,

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -57,11 +57,11 @@ pub struct ParsedQObject {
 
 impl ParsedQObject {
     #[cfg(test)]
-    pub fn mock_parsed_qobject() -> Self {
+    pub fn mock() -> Self {
         ParsedQObject {
             base_class: None,
-            name: Name::new(format_ident!("my_property")),
-            rust_type: format_ident!("i32"),
+            name: Name::new(format_ident!("MyObject")),
+            rust_type: format_ident!("MyObjectRust"),
             inherited_methods: vec![],
             constructors: vec![],
             properties: vec![],

--- a/crates/cxx-qt-gen/test_inputs/properties.rs
+++ b/crates/cxx-qt-gen/test_inputs/properties.rs
@@ -13,7 +13,7 @@ mod ffi {
         #[qproperty(QPoint, trivial)]
         #[qproperty(i32, custom_function_prop, READ = my_getter, WRITE = my_setter, NOTIFY)]
         #[qproperty(i32, readonly_prop, READ)]
-        #[qproperty(i32, custom_on_changed_prop, READ, WRITE, NOTIFY = myOnChanged)]
+        #[qproperty(i32, custom_on_changed_prop, READ, WRITE, NOTIFY = my_on_changed)]
         #[qproperty(i32, const_prop, READ, CONSTANT)]
         #[qproperty(i32, resettable_prop, READ, WRITE, RESET = myResetFn)]
         #[qproperty(i32, required_prop, READ, WRITE, REQUIRED)]
@@ -22,11 +22,14 @@ mod ffi {
     }
 
     unsafe extern "RustQt" {
-        fn my_getter(self: &MyObject) -> i32;
+        #[rust_name = "my_getter"]
+        fn myGetter(self: &MyObject) -> i32;
 
+        #[cxx_name = "MyCustomSetter"]
         fn my_setter(self: Pin<&mut MyObject>, value: i32);
 
-        fn myOnChanged(self: Pin<&mut MyObject>);
+        #[qsignal]
+        fn my_on_changed(self: Pin<&mut MyObject>);
 
         fn myResetFn(self: Pin<&mut MyObject>);
     }

--- a/crates/cxx-qt-gen/test_inputs/properties.rs
+++ b/crates/cxx-qt-gen/test_inputs/properties.rs
@@ -20,4 +20,14 @@ mod ffi {
         #[qproperty(i32, final_prop, READ, WRITE, FINAL)]
         type MyObject = super::MyObjectRust;
     }
+
+    unsafe extern "RustQt" {
+        fn my_getter(self: &MyObject) -> i32;
+
+        fn my_setter(self: Pin<&mut MyObject>, value: i32);
+
+        fn myOnChanged(self: Pin<&mut MyObject>);
+
+        fn myResetFn(self: Pin<&mut MyObject>);
+    }
 }

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -275,6 +275,34 @@ MyObject::setFinalProp(::std::int32_t const& value)
   setFinalPropWrapper(value);
 }
 
+::std::int32_t
+MyObject::myGetter() const
+{
+  const ::rust::cxxqt1::MaybeLockGuard<MyObject> guard(*this);
+  return myGetterWrapper();
+}
+
+void
+MyObject::mySetter(::std::int32_t value)
+{
+  const ::rust::cxxqt1::MaybeLockGuard<MyObject> guard(*this);
+  mySetterWrapper(value);
+}
+
+void
+MyObject::myOnChanged()
+{
+  const ::rust::cxxqt1::MaybeLockGuard<MyObject> guard(*this);
+  myOnChangedWrapper();
+}
+
+void
+MyObject::myResetFn()
+{
+  const ::rust::cxxqt1::MaybeLockGuard<MyObject> guard(*this);
+  myResetFnWrapper();
+}
+
 MyObject::MyObject(QObject* parent)
   : QObject(parent)
   , ::rust::cxxqt1::CxxQtType<MyObjectRust>(

--- a/crates/cxx-qt-gen/test_outputs/properties.cpp
+++ b/crates/cxx-qt-gen/test_outputs/properties.cpp
@@ -176,6 +176,62 @@ MyObject_customFunctionPropChangedConnect(
 }
 } // namespace cxx_qt::my_object::rust::cxxqtgen1
 
+// Define namespace otherwise we hit a GCC bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+namespace rust::cxxqt1 {
+template<>
+SignalHandler<
+  ::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalParamsmyOnChanged*>::
+  ~SignalHandler() noexcept
+{
+  if (data[0] == nullptr && data[1] == nullptr) {
+    return;
+  }
+
+  drop_MyObject_signal_handler_myOnChanged(::std::move(*this));
+}
+
+template<>
+template<>
+void
+SignalHandler<
+  ::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalParamsmyOnChanged*>::
+operator()<cxx_qt::my_object::MyObject&>(cxx_qt::my_object::MyObject& self)
+{
+  call_MyObject_signal_handler_myOnChanged(*this, self);
+}
+
+static_assert(alignof(SignalHandler<::cxx_qt::my_object::rust::cxxqtgen1::
+                                      MyObjectCxxQtSignalParamsmyOnChanged*>) <=
+                alignof(::std::size_t),
+              "unexpected aligment");
+static_assert(sizeof(SignalHandler<::cxx_qt::my_object::rust::cxxqtgen1::
+                                     MyObjectCxxQtSignalParamsmyOnChanged*>) ==
+                sizeof(::std::size_t[2]),
+              "unexpected size");
+} // namespace rust::cxxqt1
+
+namespace cxx_qt::my_object::rust::cxxqtgen1 {
+::QMetaObject::Connection
+MyObject_myOnChangedConnect(
+  cxx_qt::my_object::MyObject& self,
+  ::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlermyOnChanged
+    closure,
+  ::Qt::ConnectionType type)
+{
+  return ::QObject::connect(
+    &self,
+    &cxx_qt::my_object::MyObject::myOnChanged,
+    &self,
+    [&, closure = ::std::move(closure)]() mutable {
+      const ::rust::cxxqt1::MaybeLockGuard<cxx_qt::my_object::MyObject> guard(
+        self);
+      closure.template operator()<cxx_qt::my_object::MyObject&>(self);
+    },
+    type);
+}
+} // namespace cxx_qt::my_object::rust::cxxqtgen1
+
 namespace cxx_qt::my_object {
 ::std::int32_t const&
 MyObject::getPrimitive() const
@@ -283,17 +339,10 @@ MyObject::myGetter() const
 }
 
 void
-MyObject::mySetter(::std::int32_t value)
+MyObject::MyCustomSetter(::std::int32_t value)
 {
   const ::rust::cxxqt1::MaybeLockGuard<MyObject> guard(*this);
-  mySetterWrapper(value);
-}
-
-void
-MyObject::myOnChanged()
-{
-  const ::rust::cxxqt1::MaybeLockGuard<MyObject> guard(*this);
-  myOnChangedWrapper();
+  MyCustomSetterWrapper(value);
 }
 
 void

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -27,6 +27,11 @@ using MyObjectCxxQtSignalHandlercustomFunctionPropChanged =
     struct MyObjectCxxQtSignalParamscustomFunctionPropChanged*>;
 } // namespace cxx_qt::my_object::rust::cxxqtgen1
 
+namespace cxx_qt::my_object::rust::cxxqtgen1 {
+using MyObjectCxxQtSignalHandlermyOnChanged =
+  ::rust::cxxqt1::SignalHandler<struct MyObjectCxxQtSignalParamsmyOnChanged*>;
+} // namespace cxx_qt::my_object::rust::cxxqtgen1
+
 #include "cxx-qt-gen/ffi.cxx.h"
 
 namespace cxx_qt::my_object::rust::cxxqtgen1 {
@@ -56,6 +61,15 @@ MyObject_customFunctionPropChangedConnect(
   ::Qt::ConnectionType type);
 } // namespace cxx_qt::my_object::rust::cxxqtgen1
 
+namespace cxx_qt::my_object::rust::cxxqtgen1 {
+::QMetaObject::Connection
+MyObject_myOnChangedConnect(
+  cxx_qt::my_object::MyObject& self,
+  ::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlermyOnChanged
+    closure,
+  ::Qt::ConnectionType type);
+} // namespace cxx_qt::my_object::rust::cxxqtgen1
+
 namespace cxx_qt::my_object {
 class MyObject
   : public QObject
@@ -68,8 +82,8 @@ public:
                NOTIFY primitiveChanged)
   Q_PROPERTY(
     QPoint trivial READ getTrivial WRITE setTrivial NOTIFY trivialChanged)
-  Q_PROPERTY(::std::int32_t customFunctionProp READ myGetter WRITE mySetter
-               NOTIFY customFunctionPropChanged)
+  Q_PROPERTY(::std::int32_t customFunctionProp READ myGetter WRITE
+               MyCustomSetter NOTIFY customFunctionPropChanged)
   Q_PROPERTY(::std::int32_t readonlyProp READ getReadonlyProp)
   Q_PROPERTY(::std::int32_t customOnChangedProp READ getCustomOnChangedProp
                WRITE setCustomOnChangedProp NOTIFY myOnChanged)
@@ -102,9 +116,9 @@ public:
   Q_SIGNAL void trivialChanged();
   Q_SIGNAL void customFunctionPropChanged();
   ::std::int32_t myGetter() const;
-  void mySetter(::std::int32_t value);
-  void myOnChanged();
+  void MyCustomSetter(::std::int32_t value);
   void myResetFn();
+  Q_SIGNAL void myOnChanged();
   explicit MyObject(QObject* parent = nullptr);
 
 private:
@@ -123,8 +137,7 @@ private:
   ::std::int32_t const& getFinalPropWrapper() const noexcept;
   void setFinalPropWrapper(::std::int32_t value) noexcept;
   ::std::int32_t myGetterWrapper() const noexcept;
-  void mySetterWrapper(::std::int32_t value) noexcept;
-  void myOnChangedWrapper() noexcept;
+  void MyCustomSetterWrapper(::std::int32_t value) noexcept;
   void myResetFnWrapper() noexcept;
 };
 

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -68,7 +68,7 @@ public:
                NOTIFY primitiveChanged)
   Q_PROPERTY(
     QPoint trivial READ getTrivial WRITE setTrivial NOTIFY trivialChanged)
-  Q_PROPERTY(::std::int32_t customFunctionProp READ my_getter WRITE my_setter
+  Q_PROPERTY(::std::int32_t customFunctionProp READ myGetter WRITE mySetter
                NOTIFY customFunctionPropChanged)
   Q_PROPERTY(::std::int32_t readonlyProp READ getReadonlyProp)
   Q_PROPERTY(::std::int32_t customOnChangedProp READ getCustomOnChangedProp
@@ -101,6 +101,10 @@ public:
   Q_SIGNAL void primitiveChanged();
   Q_SIGNAL void trivialChanged();
   Q_SIGNAL void customFunctionPropChanged();
+  ::std::int32_t myGetter() const;
+  void mySetter(::std::int32_t value);
+  void myOnChanged();
+  void myResetFn();
   explicit MyObject(QObject* parent = nullptr);
 
 private:
@@ -118,6 +122,10 @@ private:
   void setRequiredPropWrapper(::std::int32_t value) noexcept;
   ::std::int32_t const& getFinalPropWrapper() const noexcept;
   void setFinalPropWrapper(::std::int32_t value) noexcept;
+  ::std::int32_t myGetterWrapper() const noexcept;
+  void mySetterWrapper(::std::int32_t value) noexcept;
+  void myOnChangedWrapper() noexcept;
+  void myResetFnWrapper() noexcept;
 };
 
 static_assert(::std::is_base_of<QObject, MyObject>::value,

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -193,18 +193,41 @@ mod ffi {
     }
     extern "Rust" {
         #[doc(hidden)]
-        #[cxx_name = "mySetterWrapper"]
+        #[cxx_name = "MyCustomSetterWrapper"]
         fn my_setter(self: Pin<&mut MyObject>, value: i32);
-    }
-    extern "Rust" {
-        #[doc(hidden)]
-        #[cxx_name = "myOnChangedWrapper"]
-        fn myOnChanged(self: Pin<&mut MyObject>);
     }
     extern "Rust" {
         #[doc(hidden)]
         #[cxx_name = "myResetFnWrapper"]
         fn myResetFn(self: Pin<&mut MyObject>);
+    }
+    unsafe extern "C++" {
+        #[cxx_name = "myOnChanged"]
+        fn my_on_changed(self: Pin<&mut MyObject>);
+    }
+    unsafe extern "C++" {
+        #[doc(hidden)]
+        #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
+        type MyObjectCxxQtSignalHandlermyOnChanged =
+            cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosuremyOnChanged>;
+        #[doc(hidden)]
+        #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
+        #[cxx_name = "MyObject_myOnChangedConnect"]
+        fn MyObject_connect_my_on_changed(
+            self_value: Pin<&mut MyObject>,
+            signal_handler: MyObjectCxxQtSignalHandlermyOnChanged,
+            conn_type: CxxQtConnectionType,
+        ) -> CxxQtQMetaObjectConnection;
+    }
+    #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
+    extern "Rust" {
+        #[doc(hidden)]
+        fn drop_MyObject_signal_handler_myOnChanged(handler: MyObjectCxxQtSignalHandlermyOnChanged);
+        #[doc(hidden)]
+        fn call_MyObject_signal_handler_myOnChanged(
+            handler: &mut MyObjectCxxQtSignalHandlermyOnChanged,
+            self_value: Pin<&mut MyObject>,
+        );
     }
     extern "Rust" {
         #[cxx_name = "createRs"]
@@ -283,7 +306,7 @@ impl ffi::MyObject {
             return;
         }
         self.as_mut().rust_mut().custom_on_changed_prop = value;
-        self.as_mut().myOnChanged();
+        self.as_mut().my_on_changed();
     }
 }
 impl ffi::MyObject {
@@ -535,6 +558,66 @@ cxx_qt::static_assertions::assert_eq_align!(
 );
 cxx_qt::static_assertions::assert_eq_size!(
     cxx_qt::signalhandler::CxxQtSignalHandler<MyObjectCxxQtSignalClosurecustomFunctionPropChanged>,
+    [usize; 2]
+);
+impl ffi::MyObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "myOnChanged"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    pub fn connect_my_on_changed<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static>(
+        self: core::pin::Pin<&mut ffi::MyObject>,
+        mut closure: F,
+        conn_type: cxx_qt::ConnectionType,
+    ) -> cxx_qt::QMetaObjectConnectionGuard {
+        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_my_on_changed(
+            self,
+            cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosuremyOnChanged>::new(
+                Box::new(closure),
+            ),
+            conn_type,
+        ))
+    }
+}
+impl ffi::MyObject {
+    #[doc = "Connect the given function pointer to the signal "]
+    #[doc = "myOnChanged"]
+    #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[doc = "\n"]
+    #[doc = "Note that this method uses a AutoConnection connection type."]
+    pub fn on_my_on_changed<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static>(
+        self: core::pin::Pin<&mut ffi::MyObject>,
+        mut closure: F,
+    ) -> cxx_qt::QMetaObjectConnectionGuard {
+        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_my_on_changed(
+            self,
+            cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosuremyOnChanged>::new(
+                Box::new(closure),
+            ),
+            cxx_qt::ConnectionType::AutoConnection,
+        ))
+    }
+}
+#[doc(hidden)]
+pub struct MyObjectCxxQtSignalClosuremyOnChanged {}
+impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosuremyOnChanged {
+    type Id = cxx::type_id!(
+        "::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlermyOnChanged"
+    );
+    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>);
+}
+use core::mem::drop as drop_MyObject_signal_handler_myOnChanged;
+fn call_MyObject_signal_handler_myOnChanged(
+    handler: &mut cxx_qt::signalhandler::CxxQtSignalHandler<MyObjectCxxQtSignalClosuremyOnChanged>,
+    self_value: core::pin::Pin<&mut ffi::MyObject>,
+) {
+    handler.closure()(self_value);
+}
+cxx_qt::static_assertions::assert_eq_align!(
+    cxx_qt::signalhandler::CxxQtSignalHandler<MyObjectCxxQtSignalClosuremyOnChanged>,
+    usize
+);
+cxx_qt::static_assertions::assert_eq_size!(
+    cxx_qt::signalhandler::CxxQtSignalHandler<MyObjectCxxQtSignalClosuremyOnChanged>,
     [usize; 2]
 );
 impl cxx_qt::Locking for ffi::MyObject {}

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -187,6 +187,26 @@ mod ffi {
         );
     }
     extern "Rust" {
+        #[doc(hidden)]
+        #[cxx_name = "myGetterWrapper"]
+        fn my_getter(self: &MyObject) -> i32;
+    }
+    extern "Rust" {
+        #[doc(hidden)]
+        #[cxx_name = "mySetterWrapper"]
+        fn my_setter(self: Pin<&mut MyObject>, value: i32);
+    }
+    extern "Rust" {
+        #[doc(hidden)]
+        #[cxx_name = "myOnChangedWrapper"]
+        fn myOnChanged(self: Pin<&mut MyObject>);
+    }
+    extern "Rust" {
+        #[doc(hidden)]
+        #[cxx_name = "myResetFnWrapper"]
+        fn myResetFn(self: Pin<&mut MyObject>);
+    }
+    extern "Rust" {
         #[cxx_name = "createRs"]
         #[namespace = "cxx_qt::my_object::cxx_qt_my_object"]
         fn create_rs_my_object_rust() -> Box<MyObjectRust>;


### PR DESCRIPTION
StructuredQObject is passed through various functions so that in NameState, a method lookup can be used for the user defined functions, and this also requires modifying some test data to create Structures