### PR TITLE
Fix alignment & size assertions

### DIFF
--- a/crates/cxx-qt-lib-extras/src/assertion_utils.h
+++ b/crates/cxx-qt-lib-extras/src/assertion_utils.h
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <cstdint>
 
-namespace assertion_util {
+namespace rust::cxxqtlib1 {
 template<typename iter>
 constexpr static ::std::size_t
 calc_align_size(const iter rbegin,
@@ -44,7 +44,7 @@ calc_align_size(const iter rbegin,
 
   return rows * actual_alignment;
 }
-} // namespace assertion_util
+} // namespace rust::cxxqtlib1
 
 #define assert_alignment_and_size(TYPE, EXP_ALIGN, ARR, ARR_SZ)                \
   static_assert(EXP_ALIGN == alignof(TYPE));                                   \

--- a/crates/cxx-qt-lib-extras/src/assertion_utils.h
+++ b/crates/cxx-qt-lib-extras/src/assertion_utils.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <array>
-#include <cstdint>
 #include <cassert>
+#include <cstdint>
 
 namespace assertion_util {
 constexpr static ::std::size_t

--- a/crates/cxx-qt-lib-extras/src/assertion_utils.h
+++ b/crates/cxx-qt-lib-extras/src/assertion_utils.h
@@ -12,13 +12,13 @@
 #include <cstdint>
 
 namespace assertion_util {
+template<typename iter>
 constexpr static ::std::size_t
-calc_align_size(const ::std::reverse_iterator<const ::std::size_t*> rbegin,
-                const ::std::reverse_iterator<const ::std::size_t*> rend,
+calc_align_size(const iter rbegin,
+                const iter rend,
                 const ::std::size_t actual_alignment)
 {
   ::std::size_t rows = 0;
-
   ::std::size_t accum = 0;
 
   for (auto it = rbegin; it != rend; ++it) {
@@ -46,8 +46,9 @@ calc_align_size(const ::std::reverse_iterator<const ::std::size_t*> rbegin,
 }
 } // namespace assertion_util
 
-#define assert_alignment_and_size(TYPE, ALIGNMENT, ARR)                        \
-  static_assert(ALIGNMENT == alignof(TYPE));                                   \
-  static_assert(assertion_util::calc_align_size(                               \
-                  ::std::rbegin(ARR), ::std::rend(ARR), alignof(TYPE)) ==      \
-                sizeof(TYPE));
+#define assert_alignment_and_size(TYPE, EXP_ALIGN, ARR, ARR_SZ)                \
+  static_assert(EXP_ALIGN == alignof(TYPE));                                   \
+  static_assert(                                                               \
+    assertion_util::calc_align_size<                                           \
+      ::std::array<::std::size_t, ARR_SZ>::const_reverse_iterator>(            \
+      ::std::rbegin(ARR), ::std::rend(ARR), alignof(TYPE)) == sizeof(TYPE));

--- a/crates/cxx-qt-lib-extras/src/assertion_utils.h
+++ b/crates/cxx-qt-lib-extras/src/assertion_utils.h
@@ -7,7 +7,47 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #pragma once
 
-#define assert_alignment_and_size(TYPE, ALIGNMENT, SIZE)                       \
-  static_assert(alignof(TYPE) <= (ALIGNMENT),                                  \
-                "unexpectedly large " #TYPE " alignment!");                    \
-  static_assert(sizeof(TYPE) == (SIZE), "unexpected " #TYPE " size!");
+#include <array>
+#include <cstdint>
+#include <cassert>
+
+namespace assertion_util {
+constexpr static ::std::size_t
+calc_align_size(const ::std::reverse_iterator<const ::std::size_t*> rbegin,
+                const ::std::reverse_iterator<const ::std::size_t*> rend,
+                const ::std::size_t actual_alignment)
+{
+  ::std::size_t rows = 0;
+
+  ::std::size_t accum = 0;
+
+  for (auto it = rbegin; it != rend; ++it) {
+    assert(*it <= actual_alignment);
+
+    if (it + 1 != rend) {
+      if (accum + *it == actual_alignment) {
+        accum += *it;
+      } else {
+        if (accum + *it + *(it + 1) <= actual_alignment)
+          accum += *it;
+        else
+          accum = actual_alignment;
+      }
+      if (accum == actual_alignment) {
+        accum = 0;
+        ++rows;
+      }
+    } else {
+      ++rows;
+    }
+  }
+
+  return rows * actual_alignment;
+}
+} // namespace assertion_util
+
+#define assert_alignment_and_size(TYPE, ALIGNMENT, ARR)                        \
+  static_assert(ALIGNMENT == alignof(TYPE));                                   \
+  static_assert(assertion_util::calc_align_size(                               \
+                  ::std::rbegin(ARR), ::std::rend(ARR), alignof(TYPE)) ==      \
+                sizeof(TYPE));

--- a/crates/cxx-qt-lib-extras/src/assertion_utils.h
+++ b/crates/cxx-qt-lib-extras/src/assertion_utils.h
@@ -49,6 +49,6 @@ calc_align_size(const iter rbegin,
 #define assert_alignment_and_size(TYPE, EXP_ALIGN, ARR, ARR_SZ)                \
   static_assert(EXP_ALIGN == alignof(TYPE));                                   \
   static_assert(                                                               \
-    rust::cxxqtlib1::assertion_utils::calc_align_size<                         \
+    ::rust::cxxqtlib1::assertion_utils::calc_align_size<                       \
       ::std::array<::std::size_t, ARR_SZ>::const_reverse_iterator>(            \
       ::std::rbegin(ARR), ::std::rend(ARR), alignof(TYPE)) == sizeof(TYPE));

--- a/crates/cxx-qt-lib-extras/src/assertion_utils.h
+++ b/crates/cxx-qt-lib-extras/src/assertion_utils.h
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <cstdint>
 
-namespace rust::cxxqtlib1 {
+namespace rust::cxxqtlib1::assertion_utils {
 template<typename iter>
 constexpr static ::std::size_t
 calc_align_size(const iter rbegin,
@@ -44,11 +44,11 @@ calc_align_size(const iter rbegin,
 
   return rows * actual_alignment;
 }
-} // namespace rust::cxxqtlib1
+} // namespace rust::cxxqtlib1::assertion_utils
 
 #define assert_alignment_and_size(TYPE, EXP_ALIGN, ARR, ARR_SZ)                \
   static_assert(EXP_ALIGN == alignof(TYPE));                                   \
   static_assert(                                                               \
-    assertion_util::calc_align_size<                                           \
+    rust::cxxqtlib1::assertion_utils::calc_align_size<                         \
       ::std::array<::std::size_t, ARR_SZ>::const_reverse_iterator>(            \
       ::std::rbegin(ARR), ::std::rend(ARR), alignof(TYPE)) == sizeof(TYPE));

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.cpp
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.cpp
@@ -14,9 +14,8 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qcommandlineoption.h?h=v5.15.6-lts-lgpl#n59
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qcommandlineoption.h?h=v6.2.4#n96
-assert_alignment_and_size(QCommandLineOption,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QCommandLineOption, alignof(::std::size_t), arr);
 
 static_assert(!::std::is_trivially_copy_assignable<QCommandLineOption>::value);
 static_assert(

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.cpp
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.cpp
@@ -15,7 +15,10 @@
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qcommandlineoption.h?h=v6.2.4#n96
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QCommandLineOption, alignof(::std::size_t), arr);
+assert_alignment_and_size(QCommandLineOption,
+                          alignof(::std::size_t),
+                          arr,
+                          arr.size());
 
 static_assert(!::std::is_trivially_copy_assignable<QCommandLineOption>::value);
 static_assert(

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.cpp
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.cpp
@@ -13,7 +13,10 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qcommandlineparser.h?h=v5.15.6-lts-lgpl#n107
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qcommandlineparser.h?h=v6.2.4#n109
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QCommandLineParser, alignof(::std::size_t), arr);
+assert_alignment_and_size(QCommandLineParser,
+                          alignof(::std::size_t),
+                          arr,
+                          arr.size());
 
 static_assert(!::std::is_trivially_copy_assignable<QCommandLineParser>::value);
 

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.cpp
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.cpp
@@ -12,9 +12,8 @@
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qcommandlineparser.h?h=v5.15.6-lts-lgpl#n107
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qcommandlineparser.h?h=v6.2.4#n109
-assert_alignment_and_size(QCommandLineParser,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QCommandLineParser, alignof(::std::size_t), arr);
 
 static_assert(!::std::is_trivially_copy_assignable<QCommandLineParser>::value);
 

--- a/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.cpp
+++ b/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.cpp
@@ -15,8 +15,8 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qelapsedtimer.h#n57
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qelapsedtimer.h?h=v6.2.4#n89
-constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::int64_t,
-                                                            ::std::int64_t) };
+constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::int64_t),
+                                                     sizeof(::std::int64_t) };
 assert_alignment_and_size(QElapsedTimer, alignof(::std::int64_t), arr);
 
 static_assert(::std::is_trivially_copyable<QElapsedTimer>::value,

--- a/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.cpp
+++ b/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.cpp
@@ -17,7 +17,10 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qelapsedtimer.h?h=v6.2.4#n89
 constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::int64_t),
                                                      sizeof(::std::int64_t) };
-assert_alignment_and_size(QElapsedTimer, alignof(::std::int64_t), arr);
+assert_alignment_and_size(QElapsedTimer,
+                          alignof(::std::int64_t),
+                          arr,
+                          arr.size());
 
 static_assert(::std::is_trivially_copyable<QElapsedTimer>::value,
               "QElapsedTimer must be trivially copyable!");

--- a/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.cpp
+++ b/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.cpp
@@ -15,9 +15,9 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qelapsedtimer.h#n57
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qelapsedtimer.h?h=v6.2.4#n89
-assert_alignment_and_size(QElapsedTimer,
-                          alignof(::std::int64_t),
-                          sizeof(::std::int64_t[2]));
+constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::int64_t,
+                                                            ::std::int64_t) };
+assert_alignment_and_size(QElapsedTimer, alignof(::std::int64_t), arr);
 
 static_assert(::std::is_trivially_copyable<QElapsedTimer>::value,
               "QElapsedTimer must be trivially copyable!");

--- a/crates/cxx-qt-lib/src/assertion_utils.h
+++ b/crates/cxx-qt-lib/src/assertion_utils.h
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <cstdint>
 
-namespace assertion_util {
+namespace rust::cxxqtlib1 {
 template<typename iter>
 constexpr static ::std::size_t
 calc_align_size(const iter rbegin,
@@ -44,7 +44,7 @@ calc_align_size(const iter rbegin,
 
   return rows * actual_alignment;
 }
-} // namespace assertion_util
+} // namespace rust::cxxqtlib1
 
 #define assert_alignment_and_size(TYPE, EXP_ALIGN, ARR, ARR_SZ)                \
   static_assert(EXP_ALIGN == alignof(TYPE));                                   \

--- a/crates/cxx-qt-lib/src/assertion_utils.h
+++ b/crates/cxx-qt-lib/src/assertion_utils.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <array>
-#include <cstdint>
 #include <cassert>
+#include <cstdint>
 
 namespace assertion_util {
 constexpr static ::std::size_t

--- a/crates/cxx-qt-lib/src/assertion_utils.h
+++ b/crates/cxx-qt-lib/src/assertion_utils.h
@@ -12,13 +12,13 @@
 #include <cstdint>
 
 namespace assertion_util {
+template<typename iter>
 constexpr static ::std::size_t
-calc_align_size(const ::std::reverse_iterator<const ::std::size_t*> rbegin,
-                const ::std::reverse_iterator<const ::std::size_t*> rend,
+calc_align_size(const iter rbegin,
+                const iter rend,
                 const ::std::size_t actual_alignment)
 {
   ::std::size_t rows = 0;
-
   ::std::size_t accum = 0;
 
   for (auto it = rbegin; it != rend; ++it) {
@@ -46,8 +46,9 @@ calc_align_size(const ::std::reverse_iterator<const ::std::size_t*> rbegin,
 }
 } // namespace assertion_util
 
-#define assert_alignment_and_size(TYPE, ALIGNMENT, ARR)                        \
-  static_assert(ALIGNMENT == alignof(TYPE));                                   \
-  static_assert(assertion_util::calc_align_size(                               \
-                  ::std::rbegin(ARR), ::std::rend(ARR), alignof(TYPE)) ==      \
-                sizeof(TYPE));
+#define assert_alignment_and_size(TYPE, EXP_ALIGN, ARR, ARR_SZ)                \
+  static_assert(EXP_ALIGN == alignof(TYPE));                                   \
+  static_assert(                                                               \
+    assertion_util::calc_align_size<                                           \
+      ::std::array<::std::size_t, ARR_SZ>::const_reverse_iterator>(            \
+      ::std::rbegin(ARR), ::std::rend(ARR), alignof(TYPE)) == sizeof(TYPE));

--- a/crates/cxx-qt-lib/src/assertion_utils.h
+++ b/crates/cxx-qt-lib/src/assertion_utils.h
@@ -7,7 +7,47 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #pragma once
 
-#define assert_alignment_and_size(TYPE, ALIGNMENT, SIZE)                       \
-  static_assert(alignof(TYPE) <= (ALIGNMENT),                                  \
-                "unexpectedly large " #TYPE " alignment!");                    \
-  static_assert(sizeof(TYPE) == (SIZE), "unexpected " #TYPE " size!");
+#include <array>
+#include <cstdint>
+#include <cassert>
+
+namespace assertion_util {
+constexpr static ::std::size_t
+calc_align_size(const ::std::reverse_iterator<const ::std::size_t*> rbegin,
+                const ::std::reverse_iterator<const ::std::size_t*> rend,
+                const ::std::size_t actual_alignment)
+{
+  ::std::size_t rows = 0;
+
+  ::std::size_t accum = 0;
+
+  for (auto it = rbegin; it != rend; ++it) {
+    assert(*it <= actual_alignment);
+
+    if (it + 1 != rend) {
+      if (accum + *it == actual_alignment) {
+        accum += *it;
+      } else {
+        if (accum + *it + *(it + 1) <= actual_alignment)
+          accum += *it;
+        else
+          accum = actual_alignment;
+      }
+      if (accum == actual_alignment) {
+        accum = 0;
+        ++rows;
+      }
+    } else {
+      ++rows;
+    }
+  }
+
+  return rows * actual_alignment;
+}
+} // namespace assertion_util
+
+#define assert_alignment_and_size(TYPE, ALIGNMENT, ARR)                        \
+  static_assert(ALIGNMENT == alignof(TYPE));                                   \
+  static_assert(assertion_util::calc_align_size(                               \
+                  ::std::rbegin(ARR), ::std::rend(ARR), alignof(TYPE)) ==      \
+                sizeof(TYPE));

--- a/crates/cxx-qt-lib/src/assertion_utils.h
+++ b/crates/cxx-qt-lib/src/assertion_utils.h
@@ -49,6 +49,6 @@ calc_align_size(const iter rbegin,
 #define assert_alignment_and_size(TYPE, EXP_ALIGN, ARR, ARR_SZ)                \
   static_assert(EXP_ALIGN == alignof(TYPE));                                   \
   static_assert(                                                               \
-    rust::cxxqtlib1::assertion_utils::calc_align_size<                         \
+    ::rust::cxxqtlib1::assertion_utils::calc_align_size<                       \
       ::std::array<::std::size_t, ARR_SZ>::const_reverse_iterator>(            \
       ::std::rbegin(ARR), ::std::rend(ARR), alignof(TYPE)) == sizeof(TYPE));

--- a/crates/cxx-qt-lib/src/assertion_utils.h
+++ b/crates/cxx-qt-lib/src/assertion_utils.h
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <cstdint>
 
-namespace rust::cxxqtlib1 {
+namespace rust::cxxqtlib1::assertion_utils {
 template<typename iter>
 constexpr static ::std::size_t
 calc_align_size(const iter rbegin,
@@ -44,11 +44,11 @@ calc_align_size(const iter rbegin,
 
   return rows * actual_alignment;
 }
-} // namespace rust::cxxqtlib1
+} // namespace rust::cxxqtlib1::assertion_utils
 
 #define assert_alignment_and_size(TYPE, EXP_ALIGN, ARR, ARR_SZ)                \
   static_assert(EXP_ALIGN == alignof(TYPE));                                   \
   static_assert(                                                               \
-    assertion_util::calc_align_size<                                           \
+    rust::cxxqtlib1::assertion_utils::calc_align_size<                         \
       ::std::array<::std::size_t, ARR_SZ>::const_reverse_iterator>(            \
       ::std::rbegin(ARR), ::std::rend(ARR), alignof(TYPE)) == sizeof(TYPE));

--- a/crates/cxx-qt-lib/src/core/qbytearray.cpp
+++ b/crates/cxx-qt-lib/src/core/qbytearray.cpp
@@ -18,13 +18,13 @@
 // DataPointer is then a QByteArrayData, which is a QArrayDataPointer<char>
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qarraydatapointer.h?h=v6.2.4#n390
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-assert_alignment_and_size(QByteArray,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t[3]));
+constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::size_t),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(::std::size_t) };
+assert_alignment_and_size(QByteArray, alignof(::std::size_t), arr);
 #else
-assert_alignment_and_size(QByteArray,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QByteArray, alignof(::std::size_t), arr);
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QByteArray>::value);

--- a/crates/cxx-qt-lib/src/core/qbytearray.cpp
+++ b/crates/cxx-qt-lib/src/core/qbytearray.cpp
@@ -21,10 +21,10 @@
 constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::size_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t) };
-assert_alignment_and_size(QByteArray, alignof(::std::size_t), arr);
+assert_alignment_and_size(QByteArray, alignof(::std::size_t), arr, arr.size());
 #else
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QByteArray, alignof(::std::size_t), arr);
+assert_alignment_and_size(QByteArray, alignof(::std::size_t), arr, arr.size());
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QByteArray>::value);

--- a/crates/cxx-qt-lib/src/core/qdate.cpp
+++ b/crates/cxx-qt-lib/src/core/qdate.cpp
@@ -14,7 +14,7 @@
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n147
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::int64_t) };
-assert_alignment_and_size(QDate, alignof(::std::int64_t), arr);
+assert_alignment_and_size(QDate, alignof(::std::int64_t), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QDate>::value,
               "QDate must be trivially copyable!");

--- a/crates/cxx-qt-lib/src/core/qdate.cpp
+++ b/crates/cxx-qt-lib/src/core/qdate.cpp
@@ -13,9 +13,8 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v5.15.6-lts-lgpl#n176
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n147
-assert_alignment_and_size(QDate,
-                          alignof(::std::int64_t),
-                          sizeof(::std::int64_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::int64_t) };
+assert_alignment_and_size(QDate, alignof(::std::int64_t), arr);
 
 static_assert(::std::is_trivially_copyable<QDate>::value,
               "QDate must be trivially copyable!");

--- a/crates/cxx-qt-lib/src/core/qdatetime.cpp
+++ b/crates/cxx-qt-lib/src/core/qdatetime.cpp
@@ -16,9 +16,8 @@
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n394
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n255
-assert_alignment_and_size(QDateTime,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QDateTime, alignof(::std::size_t), arr);
 
 static_assert(!::std::is_trivially_copy_assignable<QDateTime>::value);
 static_assert(!::std::is_trivially_copy_constructible<QDateTime>::value);

--- a/crates/cxx-qt-lib/src/core/qdatetime.cpp
+++ b/crates/cxx-qt-lib/src/core/qdatetime.cpp
@@ -17,7 +17,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n394
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n255
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QDateTime, alignof(::std::size_t), arr);
+assert_alignment_and_size(QDateTime, alignof(::std::size_t), arr, arr.size());
 
 static_assert(!::std::is_trivially_copy_assignable<QDateTime>::value);
 static_assert(!::std::is_trivially_copy_constructible<QDateTime>::value);

