### PR TITLE
Refactor assert_parse_errors macro to be more generic

### DIFF
--- a/crates/cxx-qt-gen/src/generator/structuring/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/structuring/mod.rs
@@ -119,6 +119,7 @@ impl<'a> Structures<'a> {
 mod tests {
     use super::*;
     // use crate::tests::assert_parse_errors;
+    use crate::tests::assert_parse_errors;
     use crate::Parser;
     use quote::format_ident;
     use syn::{parse_quote, ItemMod};
@@ -354,74 +355,72 @@ mod tests {
         ]);
     }
 
-    // TODO: figure out how to do this since the reference to parser is a problem
-    // #[test]
-    // fn test_create_invalid_structures() {
-    //     assert_parse_errors! {
-    //         |module| {
-    //             let parser = Parser::from(module).unwrap();
-    //             Structures::new(&parser.cxx_qt_data)
-    //         } =>
-    //
-    //         {
-    //             // Unknown QObject
-    //             #[cxx_qt::bridge]
-    //             mod ffi {
-    //                 extern "RustQt" {
-    //                     #[qobject]
-    //                     type MyObject = super::MyObjectRust;
-    //                 }
-    //
-    //                 unsafe extern "RustQt" {
-    //                     #[qsignal]
-    //                     fn ready(self: Pin<&mut UnknownObject>);
-    //                 }
-    //             }
-    //         }
-    //
-    //         {
-    //             // Invalid QObject for QEnum
-    //             #[cxx_qt::bridge]
-    //             mod ffi {
-    //                 #[qenum(MyObject)]
-    //                 enum MyEnum {
-    //                     A,
-    //                 }
-    //             }
-    //         }
-    //
-    //         {
-    //             // Undeclared QObject for method
-    //             #[cxx_qt::bridge]
-    //             mod ffi {
-    //                 unsafe extern "RustQt" {
-    //                     #[qinvokable]
-    //                     fn test_fn(self: Pin<&mut MyObject>);
-    //                 }
-    //             }
-    //         }
-    //
-    //         {
-    //             // Undeclared QObject for signal
-    //             #[cxx_qt::bridge]
-    //             mod ffi {
-    //                 unsafe extern "RustQt" {
-    //                     #[qsignal]
-    //                     fn test_fn(self: Pin<&mut MyObject>);
-    //                 }
-    //             }
-    //         }
-    //
-    //         {
-    //             // Undeclared QObject for inherited method
-    //             #[cxx_qt::bridge]
-    //             mod ffi {
-    //                 unsafe extern "RustQt" {
-    //                     #[inherit]
-    //                     fn test_fn(self: Pin<&mut MyObject>);
-    //                 }
-    //             }
-    //         }
-    //     }
-    // }
+    #[test]
+    fn test_create_invalid_structures() {
+        assert_parse_errors! {
+            |module| {
+                Structures::new(&Parser::from(module).unwrap().cxx_qt_data).map(|_| ())
+            } =>
+
+            {
+                // Unknown QObject
+                #[cxx_qt::bridge]
+                mod ffi {
+                    extern "RustQt" {
+                        #[qobject]
+                        type MyObject = super::MyObjectRust;
+                    }
+
+                    unsafe extern "RustQt" {
+                        #[qsignal]
+                        fn ready(self: Pin<&mut UnknownObject>);
+                    }
+                }
+            }
+
+            {
+                // Invalid QObject for QEnum
+                #[cxx_qt::bridge]
+                mod ffi {
+                    #[qenum(MyObject)]
+                    enum MyEnum {
+                        A,
+                    }
+                }
+            }
+
+            {
+                // Undeclared QObject for method
+                #[cxx_qt::bridge]
+                mod ffi {
+                    unsafe extern "RustQt" {
+                        #[qinvokable]
+                        fn test_fn(self: Pin<&mut MyObject>);
+                    }
+                }
+            }
+
+            {
+                // Undeclared QObject for signal
+                #[cxx_qt::bridge]
+                mod ffi {
+                    unsafe extern "RustQt" {
+                        #[qsignal]
+                        fn test_fn(self: Pin<&mut MyObject>);
+                    }
+                }
+            }
+
+            {
+                // Undeclared QObject for inherited method
+                #[cxx_qt::bridge]
+                mod ffi {
+                    unsafe extern "RustQt" {
+                        #[inherit]
+                        fn test_fn(self: Pin<&mut MyObject>);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/crates/cxx-qt-gen/src/generator/structuring/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/structuring/mod.rs
@@ -118,7 +118,6 @@ impl<'a> Structures<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // use crate::tests::assert_parse_errors;
     use crate::tests::assert_parse_errors;
     use crate::Parser;
     use quote::format_ident;

--- a/crates/cxx-qt-gen/src/generator/structuring/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/structuring/mod.rs
@@ -118,6 +118,7 @@ impl<'a> Structures<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // use crate::tests::assert_parse_errors;
     use crate::Parser;
     use quote::format_ident;
     use syn::{parse_quote, ItemMod};
@@ -346,9 +347,81 @@ mod tests {
 
     #[test]
     fn test_incompatible_trait_impl() {
+        // TODO: Possible to use assert_parse_errors?
         assert_structuring_error([
             parse_quote! {impl cxx_qt::Threading for MyObject {}},
             parse_quote! {impl cxx_qt::Threading for MyObject {}},
         ]);
     }
+
+    // TODO: figure out how to do this since the reference to parser is a problem
+    // #[test]
+    // fn test_create_invalid_structures() {
+    //     assert_parse_errors! {
+    //         |module| {
+    //             let parser = Parser::from(module).unwrap();
+    //             Structures::new(&parser.cxx_qt_data)
+    //         } =>
+    //
+    //         {
+    //             // Unknown QObject
+    //             #[cxx_qt::bridge]
+    //             mod ffi {
+    //                 extern "RustQt" {
+    //                     #[qobject]
+    //                     type MyObject = super::MyObjectRust;
+    //                 }
+    //
+    //                 unsafe extern "RustQt" {
+    //                     #[qsignal]
+    //                     fn ready(self: Pin<&mut UnknownObject>);
+    //                 }
+    //             }
+    //         }
+    //
+    //         {
+    //             // Invalid QObject for QEnum
+    //             #[cxx_qt::bridge]
+    //             mod ffi {
+    //                 #[qenum(MyObject)]
+    //                 enum MyEnum {
+    //                     A,
+    //                 }
+    //             }
+    //         }
+    //
+    //         {
+    //             // Undeclared QObject for method
+    //             #[cxx_qt::bridge]
+    //             mod ffi {
+    //                 unsafe extern "RustQt" {
+    //                     #[qinvokable]
+    //                     fn test_fn(self: Pin<&mut MyObject>);
+    //                 }
+    //             }
+    //         }
+    //
+    //         {
+    //             // Undeclared QObject for signal
+    //             #[cxx_qt::bridge]
+    //             mod ffi {
+    //                 unsafe extern "RustQt" {
+    //                     #[qsignal]
+    //                     fn test_fn(self: Pin<&mut MyObject>);
+    //                 }
+    //             }
+    //         }
+    //
+    //         {
+    //             // Undeclared QObject for inherited method
+    //             #[cxx_qt::bridge]
+    //             mod ffi {
+    //                 unsafe extern "RustQt" {
+    //                     #[inherit]
+    //                     fn test_fn(self: Pin<&mut MyObject>);
+    //                 }
+    //             }
+    //         }
+    //     }
+    // }
 }

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -64,8 +64,8 @@ mod tests {
     }
 
     macro_rules! assert_parse_errors {
-        { $type:ident: $($input:tt)* } => {
-            $(assert!($type::parse(syn::parse_quote! $input).is_err());)*
+        { $parse_fn:expr => $($input:tt)* } => {
+            $(assert!($parse_fn(syn::parse_quote! $input).is_err());)*
         }
     }
     pub(crate) use assert_parse_errors;

--- a/crates/cxx-qt-gen/src/naming/cpp.rs
+++ b/crates/cxx-qt-gen/src/naming/cpp.rs
@@ -356,9 +356,12 @@ mod tests {
 
     #[test]
     fn test_invalid_types() {
-        let type_names = TypeNames::default();
+        let mut type_names = TypeNames::default();
         assert_parse_errors! {
-            |ty| syn_type_to_cpp_type(&ty, &type_names) =>
+            |ty| {
+                type_names.mock_insert("A", None, Some("A1"), None);
+                syn_type_to_cpp_type(&ty, &type_names)
+            } =>
 
             { (A) }
             { Option<A> }

--- a/crates/cxx-qt-gen/src/naming/cpp.rs
+++ b/crates/cxx-qt-gen/src/naming/cpp.rs
@@ -270,9 +270,9 @@ fn possible_built_in_template_base(ty: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use syn::parse_quote;
-
     use super::*;
+    use crate::tests::assert_parse_errors;
+    use syn::parse_quote;
 
     #[test]
     fn test_syn_return_type_to_cpp_except_default() {
@@ -355,44 +355,23 @@ mod tests {
     }
 
     #[test]
-    fn test_syn_type_invalid() {
-        let ty = parse_quote! { (A) };
-        let mut type_names = TypeNames::default();
-        type_names.mock_insert("A", None, Some("A1"), None);
-        assert!(syn_type_to_cpp_type(&ty, &type_names).is_err());
+    fn test_invalid_types() {
+        let type_names = TypeNames::default();
+        assert_parse_errors! {
+            |ty| syn_type_to_cpp_type(&ty, &type_names) =>
 
-        let ty = parse_quote! { Option<A> };
-        let mut type_names = TypeNames::default();
-        type_names.mock_insert("A", None, Some("A1"), None);
-        assert!(syn_type_to_cpp_type(&ty, &type_names).is_err());
-
-        let ty = parse_quote! { Result<A> };
-        let mut type_names = TypeNames::default();
-        type_names.mock_insert("A", None, Some("A1"), None);
-        assert!(syn_type_to_cpp_type(&ty, &type_names).is_err());
-
-        let ty = parse_quote! { Pin<> };
-        let mut type_names = TypeNames::default();
-        type_names.mock_insert("A", None, Some("A1"), None);
-        assert!(syn_type_to_cpp_type(&ty, &type_names).is_err());
-
-        let ty = parse_quote! { Vec<'a,T> };
-        let mut type_names = TypeNames::default();
-        type_names.mock_insert("A", None, Some("A1"), None);
-        assert!(syn_type_to_cpp_type(&ty, &type_names).is_err());
-
-        let ty = parse_quote! { f32::f32::f32 };
-        let mut type_names = TypeNames::default();
-        type_names.mock_insert("A", None, Some("A1"), None);
-        assert!(syn_type_to_cpp_type(&ty, &type_names).is_err());
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_no_template() {
-        let ty = parse_quote! { NotATemplate<A> };
-        let mut type_names = TypeNames::default();
-        type_names.mock_insert("A", None, Some("A1"), None);
-        assert!(syn_type_to_cpp_type(&ty, &type_names).is_err(),);
+            { (A) }
+            { Option<A> }
+            { Result<A> }
+            { Pin<> }
+            { Vec<'a, T> }
+            { f32::f32::f32 }
+            { NotATemplate<A> }
+            { [i32; 0] }
+            { [i32; String] }
+            { [i32; 1.5f32] }
+            { (i32, ) }
+        }
     }
 
     #[test]
@@ -409,30 +388,6 @@ mod tests {
         let mut type_names = TypeNames::default();
         type_names.mock_insert("A", None, Some("A1"), Some("N1"));
         assert_eq!(syn_type_to_cpp_type(&ty, &type_names).unwrap(), "N1::A1");
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_array_length_zero() {
-        let ty = parse_quote! { [i32; 0] };
-        assert!(syn_type_to_cpp_type(&ty, &TypeNames::default()).is_err());
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_array_length_invalid() {
-        let ty = parse_quote! { [i32; String] };
-        assert!(syn_type_to_cpp_type(&ty, &TypeNames::default()).is_err());
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_array_length_non_integer() {
-        let ty = parse_quote! { [i32; 1.5f32] };
-        assert!(syn_type_to_cpp_type(&ty, &TypeNames::default()).is_err());
-    }
-
-    #[test]
-    fn test_syn_type_to_cpp_type_tuple_multiple() {
-        let ty = parse_quote! { (i32, ) };
-        assert!(syn_type_to_cpp_type(&ty, &TypeNames::default()).is_err());
     }
 
     #[test]

--- a/crates/cxx-qt-gen/src/naming/type_names.rs
+++ b/crates/cxx-qt-gen/src/naming/type_names.rs
@@ -423,6 +423,7 @@ impl TypeNames {
 mod tests {
     use super::*;
 
+    use crate::tests::assert_parse_errors;
     use quote::format_ident;
     use syn::parse_quote;
 

--- a/crates/cxx-qt-gen/src/naming/type_names.rs
+++ b/crates/cxx-qt-gen/src/naming/type_names.rs
@@ -423,7 +423,6 @@ impl TypeNames {
 mod tests {
     use super::*;
 
-    use crate::tests::assert_parse_errors;
     use quote::format_ident;
     use syn::parse_quote;
 

--- a/crates/cxx-qt-gen/src/parser/constructor.rs
+++ b/crates/cxx-qt-gen/src/parser/constructor.rs
@@ -180,105 +180,64 @@ impl Constructor {
 
 #[cfg(test)]
 mod tests {
-    use syn::parse_quote;
-
     use super::*;
-
-    // CODECOV_EXCLUDE_START
-    fn assert_parse_error(item: ItemImpl, message: &str) {
-        assert!(
-            Constructor::parse(item).is_err(),
-            // Excluded as this is just a custom error message for if asserts fail
-            "Constructor shouldn't have parsed because '{message}'."
-        );
-    }
-    // CODECOV_EXCLUDE_STOP
+    use crate::tests::assert_parse_errors;
+    use syn::parse_quote;
 
     #[test]
     fn parse_invalid_constructors() {
-        assert_parse_error(
-            parse_quote! {
+        assert_parse_errors! {
+            Constructor::parse =>
+
+            {
+                /// Missing type arguments
                 impl cxx_qt::Constructor for X {}
-            },
-            "missing type arguments",
-        );
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Missing main argument list
                 impl cxx_qt::Constructor<NewArguments=()> for X {}
-            },
-            "missing main argument list",
-        );
-
-        // Hard to tell if this actually hits the error as the rest of the project isn't compiling
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Negative impls for cxx_qt::Constructor are not allowed
                 impl !cxx_qt::Constructor<(i32, i32)> for T {}
-            },
-            "Negative impls for cxx_qt::Constructor are not allowed",
-        );
-
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Generics on impl block are not allowed
                 impl<T> cxx_qt::Constructor<()> for T {}
-            },
-            "generics on impl block",
-        );
-        // TODO This should be allowed at some point if the lifetime is actually used.
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Multiple Lifetimes are not allowed
                 impl<'a, 'b> cxx_qt::Constructor<()> for T {}
-            },
-            "multiple lifetimes on impl block",
-        );
-
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Unknown named args
                 impl cxx_qt::Constructor<(), UnknownArguments=()> for X {}
-            },
-            "unknown named type argument",
-        );
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Duplicate args
                 impl cxx_qt::Constructor<(), NewArguments=(), NewArguments=()> for X {}
-            },
-            "duplicate named type argument",
-        );
-
-        // Not a tuple, missing `,`
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Expects a tuple
                 impl cxx_qt::Constructor<> for X {}
-            },
-            "cxx_qt::Constructor expects a tuple as the first generic argument",
-        );
-
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Not a tuple
                 impl cxx_qt::Constructor<(i32)> for X {}
-            },
-            "type argument is not a tuple",
-        );
-
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Expected 2nd generic arg to be an associated type
                 impl cxx_qt::Constructor<(i32,String),'a> for X {}
-            },
-            "Expected associated type as a generic argument!",
-        );
-
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Where clauses are not allowed
                 impl cxx_qt::Constructor<(T,S)> for X where S: Debug, T: Clone {}
-            },
-            "Where clauses are not allowed on cxx_qt::Constructor impls!",
-        );
-
-        assert_parse_error(
-            parse_quote! {
+            }
+            {
+                /// Unnecessary unsafe impl
                 unsafe impl cxx_qt::Constructor<(i32,String)> for X {}
-            },
-            "Unnecessary unsafe around constructor impl.",
-        );
+            }
+        }
     }
 
     #[test]

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -176,6 +176,7 @@ impl Parser {
 mod tests {
     use super::*;
 
+    use crate::tests::assert_parse_errors;
     use pretty_assertions::assert_eq;
     use quote::format_ident;
     use syn::{parse_quote, ItemMod, Type};
@@ -333,31 +334,29 @@ mod tests {
     }
 
     #[test]
-    fn test_non_string_namespace() {
-        let module: ItemMod = parse_quote! {
-            #[cxx_qt::bridge]
-            mod ffi {
-                extern "Rust" {
-                    #[namespace = 1]
-                    type MyObject = super::MyObjectRust;
-                }
-            }
-        };
-        let parser = Parser::from(module);
-        assert!(parser.is_err());
-    }
+    fn test_parser_invalid() {
+        assert_parse_errors! {
+            Parser::from =>
 
-    #[test]
-    fn test_parser_from_error_no_attribute() {
-        let module: ItemMod = parse_quote! {
-            mod ffi {
-                extern "Rust" {
-                    fn test();
+            {
+                // Non-string namespace
+                #[cxx_qt::bridge]
+                mod ffi {
+                    extern "Rust" {
+                        #[namespace = 1]
+                        type MyObject = super::MyObjectRust;
+                    }
                 }
             }
-        };
-        let parser = Parser::from(module);
-        assert!(parser.is_err());
+            {
+                // No cxx_qt bridge on module
+                mod ffi {
+                    extern "Rust" {
+                        fn test();
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/cxx-qt-gen/src/parser/qenum.rs
+++ b/crates/cxx-qt-gen/src/parser/qenum.rs
@@ -159,53 +159,48 @@ mod tests {
         assert_tokens_eq(&parsed.item, qenum.to_token_stream());
     }
 
-    macro_rules! assert_parse_error {
-        ($( $input:tt )*) => {
-            let qenum: ItemEnum = parse_quote! { $($input)* };
-            assert!(ParsedQEnum::parse(qenum, Some(format_ident!("QObject")), None, &mock_module()).is_err());
-        }
-    }
+    use crate::tests::assert_parse_errors;
 
     #[test]
     fn parse_errors() {
-        assert_parse_error! {
+        assert_parse_errors! {
+            |qenum| ParsedQEnum::parse(qenum, Some(format_ident!("QObject")), None, &mock_module()) =>
             // No variants
-            enum MyEnum {}
-        }
-        assert_parse_error! {
-            // Unkown attributes
-            #[any_attribute]
-            enum MyEnum { A }
-        }
-        assert_parse_error! {
-            // Repr is not allowed either
-            #[repr(u32)]
-            enum MyEnum { A }
-        }
-        assert_parse_error! {
-            // Fields are not allowed
-            enum MyEnum {
-                A { field: i32 }
-            }
-        }
-        assert_parse_error! {
-            // Fields are not allowed
-            enum MyEnum {
-                A(i32)
-            }
-        }
-        assert_parse_error! {
-            // Attributes on variants are not allowed
-            enum MyEnum {
+            { enum MyEnum {} }
+            {
+                // Unknown attributes
                 #[any_attribute]
-                A
+                enum MyEnum { A }
             }
-        }
-
-        // TODO: allow discriminants
-        assert_parse_error! {
-            enum MyEnum {
-                A = 1
+            {
+                // Repr is not allowed either
+                #[repr(u32)]
+                enum MyEnum { A }
+            }
+            {
+                // Fields are not allowed
+                enum MyEnum {
+                    A { field: i32 }
+                }
+            }
+            {
+                // Fields are not allowed
+                enum MyEnum {
+                    A(i32)
+                }
+            }
+            {
+                // Attributes on variants are not allowed
+                enum MyEnum {
+                    #[any_attribute]
+                    A
+                }
+            }
+            {
+                // TODO: Allow discriminants
+                enum MyEnum {
+                    A = 1
+                }
             }
         }
     }

--- a/crates/cxx-qt-gen/src/parser/qnamespace.rs
+++ b/crates/cxx-qt-gen/src/parser/qnamespace.rs
@@ -85,42 +85,29 @@ mod test {
         assert!(parsed.qml_element);
     }
 
-    macro_rules! assert_parse_error {
-        { $($input:tt)* } => {
-            assert!(ParsedQNamespace::parse(syn::parse_quote! { $($input)* }).is_err())
-        }
-    }
+    use crate::tests::assert_parse_errors;
 
     #[test]
     fn parse_errors() {
-        assert_parse_error! {
-            qnamespace!(my_namespace);
-        }
-        assert_parse_error! {
-            qnamespace!();
-        }
-        assert_parse_error! {
-            #[my_attribute]
-            qnamespace!("hello");
-        }
-        assert_parse_error! {
-            qnamespace! test ("hello");
-        }
-        assert_parse_error! {
-            qnamespace!("hello" "world");
-        }
-        assert_parse_error! {
-            /// A doc comment
-            qnamespace!("my_namespace");
-        }
-        assert_parse_error! {
-            qnamespace!("");
-        }
-        assert_parse_error! {
-            qnamespace!(" ");
-        }
-        assert_parse_error! {
-            qnamespace!("my namespace");
+        assert_parse_errors! {
+            ParsedQNamespace::parse =>
+
+            { qnamespace!(my_namespace); }
+            { qnamespace!(); }
+            {
+                #[my_attribute]
+                qnamespace!("hello");
+            }
+            { qnamespace! test ("hello"); }
+            { qnamespace!("hello" "world"); }
+            {
+                /// A doc comment
+                qnamespace!("my_namespace");
+            }
+            { qnamespace!(""); }
+            { qnamespace!(" "); }
+            { qnamespace!("my namespace"); }
+
         }
     }
 }

--- a/crates/cxx-qt-gen/src/parser/trait_impl.rs
+++ b/crates/cxx-qt-gen/src/parser/trait_impl.rs
@@ -135,26 +135,23 @@ mod tests {
     #[test]
     fn test_parse_errors() {
         assert_parse_errors! {
-            TraitImpl:
+            TraitImpl::parse =>
 
             // Threading is safe to implement
             { unsafe impl cxx_qt::Threading for QObject {} }
             // Threading cannot be negated
             { impl !cxx_qt::Threading for QObject {} }
-
             // Invalid QObject name
-            { impl cxx_qt::Threading for my::path {} }
+            { impl cxx_qt::Locking for my::path {} }
             // Invalid trait name
             { impl cxx_qt::AnotherTrait for QObject {} }
             // Invalid Path to self type
             { impl cxx_qt::Threading for *mut QObject{} }
-
             {
                 // Attributes are not allowed
                 #[my_attribute]
                 impl cxx_qt::Threading for QObject {}
             }
-
             {
                 // Item in the impl block
                 impl cxx_qt::Threading for X {

--- a/crates/cxx-qt-gen/src/syntax/types.rs
+++ b/crates/cxx-qt-gen/src/syntax/types.rs
@@ -132,6 +132,7 @@ pub fn extract_qobject_ident(ty: &Type) -> Result<(Ident, Option<Mut>)> {
 mod tests {
     use crate::parser::method::ParsedMethod;
     use crate::syntax::safety::Safety;
+    use crate::tests::assert_parse_errors;
     use syn::{parse_quote, ForeignItemFn, Type};
 
     #[test]
@@ -161,13 +162,16 @@ mod tests {
         assert_qobject_ident(parse_quote! { &Foo }, "Foo", false);
         assert_qobject_ident(parse_quote! { Pin<&mut Foo> }, "Foo", true);
 
-        assert!(super::extract_qobject_ident(&parse_quote! { Foo }).is_err());
-        assert!(super::extract_qobject_ident(&parse_quote! { &mut Foo }).is_err());
-        assert!(super::extract_qobject_ident(&parse_quote! { Pin<&Foo> }).is_err());
-        assert!(super::extract_qobject_ident(&parse_quote! { Foo }).is_err());
-        assert!(super::extract_qobject_ident(&parse_quote! { X::Foo }).is_err());
-        assert!(super::extract_qobject_ident(&parse_quote! { Self }).is_err());
-        assert!(super::extract_qobject_ident(&parse_quote! { Pin<T = A> }).is_err());
+        assert_parse_errors! {
+            |ty| super::extract_qobject_ident(&ty) =>
+
+            { Foo }
+            { &mut Foo }
+            { Pin<&Foo> }
+            { X::Foo }
+            { Self }
+            { Pin<T = A> }
+        }
     }
 
     #[test]

--- a/crates/cxx-qt-gen/src/syntax/types.rs
+++ b/crates/cxx-qt-gen/src/syntax/types.rs
@@ -84,7 +84,8 @@ fn extract_qobject_ident_from_ref(ty: &TypeReference) -> Result<(Ident, Option<M
 
 fn extract_qobject_from_mut_pin(ty: &TypePath) -> Result<(Ident, Mut)> {
     if path_compare_str(&ty.path, &["Pin"]) {
-        if let PathArguments::AngleBracketed(angles) = &ty.path.segments.first().unwrap().arguments
+        return if let PathArguments::AngleBracketed(angles) =
+            &ty.path.segments.first().unwrap().arguments
         {
             if let [GenericArgument::Type(Type::Reference(reference))] =
                 *angles.args.iter().collect::<Vec<_>>()
@@ -93,16 +94,16 @@ fn extract_qobject_from_mut_pin(ty: &TypePath) -> Result<(Ident, Mut)> {
                 if mutability.is_none() {
                     return Err(err_pin_misuse(reference));
                 }
-                return Ok((ident, mutability.unwrap()));
+                Ok((ident, mutability.unwrap()))
             } else {
-                return Err(err_pin_misuse(ty));
+                Err(err_pin_misuse(ty))
             }
         } else {
-            return Err(Error::new_spanned(
+            Err(Error::new_spanned(
                 ty,
                 "Pin must use angle brackets not parentheses for generic args! Use Pin<&mut T>",
-            ));
-        }
+            ))
+        };
     }
 
     Err(err_pin_misuse(ty))


### PR DESCRIPTION
assert_parse_errors is now more generic thanks to some help from Leon, and I've used this in as many places as possible.
