### PR TITLE
Fix namespace bug

### DIFF
--- a/crates/cxx-qt-gen/src/generator/naming/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/qobject.rs
@@ -7,7 +7,8 @@ use crate::{
     parser::qobject::ParsedQObject,
 };
 use convert_case::{Case, Casing};
-use quote::format_ident;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 use syn::{Ident, Result};
 
 /// Names for parts of a Q_OBJECT
@@ -61,6 +62,15 @@ impl QObjectNames {
             "cxx_qt_ffi_{ident}_{suffix}",
             ident = self.name.cxx_unqualified().to_case(Case::Snake)
         )
+    }
+
+    pub fn namespace_tokens(&self) -> TokenStream {
+        let namespace = self.name.namespace();
+        if namespace.is_none() {
+            quote! {}
+        } else {
+            quote! { #[namespace = #namespace ] }
+        }
     }
 }
 

--- a/crates/cxx-qt-gen/src/generator/naming/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/qobject.rs
@@ -64,12 +64,13 @@ impl QObjectNames {
         )
     }
 
+    /// Returns the tokens of the namespace attribute to be added to a rust line, or no tokens if this instance has no namespace
+    /// attribute looks like `#[namespace = "namespace::here"]`
     pub fn namespace_tokens(&self) -> TokenStream {
-        let namespace = self.name.namespace();
-        if namespace.is_none() {
-            quote! {}
-        } else {
+        if let Some(namespace) = self.name.namespace() {
             quote! { #[namespace = #namespace ] }
+        } else {
+            quote! {}
         }
     }
 }

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -53,7 +53,11 @@ pub fn generate_rust_methods(
                     //
                     // CXX ends up generating the source, then we generate the matching header.
                     #[cxx_name = #wrapper_ident_cpp]
-                    #cxx_namespace // Needed so QObjects can have a namespace
+                    // Needed for QObjects to have a namespace on their type or extern block
+                    //
+                    // A Namespace from cxx_qt::bridge would be automatically applied to all children
+                    // but to apply it to only certain types, it is needed here too
+                    #cxx_namespace
                     #[doc(hidden)]
                     #unsafe_call fn #invokable_ident_rust(#parameter_signatures) #return_type;
                 }

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -42,7 +42,7 @@ pub fn generate_rust_methods(
             std::mem::swap(&mut unsafe_call, &mut None);
         }
 
-        let cxx_namespace = qobject_idents.namespace_tokens();
+        let cxx_namespace = qobject_names.namespace_tokens();
 
         let fragment = RustFragmentPair {
             cxx_bridge: vec![quote_spanned! {

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -42,12 +42,7 @@ pub fn generate_rust_methods(
             std::mem::swap(&mut unsafe_call, &mut None);
         }
 
-        let namespace = qobject_idents.name.namespace();
-        let cxx_namespace = if namespace.is_none() {
-            quote! {}
-        } else {
-            quote! { #[namespace = #namespace ] }
-        };
+        let cxx_namespace = qobject_idents.namespace_tokens();
 
         let fragment = RustFragmentPair {
             cxx_bridge: vec![quote_spanned! {
@@ -58,8 +53,7 @@ pub fn generate_rust_methods(
                     //
                     // CXX ends up generating the source, then we generate the matching header.
                     #[cxx_name = #wrapper_ident_cpp]
-                    // Namespace is not needed here
-                    #cxx_namespace
+                    #cxx_namespace // Needed so QObjects can have a namespace
                     #[doc(hidden)]
                     #unsafe_call fn #invokable_ident_rust(#parameter_signatures) #return_type;
                 }

--- a/crates/cxx-qt-gen/src/generator/rust/method.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/method.rs
@@ -42,6 +42,13 @@ pub fn generate_rust_methods(
             std::mem::swap(&mut unsafe_call, &mut None);
         }
 
+        let namespace = qobject_idents.name.namespace();
+        let cxx_namespace = if namespace.is_none() {
+            quote! {}
+        } else {
+            quote! { #[namespace = #namespace ] }
+        };
+
         let fragment = RustFragmentPair {
             cxx_bridge: vec![quote_spanned! {
                 invokable.method.span() =>
@@ -52,6 +59,7 @@ pub fn generate_rust_methods(
                     // CXX ends up generating the source, then we generate the matching header.
                     #[cxx_name = #wrapper_ident_cpp]
                     // Namespace is not needed here
+                    #cxx_namespace
                     #[doc(hidden)]
                     #unsafe_call fn #invokable_ident_rust(#parameter_signatures) #return_type;
                 }

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -40,7 +40,11 @@ pub fn generate(
             cxx_bridge: vec![quote! {
                 extern "Rust" {
                     #[cxx_name = #getter_wrapper_cpp]
-                    #cxx_namespace // Needed so QObjects can have a namespace
+                    // Needed for QObjects to have a namespace on their type or extern block
+                    //
+                    // A Namespace from cxx_qt::bridge would be automatically applied to all children
+                    // but to apply it to only certain types, it is needed here too
+                    #cxx_namespace
                     unsafe fn #getter_rust<'a>(self: &'a #cpp_class_name_rust) -> &'a #cxx_ty;
                 }
             }],

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -34,19 +34,13 @@ pub fn generate(
         let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, type_names)?;
         let qualified_impl = type_names.rust_qualified(cpp_class_name_rust)?;
 
-        let namespace = qobject_idents.name.namespace();
-        let cxx_namespace = if namespace.is_none() {
-            quote! {}
-        } else {
-            quote! { #[namespace = #namespace ] }
-        };
+        let cxx_namespace = qobject_idents.namespace_tokens();
 
         Ok(Some(RustFragmentPair {
             cxx_bridge: vec![quote! {
                 extern "Rust" {
                     #[cxx_name = #getter_wrapper_cpp]
-                    // Namespace is not needed here
-                    #cxx_namespace
+                    #cxx_namespace // Needed so QObjects can have a namespace
                     unsafe fn #getter_rust<'a>(self: &'a #cpp_class_name_rust) -> &'a #cxx_ty;
                 }
             }],

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -34,11 +34,19 @@ pub fn generate(
         let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, type_names)?;
         let qualified_impl = type_names.rust_qualified(cpp_class_name_rust)?;
 
+        let namespace = qobject_idents.name.namespace();
+        let cxx_namespace = if namespace.is_none() {
+            quote! {}
+        } else {
+            quote! { #[namespace = #namespace ] }
+        };
+
         Ok(Some(RustFragmentPair {
             cxx_bridge: vec![quote! {
                 extern "Rust" {
                     #[cxx_name = #getter_wrapper_cpp]
                     // Namespace is not needed here
+                    #cxx_namespace
                     unsafe fn #getter_rust<'a>(self: &'a #cpp_class_name_rust) -> &'a #cxx_ty;
                 }
             }],

--- a/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/getter.rs
@@ -34,7 +34,7 @@ pub fn generate(
         let qualified_ty = syn_type_cxx_bridge_to_qualified(cxx_ty, type_names)?;
         let qualified_impl = type_names.rust_qualified(cpp_class_name_rust)?;
 
-        let cxx_namespace = qobject_idents.namespace_tokens();
+        let cxx_namespace = qobject_names.namespace_tokens();
 
         Ok(Some(RustFragmentPair {
             cxx_bridge: vec![quote! {

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -53,7 +53,7 @@ pub fn generate(
             quote! {}
         };
 
-        let cxx_namespace = qobject_idents.namespace_tokens();
+        let cxx_namespace = qobject_names.namespace_tokens();
 
         Ok(Some(RustFragmentPair {
             cxx_bridge: vec![quote! {

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -53,19 +53,13 @@ pub fn generate(
             quote! {}
         };
 
-        let namespace = qobject_idents.name.namespace();
-        let cxx_namespace = if namespace.is_none() {
-            quote! {}
-        } else {
-            quote! { #[namespace = #namespace ] }
-        };
+        let cxx_namespace = qobject_idents.namespace_tokens();
 
         Ok(Some(RustFragmentPair {
             cxx_bridge: vec![quote! {
                 extern "Rust" {
                     #[cxx_name = #setter_wrapper_cpp]
-                    // Namespace is not needed here
-                    #cxx_namespace
+                    #cxx_namespace // Needed so QObjects can have a namespace
                     #has_unsafe fn #setter_rust(self: Pin<&mut #cpp_class_name_rust>, value: #cxx_ty);
                 }
             }],

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -59,7 +59,11 @@ pub fn generate(
             cxx_bridge: vec![quote! {
                 extern "Rust" {
                     #[cxx_name = #setter_wrapper_cpp]
-                    #cxx_namespace // Needed so QObjects can have a namespace
+                    // Needed for QObjects to have a namespace on their type or extern block
+                    //
+                    // A Namespace from cxx_qt::bridge would be automatically applied to all children
+                    // but to apply it to only certain types, it is needed here too
+                    #cxx_namespace
                     #has_unsafe fn #setter_rust(self: Pin<&mut #cpp_class_name_rust>, value: #cxx_ty);
                 }
             }],

--- a/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/setter.rs
@@ -53,11 +53,19 @@ pub fn generate(
             quote! {}
         };
 
+        let namespace = qobject_idents.name.namespace();
+        let cxx_namespace = if namespace.is_none() {
+            quote! {}
+        } else {
+            quote! { #[namespace = #namespace ] }
+        };
+
         Ok(Some(RustFragmentPair {
             cxx_bridge: vec![quote! {
                 extern "Rust" {
                     #[cxx_name = #setter_wrapper_cpp]
                     // Namespace is not needed here
+                    #cxx_namespace
                     #has_unsafe fn #setter_rust(self: Pin<&mut #cpp_class_name_rust>, value: #cxx_ty);
                 }
             }],

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -34,7 +34,7 @@ impl GeneratedRustFragment {
         let namespace_idents = NamespaceName::from(qobject);
         let mut generated = Self::default();
 
-        generated.append(&mut generate_qobject_definitions(&qobject_idents)?);
+        generated.append(&mut generate_qobject_definitions(&qobject_names)?);
 
         // Generate methods for the properties, invokables, signals
         generated.append(&mut generate_rust_properties(

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -155,6 +155,7 @@ fn generate_qobject_definitions(
             },
             quote! {
                 extern "Rust" {
+                    #namespace
                     type #rust_struct_name_rust;
                 }
             },

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -155,7 +155,7 @@ fn generate_qobject_definitions(
             },
             quote! {
                 extern "Rust" {
-                    #namespace
+                    #namespace // Needed for namespacing QObjects
                     type #rust_struct_name_rust;
                 }
             },
@@ -233,6 +233,7 @@ mod tests {
             &rust.cxx_mod_contents[1],
             quote! {
                 extern "Rust" {
+                    #[namespace = "cxx_qt"]
                     type MyObjectRust;
                 }
             },

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -38,6 +38,7 @@ mod ffi {
         type MyObject;
     }
     extern "Rust" {
+        #[namespace = "cxx_qt::my_object"]
         type MyObjectRust;
     }
     extern "Rust" {

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -42,56 +42,67 @@ mod ffi {
     }
     extern "Rust" {
         #[cxx_name = "cppMethodWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn cpp_method(self: &MyObject);
     }
     extern "Rust" {
         #[cxx_name = "invokableWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable(self: &MyObject);
     }
     extern "Rust" {
         #[cxx_name = "invokableMutableWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable_mutable(self: Pin<&mut MyObject>);
     }
     extern "Rust" {
         #[cxx_name = "invokableParametersWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable_parameters(self: &MyObject, opaque: &QColor, trivial: &QPoint, primitive: i32);
     }
     extern "Rust" {
         #[cxx_name = "invokableReturnOpaqueWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable_return_opaque(self: Pin<&mut MyObject>) -> UniquePtr<Opaque>;
     }
     extern "Rust" {
         #[cxx_name = "invokableReturnTrivialWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable_return_trivial(self: Pin<&mut MyObject>) -> QPoint;
     }
     extern "Rust" {
         #[cxx_name = "invokableFinalWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable_final(self: &MyObject);
     }
     extern "Rust" {
         #[cxx_name = "invokableOverrideWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable_override(self: &MyObject);
     }
     extern "Rust" {
         #[cxx_name = "invokableVirtualWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable_virtual(self: &MyObject);
     }
     extern "Rust" {
         #[cxx_name = "invokableResultTupleWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable_result_tuple(self: &MyObject) -> Result<()>;
     }
     extern "Rust" {
         #[cxx_name = "invokableResultTypeWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable_result_type(self: &MyObject) -> Result<String>;
     }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -125,6 +125,7 @@ pub mod ffi {
     }
     extern "Rust" {
         #[cxx_name = "invokableNameWrapper"]
+        #[namespace = "cxx_qt::multi_object"]
         #[doc(hidden)]
         fn invokable_name(self: Pin<&mut MyObject>);
     }
@@ -227,6 +228,7 @@ pub mod ffi {
     }
     extern "Rust" {
         #[cxx_name = "invokableNameWrapper"]
+        #[namespace = "second_object"]
         #[doc(hidden)]
         fn invokable_name(self: Pin<&mut SecondObject>);
     }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -80,14 +80,17 @@ pub mod ffi {
         type MyObject;
     }
     extern "Rust" {
+        #[namespace = "cxx_qt::multi_object"]
         type MyObjectRust;
     }
     extern "Rust" {
         #[cxx_name = "getPropertyNameWrapper"]
+        #[namespace = "cxx_qt::multi_object"]
         unsafe fn property_name<'a>(self: &'a MyObject) -> &'a i32;
     }
     extern "Rust" {
         #[cxx_name = "setPropertyNameWrapper"]
+        #[namespace = "cxx_qt::multi_object"]
         fn set_property_name(self: Pin<&mut MyObject>, value: i32);
     }
     unsafe extern "C++" {
@@ -183,14 +186,17 @@ pub mod ffi {
         type SecondObject;
     }
     extern "Rust" {
+        #[namespace = "second_object"]
         type SecondObjectRust;
     }
     extern "Rust" {
         #[cxx_name = "getPropertyNameWrapper"]
+        #[namespace = "second_object"]
         unsafe fn property_name<'a>(self: &'a SecondObject) -> &'a i32;
     }
     extern "Rust" {
         #[cxx_name = "setPropertyNameWrapper"]
+        #[namespace = "second_object"]
         fn set_property_name(self: Pin<&mut SecondObject>, value: i32);
     }
     unsafe extern "C++" {
@@ -289,6 +295,7 @@ pub mod ffi {
         type MyRustName;
     }
     extern "Rust" {
+        #[namespace = "my_namespace"]
         type ThirdObjectRust;
     }
     extern "Rust" {

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -31,62 +31,77 @@ mod ffi {
         type MyObject;
     }
     extern "Rust" {
+        #[namespace = "cxx_qt::my_object"]
         type MyObjectRust;
     }
     extern "Rust" {
         #[cxx_name = "getPrimitiveWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         unsafe fn primitive<'a>(self: &'a MyObject) -> &'a i32;
     }
     extern "Rust" {
         #[cxx_name = "setPrimitiveWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         fn set_primitive(self: Pin<&mut MyObject>, value: i32);
     }
     extern "Rust" {
         #[cxx_name = "getTrivialWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         unsafe fn trivial<'a>(self: &'a MyObject) -> &'a QPoint;
     }
     extern "Rust" {
         #[cxx_name = "setTrivialWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         fn set_trivial(self: Pin<&mut MyObject>, value: QPoint);
     }
     extern "Rust" {
         #[cxx_name = "getReadonlyPropWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         unsafe fn readonly_prop<'a>(self: &'a MyObject) -> &'a i32;
     }
     extern "Rust" {
         #[cxx_name = "getCustomOnChangedPropWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         unsafe fn custom_on_changed_prop<'a>(self: &'a MyObject) -> &'a i32;
     }
     extern "Rust" {
         #[cxx_name = "setCustomOnChangedPropWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         fn set_custom_on_changed_prop(self: Pin<&mut MyObject>, value: i32);
     }
     extern "Rust" {
         #[cxx_name = "getConstPropWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         unsafe fn const_prop<'a>(self: &'a MyObject) -> &'a i32;
     }
     extern "Rust" {
         #[cxx_name = "getResettablePropWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         unsafe fn resettable_prop<'a>(self: &'a MyObject) -> &'a i32;
     }
     extern "Rust" {
         #[cxx_name = "setResettablePropWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         fn set_resettable_prop(self: Pin<&mut MyObject>, value: i32);
     }
     extern "Rust" {
         #[cxx_name = "getRequiredPropWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         unsafe fn required_prop<'a>(self: &'a MyObject) -> &'a i32;
     }
     extern "Rust" {
         #[cxx_name = "setRequiredPropWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         fn set_required_prop(self: Pin<&mut MyObject>, value: i32);
     }
     extern "Rust" {
         #[cxx_name = "getFinalPropWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         unsafe fn final_prop<'a>(self: &'a MyObject) -> &'a i32;
     }
     extern "Rust" {
         #[cxx_name = "setFinalPropWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         fn set_final_prop(self: Pin<&mut MyObject>, value: i32);
     }
     unsafe extern "C++" {

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -188,16 +188,19 @@ mod ffi {
     }
     extern "Rust" {
         #[cxx_name = "myGetterWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn my_getter(self: &MyObject) -> i32;
     }
     extern "Rust" {
         #[cxx_name = "MyCustomSetterWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn my_setter(self: Pin<&mut MyObject>, value: i32);
     }
     extern "Rust" {
         #[cxx_name = "myResetFnWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn myResetFn(self: Pin<&mut MyObject>);
     }

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs
@@ -79,6 +79,7 @@ mod ffi {
     }
     extern "Rust" {
         #[cxx_name = "myInvokableWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn my_invokable(self: &MyObject, qenum: MyEnum, other_qenum: MyOtherEnum);
     }

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs
@@ -75,6 +75,7 @@ mod ffi {
         type MyObject;
     }
     extern "Rust" {
+        #[namespace = "cxx_qt::my_object"]
         type MyObjectRust;
     }
     extern "Rust" {
@@ -112,6 +113,7 @@ mod ffi {
         type MyRenamedObject;
     }
     extern "Rust" {
+        #[namespace = "cxx_qt::my_object"]
         type InternalObject;
     }
     extern "Rust" {

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -32,6 +32,7 @@ mod ffi {
         type MyObject;
     }
     extern "Rust" {
+        #[namespace = "cxx_qt::my_object"]
         type MyObjectRust;
     }
     extern "Rust" {

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -36,6 +36,7 @@ mod ffi {
     }
     extern "Rust" {
         #[cxx_name = "invokableWrapper"]
+        #[namespace = "cxx_qt::my_object"]
         #[doc(hidden)]
         fn invokable(self: Pin<&mut MyObject>);
     }

--- a/examples/qml_minimal/rust/src/cxxqt_object.rs
+++ b/examples/qml_minimal/rust/src/cxxqt_object.rs
@@ -30,6 +30,7 @@ pub mod qobject {
         #[qml_element]
         #[qproperty(i32, number)]
         #[qproperty(QString, string)]
+        #[namespace = "my_object"]
         type MyObject = super::MyObjectRust;
     }
     // ANCHOR_END: book_rustobj_struct_signature


### PR DESCRIPTION
Putting Namespace attrs on a type in RustQt or the block itself doesn't compile, with a big string of cpp errors.

I've tried putting namespace back into the rust generate fn, along with a host of other options, such as putting the namespace on the method block as well.

However, putting namespace on the bridge works fine, and everything works properly.