--- a/crates/cxx-qt-lib/src/core/qhash/qhash.cpp
+++ b/crates/cxx-qt-lib/src/core/qhash/qhash.cpp
@@ -11,8 +11,10 @@
 #define CXX_QT_QHASH_ASSERTS(keyTypeName, valueTypeName, combinedName)         \
   constexpr static ::std::array<::std::size_t, 1> arr_##combinedName{ sizeof(  \
     ::std::size_t) };                                                          \
-  assert_alignment_and_size(                                                   \
-    QHash_##combinedName, alignof(::std::size_t), arr_##combinedName);         \
+  assert_alignment_and_size(QHash_##combinedName,                              \
+                            alignof(::std::size_t),                            \
+                            arr_##combinedName,                                \
+                            arr_##combinedName.size());                        \
                                                                                \
   static_assert(                                                               \
     !::std::is_trivially_copy_assignable<QHash_##combinedName>::value);        \

--- a/crates/cxx-qt-lib/src/core/qhash/qhash.cpp
+++ b/crates/cxx-qt-lib/src/core/qhash/qhash.cpp
@@ -9,8 +9,10 @@
 #include "../../assertion_utils.h"
 
 #define CXX_QT_QHASH_ASSERTS(keyTypeName, valueTypeName, combinedName)         \
+  constexpr static ::std::array<::std::size_t, 1> arr_##combinedName{ sizeof(  \
+    ::std::size_t) };                                                          \
   assert_alignment_and_size(                                                   \
-    QHash_##combinedName, alignof(::std::size_t), sizeof(::std::size_t));      \
+    QHash_##combinedName, alignof(::std::size_t), arr_##combinedName);         \
                                                                                \
   static_assert(                                                               \
     !::std::is_trivially_copy_assignable<QHash_##combinedName>::value);        \

--- a/crates/cxx-qt-lib/src/core/qline.cpp
+++ b/crates/cxx-qt-lib/src/core/qline.cpp
@@ -15,8 +15,10 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qline.h?h=v5.15.6-lts-lgpl#n90
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qline.h?h=v6.2.4#n90
-assert_alignment_and_size(QLine,
-                          alignof(::std::int32_t),
-                          sizeof(::std::int32_t[4]));
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t) };
+assert_alignment_and_size(QLine, alignof(::std::int32_t), arr);
 
 static_assert(::std::is_trivially_copyable<QLine>::value);

--- a/crates/cxx-qt-lib/src/core/qline.cpp
+++ b/crates/cxx-qt-lib/src/core/qline.cpp
@@ -19,6 +19,6 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t) };
-assert_alignment_and_size(QLine, alignof(::std::int32_t), arr);
+assert_alignment_and_size(QLine, alignof(::std::int32_t), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QLine>::value);

