### PR TITLE
ci: disable failing tests due to differing clang-format on macOS

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       # Note ensure that matrix runner is updated too
       - run: |
-          pip install --user clang-format==14.0.6
+          pip install --user clang-format==18.1.8
           test -x ~/.local/bin/clang-format
           test -x /home/runner/.local/bin/clang-format
       - run: ./scripts/clang_format_check.sh /home/runner/.local/bin/clang-format .
@@ -413,7 +413,7 @@ jobs:
     - name: "Install clang-format"
       # Note ensure that clang-format runner is updated too
       run: |
-        pip install --user clang-format==14.0.6
+        pip install --user clang-format==18.1.8
         test -x ${{ matrix.clang_format_path }}
 
     - name: "[Ubuntu] Install dependencies"

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -21,8 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get update && sudo apt-get install -y clang-format-12
-      - run: ./scripts/clang_format_check.sh .
+      # Note ensure that matrix runner is updated too
+      - run: |
+          pip install --user clang-format==14.0.6
+          test -x ~/.local/bin/clang-format
+          test -x /home/runner/.local/bin/clang-format
+      - run: ./scripts/clang_format_check.sh /home/runner/.local/bin/clang-format .
 
   license_check:
     runs-on: ubuntu-latest
@@ -235,6 +239,7 @@ jobs:
             ctest_args: --exclude-regex '^(example_qml_features_test_valgrind|example_qml_minimal_myobject_test_valgrind)$'
             qt_qpa_platform: offscreen
             compiler_cache_path: /home/runner/.cache/sccache
+            clang_format_path: /home/runner/.local/bin/clang-format
             cargo_dir: ~/.cargo
             packages-extra: >-
                 qtbase5-dev
@@ -255,6 +260,7 @@ jobs:
             ctest_args: --exclude-regex '^(example_qml_features_test_valgrind|example_qml_minimal_myobject_test_valgrind)$'
             qt_qpa_platform: offscreen
             compiler_cache_path: /home/runner/.cache/sccache
+            clang_format_path: /home/runner/.local/bin/clang-format
             cargo_dir: ~/.cargo
             packages-extra: >-
                 qt6-base-dev
@@ -277,14 +283,10 @@ jobs:
             cores: 3
             # FIXME: qmltestrunner fails to import QtQuick module
             # https://github.com/KDAB/cxx-qt/issues/110
-            #
-            # FIXME: clang-format-14 causes formatting differences if it is selected by brew
-            # once Ubuntu 22.04 is we can move to clang-format-14 everywhere
-            # for now we need at least clang-format-12 otherwise include reordering fails after clang-format off
-            # https://github.com/KDAB/cxx-qt/issues/121
             ctest_args: --exclude-regex '^(cargo_clippy|cargo_doc|example_qml_features_test|example_qml_minimal_myobject_test|cargo_build_rerun|.*valgrind)$'
             qt_qpa_platform: cocoa
             compiler_cache_path: /Users/runner/Library/Caches/Mozilla.sccache
+            clang_format_path: /Users/runner/Library/Python/3.12/bin/clang-format
             cargo_dir: ~/.cargo
             workspace: /Users/runner/cxx-qt
             cc: clang
@@ -300,6 +302,7 @@ jobs:
             ctest_args: --exclude-regex '^(cargo_clippy|cargo_doc|example_qml_features_test|example_qml_minimal_myobject_test|cargo_build_rerun|.*valgrind)$'
             qt_qpa_platform: cocoa
             compiler_cache_path: /Users/runner/Library/Caches/Mozilla.sccache
+            clang_format_path: /Users/runner/Library/Python/3.12/bin/clang-format
             cargo_dir: ~/.cargo
             workspace: /Users/runner/cxx-qt
             cc: clang
@@ -317,6 +320,7 @@ jobs:
             exe_suffix: .exe
             qt_qpa_platform: windows
             compiler_cache_path: C:\Users\runneradmin\AppData\Local\Mozilla\sccache\cache
+            clang_format_path: C:\Users\runneradmin\AppData\Roaming\Python\Python39\Scripts\clang-format.exe
             cargo_dir: C:\Users\runneradmin\.cargo
             cc: cl
             cxx: cl
@@ -334,6 +338,7 @@ jobs:
             exe_suffix: .exe
             qt_qpa_platform: windows
             compiler_cache_path: C:\Users\runneradmin\AppData\Local\Mozilla\sccache\cache
+            clang_format_path: C:\Users\runneradmin\AppData\Roaming\Python\Python39\Scripts\clang-format.exe
             cargo_dir: C:\Users\runneradmin\.cargo
             cc: cl
             cxx: cl
@@ -405,13 +410,18 @@ jobs:
         path: ${{ matrix.compiler_cache_path }}
         key: ${{ matrix.name }}_compiler_cache
 
