### PR TITLE
cxx-qt: use cxx-qt-build and reexport from cxx-qt-lib

### DIFF
--- a/crates/cxx-qt-build/Cargo.toml
+++ b/crates/cxx-qt-build/Cargo.toml
@@ -15,7 +15,6 @@ repository.workspace = true
 [dependencies]
 cc.workspace = true
 cxx-gen.workspace = true
-cxx-qt.workspace = true
 cxx-qt-gen.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -585,8 +585,7 @@ impl CxxQtBuilder {
 
     fn write_common_headers() {
         let header_root = dir::header_root();
-        // Write cxx-qt and cxx headers
-        cxx_qt::write_headers(header_root.join("cxx-qt"));
+        // Write cxx headers
         std::fs::create_dir_all(header_root.join("rust"))
             .expect("Could not create cxx header directory");
         let h_path = header_root.join("rust").join("cxx.h");
@@ -649,7 +648,7 @@ impl CxxQtBuilder {
         include_paths: &[impl AsRef<Path>],
         defines: &[(String, Option<String>)],
     ) {
-        // Note, ensure our settings stay in sync across cxx-qt, cxx-qt-build, and cxx-qt-lib
+        // Note, ensure our settings stay in sync across cxx-qt and cxx-qt-lib
         builder.cpp(true);
         builder.std("c++17");
         // MSVC

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -313,7 +313,8 @@ fn main() {
     let mut interface = cxx_qt_build::Interface::default()
         .initializer("src/core/init.cpp")
         .export_include_prefixes([])
-        .export_include_directory(header_dir(), "cxx-qt-lib");
+        .export_include_directory(header_dir(), "cxx-qt-lib")
+        .reexport_dependency("cxx-qt");
 
     if qt_gui_enabled() {
         interface = interface

--- a/crates/cxx-qt/Cargo.toml
+++ b/crates/cxx-qt/Cargo.toml
@@ -17,13 +17,19 @@ readme = "README.md"
 keywords = ["cxx", "ffi", "QML", "Qt"]
 categories = ["api-bindings", "gui"]
 
+# When creating a library with cxx-qt-build, we need to set a fake "links" key
+# to make sure the build scripts are run in the correct order and the build scripts
+# can pass metadata from library to dependent.
+# See also: https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key
+links = "cxx-qt"
+
 [dependencies]
 cxx.workspace = true
 cxx-qt-macro.workspace = true
 static_assertions = "1.1.0"
 
 [build-dependencies]
-cxx-build.workspace = true
+cxx-qt-build.workspace = true
 qt-build-utils.workspace = true
 
 [dev-dependencies]

--- a/crates/cxx-qt/build.rs
+++ b/crates/cxx-qt/build.rs
@@ -3,60 +3,55 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::{fs::File, io::Write};
+use std::path::PathBuf;
+
+use cxx_qt_build::{CxxQtBuilder, Interface};
+
+fn header_dir() -> PathBuf {
+    PathBuf::from(std::env::var("OUT_DIR").unwrap())
+        .join("include")
+        .join("cxx-qt")
+}
+
+fn write_headers() {
+    println!("cargo::rerun-if-changed=include/");
+    std::fs::create_dir_all(header_dir()).expect("Failed to create include directory");
+
+    for file_path in [
+        "connection.h",
+        "signalhandler.h",
+        "thread.h",
+        "threading.h",
+        "type.h",
+    ] {
+        println!("cargo::rerun-if-changed=include/{file_path}");
+        std::fs::copy(format!("include/{file_path}"), header_dir().join(file_path))
+            .expect("Failed to copy header file!");
+    }
+}
 
 fn main() {
-    let qtbuild = qt_build_utils::QtBuild::new(vec!["Core".to_owned()])
-        .expect("Could not find Qt installation");
+    write_headers();
 
-    // Required for tests
-    qt_build_utils::setup_linker();
+    let interface = Interface::default()
+        .export_include_prefixes([])
+        .export_include_directory(header_dir(), "cxx-qt");
+
+    let mut builder = CxxQtBuilder::library(interface);
 
     let cpp_files = ["src/connection.cpp"];
     let rust_bridges = ["src/connection.rs"];
 
     for bridge in &rust_bridges {
-        println!("cargo:rerun-if-changed={bridge}");
+        builder = builder.file(bridge);
     }
 
-    let mut builder = cxx_build::bridges(rust_bridges);
+    builder = builder.cc_builder(move |cc| {
+        for cpp_file in &cpp_files {
+            cc.file(cpp_file);
+            println!("cargo::rerun-if-changed={cpp_file}");
+        }
+    });
 
-    qtbuild.cargo_link_libraries(&mut builder);
-
-    for cpp_file in &cpp_files {
-        builder.file(cpp_file);
-        println!("cargo:rerun-if-changed={cpp_file}");
-    }
-
-    // Write this library's manually written C++ headers to files and add them to include paths
-    let out_dir = std::env::var("OUT_DIR").unwrap();
-    let directory = format!("{out_dir}/cxx-qt");
-    std::fs::create_dir_all(&directory).expect("Could not create cxx-qt header directory");
-    // Note we only need connection.h for now, but lets move all headers to be consistent
-    // ensure src/lib write_headers is consistent
-    for (file_contents, file_name) in [
-        (include_str!("include/connection.h"), "connection.h"),
-        (include_str!("include/signalhandler.h"), "signalhandler.h"),
-        (include_str!("include/thread.h"), "thread.h"),
-        (include_str!("include/threading.h"), "threading.h"),
-        (include_str!("include/type.h"), "type.h"),
-    ] {
-        let h_path = format!("{directory}/{file_name}");
-        let mut header = File::create(h_path).expect("Could not create cxx-qt header");
-        write!(header, "{file_contents}").expect("Could not write cxx-qt header");
-    }
-    builder.include(out_dir);
-    builder.includes(qtbuild.include_paths());
-
-    // Note, ensure our settings stay in sync across cxx-qt, cxx-qt-build, and cxx-qt-lib
-    builder.cpp(true);
-    builder.std("c++17");
-    // MSVC
-    builder.flag_if_supported("/Zc:__cplusplus");
-    builder.flag_if_supported("/permissive-");
-    builder.flag_if_supported("/bigobj");
-    // MinGW requires big-obj otherwise debug builds fail
-    builder.flag_if_supported("-Wa,-mbig-obj");
-
-    builder.compile("cxx-qt");
+    builder.build();
 }

--- a/scripts/release_crates.sh
+++ b/scripts/release_crates.sh
@@ -70,11 +70,11 @@ release_crate "cxx-qt-gen"
 # Requires cxx-qt-gen
 release_crate "cxx-qt-macro"
 
-# Requires cxx-qt-macro and qt-build-utils
-release_crate "cxx-qt"
-
-# Requires cxx-qt, cxx-qt-gen, and qt-build-utils
+# Requires cxx-qt-gen and qt-build-utils
 release_crate "cxx-qt-build"
+
+# Requires cxx-qt-build, cxx-qt-macro, and qt-build-utils
+release_crate "cxx-qt"
 
 # Requires cxx-qt, cxx-qt-build
 release_crate "cxx-qt-lib"


### PR DESCRIPTION
This removes a build depends of cxx-qt-build on cxx-qt