--- a/crates/cxx-qt-lib/src/core/qlinef.cpp
+++ b/crates/cxx-qt-lib/src/core/qlinef.cpp
@@ -19,6 +19,6 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(double),
                                                      sizeof(double),
                                                      sizeof(double),
                                                      sizeof(double) };
-assert_alignment_and_size(QLineF, alignof(double), arr);
+assert_alignment_and_size(QLineF, alignof(double), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QLineF>::value);

--- a/crates/cxx-qt-lib/src/core/qlinef.cpp
+++ b/crates/cxx-qt-lib/src/core/qlinef.cpp
@@ -15,6 +15,10 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qline.h?h=v5.15.6-lts-lgpl#n281
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qline.h?h=v6.2.4#n295
-assert_alignment_and_size(QLineF, alignof(double), sizeof(double[4]));
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(double),
+                                                     sizeof(double),
+                                                     sizeof(double),
+                                                     sizeof(double) };
+assert_alignment_and_size(QLineF, alignof(double), arr);
 
 static_assert(::std::is_trivially_copyable<QLineF>::value);

--- a/crates/cxx-qt-lib/src/core/qlist/qlist.cpp
+++ b/crates/cxx-qt-lib/src/core/qlist/qlist.cpp
@@ -13,12 +13,14 @@
   constexpr static ::std::array<::std::size_t, 3> arr_##name{                  \
     sizeof(::std::size_t), sizeof(::std::size_t), sizeof(::std::size_t)        \
   };                                                                           \
-  assert_alignment_and_size(QList_##name, alignof(::std::size_t), arr_##name);
+  assert_alignment_and_size(                                                   \
+    QList_##name, alignof(::std::size_t), arr_##name, arr_##name.size());
 #else
 #define CXX_QT_QLIST_ALIGN_AND_SIZE(typeName, name)                            \
   constexpr static ::std::array<::std::size_t, 1> arr_##name{ sizeof(          \
     ::std::size_t) };                                                          \
-  assert_alignment_and_size(QList_##name, alignof(::std::size_t), arr_##name);
+  assert_alignment_and_size(                                                   \
+    QList_##name, alignof(::std::size_t), arr_##name, arr_##name.size());
 #endif
 
 #define CXX_QT_QLIST_ASSERTS(typeName, name)                                   \

--- a/crates/cxx-qt-lib/src/core/qlist/qlist.cpp
+++ b/crates/cxx-qt-lib/src/core/qlist/qlist.cpp
@@ -10,12 +10,15 @@
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #define CXX_QT_QLIST_ALIGN_AND_SIZE(typeName, name)                            \
-  assert_alignment_and_size(                                                   \
-    QList_##name, alignof(::std::size_t), sizeof(::std::size_t[3]));
+  constexpr static ::std::array<::std::size_t, 3> arr_##name{                  \
+    sizeof(::std::size_t), sizeof(::std::size_t), sizeof(::std::size_t)        \
+  };                                                                           \
+  assert_alignment_and_size(QList_##name, alignof(::std::size_t), arr_##name);
 #else
 #define CXX_QT_QLIST_ALIGN_AND_SIZE(typeName, name)                            \
-  assert_alignment_and_size(                                                   \
-    QList_##name, alignof(::std::size_t), sizeof(::std::size_t));
+  constexpr static ::std::array<::std::size_t, 1> arr_##name{ sizeof(          \
+    ::std::size_t) };                                                          \
+  assert_alignment_and_size(QList_##name, alignof(::std::size_t), arr_##name);
 #endif
 
 #define CXX_QT_QLIST_ASSERTS(typeName, name)                                   \

--- a/crates/cxx-qt-lib/src/core/qmap/qmap.cpp
+++ b/crates/cxx-qt-lib/src/core/qmap/qmap.cpp
@@ -11,8 +11,10 @@
 #define CXX_QT_QMAP_ASSERTS(keyTypeName, valueTypeName, combinedName)          \
   constexpr static ::std::array<::std::size_t, 1> arr_##combinedName{ sizeof(  \
     ::std::size_t) };                                                          \
-  assert_alignment_and_size(                                                   \
-    QMap_##combinedName, alignof(::std::size_t), arr_##combinedName);          \
+  assert_alignment_and_size(QMap_##combinedName,                               \
+                            alignof(::std::size_t),                            \
+                            arr_##combinedName,                                \
+                            arr_##combinedName.size());                        \
                                                                                \
   static_assert(                                                               \
     !::std::is_trivially_copy_assignable<QMap_##combinedName>::value);         \

--- a/crates/cxx-qt-lib/src/core/qmap/qmap.cpp
+++ b/crates/cxx-qt-lib/src/core/qmap/qmap.cpp
@@ -9,8 +9,10 @@
 #include "../../assertion_utils.h"
 
 #define CXX_QT_QMAP_ASSERTS(keyTypeName, valueTypeName, combinedName)          \
+  constexpr static ::std::array<::std::size_t, 1> arr_##combinedName{ sizeof(  \
+    ::std::size_t) };                                                          \
   assert_alignment_and_size(                                                   \
-    QMap_##combinedName, alignof(::std::size_t), sizeof(::std::size_t));       \
+    QMap_##combinedName, alignof(::std::size_t), arr_##combinedName);          \
                                                                                \
   static_assert(                                                               \
     !::std::is_trivially_copy_assignable<QMap_##combinedName>::value);         \

--- a/crates/cxx-qt-lib/src/core/qmargins.cpp
+++ b/crates/cxx-qt-lib/src/core/qmargins.cpp
@@ -15,8 +15,10 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qmargins.h?h=v5.15.6-lts-lgpl#n79
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qmargins.h?h=v6.2.4#n79
-assert_alignment_and_size(QMargins,
-                          alignof(::std::int32_t),
-                          sizeof(::std::int32_t[4]));
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t) };
+assert_alignment_and_size(QMargins, alignof(::std::int32_t), arr);
 
 static_assert(::std::is_trivially_copyable<QMargins>::value);

--- a/crates/cxx-qt-lib/src/core/qmargins.cpp
+++ b/crates/cxx-qt-lib/src/core/qmargins.cpp
@@ -19,6 +19,6 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t) };
-assert_alignment_and_size(QMargins, alignof(::std::int32_t), arr);
+assert_alignment_and_size(QMargins, alignof(::std::int32_t), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QMargins>::value);