+    - name: "Install clang-format"
+      # Note ensure that clang-format runner is updated too
+      run: |
+        pip install --user clang-format==14.0.6
+        test -x ${{ matrix.clang_format_path }}
+
     - name: "[Ubuntu] Install dependencies"
       if: runner.os == 'Linux'
       run: >-
         sudo apt-get update &&
         sudo apt-get install -y
         ninja-build
-        clang-format-12
         libssl-dev
         pkg-config
         valgrind
@@ -424,13 +434,8 @@ jobs:
 
     - name: "[macOS] Install dependencies"
       if: runner.os == 'macOS'
-      # FIXME: clang-format-14 causes formatting differences if it is selected by brew
-      # once Ubuntu 22.04 is we can move to clang-format-14 everywhere
-      # for now we need at least clang-format-12 otherwise include reordering fails after clang-format off
-      # https://github.com/KDAB/cxx-qt/issues/121
-      #
       # automake is needed for building libicu which is a dependency of Qt
-      run: brew install automake autoconf-archive ninja clang-format
+      run: brew install automake autoconf-archive ninja
 
     # Note that for nuget uploads to work this must be run as the kdab user
     # eg a branch on the kdab repo rather than a users fork
@@ -480,6 +485,8 @@ jobs:
       run: ctest ${{ matrix.ctest_args }} -C Release -T test --output-on-failure --parallel ${{ matrix.cores }}
       working-directory: ${{ matrix.workspace }}/build
       env:
+        # Use the version of clang-format from pip
+        CLANG_FORMAT_BINARY: ${{ matrix.clang_format_path }}
         RUSTC_WRAPPER: sccache
         QT_QPA_PLATFORM: ${{ matrix.qt_qpa_platform }}
         QT_SELECT: qt${{ matrix.qt_version }}

--- a/crates/cxx-qt-lib-extras/include/core/qcommandlineoption.h
+++ b/crates/cxx-qt-lib-extras/include/core/qcommandlineoption.h
@@ -16,7 +16,6 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QCommandLineOption> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust

--- a/crates/cxx-qt-lib-extras/include/core/qcommandlineparser.h
+++ b/crates/cxx-qt-lib-extras/include/core/qcommandlineparser.h
@@ -16,8 +16,7 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QCommandLineParser> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qbytearray.h
+++ b/crates/cxx-qt-lib/include/core/qbytearray.h
@@ -18,8 +18,7 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QByteArray> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qdatetime.h
+++ b/crates/cxx-qt-lib/include/core/qdatetime.h
@@ -21,8 +21,7 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QDateTime> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qhash.h
+++ b/crates/cxx-qt-lib/include/core/qhash.h
@@ -23,8 +23,7 @@ namespace rust {
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename K, typename V>
 struct IsRelocatable<QHash<K, V>> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qlist.h
+++ b/crates/cxx-qt-lib/include/core/qlist.h
@@ -45,8 +45,7 @@ namespace rust {
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename T>
 struct IsRelocatable<QList<T>> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 #endif

--- a/crates/cxx-qt-lib/include/core/qlist_qvector.h
+++ b/crates/cxx-qt-lib/include/core/qlist_qvector.h
@@ -23,8 +23,7 @@ namespace rust {
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename T>
 struct IsRelocatable<QList<T>> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qmap.h
+++ b/crates/cxx-qt-lib/include/core/qmap.h
@@ -20,8 +20,7 @@ namespace rust {
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename K, typename V>
 struct IsRelocatable<QMap<K, V>> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qpersistentmodelindex.h
+++ b/crates/cxx-qt-lib/include/core/qpersistentmodelindex.h
@@ -17,7 +17,6 @@ namespace rust {
 // This has static asserts in the cpp file to ensure this is valid.
 template<>
 struct IsRelocatable<QPersistentModelIndex> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust

--- a/crates/cxx-qt-lib/include/core/qset.h
+++ b/crates/cxx-qt-lib/include/core/qset.h
@@ -27,8 +27,7 @@ namespace rust {
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename T>
 struct IsRelocatable<QSet<T>> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qstring.h
+++ b/crates/cxx-qt-lib/include/core/qstring.h
@@ -18,8 +18,7 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QString> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qstringlist.h
+++ b/crates/cxx-qt-lib/include/core/qstringlist.h
@@ -18,8 +18,7 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QStringList> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qurl.h
+++ b/crates/cxx-qt-lib/include/core/qurl.h
@@ -20,8 +20,7 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QUrl> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qvariant.h
+++ b/crates/cxx-qt-lib/include/core/qvariant.h
@@ -39,8 +39,7 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QVariant> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt-lib/include/core/qvector.h
+++ b/crates/cxx-qt-lib/include/core/qvector.h
@@ -45,8 +45,7 @@ namespace rust {
 // This has static asserts in the cpp file to ensure this is valid.
 template<typename T>
 struct IsRelocatable<QVector<T>> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 #endif

--- a/crates/cxx-qt-lib/include/gui/qcolor.h
+++ b/crates/cxx-qt-lib/include/gui/qcolor.h
@@ -23,8 +23,7 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QColor> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 #endif

--- a/crates/cxx-qt-lib/include/gui/qfont.h
+++ b/crates/cxx-qt-lib/include/gui/qfont.h
@@ -16,8 +16,7 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QFont> : ::std::true_type
-{
-};
+{};
 
 namespace cxxqtlib1 {
 using QFontStyle = QFont::Style;

--- a/crates/cxx-qt-lib/include/gui/qimage.h
+++ b/crates/cxx-qt-lib/include/gui/qimage.h
@@ -17,8 +17,7 @@ namespace rust {
 // QImage has a move constructor, however it is basically trivial.
 template<>
 struct IsRelocatable<QImage> : ::std::true_type
-{
-};
+{};
 
 namespace cxxqtlib1 {
 using QImageFormat = QImage::Format;

--- a/crates/cxx-qt-lib/include/gui/qpainterpath.h
+++ b/crates/cxx-qt-lib/include/gui/qpainterpath.h
@@ -16,7 +16,6 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QPainterPath> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust

--- a/crates/cxx-qt-lib/include/gui/qpen.h
+++ b/crates/cxx-qt-lib/include/gui/qpen.h
@@ -16,7 +16,6 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QPen> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust

--- a/crates/cxx-qt-lib/include/gui/qpolygon.h
+++ b/crates/cxx-qt-lib/include/gui/qpolygon.h
@@ -16,7 +16,6 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QPolygon> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust

--- a/crates/cxx-qt-lib/include/gui/qpolygonf.h
+++ b/crates/cxx-qt-lib/include/gui/qpolygonf.h
@@ -16,7 +16,6 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QPolygonF> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust

--- a/crates/cxx-qt-lib/include/gui/qregion.h
+++ b/crates/cxx-qt-lib/include/gui/qregion.h
@@ -16,7 +16,6 @@ namespace rust {
 
 template<>
 struct IsRelocatable<QRegion> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust

--- a/crates/cxx-qt/include/connection.h
+++ b/crates/cxx-qt/include/connection.h
@@ -17,8 +17,7 @@ namespace rust {
 
 template<>
 struct IsRelocatable<::QMetaObject::Connection> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust
 

--- a/crates/cxx-qt/include/signalhandler.h
+++ b/crates/cxx-qt/include/signalhandler.h
@@ -48,7 +48,6 @@ namespace rust {
 template<typename CXXArguments>
 struct IsRelocatable<rust::cxxqt1::SignalHandler<CXXArguments>>
   : ::std::true_type
-{
-};
+{};
 
 } // namespace rust

--- a/crates/cxx-qt/include/thread.h
+++ b/crates/cxx-qt/include/thread.h
@@ -116,7 +116,6 @@ namespace rust {
 
 template<typename T>
 struct IsRelocatable<::rust::cxxqt1::CxxQtThread<T>> : ::std::true_type
-{
-};
+{};
 
 } // namespace rust

--- a/scripts/clang_format_check.sh
+++ b/scripts/clang_format_check.sh
@@ -7,14 +7,15 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 set -e
 
-DIR=$1
-echo "Executing clang-format on directory: $DIR"
+CLANG_FORMAT_CMD=$1
+DIR=$2
+echo "Executing $CLANG_FORMAT_CMD on directory: $DIR"
 
 function clang_format_files() {
     while IFS= read -r -d '' file
     do
         if ! git check-ignore -q "$file"; then
-            clang-format --dry-run -Werror "$file"
+            $CLANG_FORMAT_CMD --dry-run -Werror "$file"
         fi
     done < <(find "$DIR" -type f -name "$1" -a -not -path "$DIR/.git/*" -not -path "$DIR/vcpkg/*" -not -path "$DIR/*/vcpkg_installed/*" -print0)
 }

--- a/scripts/clang_format_inplace.sh
+++ b/scripts/clang_format_inplace.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
-# SPDX-FileContributor: Gerhard de Clercq <gerhard.declercq@kdab.com>
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
-set -e
 
 CLANG_FORMAT_CMD=$1
 DIR=$2
@@ -15,8 +13,7 @@ function clang_format_files() {
     while IFS= read -r -d '' FILE
     do
         if git ls-files --error-unmatch "$FILE" &> /dev/null; then
-            $CLANG_FORMAT_CMD --dry-run -Werror "$FILE"
-            RET=$((RET | $?))
+            $CLANG_FORMAT_CMD -i -Werror "$FILE"
         fi
     done < <(find "$DIR" -type f -name "$1" -a -print0)
 }


### PR DESCRIPTION
A better way would be to have a consistent clang-format version everywhere