### PR TITLE
Add support for inherited method to structuring phase

### DIFF
--- a/crates/cxx-qt-gen/src/generator/structuring/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/structuring/mod.rs
@@ -64,6 +64,20 @@ impl<'a> Structures<'a> {
             qobject.methods.push(method);
         }
 
+        // Associate each inherited method parsed with its appropriate qobject
+        for inherited_method in &cxxqtdata.inherited_methods {
+            let qobject = qobjects
+                .iter_mut()
+                .find(|qobject| qobject.has_qobject_name(&inherited_method.qobject_ident))
+                .ok_or_else(|| {
+                    Error::new_spanned(
+                        &inherited_method.qobject_ident,
+                        format!("Unknown QObject: {:?}", &inherited_method.qobject_ident),
+                    )
+                })?;
+            qobject.inherited_methods.push(inherited_method);
+        }
+
         // Associate each signal parsed with its appropriate qobject
         for signal in &cxxqtdata.signals {
             let qobject = qobjects

--- a/crates/cxx-qt-gen/src/generator/structuring/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/structuring/qobject.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::parser::inherit::ParsedInheritedMethod;
 use crate::parser::method::ParsedMethod;
 use crate::parser::signals::ParsedSignal;
 use crate::parser::{qenum::ParsedQEnum, qobject::ParsedQObject};
@@ -14,6 +15,7 @@ pub struct StructuredQObject<'a> {
     pub declaration: &'a ParsedQObject,
     pub qenums: Vec<&'a ParsedQEnum>,
     pub methods: Vec<&'a ParsedMethod>,
+    pub inherited_methods: Vec<&'a ParsedInheritedMethod>,
     pub signals: Vec<&'a ParsedSignal>,
 }
 
@@ -28,6 +30,7 @@ impl<'a> StructuredQObject<'a> {
             declaration: qobject,
             qenums: vec![],
             methods: vec![],
+            inherited_methods: vec![],
             signals: vec![],
         }
     }

--- a/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
+++ b/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
@@ -35,6 +35,8 @@ pub struct ParsedCxxQtData {
     pub methods: Vec<ParsedMethod>,
     /// List of the Q_SIGNALS found
     pub signals: Vec<ParsedSignal>,
+    /// List of the inherited methods found
+    pub inherited_methods: Vec<ParsedInheritedMethod>,
     /// List of QNamespace declarations
     pub qnamespaces: Vec<ParsedQNamespace>,
     /// Blocks of extern "C++Qt"
@@ -53,6 +55,7 @@ impl ParsedCxxQtData {
             qenums: vec![],
             methods: vec![],
             signals: vec![],
+            inherited_methods: vec![],
             qnamespaces: vec![],
             extern_cxxqt_blocks: Vec::<ParsedExternCxxQt>::default(),
             module_ident,
@@ -217,8 +220,13 @@ impl ParsedCxxQtData {
                     //
                     // Note that we need to test for qsignal first as qsignals have their own inherit meaning
                 } else if attribute_take_path(&mut foreign_fn.attrs, &["inherit"]).is_some() {
+                    let parsed_inherited_method_self =
+                        ParsedInheritedMethod::parse(foreign_fn.clone(), safe_call)?;
+
                     let parsed_inherited_method =
                         ParsedInheritedMethod::parse(foreign_fn, safe_call)?;
+
+                    self.inherited_methods.push(parsed_inherited_method_self);
 
                     self.with_qobject(&parsed_inherited_method.qobject_ident)?
                         .inherited_methods


### PR DESCRIPTION
Start moving ParsedInheritedMethod into structuring phase by adding fields to StructuredQObject and ParsedCxxQtData, and associate inherited methods with their StructuredQObject in structuring phase.