### PR TITLE
Add base upcast

### DIFF
--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -234,7 +234,7 @@ mod tests {
             mod ffi {
                 extern "RustQt" {
                     #[qobject]
-                    #[base = "QStringListModel"]
+                    #[base = QStringListModel]
                     type MyObject = super::MyObjectRust;
                 }
             }

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -238,7 +238,7 @@ mod tests {
             #[cxx_qt::bridge]
             mod ffi {
                 extern "RustQt" {
-                    #[base = "MyBase"]
+                    #[base = MyBase]
                     type MyObject = super::MyObjectRust;
                 }
             }

--- a/crates/cxx-qt-gen/test_inputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_inputs/inheritance.rs
@@ -9,7 +9,7 @@ mod inheritance {
 
     extern "RustQt" {
         #[qobject]
-        #[base = "QAbstractItemModel"]
+        #[base = QAbstractItemModel]
         type MyObject = super::MyObjectRust;
     }
 

--- a/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
@@ -115,7 +115,7 @@ pub mod ffi {
 
     extern "RustQt" {
         #[qobject]
-        #[base = "QStringListModel"]
+        #[base = QStringListModel]
         #[qproperty(i32, property_name)]
         type MyObject = super::MyObjectRust;
     }


### PR DESCRIPTION
Add support to impl Upcast under the hood to silence dead code warning of base types.
Also switch from `#[base = "BaseClass"]` to `#[base = BaseClass]`
