### PR TITLE
Improve code coverage in syntax directory

### DIFF
--- a/crates/cxx-qt-gen/src/syntax/foreignmod.rs
+++ b/crates/cxx-qt-gen/src/syntax/foreignmod.rs
@@ -232,6 +232,17 @@ mod tests {
     }
 
     #[test]
+    fn test_foreign_mod_to_foreign_item_types_invalid() {
+        let item: ItemForeignMod = parse_quote! {
+            extern "RustQt" {
+                fn my_function() {}
+            }
+        };
+        let result = foreign_mod_to_foreign_item_types(&item);
+        assert!(result.is_err())
+    }
+
+    #[test]
     fn test_foreign_fn_self() {
         let foreign_fn: ForeignItemFn = parse_quote! {
             fn foo(self: &T, a: A) -> B;

--- a/crates/cxx-qt-gen/src/syntax/foreignmod.rs
+++ b/crates/cxx-qt-gen/src/syntax/foreignmod.rs
@@ -37,7 +37,7 @@ pub(crate) fn foreign_mod_to_foreign_item_types(
         .filter_map(|item| match foreign_item_to_type(item) {
             Ok(Some(value)) => Some(Ok(value)),
             Ok(None) => None,
-            Err(err) => Some(Err(err)), // Hard to cover since foreign_item_to_type never returns error
+            Err(err) => Some(Err(err)),
         })
         .collect::<Result<Vec<ForeignItemType>>>()
 }

--- a/crates/cxx-qt-gen/src/syntax/foreignmod.rs
+++ b/crates/cxx-qt-gen/src/syntax/foreignmod.rs
@@ -37,7 +37,7 @@ pub(crate) fn foreign_mod_to_foreign_item_types(
         .filter_map(|item| match foreign_item_to_type(item) {
             Ok(Some(value)) => Some(Ok(value)),
             Ok(None) => None,
-            Err(err) => Some(Err(err)),
+            Err(err) => Some(Err(err)), // Hard to cover since foreign_item_to_type never returns error
         })
         .collect::<Result<Vec<ForeignItemType>>>()
 }

--- a/crates/cxx-qt-gen/src/syntax/foreignmod.rs
+++ b/crates/cxx-qt-gen/src/syntax/foreignmod.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use proc_macro2::{TokenStream, TokenTree};
+use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{
     parse::{Parse, ParseStream, Parser},
@@ -53,18 +53,13 @@ fn verbatim_to_foreign_type(tokens: &TokenStream) -> Result<Option<ForeignItemTy
             let type_token: Token![type] = input.parse()?;
             let ident: Ident = input.parse()?;
 
-            // Read until the next semi colon
+            // Read until the end of the cursor
             input.step(|cursor| {
                 let mut rest = *cursor;
-                while let Some((tt, next)) = rest.token_tree() {
-                    match &tt {
-                        TokenTree::Punct(punct) if punct.as_char() == ';' => {
-                            return Ok(((), next));
-                        }
-                        _ => rest = next,
-                    }
+                while let Some((_, next)) = rest.token_tree() {
+                    rest = next;
                 }
-                Err(cursor.error("no `;` was found after this point"))
+                Ok(((), rest))
             })?;
 
             Ok(Some(syn::parse2(

--- a/crates/cxx-qt-gen/src/syntax/lifetimes.rs
+++ b/crates/cxx-qt-gen/src/syntax/lifetimes.rs
@@ -109,6 +109,8 @@ mod tests {
         assert_no_lifetimes! { [T] };
         assert_no_lifetimes! { [T;4] };
         assert_no_lifetimes! { (X, Y) };
+        assert_no_lifetimes! { (Y) };
+        assert_no_lifetimes! { std::collections::Vec<i32> };
     }
 
     macro_rules! assert_lifetimes {
@@ -148,5 +150,6 @@ mod tests {
         assert_unsupported_type! { &dyn Foo };
         assert_unsupported_type! { fn(A) };
         assert_unsupported_type! { fn(i64) -> i32 };
+        assert_unsupported_type! { fn(i64, i64) -> i32 };
     }
 }

--- a/crates/cxx-qt-gen/src/syntax/lifetimes.rs
+++ b/crates/cxx-qt-gen/src/syntax/lifetimes.rs
@@ -150,6 +150,6 @@ mod tests {
         assert_unsupported_type! { &dyn Foo };
         assert_unsupported_type! { fn(A) };
         assert_unsupported_type! { fn(i64) -> i32 };
-        assert_unsupported_type! { fn(i64, i64) -> i32 };
+        assert_unsupported_type! { Vec<T = A> };
     }
 }

--- a/crates/cxx-qt-gen/src/syntax/qtfile.rs
+++ b/crates/cxx-qt-gen/src/syntax/qtfile.rs
@@ -58,3 +58,91 @@ pub fn parse_qt_file(path: impl AsRef<std::path::Path>) -> Result<CxxQtFile> {
         syn::parse_str(&source)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::assert_tokens_eq;
+    use crate::CxxQtItem::CxxQt;
+    use quote::quote;
+    use std::env;
+    use std::path::PathBuf;
+    use syn::parse_quote;
+
+    #[test]
+    fn test_parse_qt_file() {
+        let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+        let qt_file = parse_qt_file(manifest_dir.join("test_inputs/properties.rs")).unwrap();
+
+        assert!(qt_file.attrs.is_empty());
+        assert_eq!(qt_file.items.len(), 1);
+        assert!(matches!(qt_file.items.first(), Some(CxxQt(_))))
+    }
+
+    #[test]
+    fn test_parse_qt_file_shebang_strip() {
+        let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+        let qt_file = parse_qt_file(manifest_dir.join("test_inputs/shebang.rs")).unwrap();
+
+        assert_eq!(qt_file.items.len(), 3);
+        // Testing the debug formatter
+        for item in qt_file.items {
+            println!("[Debug] item: {:?}", item);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parse_invalid_qt_file() {
+        let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+        let _qt_file = parse_qt_file(manifest_dir.join("not/real"));
+    }
+
+    #[test]
+    fn test_parse() {
+        let file: CxxQtFile = parse_quote! {
+           #[cxx_qt::bridge]
+           mod ffi {
+                //! inner doc comment
+                type MyNumType = i32;
+            }
+
+            #[cxx::bridge]
+            mod ffi {}
+
+            /// Outer doc comment
+            struct MyStruct {
+                name: &str
+            }
+        };
+        assert_tokens_eq(
+            &file,
+            quote! {
+            #[cxx_qt::bridge]
+            mod ffi {
+                 #![doc = r" inner doc comment"]
+                 type MyNumType = i32;
+             }
+
+             #[cxx::bridge]
+             mod ffi {}
+
+             #[doc = r" Outer doc comment"]
+             struct MyStruct {
+                 name: &str
+             }
+            },
+        )
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parse_invalid_mod() {
+        let _file: CxxQtFile = parse_quote! {
+           item: T
+        };
+    }
+}

--- a/crates/cxx-qt-gen/src/syntax/qtfile.rs
+++ b/crates/cxx-qt-gen/src/syntax/qtfile.rs
@@ -86,11 +86,9 @@ mod tests {
 
         let qt_file = parse_qt_file(manifest_dir.join("test_inputs/shebang.rs")).unwrap();
 
-        assert_eq!(qt_file.items.len(), 3);
-        // Testing the debug formatter
-        for item in qt_file.items {
-            println!("[Debug] item: {:?}", item);
-        }
+        assert!(qt_file.attrs.is_empty());
+        assert_eq!(qt_file.items.len(), 1);
+        assert!(matches!(qt_file.items.first(), Some(CxxQt(_))))
     }
 
     #[test]
@@ -98,7 +96,7 @@ mod tests {
     fn test_parse_invalid_qt_file() {
         let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
-        let _qt_file = parse_qt_file(manifest_dir.join("not/real"));
+        let _ = parse_qt_file(manifest_dir.join("not/real"));
     }
 
     #[test]

--- a/crates/cxx-qt-gen/src/syntax/qtitem.rs
+++ b/crates/cxx-qt-gen/src/syntax/qtitem.rs
@@ -82,3 +82,39 @@ impl ToTokens for CxxQtItem {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+    #[test]
+    fn test_format_cxx() {
+        let cxx: CxxQtItem = parse_quote! {
+          #[cxx::bridge]
+          mod ffi {}
+        };
+        let debug_formatted = format!("{:?}", cxx);
+        assert!(debug_formatted.starts_with("Cxx(ItemMod"))
+    }
+
+    #[test]
+    fn test_format_cxx_qt() {
+        let cxx_qt: CxxQtItem = parse_quote! {
+          #[cxx_qt::bridge]
+          mod ffi {}
+        };
+        let debug_formatted = format!("{:?}", cxx_qt);
+        assert!(debug_formatted.starts_with("CxxQt(ItemMod"))
+    }
+
+    #[test]
+    fn test_format_rust_item() {
+        let rust: CxxQtItem = parse_quote! {
+          struct MyStruct {
+                name: &str
+          }
+        };
+        let debug_formatted = format!("{:?}", rust);
+        assert!(debug_formatted.starts_with("Item(Item::Struct"))
+    }
+}

--- a/crates/cxx-qt-gen/test_inputs/shebang.rs
+++ b/crates/cxx-qt-gen/test_inputs/shebang.rs
@@ -1,12 +1,13 @@
 #!/usr/bin/
-// Test for qtitem and qtfile, for code coverage
+// Test for qtfile
 #[cxx_qt::bridge]
-mod ffi {}
+mod ffi {
+    extern "RustQt" {
+        #[qobject]
+        type MyObject = super::MyObjectRust;
+    }
 
-#[cxx::bridge]
-mod ffi {}
-
-struct MyStruct {
-    name: &str,
-    num: i32,
+    unsafe extern "RustQt" {
+        fn my_fn(self: &MyObject);
+    }
 }

--- a/crates/cxx-qt-gen/test_inputs/shebang.rs
+++ b/crates/cxx-qt-gen/test_inputs/shebang.rs
@@ -1,0 +1,12 @@
+#!/usr/bin/
+// Test for qtitem and qtfile, for code coverage
+#[cxx_qt::bridge]
+mod ffi {}
+
+#[cxx::bridge]
+mod ffi {}
+
+struct MyStruct {
+    name: &str,
+    num: i32,
+}

--- a/crates/cxx-qt-gen/test_inputs/shebang.rs.license
+++ b/crates/cxx-qt-gen/test_inputs/shebang.rs.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+SPDX-FileContributor: Ben Ford <ben.ford@kdab.com>
+
+SPDX-License-Identifier: MIT OR Apache-2.0


### PR DESCRIPTION
Includes adding a new test input file for reading shebang, and also for parsing of cxx and regular rust items by CxxQtFile