--- a/crates/cxx-qt-lib/src/core/qmarginsf.cpp
+++ b/crates/cxx-qt-lib/src/core/qmarginsf.cpp
@@ -18,6 +18,6 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(double),
                                                      sizeof(double),
                                                      sizeof(double),
                                                      sizeof(double) };
-assert_alignment_and_size(QMarginsF, alignof(double), arr);
+assert_alignment_and_size(QMarginsF, alignof(double), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QMarginsF>::value);

--- a/crates/cxx-qt-lib/src/core/qmarginsf.cpp
+++ b/crates/cxx-qt-lib/src/core/qmarginsf.cpp
@@ -14,6 +14,10 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qmargins.h?h=v5.15.6-lts-lgpl#n314
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qmargins.h?h=v6.2.4#n329
-assert_alignment_and_size(QMarginsF, alignof(double), sizeof(double[4]));
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(double),
+                                                     sizeof(double),
+                                                     sizeof(double),
+                                                     sizeof(double) };
+assert_alignment_and_size(QMarginsF, alignof(double), arr);
 
 static_assert(::std::is_trivially_copyable<QMarginsF>::value);

--- a/crates/cxx-qt-lib/src/core/qmodelindex.cpp
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.cpp
@@ -15,7 +15,7 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t) };
-assert_alignment_and_size(QModelIndex, alignof(::std::size_t), arr);
+assert_alignment_and_size(QModelIndex, alignof(::std::size_t), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QModelIndex>::value);
 

--- a/crates/cxx-qt-lib/src/core/qmodelindex.cpp
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.cpp
@@ -11,10 +11,11 @@
 // QModelIndex has two ints, a quint pointer (same as size_t), and a pointer.
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/itemmodels/qabstractitemmodel.h?h=v5.15.6-lts-lgpl#n93
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/itemmodels/qabstractitemmodel.h?h=v6.2.4#n195
-assert_alignment_and_size(QModelIndex,
-                          alignof(::std::size_t),
-                          (sizeof(::std::int32_t) * 2) + sizeof(::std::size_t) +
-                            sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(::std::size_t) };
+assert_alignment_and_size(QModelIndex, alignof(::std::size_t), arr);
 
 static_assert(::std::is_trivially_copyable<QModelIndex>::value);
 

--- a/crates/cxx-qt-lib/src/core/qpersistentmodelindex.cpp
+++ b/crates/cxx-qt-lib/src/core/qpersistentmodelindex.cpp
@@ -11,9 +11,8 @@
 // QPersistentModelIndex is a single pointer to a QPersistentModelIndexData
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/itemmodels/qabstractitemmodel.h?h=v5.15.6-lts-lgpl#n143
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/itemmodels/qabstractitemmodel.h?h=v6.2.4#n243
-assert_alignment_and_size(QPersistentModelIndex,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QPersistentModelIndex, alignof(::std::size_t), arr);
 
 static_assert(
   !::std::is_trivially_copy_assignable<QPersistentModelIndex>::value);

--- a/crates/cxx-qt-lib/src/core/qpersistentmodelindex.cpp
+++ b/crates/cxx-qt-lib/src/core/qpersistentmodelindex.cpp
@@ -12,7 +12,10 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/itemmodels/qabstractitemmodel.h?h=v5.15.6-lts-lgpl#n143
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/itemmodels/qabstractitemmodel.h?h=v6.2.4#n243
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QPersistentModelIndex, alignof(::std::size_t), arr);
+assert_alignment_and_size(QPersistentModelIndex,
+                          alignof(::std::size_t),
+                          arr,
+                          arr.size());
 
 static_assert(
   !::std::is_trivially_copy_assignable<QPersistentModelIndex>::value);

--- a/crates/cxx-qt-lib/src/core/qpoint.cpp
+++ b/crates/cxx-qt-lib/src/core/qpoint.cpp
@@ -14,9 +14,9 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qpoint.h?h=v5.15.6-lts-lgpl#n271
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qpoint.h?h=v6.2.4#n313
-assert_alignment_and_size(QPoint,
-                          alignof(::std::int32_t),
-                          sizeof(::std::int32_t[2]));
+constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t) };
+assert_alignment_and_size(QPoint, alignof(::std::int32_t), arr);
 
 static_assert(::std::is_trivially_copyable<QPoint>::value);
 

--- a/crates/cxx-qt-lib/src/core/qpoint.cpp
+++ b/crates/cxx-qt-lib/src/core/qpoint.cpp
@@ -16,7 +16,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qpoint.h?h=v6.2.4#n313
 constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t) };
-assert_alignment_and_size(QPoint, alignof(::std::int32_t), arr);
+assert_alignment_and_size(QPoint, alignof(::std::int32_t), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QPoint>::value);
 

--- a/crates/cxx-qt-lib/src/core/qpointf.cpp
+++ b/crates/cxx-qt-lib/src/core/qpointf.cpp
@@ -13,7 +13,9 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qpoint.h?h=v5.15.6-lts-lgpl#n271
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qpoint.h?h=v6.2.4#n313
-assert_alignment_and_size(QPointF, alignof(double), sizeof(double[2]));
+constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(double),
+                                                     sizeof(double) };
+assert_alignment_and_size(QPointF, alignof(double), arr);
 
 static_assert(::std::is_trivially_copyable<QPointF>::value,
               "QPointF should be trivially copyable");

--- a/crates/cxx-qt-lib/src/core/qpointf.cpp
+++ b/crates/cxx-qt-lib/src/core/qpointf.cpp
@@ -15,7 +15,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qpoint.h?h=v6.2.4#n313
 constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(double),
                                                      sizeof(double) };
-assert_alignment_and_size(QPointF, alignof(double), arr);
+assert_alignment_and_size(QPointF, alignof(double), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QPointF>::value,
               "QPointF should be trivially copyable");

--- a/crates/cxx-qt-lib/src/core/qrect.cpp
+++ b/crates/cxx-qt-lib/src/core/qrect.cpp
@@ -20,7 +20,7 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t) };
-assert_alignment_and_size(QRect, alignof(::std::int32_t), arr);
+assert_alignment_and_size(QRect, alignof(::std::int32_t), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QRect>::value,
               "QRect must be trivially copyable");

--- a/crates/cxx-qt-lib/src/core/qrect.cpp
+++ b/crates/cxx-qt-lib/src/core/qrect.cpp
@@ -16,9 +16,11 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qrect.h?h=v5.15.6-lts-lgpl#n161
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qrect.h?h=v6.2.4#n161
-assert_alignment_and_size(QRect,
-                          alignof(::std::int32_t),
-                          sizeof(::std::int32_t[4]));
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t) };
+assert_alignment_and_size(QRect, alignof(::std::int32_t), arr);
 
 static_assert(::std::is_trivially_copyable<QRect>::value,
               "QRect must be trivially copyable");

--- a/crates/cxx-qt-lib/src/core/qrectf.cpp
+++ b/crates/cxx-qt-lib/src/core/qrectf.cpp
@@ -17,7 +17,7 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(double),
                                                      sizeof(double),
                                                      sizeof(double),
                                                      sizeof(double) };
