### PR TITLE
clippy: fix new warnings for 1.81

### DIFF
--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -623,7 +623,7 @@ impl QtBuild {
         let mut cmd = Command::new(self.moc_executable.as_ref().unwrap());
 
         if let Some(uri) = arguments.uri {
-            cmd.arg(&format!("-Muri={uri}"));
+            cmd.arg(format!("-Muri={uri}"));
         }
 
         cmd.args(include_args.trim_end().split(' '));


### PR DESCRIPTION
This resolves the following warning

```rust
warning: the borrowed expression implements the required traits
   --> crates/qt-build-utils/src/lib.rs:626:21
    |                                         
626 |             cmd.arg(&format!("-Muri={uri}"));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `format!("-Muri={uri}")`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
    = note: `#[warn(clippy::needless_borrows_for_generic_args)]` on by default
```