### PR TITLE
Remove some duplication and improve helpers for mocking ParsedMethod

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/method.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/method.rs
@@ -149,20 +149,20 @@ mod tests {
             parse_quote! { fn specifiers_invokable(self: &MyObject, param: i32) -> i32; };
         let method5: ForeignItemFn = parse_quote! { fn cpp_method(self: &MyObject); };
         let invokables = vec![
-            ParsedMethod::mock_with_method(&method1),
-            ParsedMethod::mock_with_method(&method2).with_parameters(vec![
+            ParsedMethod::mock_qinvokable(&method1),
+            ParsedMethod::mock_qinvokable(&method2).with_parameters(vec![
                 ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { i32 },
                 },
             ]),
-            ParsedMethod::mock_with_method(&method3)
+            ParsedMethod::mock_qinvokable(&method3)
                 .with_parameters(vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { &QColor },
                 }])
                 .make_mutable(),
-            ParsedMethod::mock_with_method(&method4)
+            ParsedMethod::mock_qinvokable(&method4)
                 .with_parameters(vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { i32 },
@@ -176,7 +176,7 @@ mod tests {
                 }),
             ParsedMethod {
                 is_qinvokable: false,
-                ..ParsedMethod::mock_with_method(&method5)
+                ..ParsedMethod::mock_qinvokable(&method5)
             },
         ];
         let qobject_idents = create_qobjectname();