-assert_alignment_and_size(QRectF, alignof(double), arr);
+assert_alignment_and_size(QRectF, alignof(double), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QRectF>::value,
               "QRectF must be trivially copyable");

--- a/crates/cxx-qt-lib/src/core/qrectf.cpp
+++ b/crates/cxx-qt-lib/src/core/qrectf.cpp
@@ -13,7 +13,11 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qrect.h?h=v5.15.6-lts-lgpl#n621
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qrect.h?h=v6.2.4#n623
-assert_alignment_and_size(QRectF, alignof(double), sizeof(double[4]));
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(double),
+                                                     sizeof(double),
+                                                     sizeof(double),
+                                                     sizeof(double) };
+assert_alignment_and_size(QRectF, alignof(double), arr);
 
 static_assert(::std::is_trivially_copyable<QRectF>::value,
               "QRectF must be trivially copyable");

--- a/crates/cxx-qt-lib/src/core/qset/qset.cpp
+++ b/crates/cxx-qt-lib/src/core/qset/qset.cpp
@@ -9,8 +9,9 @@
 #include "../../assertion_utils.h"
 
 #define CXX_QT_QSET_ASSERTS(typeName, name)                                    \
-  assert_alignment_and_size(                                                   \
-    QSet_##name, alignof(::std::size_t), sizeof(::std::size_t));               \
+  constexpr static ::std::array<::std::size_t, 1> arr_##name{ sizeof(          \
+    ::std::size_t) };                                                          \
+  assert_alignment_and_size(QSet_##name, alignof(::std::size_t), arr_##name);  \
                                                                                \
   static_assert(!::std::is_trivially_copy_assignable<QSet_##name>::value);     \
   static_assert(!::std::is_trivially_copy_constructible<QSet_##name>::value);  \

--- a/crates/cxx-qt-lib/src/core/qset/qset.cpp
+++ b/crates/cxx-qt-lib/src/core/qset/qset.cpp
@@ -11,7 +11,8 @@
 #define CXX_QT_QSET_ASSERTS(typeName, name)                                    \
   constexpr static ::std::array<::std::size_t, 1> arr_##name{ sizeof(          \
     ::std::size_t) };                                                          \
-  assert_alignment_and_size(QSet_##name, alignof(::std::size_t), arr_##name);  \
+  assert_alignment_and_size(                                                   \
+    QSet_##name, alignof(::std::size_t), arr_##name, arr_##name.size());       \
                                                                                \
   static_assert(!::std::is_trivially_copy_assignable<QSet_##name>::value);     \
   static_assert(!::std::is_trivially_copy_constructible<QSet_##name>::value);  \

--- a/crates/cxx-qt-lib/src/core/qsize.cpp
+++ b/crates/cxx-qt-lib/src/core/qsize.cpp
@@ -18,7 +18,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qsize.h?h=v6.2.4#n113
 constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::int32_t),
                                                      sizeof(::std::int32_t) };
-assert_alignment_and_size(QSize, alignof(::std::int32_t), arr);
+assert_alignment_and_size(QSize, alignof(::std::int32_t), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QSize>::value,
               "QSize must be trivially copyable!");

--- a/crates/cxx-qt-lib/src/core/qsize.cpp
+++ b/crates/cxx-qt-lib/src/core/qsize.cpp
@@ -16,9 +16,9 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qsize.h?h=v5.15.6-lts-lgpl#n104
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qsize.h?h=v6.2.4#n113
-assert_alignment_and_size(QSize,
-                          alignof(::std::int32_t),
-                          sizeof(::std::int32_t[2]));
+constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::int32_t),
+                                                     sizeof(::std::int32_t) };
+assert_alignment_and_size(QSize, alignof(::std::int32_t), arr);
 
 static_assert(::std::is_trivially_copyable<QSize>::value,
               "QSize must be trivially copyable!");

--- a/crates/cxx-qt-lib/src/core/qsizef.cpp
+++ b/crates/cxx-qt-lib/src/core/qsizef.cpp
@@ -13,7 +13,9 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qsize.h?h=v5.15.6-lts-lgpl#n276
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qsize.h?h=v6.2.4#n302
-assert_alignment_and_size(QSizeF, alignof(double), sizeof(double[2]));
+constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(double),
+                                                     sizeof(double) };
+assert_alignment_and_size(QSizeF, alignof(double), arr);
 
 static_assert(::std::is_trivially_copyable<QSizeF>::value,
               "QSizeF must be trivially copyable!");

--- a/crates/cxx-qt-lib/src/core/qsizef.cpp
+++ b/crates/cxx-qt-lib/src/core/qsizef.cpp
@@ -15,7 +15,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qsize.h?h=v6.2.4#n302
 constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(double),
                                                      sizeof(double) };
-assert_alignment_and_size(QSizeF, alignof(double), arr);
+assert_alignment_and_size(QSizeF, alignof(double), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QSizeF>::value,
               "QSizeF must be trivially copyable!");

--- a/crates/cxx-qt-lib/src/core/qstring.cpp
+++ b/crates/cxx-qt-lib/src/core/qstring.cpp
@@ -19,13 +19,13 @@
 // DataPointer is then a QStringPrivate, which is a QArrayDataPointer<char16_t>
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qarraydatapointer.h?h=v6.2.4#n390
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-assert_alignment_and_size(QString,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t[3]));
+constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::size_t),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(::std::size_t) };
+assert_alignment_and_size(QString, alignof(::std::size_t), arr);
 #else
-assert_alignment_and_size(QString,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QString, alignof(::std::size_t), arr);
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QString>::value);

--- a/crates/cxx-qt-lib/src/core/qstring.cpp
+++ b/crates/cxx-qt-lib/src/core/qstring.cpp
@@ -22,10 +22,10 @@
 constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::size_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t) };
-assert_alignment_and_size(QString, alignof(::std::size_t), arr);
+assert_alignment_and_size(QString, alignof(::std::size_t), arr, arr.size());
 #else
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QString, alignof(::std::size_t), arr);
+assert_alignment_and_size(QString, alignof(::std::size_t), arr, arr.size());
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QString>::value);

--- a/crates/cxx-qt-lib/src/core/qstringlist.cpp
+++ b/crates/cxx-qt-lib/src/core/qstringlist.cpp
@@ -18,13 +18,13 @@
 // DataPointer is then a QArrayDataPointer<QString>
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qarraydatapointer.h?h=v6.2.4#n390
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-assert_alignment_and_size(QStringList,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t[3]));
+constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::size_t),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(::std::size_t) };
+assert_alignment_and_size(QStringList, alignof(::std::size_t), arr);
 #else
-assert_alignment_and_size(QStringList,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QStringList, alignof(::std::size_t), arr);
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QStringList>::value);

--- a/crates/cxx-qt-lib/src/core/qstringlist.cpp
+++ b/crates/cxx-qt-lib/src/core/qstringlist.cpp
@@ -21,10 +21,10 @@
 constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::size_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t) };
-assert_alignment_and_size(QStringList, alignof(::std::size_t), arr);
+assert_alignment_and_size(QStringList, alignof(::std::size_t), arr, arr.size());
 #else
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QStringList, alignof(::std::size_t), arr);
+assert_alignment_and_size(QStringList, alignof(::std::size_t), arr, arr.size());
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QStringList>::value);

--- a/crates/cxx-qt-lib/src/core/qtime.cpp
+++ b/crates/cxx-qt-lib/src/core/qtime.cpp
@@ -15,7 +15,7 @@
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n217
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::int32_t) };
-assert_alignment_and_size(QTime, alignof(::std::int32_t), arr);
+assert_alignment_and_size(QTime, alignof(::std::int32_t), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QTime>::value,
               "QTime must be trivially copyable!");

--- a/crates/cxx-qt-lib/src/core/qtime.cpp
+++ b/crates/cxx-qt-lib/src/core/qtime.cpp
@@ -14,9 +14,8 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v5.15.6-lts-lgpl#n242
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/time/qdatetime.h?h=v6.2.4#n217
-assert_alignment_and_size(QTime,
-                          alignof(::std::int32_t),
-                          sizeof(::std::int32_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::int32_t) };
+assert_alignment_and_size(QTime, alignof(::std::int32_t), arr);
 
 static_assert(::std::is_trivially_copyable<QTime>::value,
               "QTime must be trivially copyable!");

--- a/crates/cxx-qt-lib/src/core/qurl.cpp
+++ b/crates/cxx-qt-lib/src/core/qurl.cpp
@@ -15,7 +15,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/io/qurl.h?h=v5.15.6-lts-lgpl#n367
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/io/qurl.h?h=v6.2.4#n294
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QUrl, alignof(::std::size_t), arr);
+assert_alignment_and_size(QUrl, alignof(::std::size_t), arr, arr.size());
 
 static_assert(!::std::is_trivially_copy_assignable<QUrl>::value);
 static_assert(!::std::is_trivially_copy_constructible<QUrl>::value);

