### PR TITLE
Setup Code coverage

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -56,6 +56,40 @@ jobs:
       - name: shellcheck
         run: shellcheck scripts/*.sh
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup toolchain
+        run: |
+          cargo install grcov
+          rustup component add llvm-tools
+      - name: build
+        env:
+          RUSTFLAGS: -Cinstrument-coverage
+          LLVM_PROFILE_FILE: coverage/coverage_data-%p-%m.profraw
+        run: |
+          cd crates/cxx-qt-gen
+          cargo build
+      - name: test
+        env:
+          RUSTFLAGS: -Cinstrument-coverage
+          LLVM_PROFILE_FILE: coverage/coverage_data-%p-%m.profraw
+        run: |
+          cd crates/cxx-qt-gen 
+          cargo test --lib
+      - name: generate-report
+        run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/debug/lcov.info
+      - name: upload-report
+        uses: codecov/codecov-action@v4
+        with:
+          directory: ./target/debug/
+          files: lcov.info
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
   build:
     # Run after pre checks
     needs: [clang_format, license_check, rust_format_check, markdown_lint, shellcheck]

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -57,6 +57,8 @@ jobs:
         run: shellcheck scripts/*.sh
 
   coverage:
+    # Run after pre checks
+    needs: [ clang_format, license_check, rust_format_check, markdown_lint, shellcheck ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -69,16 +71,12 @@ jobs:
         env:
           RUSTFLAGS: -Cinstrument-coverage
           LLVM_PROFILE_FILE: coverage/coverage_data-%p-%m.profraw
-        run: |
-          cd crates/cxx-qt-gen
-          cargo build
+        run: cargo build --package cxx-qt-gen
       - name: test
         env:
           RUSTFLAGS: -Cinstrument-coverage
           LLVM_PROFILE_FILE: coverage/coverage_data-%p-%m.profraw
-        run: |
-          cd crates/cxx-qt-gen 
-          cargo test --lib
+        run: cargo test --lib --package cxx-qt-gen
       - name: generate-report
         run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/debug/lcov.info
       - name: upload-report

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileContributor: Ben Ford <ben.ford@kdab.com>
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 2%
+    patch: true
+
+
+ignore:
+  - "./tests/" # This got included for some reason in either build or test and is not relevant to unit tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # SPDX-FileContributor: Ben Ford <ben.ford@kdab.com>
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0


### PR DESCRIPTION
Setup codecov.io as a coverage tool, generating reports with grcov and publishing them in a CI action.
This should also allow codecov.io's bot to leave comments in PRs about coverage info, and disallow them if coverage drops too much