### PR TITLE
Disable workflow runs for pushes outside main

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -7,6 +7,9 @@
 name: cxx-qt tests
 on:
   push:
+    branches:
+      - 'main'
+      - '[0-9]+\.[0-9]+\.x'
   pull_request:
   schedule:
     # Run daily at 01:01


### PR DESCRIPTION
This prevents dependabot/... branches from running their tests twice.
First as a push to the dependabot/... branch and then as the PR into
main.