--- a/crates/cxx-qt-lib/src/core/qurl.cpp
+++ b/crates/cxx-qt-lib/src/core/qurl.cpp
@@ -14,7 +14,8 @@
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/io/qurl.h?h=v5.15.6-lts-lgpl#n367
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/io/qurl.h?h=v6.2.4#n294
-assert_alignment_and_size(QUrl, alignof(::std::size_t), sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QUrl, alignof(::std::size_t), arr);
 
 static_assert(!::std::is_trivially_copy_assignable<QUrl>::value);
 static_assert(!::std::is_trivially_copy_constructible<QUrl>::value);

--- a/crates/cxx-qt-lib/src/core/qvariant/qvariant.cpp
+++ b/crates/cxx-qt-lib/src/core/qvariant/qvariant.cpp
@@ -30,9 +30,7 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::size_t),
                                                      sizeof(double) };
 assert_alignment_and_size(QVariant, alignof(double), arr, arr.size());
 #else
-constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::uint16_t),
-                                                     sizeof(::std::uint16_t),
-                                                     sizeof(::std::uint16_t),
+constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::uint32_t),
                                                      sizeof(double) };
 assert_alignment_and_size(QVariant, alignof(double), arr, arr.size());
 #endif

--- a/crates/cxx-qt-lib/src/core/qvariant/qvariant.cpp
+++ b/crates/cxx-qt-lib/src/core/qvariant/qvariant.cpp
@@ -30,9 +30,9 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::size_t),
                                                      sizeof(double) };
 assert_alignment_and_size(QVariant, alignof(double), arr);
 #else
-constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(uint),
-                                                     sizeof(uint),
-                                                     sizeof(uint),
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::uint16_t),
+                                                     sizeof(::std::uint16_t),
+                                                     sizeof(::std::uint16_t),
                                                      sizeof(double) };
 assert_alignment_and_size(QVariant, alignof(double), arr);
 #endif

--- a/crates/cxx-qt-lib/src/core/qvariant/qvariant.cpp
+++ b/crates/cxx-qt-lib/src/core/qvariant/qvariant.cpp
@@ -28,13 +28,13 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::size_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(double) };
-assert_alignment_and_size(QVariant, alignof(double), arr);
+assert_alignment_and_size(QVariant, alignof(double), arr, arr.size());
 #else
 constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::uint16_t),
                                                      sizeof(::std::uint16_t),
                                                      sizeof(::std::uint16_t),
                                                      sizeof(double) };
-assert_alignment_and_size(QVariant, alignof(double), arr);
+assert_alignment_and_size(QVariant, alignof(double), arr, arr.size());
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QVariant>::value);

--- a/crates/cxx-qt-lib/src/core/qvariant/qvariant.cpp
+++ b/crates/cxx-qt-lib/src/core/qvariant/qvariant.cpp
@@ -24,34 +24,17 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qvariant.h?h=v5.15.6-lts-lgpl#n491
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qvariant.h?h=v5.15.6-lts-lgpl#n411
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-
-#if (QT_POINTER_SIZE == 4)
-// 32bit is 3 * 32bit ptr (12) + union with double (8) + 4 bytes padding
-// alignment is 8 byte on 32bit systems as well due to the double
-assert_alignment_and_size(QVariant,
-                          alignof(double),
-                          (sizeof(::std::size_t) * 3) + sizeof(double) +
-                            4 /* compiler padding */);
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::size_t),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(double) };
+assert_alignment_and_size(QVariant, alignof(double), arr);
 #else
-// 64bit is 3 * 64ptr ptr (16) + union with double (8)
-// alignment is 8 bytes from the double or the pointer on 64bit systems
-assert_alignment_and_size(QVariant,
-                          alignof(double),
-                          (sizeof(::std::size_t) * 3) + sizeof(double));
-#endif
-
-#else
-
-// 3 * uint (12) + union with double (8)
-// but due to compiler optimisation it ends up as
-// 3 * ushort (6) + union with double (8) + 2 bytes padding
-// alignment is 8 byte on 32bit systems as well due to the double
-assert_alignment_and_size(
-  QVariant,
-  alignof(double),
-  (sizeof(::std::uint16_t /* compiler optimised from ::std::uint32_t */) * 3) +
-    sizeof(double) + 2 /* compiler padding */);
-
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(uint),
+                                                     sizeof(uint),
+                                                     sizeof(uint),
+                                                     sizeof(double) };
+assert_alignment_and_size(QVariant, alignof(double), arr);
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QVariant>::value);

--- a/crates/cxx-qt-lib/src/core/qvector/qvector.cpp
+++ b/crates/cxx-qt-lib/src/core/qvector/qvector.cpp
@@ -10,12 +10,15 @@
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #define CXX_QT_QVECTOR_ALIGN_AND_SIZE(typeName, name)                          \
-  assert_alignment_and_size(                                                   \
-    QVector_##name, alignof(::std::size_t), sizeof(::std::size_t[3]));
+  constexpr static ::std::array<::std::size_t, 3> arr_##name{                  \
+    sizeof(::std::size_t), sizeof(::std::size_t), sizeof(::std::size_t)        \
+  };                                                                           \
+  assert_alignment_and_size(QVector_##name, alignof(::std::size_t), arr_##name);
 #else
 #define CXX_QT_QVECTOR_ALIGN_AND_SIZE(typeName, name)                          \
-  assert_alignment_and_size(                                                   \
-    QVector_##name, alignof(::std::size_t), sizeof(::std::size_t));
+  constexpr static ::std::array<::std::size_t, 1> arr_##name{ sizeof(          \
+    ::std::size_t) };                                                          \
+  assert_alignment_and_size(QVector_##name, alignof(::std::size_t), arr_##name);
 #endif
 
 #define CXX_QT_QVECTOR_ASSERTS(typeName, name)                                 \

--- a/crates/cxx-qt-lib/src/core/qvector/qvector.cpp
+++ b/crates/cxx-qt-lib/src/core/qvector/qvector.cpp
@@ -13,12 +13,14 @@
   constexpr static ::std::array<::std::size_t, 3> arr_##name{                  \
     sizeof(::std::size_t), sizeof(::std::size_t), sizeof(::std::size_t)        \
   };                                                                           \
-  assert_alignment_and_size(QVector_##name, alignof(::std::size_t), arr_##name);
+  assert_alignment_and_size(                                                   \
+    QVector_##name, alignof(::std::size_t), arr_##name, arr_##name.size());
 #else
 #define CXX_QT_QVECTOR_ALIGN_AND_SIZE(typeName, name)                          \
   constexpr static ::std::array<::std::size_t, 1> arr_##name{ sizeof(          \
     ::std::size_t) };                                                          \
-  assert_alignment_and_size(QVector_##name, alignof(::std::size_t), arr_##name);
+  assert_alignment_and_size(                                                   \
+    QVector_##name, alignof(::std::size_t), arr_##name, arr_##name.size());
 #endif
 
 #define CXX_QT_QVECTOR_ASSERTS(typeName, name)                                 \

--- a/crates/cxx-qt-lib/src/gui/qcolor.cpp
+++ b/crates/cxx-qt-lib/src/gui/qcolor.cpp
@@ -20,7 +20,7 @@ constexpr static ::std::array<::std::size_t, 6> arr{
   sizeof(::std::int32_t),  sizeof(::std::uint16_t), sizeof(::std::uint16_t),
   sizeof(::std::uint16_t), sizeof(::std::uint16_t), sizeof(::std::uint16_t)
 };
-assert_alignment_and_size(QColor, alignof(::std::int32_t), arr);
+assert_alignment_and_size(QColor, alignof(::std::int32_t), arr, arr.size());
 
 // QColor still had copy & move constructors in Qt 5 but they were basically
 // trivial.

--- a/crates/cxx-qt-lib/src/gui/qcolor.cpp
+++ b/crates/cxx-qt-lib/src/gui/qcolor.cpp
@@ -16,11 +16,11 @@
 // compiler padding this results in a sizeof 16.
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qcolor.h?h=v5.15.6-lts-lgpl#n262
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qcolor.h?h=v6.2.4#n237
-assert_alignment_and_size(QColor,
-                          alignof(::std::size_t),
-                          sizeof(::std::int32_t) +
-                            (sizeof(::std::uint16_t) * 5) +
-                            2 /* compiler padding */);
+constexpr static ::std::array<::std::size_t, 6> arr{
+  sizeof(::std::int32_t),  sizeof(::std::uint16_t), sizeof(::std::uint16_t),
+  sizeof(::std::uint16_t), sizeof(::std::uint16_t), sizeof(::std::uint16_t)
+};
+assert_alignment_and_size(QColor, alignof(::std::int32_t), arr);
 
 // QColor still had copy & move constructors in Qt 5 but they were basically
 // trivial.

--- a/crates/cxx-qt-lib/src/gui/qcolor.rs
+++ b/crates/cxx-qt-lib/src/gui/qcolor.rs
@@ -276,7 +276,6 @@ pub use ffi::{QColorNameFormat, QColorSpec};
 pub struct QColor {
     _cspec: MaybeUninit<i32>,
     _ct: MaybeUninit<[u16; 5]>,
-    _padding: MaybeUninit<u16>,
 }
 
 impl QColor {

--- a/crates/cxx-qt-lib/src/gui/qfont.cpp
+++ b/crates/cxx-qt-lib/src/gui/qfont.cpp
@@ -11,9 +11,9 @@
 
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.h?h=v5.15.6-lts-lgpl#n344
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.h?h=v6.2.4#n323
-assert_alignment_and_size(QFont,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t) + sizeof(::std::int64_t));
+constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::size_t),
+                                                     sizeof(uint) };
+assert_alignment_and_size(QFont, alignof(::std::size_t), arr);
 
 static_assert(!::std::is_trivially_copy_assignable<QFont>::value);
 static_assert(!::std::is_trivially_copy_constructible<QFont>::value);

