### PR TITLE
Hotfix: rust_name on #[inherit]

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/inherit.rs
@@ -31,7 +31,7 @@ pub fn generate(
                 })
                 .collect::<Vec<TokenStream>>();
 
-            let ident = &method.method.sig.ident;
+            let ident = &method.method_fields.name.rust_unqualified();
             let cxx_name_string = &method.wrapper_ident().to_string();
             let self_param = if method.mutable {
                 quote! { self: Pin<&mut #qobject_name> }

--- a/crates/cxx-qt-gen/test_inputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_inputs/inheritance.rs
@@ -20,6 +20,10 @@ mod inheritance {
         #[cxx_name = "hasChildren"]
         #[inherit]
         fn has_children_super(self: &MyObject, parent: &QModelIndex) -> bool;
+
+        #[rust_name = "hello_world"]
+        #[inherit]
+        fn helloWorld(self: &MyObject, parent: &QModelIndex) -> bool;
     }
 
     extern "RustQt" {

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -25,6 +25,11 @@ public:
     return QAbstractItemModel::hasChildren(args...);
   }
   template<class... Args>
+  bool helloWorldCxxQtInherit(Args... args) const
+  {
+    return QAbstractItemModel::helloWorld(args...);
+  }
+  template<class... Args>
   void fetchMoreCxxQtInherit(Args... args)
   {
     return QAbstractItemModel::fetchMore(args...);

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -51,6 +51,10 @@ mod inheritance {
         #[doc = " Inherited hasChildren from the base class"]
         fn has_children_super(self: &MyObject, parent: &QModelIndex) -> bool;
     }
+    unsafe extern "C++" {
+        #[cxx_name = "helloWorldCxxQtInherit"]
+        fn hello_world(self: &MyObject, parent: &QModelIndex) -> bool;
+    }
     extern "C++" {
         #[cxx_name = "fetchMoreCxxQtInherit"]
         #[doc = " Inherited fetchMore from the base class"]


### PR DESCRIPTION
This used ident directly, instead of rust_unqualified()

Also, add a corresponding regression test