### PR TITLE
Replace use of syn::parse2(quote! {...}).unwrap()

### DIFF
--- a/crates/cxx-qt-gen/src/syntax/foreignmod.rs
+++ b/crates/cxx-qt-gen/src/syntax/foreignmod.rs
@@ -280,11 +280,11 @@ mod tests {
 
     #[test]
     fn test_foreign_type_ident_alias() {
-        let alias = syn::parse2::<ForeignTypeIdentAlias>(quote! {
+        let alias: ForeignTypeIdentAlias = parse_quote! {
             #[attr]
             type A = super::B;
-        })
-        .unwrap();
+        };
+
         assert_eq!(alias.attrs.len(), 1);
         assert_eq!(alias.ident_left, "A");
         assert_eq!(alias.ident_right, "B");
@@ -325,11 +325,10 @@ mod tests {
     #[test]
     fn test_foreign_type_ident_visibility() {
         // Ensure that visibility does not error, later it might be stored
-        let alias = syn::parse2::<ForeignTypeIdentAlias>(quote! {
+        let alias: ForeignTypeIdentAlias = parse_quote! {
             #[attr]
             pub type A = super::B;
-        })
-        .unwrap();
+        };
         assert_eq!(alias.attrs.len(), 1);
         assert_eq!(alias.ident_left, "A");
         assert_eq!(alias.ident_right, "B");


### PR DESCRIPTION
Use of `syn::parse2( quote! { ... } ).unwrap()` should be avoided as per #638, instead preferring to use `parse_quote! { ... }`