--- a/crates/cxx-qt-lib/src/gui/qfont.cpp
+++ b/crates/cxx-qt-lib/src/gui/qfont.cpp
@@ -11,8 +11,11 @@
 
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.h?h=v5.15.6-lts-lgpl#n344
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.h?h=v6.2.4#n323
-constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::size_t),
-                                                     sizeof(uint) };
+constexpr static ::std::array<::std::size_t, 2> arr{
+  sizeof(::std::size_t),
+  sizeof(::std::uint32_t)
+}; // uint can be 16 or 32 but should align to at least 32
+
 assert_alignment_and_size(QFont, alignof(::std::size_t), arr, arr.size());
 
 static_assert(!::std::is_trivially_copy_assignable<QFont>::value);

--- a/crates/cxx-qt-lib/src/gui/qfont.cpp
+++ b/crates/cxx-qt-lib/src/gui/qfont.cpp
@@ -13,7 +13,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.h?h=v6.2.4#n323
 constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(::std::size_t),
                                                      sizeof(uint) };
-assert_alignment_and_size(QFont, alignof(::std::size_t), arr);
+assert_alignment_and_size(QFont, alignof(::std::size_t), arr, arr.size());
 
 static_assert(!::std::is_trivially_copy_assignable<QFont>::value);
 static_assert(!::std::is_trivially_copy_constructible<QFont>::value);

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -368,8 +368,8 @@ pub use ffi::{
 
 #[repr(C)]
 pub struct QFont {
-    _cspec: MaybeUninit<i32>,
-    _resolve_mask: MaybeUninit<u16>,
+    _cspec: MaybeUninit<usize>,
+    _resolve_mask: MaybeUninit<i32>,
 }
 
 impl Default for QFont {

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -369,7 +369,7 @@ pub use ffi::{
 #[repr(C)]
 pub struct QFont {
     _cspec: MaybeUninit<usize>,
-    _resolve_mask: MaybeUninit<i32>,
+    _resolve_mask: MaybeUninit<u32>,
 }
 
 impl Default for QFont {

--- a/crates/cxx-qt-lib/src/gui/qimage.cpp
+++ b/crates/cxx-qt-lib/src/gui/qimage.cpp
@@ -24,14 +24,14 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(ushort),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t) };
-assert_alignment_and_size(QImage, alignof(::std::size_t), arr);
+assert_alignment_and_size(QImage, alignof(::std::size_t), arr, arr.size());
 #else
 // In Qt6 the QPaintDevice doesn't contain the `reserved` pointer, making it 1
 // pointer smaller
 constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(ushort),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t) };
-assert_alignment_and_size(QImage, alignof(::std::size_t), arr);
+assert_alignment_and_size(QImage, alignof(::std::size_t), arr, arr.size());
 #endif
 
 namespace rust {

--- a/crates/cxx-qt-lib/src/gui/qimage.cpp
+++ b/crates/cxx-qt-lib/src/gui/qimage.cpp
@@ -20,7 +20,7 @@
 // 3. QImageData *d;
 // For a total of 3 pointers in length.
 // Because of the added v-table, it's a total of 4 pointers in size.
-constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(ushort),
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(::std::uint16_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t) };
@@ -28,7 +28,7 @@ assert_alignment_and_size(QImage, alignof(::std::size_t), arr, arr.size());
 #else
 // In Qt6 the QPaintDevice doesn't contain the `reserved` pointer, making it 1
 // pointer smaller
-constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(ushort),
+constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::uint16_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t) };
 assert_alignment_and_size(QImage, alignof(::std::size_t), arr, arr.size());

--- a/crates/cxx-qt-lib/src/gui/qimage.cpp
+++ b/crates/cxx-qt-lib/src/gui/qimage.cpp
@@ -20,15 +20,18 @@
 // 3. QImageData *d;
 // For a total of 3 pointers in length.
 // Because of the added v-table, it's a total of 4 pointers in size.
-assert_alignment_and_size(QImage,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t) * 4);
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(ushort),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(::std::size_t) };
+assert_alignment_and_size(QImage, alignof(::std::size_t), arr);
 #else
 // In Qt6 the QPaintDevice doesn't contain the `reserved` pointer, making it 1
 // pointer smaller
-assert_alignment_and_size(QImage,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t) * 3);
+constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(ushort),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(::std::size_t) };
+assert_alignment_and_size(QImage, alignof(::std::size_t), arr);
 #endif
 
 namespace rust {

--- a/crates/cxx-qt-lib/src/gui/qimage.rs
+++ b/crates/cxx-qt-lib/src/gui/qimage.rs
@@ -274,9 +274,13 @@ pub struct QImage {
     // Static checks on the C++ side ensure this is true.
     // See qcolor.cpp
     #[cfg(cxxqt_qt_version_major = "5")]
-    _data: MaybeUninit<[usize; 4]>,
+    _painters: MaybeUninit<u16>,
+    #[cfg(cxxqt_qt_version_major = "5")]
+    _pointers: MaybeUninit<[usize; 3]>,
     #[cfg(cxxqt_qt_version_major = "6")]
-    _data: MaybeUninit<[usize; 3]>,
+    _painters: MaybeUninit<u16>,
+    #[cfg(cxxqt_qt_version_major = "6")]
+    _pointers: MaybeUninit<[usize; 2]>,
 }
 
 impl Clone for QImage {

--- a/crates/cxx-qt-lib/src/gui/qimage.rs
+++ b/crates/cxx-qt-lib/src/gui/qimage.rs
@@ -273,12 +273,9 @@ pub use ffi::{QImageFormat, QImageInvertMode};
 pub struct QImage {
     // Static checks on the C++ side ensure this is true.
     // See qcolor.cpp
-    #[cfg(cxxqt_qt_version_major = "5")]
     _painters: MaybeUninit<u16>,
     #[cfg(cxxqt_qt_version_major = "5")]
     _pointers: MaybeUninit<[usize; 3]>,
-    #[cfg(cxxqt_qt_version_major = "6")]
-    _painters: MaybeUninit<u16>,
     #[cfg(cxxqt_qt_version_major = "6")]
     _pointers: MaybeUninit<[usize; 2]>,
 }

--- a/crates/cxx-qt-lib/src/gui/qpainterpath.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpainterpath.cpp
@@ -11,9 +11,8 @@
 
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qpainterpath.h?h=v5.15.6-lts-lgpl#n227
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qpainterpath.h?h=v6.2.4#n200
-assert_alignment_and_size(QPainterPath,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QPainterPath, alignof(::std::size_t), arr);
 
 static_assert(QTypeInfo<QPainterPath>::isRelocatable);
 

--- a/crates/cxx-qt-lib/src/gui/qpainterpath.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpainterpath.cpp
@@ -12,7 +12,10 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qpainterpath.h?h=v5.15.6-lts-lgpl#n227
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qpainterpath.h?h=v6.2.4#n200
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QPainterPath, alignof(::std::size_t), arr);
+assert_alignment_and_size(QPainterPath,
+                          alignof(::std::size_t),
+                          arr,
+                          arr.size());
 
 static_assert(QTypeInfo<QPainterPath>::isRelocatable);
 

--- a/crates/cxx-qt-lib/src/gui/qpainterpath.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainterpath.rs
@@ -207,7 +207,7 @@ mod ffi {
 
 #[repr(C)]
 pub struct QPainterPath {
-    _cspec: MaybeUninit<i32>,
+    _cspec: MaybeUninit<usize>,
 }
 
 impl Default for QPainterPath {

--- a/crates/cxx-qt-lib/src/gui/qpen.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpen.cpp
@@ -11,7 +11,8 @@
 
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qpen.h?h=v5.15.6-lts-lgpl#n124
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qpen.h?h=v6.2.4#n94
-assert_alignment_and_size(QPen, alignof(::std::size_t), sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QPen, alignof(::std::size_t), arr);
 
 static_assert(!::std::is_trivially_copy_assignable<QPen>::value);
 static_assert(!::std::is_trivially_copy_constructible<QPen>::value);

--- a/crates/cxx-qt-lib/src/gui/qpen.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpen.cpp
@@ -12,7 +12,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qpen.h?h=v5.15.6-lts-lgpl#n124
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qpen.h?h=v6.2.4#n94
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QPen, alignof(::std::size_t), arr);
+assert_alignment_and_size(QPen, alignof(::std::size_t), arr, arr.size());
 
 static_assert(!::std::is_trivially_copy_assignable<QPen>::value);
 static_assert(!::std::is_trivially_copy_constructible<QPen>::value);

--- a/crates/cxx-qt-lib/src/gui/qpolygon.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.cpp
@@ -18,13 +18,13 @@
 // DataPointer is then a QArrayDataPointer<QPoint>
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qarraydatapointer.h?h=v6.2.4#n390
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-assert_alignment_and_size(QPolygon,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t[3]));
+constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::size_t),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(::std::size_t) };
+assert_alignment_and_size(QPolygon, alignof(::std::size_t), arr);
 #else