@@ -303,7 +303,7 @@ mod tests {
         let method_declaration: ForeignItemFn =
             parse_quote! { fn trivial_invokable(self: &MyObject, param: A) -> B; };
 
-        let method = ParsedMethod::mock_with_method(&method_declaration).with_parameters(vec![
+        let method = ParsedMethod::mock_qinvokable(&method_declaration).with_parameters(vec![
             ParsedFunctionParameter {
                 ident: format_ident!("param"),
                 ty: parse_quote! { i32 },

--- a/crates/cxx-qt-gen/src/generator/cpp/method.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/method.rs
@@ -132,10 +132,8 @@ mod tests {
 
     use crate::generator::cpp::property::tests::{require_header, require_pair};
     use crate::generator::naming::qobject::tests::create_qobjectname;
-    use crate::parser::parameter::ParsedFunctionParameter;
     use indoc::indoc;
     use pretty_assertions::assert_str_eq;
-    use quote::format_ident;
     use std::collections::HashSet;
     use syn::{parse_quote, ForeignItemFn};
 
@@ -150,30 +148,15 @@ mod tests {
         let method5: ForeignItemFn = parse_quote! { fn cpp_method(self: &MyObject); };
         let invokables = vec![
             ParsedMethod::mock_qinvokable(&method1),
-            ParsedMethod::mock_qinvokable(&method2).with_parameters(vec![
-                ParsedFunctionParameter {
-                    ident: format_ident!("param"),
-                    ty: parse_quote! { i32 },
-                },
-            ]),
-            ParsedMethod::mock_qinvokable(&method3)
-                .with_parameters(vec![ParsedFunctionParameter {
-                    ident: format_ident!("param"),
-                    ty: parse_quote! { &QColor },
-                }])
-                .make_mutable(),
-            ParsedMethod::mock_qinvokable(&method4)
-                .with_parameters(vec![ParsedFunctionParameter {
-                    ident: format_ident!("param"),
-                    ty: parse_quote! { i32 },
-                }])
-                .with_specifiers({
-                    let mut specifiers = HashSet::new();
-                    specifiers.insert(ParsedQInvokableSpecifiers::Final);
-                    specifiers.insert(ParsedQInvokableSpecifiers::Override);
-                    specifiers.insert(ParsedQInvokableSpecifiers::Virtual);
-                    specifiers
-                }),
+            ParsedMethod::mock_qinvokable(&method2),
+            ParsedMethod::mock_qinvokable(&method3).make_mutable(),
+            ParsedMethod::mock_qinvokable(&method4).with_specifiers({
+                let mut specifiers = HashSet::new();
+                specifiers.insert(ParsedQInvokableSpecifiers::Final);
+                specifiers.insert(ParsedQInvokableSpecifiers::Override);
+                specifiers.insert(ParsedQInvokableSpecifiers::Virtual);
+                specifiers
+            }),
             ParsedMethod {
                 is_qinvokable: false,
                 ..ParsedMethod::mock_qinvokable(&method5)
@@ -303,12 +286,7 @@ mod tests {
         let method_declaration: ForeignItemFn =
             parse_quote! { fn trivial_invokable(self: &MyObject, param: A) -> B; };
 
-        let method = ParsedMethod::mock_qinvokable(&method_declaration).with_parameters(vec![
-            ParsedFunctionParameter {
-                ident: format_ident!("param"),
-                ty: parse_quote! { i32 },
-            },
-        ]);
+        let method = ParsedMethod::mock_qinvokable(&method_declaration);
         let invokables = vec![&method];
         let qobject_idents = create_qobjectname();
 

--- a/crates/cxx-qt-gen/src/generator/cpp/method.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/method.rs
@@ -132,7 +132,6 @@ mod tests {
 
     use crate::generator::cpp::property::tests::{require_header, require_pair};
     use crate::generator::naming::qobject::tests::create_qobjectname;
-    use crate::naming::Name;
     use crate::parser::parameter::ParsedFunctionParameter;
     use indoc::indoc;
     use pretty_assertions::assert_str_eq;
@@ -150,40 +149,34 @@ mod tests {
             parse_quote! { fn specifiers_invokable(self: &MyObject, param: i32) -> i32; };
         let method5: ForeignItemFn = parse_quote! { fn cpp_method(self: &MyObject); };
         let invokables = vec![
-            ParsedMethod::from_method_and_params(&method1, vec![]),
-            ParsedMethod::from_method_and_params(
-                &method2,
-                vec![ParsedFunctionParameter {
+            ParsedMethod::mock_with_method(&method1),
+            ParsedMethod::mock_with_method(&method2).with_parameters(vec![
+                ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { i32 },
-                }],
-            ),
-            ParsedMethod::mut_from_method_and_params(
-                &method3,
-                vec![ParsedFunctionParameter {
+                },
+            ]),
+            ParsedMethod::mock_with_method(&method3)
+                .with_parameters(vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { &QColor },
-                }],
-            ),
-            ParsedMethod {
-                specifiers: {
+                }])
+                .make_mutable(),
+            ParsedMethod::mock_with_method(&method4)
+                .with_parameters(vec![ParsedFunctionParameter {
+                    ident: format_ident!("param"),
+                    ty: parse_quote! { i32 },
+                }])
+                .with_specifiers({
                     let mut specifiers = HashSet::new();
                     specifiers.insert(ParsedQInvokableSpecifiers::Final);
                     specifiers.insert(ParsedQInvokableSpecifiers::Override);
                     specifiers.insert(ParsedQInvokableSpecifiers::Virtual);
                     specifiers
-                },
-                ..ParsedMethod::from_method_and_params(
-                    &method4,
-                    vec![ParsedFunctionParameter {
-                        ident: format_ident!("param"),
-                        ty: parse_quote! { i32 },
-                    }],
-                )
-            },
+                }),
             ParsedMethod {
                 is_qinvokable: false,
-                ..ParsedMethod::from_method_and_params(&method5, vec![])
+                ..ParsedMethod::mock_with_method(&method5)
             },
         ];
         let qobject_idents = create_qobjectname();
@@ -310,25 +303,12 @@ mod tests {
         let method_declaration: ForeignItemFn =
             parse_quote! { fn trivial_invokable(self: &MyObject, param: A) -> B; };
 
-        let method = ParsedMethod {
-            method: method_declaration.clone(),
-            qobject_ident: format_ident!("MyObject"),
-            mutable: false,
-            safe: true,
-            parameters: vec![ParsedFunctionParameter {
+        let method = ParsedMethod::mock_with_method(&method_declaration).with_parameters(vec![
+            ParsedFunctionParameter {
                 ident: format_ident!("param"),
                 ty: parse_quote! { i32 },
-            }],
-            specifiers: HashSet::new(),
-            is_qinvokable: true,
-            name: Name::from_rust_ident_and_attrs(
-                &method_declaration.sig.ident,
-                &method_declaration.attrs,
-                None,
-                None,
-            )
-            .unwrap(),
-        };
+            },
+        ]);
         let invokables = vec![&method];
         let qobject_idents = create_qobjectname();
 

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -202,6 +202,7 @@ impl GeneratedCppQObject {
 mod tests {
     use super::*;
 
+    use crate::generator::mock_qml_singleton;
     use crate::{generator::structuring::Structures, parser::Parser};
     use syn::{parse_quote, ItemMod};
 
@@ -295,17 +296,7 @@ mod tests {
 
     #[test]
     fn test_generated_cpp_qobject_singleton() {
-        let module: ItemMod = parse_quote! {
-            #[cxx_qt::bridge(namespace = "cxx_qt")]
-            mod ffi {
-                extern "RustQt" {
-                    #[qobject]
-                    #[qml_element]
-                    #[qml_singleton]
-                    type MyObject = super::MyObjectRust;
-                }
-            }
-        };
+        let module = mock_qml_singleton();
         let parser = Parser::from(module).unwrap();
         let structures = Structures::new(&parser.cxx_qt_data).unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -215,10 +215,8 @@ mod tests {
 
     use crate::generator::cpp::property::tests::{require_header, require_pair};
     use crate::generator::naming::qobject::tests::create_qobjectname;
-    use crate::parser::parameter::ParsedFunctionParameter;
     use indoc::indoc;
     use pretty_assertions::assert_str_eq;
-    use quote::format_ident;
     use syn::{parse_quote, ForeignItemFn};
 
     #[test]
@@ -226,16 +224,7 @@ mod tests {
         let method: ForeignItemFn = parse_quote! {
             fn data_changed(self: Pin<&mut MyObject>, trivial: i32, opaque: UniquePtr<QColor>);
         };
-        let signal = ParsedSignal::mock_with_method(&method).with_parameters(vec![
-            ParsedFunctionParameter {
-                ident: format_ident!("trivial"),
-                ty: parse_quote! { i32 },
-            },
-            ParsedFunctionParameter {
-                ident: format_ident!("opaque"),
-                ty: parse_quote! { UniquePtr<QColor> },
-            },
-        ]);
+        let signal = ParsedSignal::mock_with_method(&method);
         let signals = vec![&signal];
         let qobject_idents = create_qobjectname();
 
@@ -315,12 +304,7 @@ mod tests {
         let method: ForeignItemFn = parse_quote! {
             fn data_changed(self: Pin<&mut MyObject>, mapped: A);
         };
-        let signal = ParsedSignal::mock_with_method(&method).with_parameters(vec![
-            ParsedFunctionParameter {
-                ident: format_ident!("mapped"),
-                ty: parse_quote! { A },
-            },
-        ]);
+        let signal = ParsedSignal::mock_with_method(&method);
         let signals = vec![&signal];
         let qobject_idents = create_qobjectname();
 

--- a/crates/cxx-qt-gen/src/generator/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/mod.rs
@@ -1,10 +1,10 @@
-#[cfg(test)]
-use syn::{parse_quote, ItemMod};
-
 // SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cfg(test)]
+use syn::{parse_quote, ItemMod};
 pub mod cpp;
 pub mod naming;
 pub mod rust;

--- a/crates/cxx-qt-gen/src/generator/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+use syn::{parse_quote, ItemMod};
+
 // SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
@@ -6,3 +9,19 @@ pub mod cpp;
 pub mod naming;
 pub mod rust;
 pub mod structuring;
+
+#[cfg(test)]
+/// Mocks a module containing a singleton type
+pub fn mock_qml_singleton() -> ItemMod {
+    parse_quote! {
+        #[cxx_qt::bridge(namespace = "cxx_qt")]
+        mod ffi {
+            extern "RustQt" {
+                #[qobject]
+                #[qml_element]
+                #[qml_singleton]
+                type MyObject = super::MyObjectRust;
+            }
+        }
+    }
+}

--- a/crates/cxx-qt-gen/src/generator/naming/method.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/method.rs
@@ -46,7 +46,7 @@ mod tests {
         let method: ForeignItemFn = parse_quote! {
             fn my_invokable(self: &MyObject);
         };
-        let parsed = ParsedMethod::mock_with_method(&method);
+        let parsed = ParsedMethod::mock_qinvokable(&method);
 
         let invokable = QMethodName::try_from(&parsed).unwrap();
         assert_eq!(

--- a/crates/cxx-qt-gen/src/generator/naming/method.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/method.rs
@@ -40,26 +40,13 @@ mod tests {
     use syn::{parse_quote, ForeignItemFn};
 
     use super::*;
-    use quote::format_ident;
-
-    use std::collections::HashSet;
 
     #[test]
     fn test_from_impl_method() {
         let method: ForeignItemFn = parse_quote! {
             fn my_invokable(self: &MyObject);
         };
-        let parsed = ParsedMethod {
-            method: method.clone(),
-            qobject_ident: format_ident!("MyObject"),
-            mutable: false,
-            safe: true,
-            parameters: vec![],
-            specifiers: HashSet::new(),
-            is_qinvokable: true,
-            name: Name::from_rust_ident_and_attrs(&method.sig.ident, &method.attrs, None, None)
-                .unwrap(),
-        };
+        let parsed = ParsedMethod::mock_with_method(&method);
 
         let invokable = QMethodName::try_from(&parsed).unwrap();
         assert_eq!(

--- a/crates/cxx-qt-gen/src/generator/naming/property.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/property.rs
@@ -181,10 +181,9 @@ pub mod tests {
     use crate::parser::qobject::ParsedQObject;
 
     pub fn create_i32_qpropertyname() -> QPropertyNames {
-        let ty: syn::Type = parse_quote! { i32 };
         let property = ParsedQProperty {
             ident: format_ident!("my_property"),
-            ty,
+            ty: parse_quote! { i32 },
             flags: QPropertyFlags::default(),
         };
 

--- a/crates/cxx-qt-gen/src/generator/naming/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/signals.rs
@@ -107,19 +107,10 @@ mod tests {
 
     #[test]
     fn test_parsed_signal() {
-        let qsignal = ParsedSignal {
-            method: parse_quote! {
-                fn data_changed(self: Pin<&mut MyObject>);
-            },
-            qobject_ident: format_ident!("MyObject"),
-            mutable: true,
-            parameters: vec![],
-            name: Name::new(format_ident!("data_changed")).with_cxx_name("dataChanged".to_owned()),
-            safe: true,
-            inherit: false,
-            private: false,
-            docs: vec![],
+        let method = parse_quote! {
+            fn data_changed(self: Pin<&mut MyObject>);
         };
+        let qsignal = ParsedSignal::mock_with_method(&method);
 
         let names = QSignalNames::from(&qsignal);
         assert_eq!(names.name.cxx_unqualified(), "dataChanged");
@@ -137,20 +128,11 @@ mod tests {
 
     #[test]
     fn test_parsed_signal_existing_cxx_name() {
-        let qsignal = ParsedSignal {
-            method: parse_quote! {
-                #[cxx_name = "baseName"]
-                fn existing_signal(self: Pin<&mut MyObject>);
-            },
-            qobject_ident: format_ident!("MyObject"),
-            mutable: true,
-            parameters: vec![],
-            name: Name::new(format_ident!("existing_signal")).with_cxx_name("baseName".to_owned()),
-            safe: true,
-            inherit: false,
-            private: false,
-            docs: vec![],
+        let method = parse_quote! {
+            #[cxx_name = "baseName"]
+            fn existing_signal(self: Pin<&mut MyObject>);
         };
+        let qsignal = ParsedSignal::mock_with_method(&method);
 
         let names = QSignalNames::from(&qsignal);
         assert_eq!(names.name.cxx_unqualified(), "baseName");

--- a/crates/cxx-qt-gen/src/generator/rust/fragment.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/fragment.rs
@@ -6,7 +6,7 @@
 use proc_macro2::TokenStream;
 use syn::{Item, Result};
 
-#[derive(Default)]
+#[derive(Default, Eq, PartialEq, Debug)]
 pub struct GeneratedRustFragment {
     /// Module for the CXX bridge
     pub cxx_mod_contents: Vec<Item>,

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -75,11 +75,9 @@ mod tests {
     use super::*;
 
     use crate::generator::naming::qobject::tests::create_qobjectname;
-    use crate::naming::Name;
     use crate::parser::parameter::ParsedFunctionParameter;
     use crate::tests::assert_tokens_eq;
     use quote::format_ident;
-    use std::collections::HashSet;
     use syn::{parse_quote, ForeignItemFn};
 
     #[test]
@@ -91,79 +89,25 @@ mod tests {
         let method4: ForeignItemFn =
             parse_quote! { unsafe fn unsafe_invokable(self: &MyObject, param: *mut T) -> *mut T; };
         let invokables = vec![
-            ParsedMethod {
-                method: method1.clone(),
-                qobject_ident: format_ident!("MyObject"),
-                mutable: false,
-                safe: true,
-                parameters: vec![],
-                specifiers: HashSet::new(),
-                is_qinvokable: true,
-                name: Name::from_rust_ident_and_attrs(
-                    &method1.sig.ident,
-                    &method1.attrs,
-                    None,
-                    None,
-                )
-                .unwrap(),
-            },
-            ParsedMethod {
-                method: method2.clone(),
-                qobject_ident: format_ident!("MyObject"),
-                mutable: false,
-                safe: true,
-                parameters: vec![ParsedFunctionParameter {
+            ParsedMethod::mock_with_method(&method1),
+            ParsedMethod::mock_with_method(&method2).with_parameters(vec![
+                ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { i32 },
-                }],
-                specifiers: HashSet::new(),
-                is_qinvokable: true,
-                name: Name::from_rust_ident_and_attrs(
-                    &method2.sig.ident,
-                    &method2.attrs,
-                    None,
-                    None,
-                )
-                .unwrap(),
-            },
-            ParsedMethod {
-                method: method3.clone(),
-                qobject_ident: format_ident!("MyObject"),
-                mutable: true,
-                safe: true,
-                parameters: vec![ParsedFunctionParameter {
+                },
+            ]),
+            ParsedMethod::mock_with_method(&method3)
+                .with_parameters(vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { &QColor },
-                }],
-                specifiers: HashSet::new(),
-                is_qinvokable: true,
-                name: Name::from_rust_ident_and_attrs(
-                    &method3.sig.ident,
-                    &method3.attrs,
-                    None,
-                    None,
-                )
-                .unwrap(),
-            },
-            ParsedMethod {
-                method: method4.clone(),
-                qobject_ident: format_ident!("MyObject"),
-                mutable: false,
-                safe: false,
-                parameters: vec![ParsedFunctionParameter {
+                }])
+                .make_mutable(),
+            ParsedMethod::mock_with_method(&method4)
+                .with_parameters(vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { *mut T },
-                }],
-                specifiers: HashSet::new(),
-                is_qinvokable: true,
-                name: Name::from_rust_ident_and_attrs(
-                    &method4.sig.ident,
-                    &method4.attrs,
-                    None,
-                    None,
-                )
-                .unwrap(),
-            },
+                }])
+                .make_unsafe(),
         ];
         let qobject_idents = create_qobjectname();
 

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -75,9 +75,7 @@ mod tests {
     use super::*;
 
     use crate::generator::naming::qobject::tests::create_qobjectname;
-    use crate::parser::parameter::ParsedFunctionParameter;
     use crate::tests::assert_tokens_eq;
-    use quote::format_ident;
     use syn::{parse_quote, ForeignItemFn};
 
     #[test]
@@ -90,24 +88,9 @@ mod tests {
             parse_quote! { unsafe fn unsafe_invokable(self: &MyObject, param: *mut T) -> *mut T; };
         let invokables = vec![
             ParsedMethod::mock_qinvokable(&method1),
-            ParsedMethod::mock_qinvokable(&method2).with_parameters(vec![
-                ParsedFunctionParameter {
-                    ident: format_ident!("param"),
-                    ty: parse_quote! { i32 },
-                },
-            ]),
-            ParsedMethod::mock_qinvokable(&method3)
-                .with_parameters(vec![ParsedFunctionParameter {
-                    ident: format_ident!("param"),
-                    ty: parse_quote! { &QColor },
-                }])
-                .make_mutable(),
-            ParsedMethod::mock_qinvokable(&method4)
-                .with_parameters(vec![ParsedFunctionParameter {
-                    ident: format_ident!("param"),
-                    ty: parse_quote! { *mut T },
-                }])
-                .make_unsafe(),
+            ParsedMethod::mock_qinvokable(&method2),
+            ParsedMethod::mock_qinvokable(&method3).make_mutable(),
+            ParsedMethod::mock_qinvokable(&method4).make_unsafe(),
         ];
         let qobject_idents = create_qobjectname();
 

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -89,20 +89,20 @@ mod tests {
         let method4: ForeignItemFn =
             parse_quote! { unsafe fn unsafe_invokable(self: &MyObject, param: *mut T) -> *mut T; };
         let invokables = vec![
-            ParsedMethod::mock_with_method(&method1),
-            ParsedMethod::mock_with_method(&method2).with_parameters(vec![
+            ParsedMethod::mock_qinvokable(&method1),
+            ParsedMethod::mock_qinvokable(&method2).with_parameters(vec![
                 ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { i32 },
                 },
             ]),
-            ParsedMethod::mock_with_method(&method3)
+            ParsedMethod::mock_qinvokable(&method3)
                 .with_parameters(vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { &QColor },
                 }])
                 .make_mutable(),
-            ParsedMethod::mock_with_method(&method4)
+            ParsedMethod::mock_qinvokable(&method4)
                 .with_parameters(vec![ParsedFunctionParameter {
                     ident: format_ident!("param"),
                     ty: parse_quote! { *mut T },

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -178,6 +178,7 @@ fn generate_qobject_definitions(
 mod tests {
     use super::*;
 
+    use crate::generator::mock_qml_singleton;
     use crate::generator::structuring::Structures;
     use crate::parser::Parser;
     use crate::tests::assert_tokens_eq;
@@ -209,17 +210,7 @@ mod tests {
 
     #[test]
     fn test_generated_rust_qobject_blocks_singleton() {
-        let module: ItemMod = parse_quote! {
-            #[cxx_qt::bridge(namespace = "cxx_qt")]
-            mod ffi {
-                extern "RustQt" {
-                    #[qobject]
-                    #[qml_element]
-                    #[qml_singleton]
-                    type MyObject = super::MyObjectRust;
-                }
-            }
-        };
+        let module = mock_qml_singleton();
         let parser = Parser::from(module).unwrap();
         let structures = Structures::new(&parser.cxx_qt_data).unwrap();
 

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -252,7 +252,6 @@ mod tests {
     use super::*;
 
     use crate::generator::naming::qobject::tests::create_qobjectname;
-    use crate::parser::parameter::ParsedFunctionParameter;
     use crate::tests::assert_tokens_eq;
     use quote::{format_ident, quote};
     use syn::{parse_quote, ForeignItemFn, Item};
@@ -421,16 +420,7 @@ mod tests {
         let method: ForeignItemFn = parse_quote! {
             fn data_changed(self: Pin<&mut MyObject>, trivial: i32, opaque: UniquePtr<QColor>);
         };
-        let qsignal = ParsedSignal::mock_with_method(&method).with_parameters(vec![
-            ParsedFunctionParameter {
-                ident: format_ident!("trivial"),
-                ty: parse_quote! { i32 },
-            },
-            ParsedFunctionParameter {
-                ident: format_ident!("opaque"),
-                ty: parse_quote! { UniquePtr<QColor> },
-            },
-        ]);
+        let qsignal = ParsedSignal::mock_with_method(&method);
         let qobject_idents = create_qobjectname();
 
         let mut type_names = TypeNames::mock();
@@ -578,12 +568,7 @@ mod tests {
         };
         let qsignal = ParsedSignal {
             safe: false,
-            ..ParsedSignal::mock_with_method(&method).with_parameters(vec![
-                ParsedFunctionParameter {
-                    ident: format_ident!("param"),
-                    ty: parse_quote! { *mut T },
-                },
-            ])
+            ..ParsedSignal::mock_with_method(&method)
         };
         let qobject_idents = create_qobjectname();
 

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -422,27 +422,16 @@ mod tests {
             #[attribute]
             fn data_changed(self: Pin<&mut MyObject>, trivial: i32, opaque: UniquePtr<QColor>);
         };
-        let qsignal = ParsedSignal {
-            method: method.clone(),
-            qobject_ident: format_ident!("MyObject"),
-            mutable: true,
-            parameters: vec![
-                ParsedFunctionParameter {
-                    ident: format_ident!("trivial"),
-                    ty: parse_quote! { i32 },
-                },
-                ParsedFunctionParameter {
-                    ident: format_ident!("opaque"),
-                    ty: parse_quote! { UniquePtr<QColor> },
-                },
-            ],
-            name: Name::from_rust_ident_and_attrs(&method.sig.ident, &method.attrs, None, None)
-                .unwrap(),
-            safe: true,
-            inherit: false,
-            private: false,
-            docs: vec![],
-        };
+        let qsignal = ParsedSignal::mock_with_method(&method).with_parameters(vec![
+            ParsedFunctionParameter {
+                ident: format_ident!("trivial"),
+                ty: parse_quote! { i32 },
+            },
+            ParsedFunctionParameter {
+                ident: format_ident!("opaque"),
+                ty: parse_quote! { UniquePtr<QColor> },
+            },
+        ]);
         let qobject_idents = create_qobjectname();
 
         let mut type_names = TypeNames::mock();
@@ -585,22 +574,17 @@ mod tests {
 
     #[test]
     fn test_generate_rust_signal_unsafe() {
+        let method = parse_quote! {
+            unsafe fn unsafe_signal(self: Pin<&mut MyObject>, param: *mut T);
+        };
         let qsignal = ParsedSignal {
-            method: parse_quote! {
-                unsafe fn unsafe_signal(self: Pin<&mut MyObject>, param: *mut T);
-            },
-            qobject_ident: format_ident!("MyObject"),
-            mutable: true,
-            parameters: vec![ParsedFunctionParameter {
-                ident: format_ident!("param"),
-                ty: parse_quote! { *mut T },
-            }],
-            name: Name::new(format_ident!("unsafe_signal"))
-                .with_cxx_name("unsafeSignal".to_owned()),
             safe: false,
-            inherit: false,
-            private: false,
-            docs: vec![],
+            ..ParsedSignal::mock_with_method(&method).with_parameters(vec![
+                ParsedFunctionParameter {
+                    ident: format_ident!("param"),
+                    ty: parse_quote! { *mut T },
+                },
+            ])
         };
         let qobject_idents = create_qobjectname();
 
@@ -743,19 +727,14 @@ mod tests {
 
     #[test]
     fn test_generate_rust_signal_existing() {
+        let method = parse_quote! {
+            #[inherit]
+            #[cxx_name = "baseName"]
+            fn existing_signal(self: Pin<&mut MyObject>, );
+        };
         let qsignal = ParsedSignal {
-            method: parse_quote! {
-                #[inherit]
-                fn existing_signal(self: Pin<&mut MyObject>, );
-            },
-            qobject_ident: format_ident!("MyObject"),
-            mutable: true,
-            parameters: vec![],
-            name: Name::new(format_ident!("existing_signal")).with_cxx_name("baseName".to_owned()),
-            safe: true,
             inherit: true,
-            private: false,
-            docs: vec![],
+            ..ParsedSignal::mock_with_method(&method)
         };
         let qobject_idents = create_qobjectname();
 

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -419,7 +419,6 @@ mod tests {
     #[test]
     fn test_generate_rust_signal_parameters() {
         let method: ForeignItemFn = parse_quote! {
-            #[attribute]
             fn data_changed(self: Pin<&mut MyObject>, trivial: i32, opaque: UniquePtr<QColor>);
         };
         let qsignal = ParsedSignal::mock_with_method(&method).with_parameters(vec![

--- a/crates/cxx-qt-gen/src/parser/method.rs
+++ b/crates/cxx-qt-gen/src/parser/method.rs
@@ -13,8 +13,6 @@ use syn::{Attribute, Error, ForeignItemFn, Ident, Result};
 
 use crate::parser::{check_safety, separate_docs};
 use crate::syntax::{foreignmod, types};
-#[cfg(test)]
-use quote::format_ident;
 
 /// Describes a C++ specifier for the Q_INVOKABLE
 #[derive(Eq, Hash, PartialEq)]
@@ -77,11 +75,6 @@ impl ParsedMethod {
             safe: false,
             ..self
         }
-    }
-
-    #[cfg(test)]
-    pub fn with_parameters(self, parameters: Vec<ParsedFunctionParameter>) -> Self {
-        Self { parameters, ..self }
     }
 
     #[cfg(test)]

--- a/crates/cxx-qt-gen/src/parser/method.rs
+++ b/crates/cxx-qt-gen/src/parser/method.rs
@@ -55,6 +55,47 @@ pub struct ParsedMethod {
 }
 
 impl ParsedMethod {
+    #[cfg(test)]
+    pub fn mock_with_method(method: &ForeignItemFn) -> Self {
+        Self {
+            method: method.clone(),
+            qobject_ident: format_ident!("MyObject"),
+            mutable: false,
+            safe: true,
+            parameters: vec![],
+            specifiers: HashSet::new(),
+            is_qinvokable: true,
+            name: Name::from_rust_ident_and_attrs(&method.sig.ident, &method.attrs, None, None)
+                .unwrap(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn make_mutable(self) -> Self {
+        Self {
+            mutable: true,
+            ..self
+        }
+    }
+
+    #[cfg(test)]
+    pub fn make_unsafe(self) -> Self {
+        Self {
+            safe: false,
+            ..self
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_parameters(self, parameters: Vec<ParsedFunctionParameter>) -> Self {
+        Self { parameters, ..self }
+    }
+
+    #[cfg(test)]
+    pub fn with_specifiers(self, specifiers: HashSet<ParsedQInvokableSpecifiers>) -> Self {
+        Self { specifiers, ..self }
+    }
+
     pub fn parse(mut method: ForeignItemFn, safety: Safety) -> Result<Self> {
         check_safety(&method, &safety)?;
 
@@ -106,35 +147,6 @@ impl ParsedMethod {
             specifiers,
             is_qinvokable,
             name: fields.name,
-        }
-    }
-
-    #[cfg(test)]
-    pub fn from_method_and_params(
-        method: &ForeignItemFn,
-        parameters: Vec<ParsedFunctionParameter>,
-    ) -> Self {
-        ParsedMethod {
-            method: method.clone(),
-            qobject_ident: format_ident!("MyObject"),
-            mutable: false,
-            safe: true,
-            parameters,
-            specifiers: HashSet::new(),
-            is_qinvokable: true,
-            name: Name::from_rust_ident_and_attrs(&method.sig.ident, &method.attrs, None, None)
-                .unwrap(),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn mut_from_method_and_params(
-        method: &ForeignItemFn,
-        parameters: Vec<ParsedFunctionParameter>,
-    ) -> Self {
-        ParsedMethod {
-            mutable: true,
-            ..ParsedMethod::from_method_and_params(method, parameters)
         }
     }
 }

--- a/crates/cxx-qt-gen/src/parser/method.rs
+++ b/crates/cxx-qt-gen/src/parser/method.rs
@@ -56,17 +56,10 @@ pub struct ParsedMethod {
 
 impl ParsedMethod {
     #[cfg(test)]
-    pub fn mock_with_method(method: &ForeignItemFn) -> Self {
+    pub fn mock_qinvokable(method: &ForeignItemFn) -> Self {
         Self {
-            method: method.clone(),
-            qobject_ident: format_ident!("MyObject"),
-            mutable: false,
-            safe: true,
-            parameters: vec![],
-            specifiers: HashSet::new(),
             is_qinvokable: true,
-            name: Name::from_rust_ident_and_attrs(&method.sig.ident, &method.attrs, None, None)
-                .unwrap(),
+            ..Self::parse(method.clone(), Safety::Safe).unwrap()
         }
     }
 

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -76,6 +76,11 @@ impl ParsedSignal {
         }
     }
 
+    #[cfg(test)]
+    pub fn with_parameters(self, parameters: Vec<ParsedFunctionParameter>) -> Self {
+        Self { parameters, ..self }
+    }
+
     pub fn parse(mut method: ForeignItemFn, safety: Safety) -> Result<Self> {
         check_safety(&method, &safety)?;
 

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -60,8 +60,8 @@ impl ParsedSignal {
     }
 
     #[cfg(test)]
-    /// Test fn for creating a dummy signal from a method body
-    pub fn from_method(method: &ForeignItemFn) -> Self {
+    /// Test fn for creating a mocked signal from a method body
+    pub fn mock_with_method(method: &ForeignItemFn) -> Self {
         Self {
             method: method.clone(),
             qobject_ident: format_ident!("MyObject"),

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -12,8 +12,6 @@ use syn::{spanned::Spanned, Attribute, Error, ForeignItemFn, Ident, Result, Visi
 
 use crate::parser::method::MethodFields;
 use crate::parser::{check_safety, separate_docs};
-#[cfg(test)]
-use quote::format_ident;
 
 #[derive(Clone)]
 /// Describes an individual Signal
@@ -62,23 +60,7 @@ impl ParsedSignal {
     #[cfg(test)]
     /// Test fn for creating a mocked signal from a method body
     pub fn mock_with_method(method: &ForeignItemFn) -> Self {
-        Self {
-            method: method.clone(),
-            qobject_ident: format_ident!("MyObject"),
-            mutable: true,
-            parameters: vec![],
-            name: Name::from_rust_ident_and_attrs(&method.sig.ident, &method.attrs, None, None)
-                .unwrap(),
-            safe: true,
-            inherit: false,
-            private: false,
-            docs: vec![],
-        }
-    }
-
-    #[cfg(test)]
-    pub fn with_parameters(self, parameters: Vec<ParsedFunctionParameter>) -> Self {
-        Self { parameters, ..self }
+        Self::parse(method.clone(), Safety::Safe).unwrap()
     }
 
     pub fn parse(mut method: ForeignItemFn, safety: Safety) -> Result<Self> {

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -5,18 +5,10 @@
 
 use std::collections::BTreeSet;
 
-use crate::generator::cpp::{fragment::CppFragment, GeneratedCppBlocks};
+use crate::generator::cpp::GeneratedCppBlocks;
+use crate::writer::cpp::{extract_extern_qt, pair_as_header};
 use crate::writer::{self, cpp::namespaced};
 use indoc::formatdoc;
-
-/// Extract the header from a given CppFragment
-fn pair_as_header(pair: &CppFragment) -> Option<String> {
-    match pair {
-        CppFragment::Pair { header, source: _ } => Some(header.clone()),
-        CppFragment::Header(header) => Some(header.clone()),
-        CppFragment::Source(_) => None,
-    }
-}
 
 /// With a given block name, join the given items and add them under the block
 fn create_block(block: &str, items: &[String]) -> String {
@@ -162,18 +154,7 @@ pub fn write_cpp_header(generated: &GeneratedCppBlocks) -> String {
             .collect::<Vec<String>>()
             .join("\n")
     };
-    let extern_cxx_qt = generated
-        .extern_cxx_qt
-        .iter()
-        .flat_map(|block| {
-            block
-                .fragments
-                .iter()
-                .filter_map(pair_as_header)
-                .collect::<Vec<String>>()
-        })
-        .collect::<Vec<String>>()
-        .join("\n");
+    let extern_cxx_qt = extract_extern_qt(generated, pair_as_header);
 
     formatdoc! {r#"
         #pragma once

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -35,6 +35,41 @@ pub fn write_cpp(generated: &GeneratedCppBlocks) -> CppFragment {
         source: clang_format_with_style(&source, &ClangFormatStyle::File).unwrap_or(source),
     }
 }
+/// Extract the header from a given CppFragment
+pub fn pair_as_header(pair: &CppFragment) -> Option<String> {
+    match pair {
+        CppFragment::Pair { header, source: _ } => Some(header.clone()),
+        CppFragment::Header(header) => Some(header.clone()),
+        CppFragment::Source(_) => None,
+    }
+}
+
+/// Extract the source from a given CppFragment
+pub fn pair_as_source(pair: &CppFragment) -> Option<String> {
+    match pair {
+        CppFragment::Pair { header: _, source } => Some(source.clone()),
+        CppFragment::Header(_) => None,
+        CppFragment::Source(source) => Some(source.clone()),
+    }
+}
+
+pub fn extract_extern_qt(
+    generated: &GeneratedCppBlocks,
+    mut filter_fn: impl FnMut(&CppFragment) -> Option<String>,
+) -> String {
+    generated
+        .extern_cxx_qt
+        .iter()
+        .flat_map(|block| {
+            block
+                .fragments
+                .iter()
+                .filter_map(&mut filter_fn)
+                .collect::<Vec<String>>()
+        })
+        .collect::<Vec<String>>()
+        .join("\n")
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/cxx-qt-gen/src/writer/cpp/source.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/source.rs
@@ -3,18 +3,10 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::generator::cpp::{fragment::CppFragment, GeneratedCppBlocks};
+use crate::generator::cpp::GeneratedCppBlocks;
+use crate::writer::cpp::{extract_extern_qt, pair_as_source};
 use crate::writer::{self, cpp::namespaced};
 use indoc::formatdoc;
-
-/// Extract the source from a given CppFragment
-fn pair_as_source(pair: &CppFragment) -> Option<String> {
-    match pair {
-        CppFragment::Pair { header: _, source } => Some(source.clone()),
-        CppFragment::Header(_) => None,
-        CppFragment::Source(source) => Some(source.clone()),
-    }
-}
 
 /// For a given GeneratedCppBlocks write the implementations
 fn qobjects_source(generated: &GeneratedCppBlocks) -> Vec<String> {
@@ -46,18 +38,7 @@ fn qobjects_source(generated: &GeneratedCppBlocks) -> Vec<String> {
 
 /// For a given GeneratedCppBlocks write this into a C++ source
 pub fn write_cpp_source(generated: &GeneratedCppBlocks) -> String {
-    let extern_cxx_qt = generated
-        .extern_cxx_qt
-        .iter()
-        .flat_map(|block| {
-            block
-                .fragments
-                .iter()
-                .filter_map(pair_as_source)
-                .collect::<Vec<String>>()
-        })
-        .collect::<Vec<String>>()
-        .join("\n");
+    let extern_cxx_qt = extract_extern_qt(generated, pair_as_source);
 
     formatdoc! {r#"
         #include "{header_prefix}/{cxx_file_stem}.cxxqt.h"


### PR DESCRIPTION
Remove some duplication in asserts, helper functions and ParsedMethod construction. This led to introducing builder like functions for mocking methods