### PR TITLE
Refactor use inherited methods from structuring

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
@@ -14,13 +14,13 @@ use crate::{
 use syn::Result;
 
 pub fn generate(
-    inherited_methods: &[ParsedInheritedMethod],
+    inherited_methods: &[&ParsedInheritedMethod],
     base_class: &Option<String>,
     type_names: &TypeNames,
 ) -> Result<GeneratedCppQObjectBlocks> {
     let mut result = GeneratedCppQObjectBlocks::default();
 
-    for method in inherited_methods {
+    for &method in inherited_methods {
         let return_type = syn_type_to_cpp_return_type(&method.method.sig.output, type_names)?;
         // Note that no qobject macro with no base class is an error
         //
@@ -58,7 +58,8 @@ mod tests {
         method: ForeignItemFn,
         base_class: Option<&str>,
     ) -> Result<GeneratedCppQObjectBlocks> {
-        let inherited_methods = vec![ParsedInheritedMethod::parse(method, Safety::Safe).unwrap()];
+        let method = ParsedInheritedMethod::parse(method, Safety::Safe).unwrap();
+        let inherited_methods = vec![&method];
         let base_class = base_class.map(|s| s.to_owned());
         generate(&inherited_methods, &base_class, &TypeNames::default())
     }

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -157,7 +157,7 @@ impl GeneratedCppQObject {
         )?);
 
         generated.blocks.append(&mut inherit::generate(
-            &qobject.inherited_methods,
+            &structured_qobject.inherited_methods,
             &qobject.base_class,
             type_names,
         )?);

--- a/crates/cxx-qt-gen/src/generator/rust/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/inherit.rs
@@ -13,7 +13,7 @@ use syn::{spanned::Spanned, Item, Result};
 
 pub fn generate(
     qobject_ident: &QObjectNames,
-    methods: &[ParsedInheritedMethod],
+    methods: &[&ParsedInheritedMethod],
 ) -> Result<GeneratedRustFragment> {
     let mut blocks = GeneratedRustFragment::default();
     let qobject_name = qobject_ident.name.rust_unqualified();
@@ -73,7 +73,8 @@ mod tests {
         method: ForeignItemFn,
         safety: Safety,
     ) -> Result<GeneratedRustFragment> {
-        let inherited_methods = vec![ParsedInheritedMethod::parse(method, safety).unwrap()];
+        let method = ParsedInheritedMethod::parse(method, safety).unwrap();
+        let inherited_methods = vec![&method];
         generate(&create_qobjectname(), &inherited_methods)
     }
 

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -54,7 +54,7 @@ impl GeneratedRustFragment {
         )?);
         generated.append(&mut inherit::generate(
             &qobject_idents,
-            &qobject.inherited_methods,
+            &structured_qobject.inherited_methods,
         )?);
         generated.append(&mut generate_rust_signals(
             &structured_qobject.signals,


### PR DESCRIPTION
Use structured_qobject.inherited_methods in place of qobject.inherited_methods