-assert_alignment_and_size(QPolygon,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QPolygon, alignof(::std::size_t), arr);
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QPolygon>::value);

--- a/crates/cxx-qt-lib/src/gui/qpolygon.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.cpp
@@ -21,10 +21,10 @@
 constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::size_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t) };
-assert_alignment_and_size(QPolygon, alignof(::std::size_t), arr);
+assert_alignment_and_size(QPolygon, alignof(::std::size_t), arr, arr.size());
 #else
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QPolygon, alignof(::std::size_t), arr);
+assert_alignment_and_size(QPolygon, alignof(::std::size_t), arr, arr.size());
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QPolygon>::value);

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.cpp
@@ -18,13 +18,13 @@
 // DataPointer is then a QArrayDataPointer<QPoint>
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qarraydatapointer.h?h=v6.2.4#n390
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-assert_alignment_and_size(QPolygonF,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t[3]));
+constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::size_t),
+                                                     sizeof(::std::size_t),
+                                                     sizeof(::std::size_t) };
+assert_alignment_and_size(QPolygonF, alignof(::std::size_t), arr);
 #else
-assert_alignment_and_size(QPolygonF,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QPolygonF, alignof(::std::size_t), arr);
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QPolygonF>::value);

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.cpp
@@ -21,10 +21,10 @@
 constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(::std::size_t),
                                                      sizeof(::std::size_t),
                                                      sizeof(::std::size_t) };
-assert_alignment_and_size(QPolygonF, alignof(::std::size_t), arr);
+assert_alignment_and_size(QPolygonF, alignof(::std::size_t), arr, arr.size());
 #else
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QPolygonF, alignof(::std::size_t), arr);
+assert_alignment_and_size(QPolygonF, alignof(::std::size_t), arr, arr.size());
 #endif
 
 static_assert(!::std::is_trivially_copy_assignable<QPolygonF>::value);

--- a/crates/cxx-qt-lib/src/gui/qregion.cpp
+++ b/crates/cxx-qt-lib/src/gui/qregion.cpp
@@ -11,9 +11,8 @@
 
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qregion.h?h=v5.15.6-lts-lgpl#n178
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qregion.h?h=v6.2.4#n161
-assert_alignment_and_size(QRegion,
-                          alignof(::std::size_t),
-                          sizeof(::std::size_t));
+constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
+assert_alignment_and_size(QRegion, alignof(::std::size_t), arr);
 
 static_assert(!::std::is_trivially_copy_assignable<QRegion>::value);
 static_assert(!::std::is_trivially_copy_constructible<QRegion>::value);

--- a/crates/cxx-qt-lib/src/gui/qregion.cpp
+++ b/crates/cxx-qt-lib/src/gui/qregion.cpp
@@ -12,7 +12,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qregion.h?h=v5.15.6-lts-lgpl#n178
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/painting/qregion.h?h=v6.2.4#n161
 constexpr static ::std::array<::std::size_t, 1> arr{ sizeof(::std::size_t) };
-assert_alignment_and_size(QRegion, alignof(::std::size_t), arr);
+assert_alignment_and_size(QRegion, alignof(::std::size_t), arr, arr.size());
 
 static_assert(!::std::is_trivially_copy_assignable<QRegion>::value);
 static_assert(!::std::is_trivially_copy_constructible<QRegion>::value);

--- a/crates/cxx-qt-lib/src/gui/qvector2d.cpp
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.cpp
@@ -13,7 +13,8 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvector2d.h?h=v5.15.6-lts-lgpl#n126
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvectornd.h?h=v6.2.4#n176
-constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(float), sizeof(float) };
+constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(float),
+                                                     sizeof(float) };
 assert_alignment_and_size(QVector2D, alignof(float), arr);
 
 static_assert(::std::is_trivially_copyable<QVector2D>::value,

--- a/crates/cxx-qt-lib/src/gui/qvector2d.cpp
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.cpp
@@ -13,7 +13,8 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvector2d.h?h=v5.15.6-lts-lgpl#n126
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvectornd.h?h=v6.2.4#n176
-assert_alignment_and_size(QVector2D, alignof(float), sizeof(float[2]));
+constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(float), sizeof(float) };
+assert_alignment_and_size(QVector2D, alignof(float), arr);
 
 static_assert(::std::is_trivially_copyable<QVector2D>::value,
               "QVector2D should be trivially copyable");

--- a/crates/cxx-qt-lib/src/gui/qvector2d.cpp
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.cpp
@@ -15,7 +15,7 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvectornd.h?h=v6.2.4#n176
 constexpr static ::std::array<::std::size_t, 2> arr{ sizeof(float),
                                                      sizeof(float) };
-assert_alignment_and_size(QVector2D, alignof(float), arr);
+assert_alignment_and_size(QVector2D, alignof(float), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QVector2D>::value,
               "QVector2D should be trivially copyable");

--- a/crates/cxx-qt-lib/src/gui/qvector3d.cpp
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.cpp
@@ -13,7 +13,9 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvector3d.h?h=v5.15.6-lts-lgpl#n141
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvectornd.h?h=v6.2.4#n334
-constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(float), sizeof(float), sizeof(float) };
+constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(float),
+                                                     sizeof(float),
+                                                     sizeof(float) };
 assert_alignment_and_size(QVector3D, alignof(float), arr);
 
 static_assert(::std::is_trivially_copyable<QVector3D>::value,

--- a/crates/cxx-qt-lib/src/gui/qvector3d.cpp
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.cpp
@@ -13,7 +13,8 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvector3d.h?h=v5.15.6-lts-lgpl#n141
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvectornd.h?h=v6.2.4#n334
-assert_alignment_and_size(QVector3D, alignof(float), sizeof(float[3]));
+constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(float), sizeof(float), sizeof(float) };
+assert_alignment_and_size(QVector3D, alignof(float), arr);
 
 static_assert(::std::is_trivially_copyable<QVector3D>::value,
               "QVector3D should be trivially copyable");

--- a/crates/cxx-qt-lib/src/gui/qvector3d.cpp
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.cpp
@@ -16,7 +16,7 @@
 constexpr static ::std::array<::std::size_t, 3> arr{ sizeof(float),
                                                      sizeof(float),
                                                      sizeof(float) };
-assert_alignment_and_size(QVector3D, alignof(float), arr);
+assert_alignment_and_size(QVector3D, alignof(float), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QVector3D>::value,
               "QVector3D should be trivially copyable");

--- a/crates/cxx-qt-lib/src/gui/qvector4d.cpp
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.cpp
@@ -13,7 +13,10 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvector4d.h?h=v5.15.6-lts-lgpl#n131
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvectornd.h?h=v6.2.4#n490
-constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(float), sizeof(float), sizeof(float), sizeof(float) };
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(float),
+                                                     sizeof(float),
+                                                     sizeof(float),
+                                                     sizeof(float) };
 assert_alignment_and_size(QVector4D, alignof(float), arr);
 
 static_assert(::std::is_trivially_copyable<QVector4D>::value,

--- a/crates/cxx-qt-lib/src/gui/qvector4d.cpp
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.cpp
@@ -17,7 +17,7 @@ constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(float),
                                                      sizeof(float),
                                                      sizeof(float),
                                                      sizeof(float) };
-assert_alignment_and_size(QVector4D, alignof(float), arr);
+assert_alignment_and_size(QVector4D, alignof(float), arr, arr.size());
 
 static_assert(::std::is_trivially_copyable<QVector4D>::value,
               "QVector4D should be trivially copyable");

--- a/crates/cxx-qt-lib/src/gui/qvector4d.cpp
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.cpp
@@ -13,7 +13,8 @@
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvector4d.h?h=v5.15.6-lts-lgpl#n131
 //
 // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/math3d/qvectornd.h?h=v6.2.4#n490
-assert_alignment_and_size(QVector4D, alignof(float), sizeof(float[4]));
+constexpr static ::std::array<::std::size_t, 4> arr{ sizeof(float), sizeof(float), sizeof(float), sizeof(float) };
+assert_alignment_and_size(QVector4D, alignof(float), arr);
 
 static_assert(::std::is_trivially_copyable<QVector4D>::value,
               "QVector4D should be trivially copyable");


### PR DESCRIPTION
Padding is currently manually added to size.
Some integer sizes are also assumed based on 64bit arch. This causes issues when compiling for 32-bit arch's and hardcoding padding is generally not the cleanest.

Resolve by calculating sizes and padding via traversing data members in reverse. Fully constexpr.