### PR TITLE
Hotfix update clippy example

### DIFF
--- a/examples/qml_features/rust/src/custom_parent_class.rs
+++ b/examples/qml_features/rust/src/custom_parent_class.rs
@@ -28,10 +28,6 @@ pub mod qobject {
 
     // Define the API from QtQuick that we need
     unsafe extern "C++" {
-        /// Define QQuickItem as a type
-        type QQuickItem;
-        include!(<QtQuick/QQuickItem>);
-
         include!(<QtQuick/QQuickPaintedItem>);
     }
 


### PR DESCRIPTION
Clippy started complaining about an unused struct which it previously didn't mind, so just removed those lines