### PR TITLE
Add `desktopFileName` static methods to QGuiApplication

### DIFF
--- a/crates/cxx-qt-lib/include/gui/qguiapplication.h
+++ b/crates/cxx-qt-lib/include/gui/qguiapplication.h
@@ -25,5 +25,11 @@ qguiapplicationSetFont(QGuiApplication& app, const QFont& font);
 QFont
 qguiapplicationFont(const QGuiApplication& app);
 
+void
+qguiapplicationSetDesktopFileName(const QString& name);
+
+QString
+qguiapplicationDesktopFileName();
+
 }
 }

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.cpp
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.cpp
@@ -41,5 +41,17 @@ qguiapplicationFont(const QGuiApplication& app)
   return app.font();
 }
 
+void
+qguiapplicationSetDesktopFileName(const QString& name)
+{
+  QGuiApplication::setDesktopFileName(name);
+}
+
+QString
+qguiapplicationDesktopFileName()
+{
+  return QGuiApplication::desktopFileName();
+}
+
 }
 }

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.rs
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.rs
@@ -212,6 +212,6 @@ impl QGuiApplication {
 
     /// Returns the application desktop file name.
     pub fn desktop_file_name() -> QString {
-        ffi::qguiapplication_desktop_file_name();
+        ffi::qguiapplication_desktop_file_name()
     }
 }

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.rs
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.rs
@@ -83,6 +83,12 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qguiapplication_set_organization_name"]
         fn qapplicationSetOrganizationName(app: Pin<&mut QGuiApplication>, name: &QString);
+        #[doc(hidden)]
+        #[rust_name = "qguiapplication_set_desktop_file_name"]
+        fn qguiapplicationSetDesktopFileName(name: &QString);
+        #[doc(hidden)]
+        #[rust_name = "qguiapplication_desktop_file_name"]
+        fn qguiapplicationDesktopFileName() -> QString;
     }
 
     // QGuiApplication is not a trivial to CXX and is not relocatable in Qt
@@ -197,5 +203,15 @@ impl QGuiApplication {
     /// Sets the name of the organization that wrote this application
     pub fn set_organization_name(self: Pin<&mut Self>, name: &QString) {
         ffi::qguiapplication_set_organization_name(self, name);
+    }
+
+    /// Changes the desktop file name to name.
+    pub fn set_desktop_file_name(name: &QString) {
+        ffi::qguiapplication_set_desktop_file_name(name);
+    }
+
+    /// Returns the application desktop file name.
+    pub fn desktop_file_name() -> QString {
+        ffi::qguiapplication_desktop_file_name();
     }
 }


### PR DESCRIPTION
Added methods : 
```rs
fn set_desktop_file_name(name: &QString);
fn desktop_file_name() -> QString;
```
This is required to set the application desktop name association on Linux. This allows desktop entries and taskbar icons.
Example: 
![image](https://github.com/user-attachments/assets/6a98669d-6795-4cd1-8323-e28379a8d8ce)

Example usage: https://github.com/mystchonky/kontrast-rs/blob/54ace175a97f044c714599bcbf645e95a766c8a0/src/main.rs#L14
