### PR TITLE
Fix: Silence warning about unused base class

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -127,7 +127,17 @@ fn generate_qobject_definitions(
 
     let base_upcast = if let Some(base) = base {
         let base_name = type_names.lookup(&base)?.rust_qualified();
-        vec![quote! { impl cxx_qt::Upcast<#base_name> for #cpp_struct_qualified {} }]
+        vec![
+            quote! { impl cxx_qt::Upcast<#base_name> for #cpp_struct_qualified {} },
+            // Until we can actually implement the Upcast trait properly, we just need to silence
+            // the warning that the base class is otherwise unused.
+            // This can be done with an unnamed import and the right attributes
+            quote! {
+                #[allow(unused_imports)]
+                #[allow(dead_code)]
+                use #base_name as _;
+            },
+        ]
     } else {
         vec![]
     };

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -77,6 +77,9 @@ mod inheritance {
     }
 }
 impl cxx_qt::Upcast<inheritance::QAbstractItemModel> for inheritance::MyObject {}
+#[allow(unused_imports)]
+#[allow(dead_code)]
+use inheritance::QAbstractItemModel as _;
 #[doc(hidden)]
 pub fn create_rs_my_object_rust() -> std::boxed::Box<MyObjectRust> {
     std::boxed::Box::new(core::default::Default::default())

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -430,6 +430,9 @@ pub mod ffi {
     }
 }
 impl cxx_qt::Upcast<ffi::QStringListModel> for ffi::MyObject {}
+#[allow(unused_imports)]
+#[allow(dead_code)]
+use ffi::QStringListModel as _;
 impl ffi::MyObject {
     #[doc = "Getter for the Q_PROPERTY "]
     #[doc = "property_name"]


### PR DESCRIPTION
For some reason when using CXX-Qt as a dependency outside of this repository, the warning about the unused struct wasn't being silenced. This PR should fix that issue