### PR TITLE
Add exclude flags to grcov in CI

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -78,7 +78,7 @@ jobs:
           LLVM_PROFILE_FILE: coverage/coverage_data-%p-%m.profraw
         run: cargo test --lib --package cxx-qt-gen
       - name: generate-report
-        run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/debug/lcov.info
+        run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/debug/lcov.info --excl-start CODECOV_EXCLUDE_START --excl-stop CODECOV_EXCLUDE_STOP
       - name: upload-report
         uses: codecov/codecov-action@v4
         with:

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -95,6 +95,7 @@ mod tests {
         code
     }
 
+    // CODECOV_EXCLUDE_START
     fn update_expected_file(path: PathBuf, source: &str) {
         println!("Updating expected file: {:?}", path);
 
@@ -105,6 +106,7 @@ mod tests {
             .unwrap();
         file.write_all(source.as_bytes()).unwrap();
     }
+    // CODECOV_EXCLUDE_STOP
 
     fn update_expected(test_name: &str, rust: &str, header: &str, source: &str) -> bool {
         // Ideally we'd be able to get the path from `file!()`, but that unfortunately only
@@ -116,6 +118,7 @@ mod tests {
         //      CXX_QT_UPDATE_EXPECTED=$(pwd) cargo test
         //
         if let Ok(path) = env::var("CXX_QT_UPDATE_EXPECTED") {
+            // CODECOV_EXCLUDE_START
             let output_folder = Path::new(&path);
             let output_folder = output_folder.join("test_outputs");
 
@@ -130,6 +133,7 @@ mod tests {
             update("cpp", source);
 
             true
+            // CODECOV_EXCLUDE_STOP
         } else {
             false
         }

--- a/scripts/grcov_cxx_qt.sh
+++ b/scripts/grcov_cxx_qt.sh
@@ -19,5 +19,5 @@ export RUSTFLAGS="-Cinstrument-coverage"
 export LLVM_PROFILE_FILE="$SCRIPTPATH/coverage/coverage_data-%p-%m.profraw"
 cargo build --package cxx-qt-gen
 cargo test --package cxx-qt-gen
-grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/
+grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/ --excl-start CODECOV_EXCLUDE_START --excl-stop CODECOV_EXCLUDE_STOP
 echo "Coverage html report generated in $(realpath "$SCRIPTPATH"/../target/debug/html)"


### PR DESCRIPTION
Also adds markers in src/lib.rs to exclude lines used in the update_expected script
- CODECOV_EXCLUDE_START in a comment before the block to exclude
- CODECOV_EXCLUDE_STOP in a comment after the block