### PR TITLE
Feature explicit case conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `#[auto_case]` attribute for `extern` blocks, which will convert function names to the appropriate case
+- `#[auto_cxx_name]` and `#[auto_rust_name]` attributes for `extern` blocks, which will convert the case of names, automatically camelCase for cxx, and snake_case for rust
 - Support for further types: `QLine`, `QLineF`, `QImage`, `QPainter`, `QFont`, `QPen`, `QPolygon`, `QPolygonF`, `QRegion`, `QAnyStringView`
 - `internal_pointer_mut()` function on `QModelIndex`
 - `c_void` in CXX-Qt-lib for easy access to `void *`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `#[auto_case]` attribute for `extern` blocks, which will convert function names to the appropriate case
 - Support for further types: `QLine`, `QLineF`, `QImage`, `QPainter`, `QFont`, `QPen`, `QPolygon`, `QPolygonF`, `QRegion`, `QAnyStringView`
 - `internal_pointer_mut()` function on `QModelIndex`
 - `c_void` in CXX-Qt-lib for easy access to `void *`

--- a/book/src/bridge/attributes.md
+++ b/book/src/bridge/attributes.md
@@ -36,4 +36,10 @@ For [`#[qproperty]`](./extern_rustqt.md#properties), a CXX or Rust name can be p
 
 > **⚠️ Deprecation warning**:
 > CXX-Qt <0.6 did automatic case conversion if no `#[cxx_name = "..."]` or `#[rust_name = "..."]` is specified.
-> Starting with CXX-Qt 0.7, this is no longer the case!
+> Starting with CXX-Qt 0.7, this is no longer the case! Automatic case conversion will be opt-in instead.
+
+### Automatic case conversion
+
+The `#[auto_cxx_name]` and `#[auto_rust_name]` attributes can be used to automatically rename cxx and rust names.
+These are placed at a block level on `extern "RustQt"` or `extern "C++Qt"` blocks, and will automatically case convert the items inside, unless they specify either a `rust_name` or `cxx_name`.
+By default `#[auto_cxx_name]` will generate a camelCase conversion for`cxx_name` and `#[auto_rust_name]` will generate a snake_case conversion for `rust_name`.

--- a/book/src/bridge/extern_cppqt.md
+++ b/book/src/bridge/extern_cppqt.md
@@ -29,6 +29,8 @@ A bridge module may contain zero or more `extern "C++Qt"` blocks.
 This complements the [`extern "C++"` CXX section](https://cxx.rs/extern-c++.html)
 but allows for declaring Qt specific features on C++ types.
 
+Automatically converting to camel or snake case can be done through an [attribute](./attributes.md#automatic-case-conversion) at the block level.
+
 ## `QObject`s
 
 QObject types that are defined in C++ can be made available to Rust, by declaring them as [opaque types](https://cxx.rs/extern-c++.html#opaque-c-types) with a `#[qobject]` attribute.

--- a/book/src/bridge/extern_rustqt.md
+++ b/book/src/bridge/extern_rustqt.md
@@ -30,6 +30,8 @@ A bridge module may contain zero or more `extern "RustQt"` blocks.
 This complements the [`extern "Rust"` CXX section](https://cxx.rs/extern-rust.html)
 but allows for declaring Qt specific features on C++ types.
 
+Automatically converting to camel or snake case can be done through an [attribute](./attributes.md#automatic-case-conversion) at the block level.
+
 ## `QObject`s
 
 The `#[qobject]` attribute may be placed on a type alias to generate a [`QObject`](https://doc.qt.io/qt-6/qobject.html) type in C++.

--- a/crates/cxx-qt-gen/Cargo.toml
+++ b/crates/cxx-qt-gen/Cargo.toml
@@ -22,6 +22,7 @@ exclude = ["update_expected.sh"]
 proc-macro2.workspace = true
 syn.workspace = true
 quote.workspace = true
+convert_case = "0.6.0"
 clang-format = "0.3"
 indoc = "2.0"
 

--- a/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
@@ -52,13 +52,14 @@ mod tests {
 
     use super::*;
     use crate::generator::cpp::property::tests::require_header;
+    use crate::parser::AutoCase;
     use crate::{parser::inherit::ParsedInheritedMethod, syntax::safety::Safety};
 
     fn generate_from_foreign(
         method: ForeignItemFn,
         base_class: Option<&str>,
     ) -> Result<GeneratedCppQObjectBlocks> {
-        let method = ParsedInheritedMethod::parse(method, Safety::Safe)?;
+        let method = ParsedInheritedMethod::parse(method, Safety::Safe, AutoCase::None)?;
         let inherited_methods = vec![&method];
         let base_class = base_class.map(|s| s.to_owned());
         generate(&inherited_methods, &base_class, &TypeNames::default())

--- a/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
@@ -52,14 +52,14 @@ mod tests {
 
     use super::*;
     use crate::generator::cpp::property::tests::require_header;
-    use crate::parser::AutoCase;
+    use crate::parser::CaseConversion;
     use crate::{parser::inherit::ParsedInheritedMethod, syntax::safety::Safety};
 
     fn generate_from_foreign(
         method: ForeignItemFn,
         base_class: Option<&str>,
     ) -> Result<GeneratedCppQObjectBlocks> {
-        let method = ParsedInheritedMethod::parse(method, Safety::Safe, AutoCase::None)?;
+        let method = ParsedInheritedMethod::parse(method, Safety::Safe, CaseConversion::none())?;
         let inherited_methods = vec![&method];
         let base_class = base_class.map(|s| s.to_owned());
         generate(&inherited_methods, &base_class, &TypeNames::default())

--- a/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
@@ -6,7 +6,7 @@
 use syn::ForeignItemFn;
 
 use crate::naming::Name;
-use crate::parser::AutoCase;
+use crate::parser::CaseConversion;
 use crate::syntax::safety::Safety;
 use crate::{
     generator::naming::property::{NameState, QPropertyNames},
@@ -26,7 +26,7 @@ pub fn generate(idents: &QPropertyNames, qobject_name: &Name) -> Option<ParsedSi
             fn #notify_rust(self: Pin<&mut #cpp_class_rust>);
         };
 
-        Some(ParsedSignal::parse(method, Safety::Safe, AutoCase::None).unwrap())
+        Some(ParsedSignal::parse(method, Safety::Safe, CaseConversion::none()).unwrap())
     } else {
         None
     }

--- a/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/property/signal.rs
@@ -6,6 +6,7 @@
 use syn::ForeignItemFn;
 
 use crate::naming::Name;
+use crate::parser::AutoCase;
 use crate::syntax::safety::Safety;
 use crate::{
     generator::naming::property::{NameState, QPropertyNames},
@@ -25,7 +26,7 @@ pub fn generate(idents: &QPropertyNames, qobject_name: &Name) -> Option<ParsedSi
             fn #notify_rust(self: Pin<&mut #cpp_class_rust>);
         };
 
-        Some(ParsedSignal::parse(method, Safety::Safe).unwrap())
+        Some(ParsedSignal::parse(method, Safety::Safe, AutoCase::None).unwrap())
     } else {
         None
     }

--- a/crates/cxx-qt-gen/src/generator/rust/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/inherit.rs
@@ -67,7 +67,7 @@ pub fn generate(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::AutoCase;
+    use crate::parser::CaseConversion;
     use crate::{
         generator::naming::qobject::tests::create_qobjectname, syntax::safety::Safety,
         tests::assert_tokens_eq,
@@ -78,7 +78,7 @@ mod tests {
         method: ForeignItemFn,
         safety: Safety,
     ) -> Result<GeneratedRustFragment> {
-        let method = ParsedInheritedMethod::parse(method, safety, AutoCase::None)?;
+        let method = ParsedInheritedMethod::parse(method, safety, CaseConversion::none())?;
         let inherited_methods = vec![&method];
         generate(&create_qobjectname(), &inherited_methods)
     }

--- a/crates/cxx-qt-gen/src/generator/rust/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/inherit.rs
@@ -67,6 +67,7 @@ pub fn generate(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::AutoCase;
     use crate::{
         generator::naming::qobject::tests::create_qobjectname, syntax::safety::Safety,
         tests::assert_tokens_eq,
@@ -77,7 +78,7 @@ mod tests {
         method: ForeignItemFn,
         safety: Safety,
     ) -> Result<GeneratedRustFragment> {
-        let method = ParsedInheritedMethod::parse(method, safety)?;
+        let method = ParsedInheritedMethod::parse(method, safety, AutoCase::None)?;
         let inherited_methods = vec![&method];
         generate(&create_qobjectname(), &inherited_methods)
     }

--- a/crates/cxx-qt-gen/src/generator/rust/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/signal.rs
@@ -5,6 +5,7 @@
 
 use syn::ForeignItemFn;
 
+use crate::parser::AutoCase;
 use crate::syntax::safety::Safety;
 use crate::{
     generator::naming::{
@@ -28,7 +29,7 @@ pub fn generate(idents: &QPropertyNames, qobject_names: &QObjectNames) -> Option
             fn #notify_rust(self: Pin<&mut #cpp_class_rust>);
         };
 
-        Some(ParsedSignal::parse(method, Safety::Safe).unwrap())
+        Some(ParsedSignal::parse(method, Safety::Safe, AutoCase::None).unwrap())
     } else {
         None
     }

--- a/crates/cxx-qt-gen/src/generator/rust/property/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/signal.rs
@@ -5,7 +5,7 @@
 
 use syn::ForeignItemFn;
 
-use crate::parser::AutoCase;
+use crate::parser::CaseConversion;
 use crate::syntax::safety::Safety;
 use crate::{
     generator::naming::{
@@ -29,7 +29,7 @@ pub fn generate(idents: &QPropertyNames, qobject_names: &QObjectNames) -> Option
             fn #notify_rust(self: Pin<&mut #cpp_class_rust>);
         };
 
-        Some(ParsedSignal::parse(method, Safety::Safe, AutoCase::None).unwrap())
+        Some(ParsedSignal::parse(method, Safety::Safe, CaseConversion::none()).unwrap())
     } else {
         None
     }

--- a/crates/cxx-qt-gen/src/naming/cpp.rs
+++ b/crates/cxx-qt-gen/src/naming/cpp.rs
@@ -224,7 +224,7 @@ fn path_segment_to_string(segment: &PathSegment, type_names: &TypeNames) -> Resu
     let arg = match &*ident_string {
         "Pin" => {
             let mut args =
-                path_argument_to_string(&segment.arguments, type_names)?.unwrap_or_else(Vec::new);
+                path_argument_to_string(&segment.arguments, type_names)?.unwrap_or_default();
 
             if args.len() != 1 {
                 return Err(Error::new(segment.span(), "Pin must have one argument!"));

--- a/crates/cxx-qt-gen/src/naming/name.rs
+++ b/crates/cxx-qt-gen/src/naming/name.rs
@@ -126,13 +126,11 @@ impl Name {
             })
             .transpose()?;
 
-        if let Some(case) = auto_case.cxx {
-            if cxx_name.is_none() {
+        if cxx_name.is_none() && rust_name.is_none() {
+            if let Some(case) = auto_case.cxx {
                 cxx_name = Some(ident.to_string().to_case(case));
             }
-        }
-        if let Some(case) = auto_case.rust {
-            if rust_name.is_none() {
+            if let Some(case) = auto_case.rust {
                 rust_name = Some(format_ident!("{}", ident.to_string().to_case(case)));
             }
         }
@@ -151,7 +149,7 @@ impl Name {
         let cxx_ident = if cxx.is_none() && rust.is_some() {
             Some(self.rust.to_string())
         } else {
-            cxx.clone()
+            cxx
         };
         Self {
             rust: rust.unwrap_or_else(|| self.rust.clone()),
@@ -218,7 +216,7 @@ impl Name {
     /// 2. Any attributes like cxx_name and namespace
     /// 3. The rust_qualified path to access the function (if not needed use _ during destructuring)
     pub fn into_cxx_parts(self) -> (Ident, Vec<Attribute>, Path) {
-        let rust_qualified = self.rust_qualified().clone();
+        let rust_qualified = self.rust_qualified();
         let cxx_name: Option<Attribute> = self.cxx.map(|cxx| {
             syn::parse_quote! { #[cxx_name = #cxx] }
         });

--- a/crates/cxx-qt-gen/src/naming/type_names.rs
+++ b/crates/cxx-qt-gen/src/naming/type_names.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use super::Name;
-use crate::parser::AutoCase;
+use crate::parser::CaseConversion;
 use crate::syntax::attribute::attribute_get_path;
 use crate::{
     parser::{cxxqtdata::ParsedCxxQtData, qobject::ParsedQObject},
@@ -368,7 +368,7 @@ impl TypeNames {
             attrs,
             parent_namespace,
             Some(module_ident),
-            AutoCase::None,
+            CaseConversion::none(),
         )?;
 
         let entry = self.names.entry(name.rust.clone());

--- a/crates/cxx-qt-gen/src/naming/type_names.rs
+++ b/crates/cxx-qt-gen/src/naming/type_names.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use super::Name;
+use crate::parser::AutoCase;
 use crate::syntax::attribute::attribute_get_path;
 use crate::{
     parser::{cxxqtdata::ParsedCxxQtData, qobject::ParsedQObject},
@@ -362,7 +363,13 @@ impl TypeNames {
         module_ident: &Ident,
         fallback: impl FnOnce(&mut Self, Name) -> Result<()>,
     ) -> Result<()> {
-        let name = Name::from_ident_and_attrs(ident, attrs, parent_namespace, Some(module_ident))?;
+        let name = Name::from_ident_and_attrs(
+            ident,
+            attrs,
+            parent_namespace,
+            Some(module_ident),
+            AutoCase::None,
+        )?;
 
         let entry = self.names.entry(name.rust.clone());
 

--- a/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
+++ b/crates/cxx-qt-gen/src/parser/cxxqtdata.rs
@@ -331,6 +331,46 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_auto_case_rustqt() {
+        let mut cxx_qt_data = create_parsed_cxx_qt_data();
+
+        let item: Item = parse_quote! {
+            #[auto_case]
+            unsafe extern "RustQt" {
+                fn foo_bar(self: &MyObject);
+            }
+        };
+        cxx_qt_data.parse_cxx_qt_item(item).unwrap();
+        assert_eq!(cxx_qt_data.methods.len(), 1);
+        assert_eq!(cxx_qt_data.methods[0].name.cxx_unqualified(), "fooBar");
+    }
+
+    #[test]
+    fn test_parse_auto_case_foreign() {
+        let mut cxx_qt_data = create_parsed_cxx_qt_data();
+
+        let item: Item = parse_quote! {
+            #[auto_case]
+            unsafe extern "C++Qt" {
+                #[qobject]
+                type MyObject;
+
+                #[qsignal]
+                fn foo_bar(self: Pin<&mut MyObject>);
+            }
+        };
+        cxx_qt_data.parse_cxx_qt_item(item).unwrap();
+        assert_eq!(cxx_qt_data.extern_cxxqt_blocks.len(), 1);
+        assert_eq!(cxx_qt_data.extern_cxxqt_blocks[0].signals.len(), 1);
+        assert_eq!(
+            cxx_qt_data.extern_cxxqt_blocks[0].signals[0]
+                .name
+                .cxx_unqualified(),
+            "fooBar"
+        );
+    }
+
+    #[test]
     fn test_parse_impl_non_path() {
         let mut cxx_qt_data = create_parsed_cxx_qt_data();
 

--- a/crates/cxx-qt-gen/src/parser/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externcxxqt.rs
@@ -5,10 +5,12 @@
 
 use crate::{
     parser::{
-        externqobject::ParsedExternQObject, require_attributes, signals::ParsedSignal, AutoCase,
+        externqobject::ParsedExternQObject, require_attributes, signals::ParsedSignal,
+        CaseConversion,
     },
     syntax::{attribute::attribute_get_path, expr::expr_to_string, safety::Safety},
 };
+use convert_case::Case;
 use syn::{spanned::Spanned, Error, ForeignItem, Ident, ItemForeignMod, Result, Token};
 
 /// Representation of an extern "C++Qt" block
@@ -35,8 +37,8 @@ impl ParsedExternCxxQt {
         let attrs = require_attributes(&foreign_mod.attrs, &["namespace", "auto_case"])?;
 
         let auto_case = match attrs.get("auto_case") {
-            Some(_) => AutoCase::CamelCase,
-            _ => AutoCase::None,
+            Some(_) => CaseConversion::new(None, Some(Case::Snake)), // For extern C++ and C++Qt blocks, we want to convert to snake
+            _ => CaseConversion::none(),
         };
 
         let namespace = attrs

--- a/crates/cxx-qt-gen/src/parser/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externcxxqt.rs
@@ -35,10 +35,10 @@ impl ParsedExternCxxQt {
     ) -> Result<Self> {
         let attrs = require_attributes(
             &foreign_mod.attrs,
-            &["namespace", "auto_cxx_case", "auto_rust_case"],
+            &["namespace", "auto_cxx_name", "auto_rust_name"],
         )?;
 
-        let auto_case = CaseConversion::from_attrs(&attrs);
+        let auto_case = CaseConversion::from_attrs(&attrs)?;
 
         let namespace = attrs
             .get("namespace")
@@ -48,7 +48,7 @@ impl ParsedExternCxxQt {
             .transpose()?;
 
         let mut extern_cxx_block = ParsedExternCxxQt {
-            namespace: namespace.clone(),
+            namespace,
             unsafety: foreign_mod.unsafety,
             ..Default::default()
         };

--- a/crates/cxx-qt-gen/src/parser/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externcxxqt.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     syntax::{attribute::attribute_get_path, expr::expr_to_string, safety::Safety},
 };
-use convert_case::Case;
 use syn::{spanned::Spanned, Error, ForeignItem, Ident, ItemForeignMod, Result, Token};
 
 /// Representation of an extern "C++Qt" block
@@ -34,12 +33,12 @@ impl ParsedExternCxxQt {
         module_ident: &Ident,
         parent_namespace: Option<&str>,
     ) -> Result<Self> {
-        let attrs = require_attributes(&foreign_mod.attrs, &["namespace", "auto_case"])?;
+        let attrs = require_attributes(
+            &foreign_mod.attrs,
+            &["namespace", "auto_cxx_case", "auto_rust_case"],
+        )?;
 
-        let auto_case = match attrs.get("auto_case") {
-            Some(_) => CaseConversion::new(None, Some(Case::Snake)), // For extern C++ and C++Qt blocks, we want to convert to snake
-            _ => CaseConversion::none(),
-        };
+        let auto_case = CaseConversion::from_attrs(&attrs);
 
         let namespace = attrs
             .get("namespace")

--- a/crates/cxx-qt-gen/src/parser/externqobject.rs
+++ b/crates/cxx-qt-gen/src/parser/externqobject.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::naming::Name;
+use crate::parser::AutoCase;
 use syn::{ForeignItemType, Ident, Result};
 
 /// A representation of a QObject to be generated in an extern C++ block
@@ -25,6 +26,7 @@ impl ParsedExternQObject {
                 &ty.attrs,
                 parent_namespace,
                 Some(module_ident),
+                AutoCase::None,
             )?,
             declaration: ty,
         })

--- a/crates/cxx-qt-gen/src/parser/externqobject.rs
+++ b/crates/cxx-qt-gen/src/parser/externqobject.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::naming::Name;
-use crate::parser::AutoCase;
+use crate::parser::CaseConversion;
 use syn::{ForeignItemType, Ident, Result};
 
 /// A representation of a QObject to be generated in an extern C++ block
@@ -26,7 +26,7 @@ impl ParsedExternQObject {
                 &ty.attrs,
                 parent_namespace,
                 Some(module_ident),
-                AutoCase::None,
+                CaseConversion::none(),
             )?,
             declaration: ty,
         })

--- a/crates/cxx-qt-gen/src/parser/inherit.rs
+++ b/crates/cxx-qt-gen/src/parser/inherit.rs
@@ -3,7 +3,9 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::{check_safety, extract_docs, method::MethodFields, require_attributes};
+use crate::parser::{
+    check_safety, extract_docs, method::MethodFields, require_attributes, AutoCase,
+};
 use crate::syntax::safety::Safety;
 use core::ops::Deref;
 use quote::format_ident;
@@ -21,7 +23,7 @@ impl ParsedInheritedMethod {
     const ALLOWED_ATTRS: [&'static str; 5] =
         ["cxx_name", "rust_name", "qinvokable", "doc", "inherit"];
 
-    pub fn parse(method: ForeignItemFn, safety: Safety) -> Result<Self> {
+    pub fn parse(method: ForeignItemFn, safety: Safety, auto_case: AutoCase) -> Result<Self> {
         check_safety(&method, &safety)?;
         require_attributes(&method.attrs, &Self::ALLOWED_ATTRS)?;
         let docs = extract_docs(&method.attrs);
@@ -58,10 +60,10 @@ mod tests {
         let function: ForeignItemFn = parse_quote! {
             fn test(self: &T);
         };
-        assert!(ParsedInheritedMethod::parse(function, Safety::Unsafe).is_err());
+        assert!(ParsedInheritedMethod::parse(function, Safety::Unsafe, AutoCase::None).is_err());
 
         assert_parse_errors! {
-            |item| ParsedInheritedMethod::parse(item, Safety::Safe) =>
+            |item| ParsedInheritedMethod::parse(item, Safety::Safe, AutoCase::None) =>
 
             // Missing self type
             { fn test(&self); }
@@ -84,7 +86,8 @@ mod tests {
             parse_quote! {
                 fn test(self: &T);
             },
-            Safety::Safe
+            Safety::Safe,
+            AutoCase::None
         )
         .is_ok());
         // T by Pin
@@ -92,7 +95,8 @@ mod tests {
             parse_quote! {
                 fn test(self: Pin<&mut T>);
             },
-            Safety::Safe
+            Safety::Safe,
+            AutoCase::None
         )
         .is_ok());
     }
@@ -104,7 +108,7 @@ mod tests {
             fn test(self: Pin<&mut T>, a: i32, b: &str);
         };
 
-        let parsed = ParsedInheritedMethod::parse(function, Safety::Safe).unwrap();
+        let parsed = ParsedInheritedMethod::parse(function, Safety::Safe, AutoCase::None).unwrap();
 
         assert_eq!(parsed.qobject_ident, format_ident!("T"));
         assert_eq!(parsed.parameters.len(), 2);

--- a/crates/cxx-qt-gen/src/parser/inherit.rs
+++ b/crates/cxx-qt-gen/src/parser/inherit.rs
@@ -29,7 +29,7 @@ impl ParsedInheritedMethod {
         let docs = extract_docs(&method.attrs);
 
         Ok(Self {
-            method_fields: MethodFields::parse(method)?,
+            method_fields: MethodFields::parse(method, auto_case)?,
             docs,
         })
     }

--- a/crates/cxx-qt-gen/src/parser/method.rs
+++ b/crates/cxx-qt-gen/src/parser/method.rs
@@ -2,6 +2,7 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::parser::AutoCase;
 use crate::{
     naming::Name,
     parser::{check_safety, parameter::ParsedFunctionParameter, require_attributes},
@@ -70,7 +71,7 @@ impl ParsedMethod {
     pub fn mock_qinvokable(method: &ForeignItemFn) -> Self {
         Self {
             is_qinvokable: true,
-            ..Self::parse(method.clone(), Safety::Safe).unwrap()
+            ..Self::parse(method.clone(), Safety::Safe, AutoCase::None).unwrap()
         }
     }
 
@@ -101,7 +102,7 @@ impl ParsedMethod {
         Self { specifiers, ..self }
     }
 
-    pub fn parse(method: ForeignItemFn, safety: Safety) -> Result<Self> {
+    pub fn parse(method: ForeignItemFn, safety: Safety, auto_case: AutoCase) -> Result<Self> {
         check_safety(&method, &safety)?;
         let fields = MethodFields::parse(method)?;
         let attrs = require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;

--- a/crates/cxx-qt-gen/src/parser/method.rs
+++ b/crates/cxx-qt-gen/src/parser/method.rs
@@ -104,7 +104,7 @@ impl ParsedMethod {
 
     pub fn parse(method: ForeignItemFn, safety: Safety, auto_case: AutoCase) -> Result<Self> {
         check_safety(&method, &safety)?;
-        let fields = MethodFields::parse(method)?;
+        let fields = MethodFields::parse(method, auto_case)?;
         let attrs = require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
 
         // Determine if the method is invokable
@@ -140,14 +140,15 @@ pub struct MethodFields {
 }
 
 impl MethodFields {
-    pub fn parse(method: ForeignItemFn) -> Result<Self> {
+    pub fn parse(method: ForeignItemFn, auto_case: AutoCase) -> Result<Self> {
         let self_receiver = foreignmod::self_type_from_foreign_fn(&method.sig)?;
         let (qobject_ident, mutability) = types::extract_qobject_ident(&self_receiver.ty)?;
         let mutable = mutability.is_some();
 
         let parameters = ParsedFunctionParameter::parse_all_ignoring_receiver(&method.sig)?;
         let safe = method.sig.unsafety.is_none();
-        let name = Name::from_ident_and_attrs(&method.sig.ident, &method.attrs, None, None)?;
+        let name =
+            Name::from_ident_and_attrs(&method.sig.ident, &method.attrs, None, None, auto_case)?;
 
         Ok(MethodFields {
             method,

--- a/crates/cxx-qt-gen/src/parser/method.rs
+++ b/crates/cxx-qt-gen/src/parser/method.rs
@@ -2,7 +2,7 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use crate::parser::AutoCase;
+use crate::parser::CaseConversion;
 use crate::{
     naming::Name,
     parser::{check_safety, parameter::ParsedFunctionParameter, require_attributes},
@@ -71,7 +71,7 @@ impl ParsedMethod {
     pub fn mock_qinvokable(method: &ForeignItemFn) -> Self {
         Self {
             is_qinvokable: true,
-            ..Self::parse(method.clone(), Safety::Safe, AutoCase::None).unwrap()
+            ..Self::parse(method.clone(), Safety::Safe, CaseConversion::none()).unwrap()
         }
     }
 
@@ -102,7 +102,7 @@ impl ParsedMethod {
         Self { specifiers, ..self }
     }
 
-    pub fn parse(method: ForeignItemFn, safety: Safety, auto_case: AutoCase) -> Result<Self> {
+    pub fn parse(method: ForeignItemFn, safety: Safety, auto_case: CaseConversion) -> Result<Self> {
         check_safety(&method, &safety)?;
         let fields = MethodFields::parse(method, auto_case)?;
         let attrs = require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
@@ -140,7 +140,7 @@ pub struct MethodFields {
 }
 
 impl MethodFields {
-    pub fn parse(method: ForeignItemFn, auto_case: AutoCase) -> Result<Self> {
+    pub fn parse(method: ForeignItemFn, auto_case: CaseConversion) -> Result<Self> {
         let self_receiver = foreignmod::self_type_from_foreign_fn(&method.sig)?;
         let (qobject_ident, mutability) = types::extract_qobject_ident(&self_receiver.ty)?;
         let mutable = mutability.is_some();

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -48,6 +48,13 @@ impl CaseConversion {
     pub fn new(cxx: Option<Case>, rust: Option<Case>) -> Self {
         Self { cxx, rust }
     }
+
+    pub fn from_attrs(attrs: &BTreeMap<&str, &Attribute>) -> Self {
+        Self {
+            rust: attrs.get("auto_rust_case").map(|_| Case::Snake),
+            cxx: attrs.get("auto_cxx_case").map(|_| Case::Camel),
+        }
+    }
 }
 
 /// Validates that an invokable is either unsafe, or is in an unsafe extern block

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     naming::TypeNames,
     syntax::{expr::expr_to_string, path::path_compare_str, safety::Safety},
 };
+use convert_case::Case;
 use cxxqtdata::ParsedCxxQtData;
 use std::collections::BTreeMap;
 use syn::{
@@ -31,9 +32,22 @@ use syn::{
 };
 
 #[derive(Copy, Clone)]
-pub enum AutoCase {
-    None,
-    CamelCase,
+pub struct CaseConversion {
+    pub cxx: Option<Case>,
+    pub rust: Option<Case>,
+}
+
+impl CaseConversion {
+    pub fn none() -> Self {
+        Self {
+            cxx: None,
+            rust: None,
+        }
+    }
+
+    pub fn new(cxx: Option<Case>, rust: Option<Case>) -> Self {
+        Self { cxx, rust }
+    }
 }
 
 /// Validates that an invokable is either unsafe, or is in an unsafe extern block

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -30,6 +30,12 @@ use syn::{
     Attribute, Error, ForeignItemFn, Ident, Item, ItemMod, Meta, Result, Token, Visibility,
 };
 
+#[derive(Copy, Clone)]
+pub enum AutoCase {
+    None,
+    CamelCase,
+}
+
 /// Validates that an invokable is either unsafe, or is in an unsafe extern block
 fn check_safety(method: &ForeignItemFn, safety: &Safety) -> Result<()> {
     if safety == &Safety::Unsafe && method.sig.unsafety.is_none() {

--- a/crates/cxx-qt-gen/src/parser/qenum.rs
+++ b/crates/cxx-qt-gen/src/parser/qenum.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::parser::AutoCase;
 use crate::{naming::Name, parser::require_attributes, syntax::path::path_compare_str};
 use quote::ToTokens;
 use syn::{Ident, ItemEnum, Result, Variant};
@@ -62,8 +63,13 @@ impl ParsedQEnum {
             ));
         }
 
-        let name =
-            Name::from_ident_and_attrs(&qenum.ident, &qenum.attrs, parent_namespace, Some(module))?;
+        let name = Name::from_ident_and_attrs(
+            &qenum.ident,
+            &qenum.attrs,
+            parent_namespace,
+            Some(module),
+            AutoCase::None,
+        )?;
 
         if name.namespace().is_none() && qobject.is_none() {
             return Err(syn::Error::new_spanned(

--- a/crates/cxx-qt-gen/src/parser/qenum.rs
+++ b/crates/cxx-qt-gen/src/parser/qenum.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::AutoCase;
+use crate::parser::CaseConversion;
 use crate::{naming::Name, parser::require_attributes, syntax::path::path_compare_str};
 use quote::ToTokens;
 use syn::{Ident, ItemEnum, Result, Variant};
@@ -68,7 +68,7 @@ impl ParsedQEnum {
             &qenum.attrs,
             parent_namespace,
             Some(module),
-            AutoCase::None,
+            CaseConversion::none(),
         )?;
 
         if name.namespace().is_none() && qobject.is_none() {

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -11,7 +11,7 @@ use crate::{
 #[cfg(test)]
 use quote::format_ident;
 
-use crate::parser::AutoCase;
+use crate::parser::CaseConversion;
 use syn::{Attribute, Error, Expr, Ident, Meta, Result};
 
 /// Metadata for registering QML element
@@ -111,7 +111,7 @@ impl ParsedQObject {
             &declaration.attrs,
             namespace,
             Some(module),
-            AutoCase::None,
+            CaseConversion::none(),
         )?;
 
         // Find any QML metadata

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -11,6 +11,7 @@ use crate::{
 #[cfg(test)]
 use quote::format_ident;
 
+use crate::parser::AutoCase;
 use syn::{Attribute, Error, Expr, Ident, Meta, Result};
 
 /// Metadata for registering QML element
@@ -110,6 +111,7 @@ impl ParsedQObject {
             &declaration.attrs,
             namespace,
             Some(module),
+            AutoCase::None,
         )?;
 
         // Find any QML metadata

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -36,7 +36,7 @@ impl ParsedSignal {
         check_safety(&method, &safety)?;
 
         let docs = extract_docs(&method.attrs);
-        let fields = MethodFields::parse(method)?;
+        let fields = MethodFields::parse(method, auto_case)?;
         let attrs = require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
 
         if !fields.mutable {

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -2,7 +2,7 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use crate::parser::AutoCase;
+use crate::parser::CaseConversion;
 use crate::{
     parser::{check_safety, extract_docs, method::MethodFields, require_attributes},
     syntax::{path::path_compare_str, safety::Safety},
@@ -29,10 +29,10 @@ impl ParsedSignal {
     #[cfg(test)]
     /// Test fn for creating a mocked signal from a method body
     pub fn mock(method: &ForeignItemFn) -> Self {
-        Self::parse(method.clone(), Safety::Safe, AutoCase::None).unwrap()
+        Self::parse(method.clone(), Safety::Safe, CaseConversion::none()).unwrap()
     }
 
-    pub fn parse(method: ForeignItemFn, safety: Safety, auto_case: AutoCase) -> Result<Self> {
+    pub fn parse(method: ForeignItemFn, safety: Safety, auto_case: CaseConversion) -> Result<Self> {
         check_safety(&method, &safety)?;
 
         let docs = extract_docs(&method.attrs);
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     fn test_parse_signal_invalid() {
         assert_parse_errors! {
-            |input| ParsedSignal::parse(input, Safety::Safe, AutoCase::None) =>
+            |input| ParsedSignal::parse(input, Safety::Safe, CaseConversion::none()) =>
 
             // No immutable signals
             { fn ready(self: &MyObject); }
@@ -105,7 +105,8 @@ mod tests {
         let method: ForeignItemFn = parse_quote! {
             fn ready(self: Pin<&mut MyObject>);
         };
-        let signal = ParsedSignal::parse(method.clone(), Safety::Safe, AutoCase::None).unwrap();
+        let signal =
+            ParsedSignal::parse(method.clone(), Safety::Safe, CaseConversion::none()).unwrap();
         assert_eq!(signal.method, method);
         assert_eq!(signal.qobject_ident, format_ident!("MyObject"));
         assert!(signal.mutable);
@@ -122,7 +123,7 @@ mod tests {
             #[cxx_name = "cppReady"]
             fn ready(self: Pin<&mut MyObject>);
         };
-        let signal = ParsedSignal::parse(method, Safety::Safe, AutoCase::None).unwrap();
+        let signal = ParsedSignal::parse(method, Safety::Safe, CaseConversion::none()).unwrap();
 
         let expected_method: ForeignItemFn = parse_quote! {
             #[cxx_name = "cppReady"]
@@ -144,7 +145,8 @@ mod tests {
             #[inherit]
             fn ready(self: Pin<&mut MyObject>);
         };
-        let signal = ParsedSignal::parse(method.clone(), Safety::Safe, AutoCase::None).unwrap();
+        let signal =
+            ParsedSignal::parse(method.clone(), Safety::Safe, CaseConversion::none()).unwrap();
 
         assert_eq!(signal.method, method);
         assert_eq!(signal.qobject_ident, format_ident!("MyObject"));
@@ -161,7 +163,8 @@ mod tests {
         let method: ForeignItemFn = parse_quote! {
             fn ready(self: Pin<&mut MyObject>, x: f64, y: f64);
         };
-        let signal = ParsedSignal::parse(method.clone(), Safety::Safe, AutoCase::None).unwrap();
+        let signal =
+            ParsedSignal::parse(method.clone(), Safety::Safe, CaseConversion::none()).unwrap();
         assert_eq!(signal.method, method);
         assert_eq!(signal.qobject_ident, format_ident!("MyObject"));
         assert!(signal.mutable);
@@ -181,7 +184,8 @@ mod tests {
         let method: ForeignItemFn = parse_quote! {
             pub(self) fn ready(self: Pin<&mut MyObject>);
         };
-        let signal = ParsedSignal::parse(method.clone(), Safety::Safe, AutoCase::None).unwrap();
+        let signal =
+            ParsedSignal::parse(method.clone(), Safety::Safe, CaseConversion::none()).unwrap();
         assert_eq!(signal.method, method);
         assert_eq!(signal.qobject_ident, format_ident!("MyObject"));
         assert!(signal.mutable);
@@ -197,7 +201,8 @@ mod tests {
         let method: ForeignItemFn = parse_quote! {
             unsafe fn ready(self: Pin<&mut MyObject>);
         };
-        let signal = ParsedSignal::parse(method.clone(), Safety::Unsafe, AutoCase::None).unwrap();
+        let signal =
+            ParsedSignal::parse(method.clone(), Safety::Unsafe, CaseConversion::none()).unwrap();
         assert_eq!(signal.method, method);
         assert_eq!(signal.qobject_ident, format_ident!("MyObject"));
         assert!(signal.mutable);
@@ -214,6 +219,6 @@ mod tests {
             fn ready(self: Pin<&mut MyObject>);
         };
         // Can't be safe on the block and the method
-        assert!(ParsedSignal::parse(method, Safety::Unsafe, AutoCase::None).is_err());
+        assert!(ParsedSignal::parse(method, Safety::Unsafe, CaseConversion::none()).is_err());
     }
 }

--- a/crates/cxx-qt-gen/src/syntax/types.rs
+++ b/crates/cxx-qt-gen/src/syntax/types.rs
@@ -132,7 +132,7 @@ pub fn extract_qobject_ident(ty: &Type) -> Result<(Ident, Option<Mut>)> {
 #[cfg(test)]
 mod tests {
     use crate::parser::method::ParsedMethod;
-    use crate::parser::AutoCase;
+    use crate::parser::CaseConversion;
     use crate::syntax::safety::Safety;
     use crate::tests::assert_parse_errors;
     use syn::{parse_quote, ForeignItemFn, Type};
@@ -182,7 +182,7 @@ mod tests {
             #[qinvokable]
             unsafe fn test(self: Pin);
         };
-        let parsed = ParsedMethod::parse(method, Safety::Unsafe, AutoCase::None);
+        let parsed = ParsedMethod::parse(method, Safety::Unsafe, CaseConversion::none());
         assert!(parsed.is_err())
     }
 }

--- a/crates/cxx-qt-gen/src/syntax/types.rs
+++ b/crates/cxx-qt-gen/src/syntax/types.rs
@@ -132,6 +132,7 @@ pub fn extract_qobject_ident(ty: &Type) -> Result<(Ident, Option<Mut>)> {
 #[cfg(test)]
 mod tests {
     use crate::parser::method::ParsedMethod;
+    use crate::parser::AutoCase;
     use crate::syntax::safety::Safety;
     use crate::tests::assert_parse_errors;
     use syn::{parse_quote, ForeignItemFn, Type};
@@ -181,7 +182,7 @@ mod tests {
             #[qinvokable]
             unsafe fn test(self: Pin);
         };
-        let parsed = ParsedMethod::parse(method, Safety::Unsafe);
+        let parsed = ParsedMethod::parse(method, Safety::Unsafe, AutoCase::None);
         assert!(parsed.is_err())
     }
 }

--- a/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
@@ -135,7 +135,7 @@ pub mod ffi {
         type SecondObject = super::SecondObjectRust;
     }
 
-    #[auto_cxx_case]
+    #[auto_cxx_name]
     unsafe extern "RustQt" {
         #[qsignal]
         fn ready(self: Pin<&mut SecondObject>);

--- a/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
@@ -135,7 +135,7 @@ pub mod ffi {
         type SecondObject = super::SecondObjectRust;
     }
 
-    #[auto_case]
+    #[auto_cxx_case]
     unsafe extern "RustQt" {
         #[qsignal]
         fn ready(self: Pin<&mut SecondObject>);

--- a/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
@@ -135,12 +135,16 @@ pub mod ffi {
         type SecondObject = super::SecondObjectRust;
     }
 
+    #[auto_case]
     unsafe extern "RustQt" {
         #[qsignal]
         fn ready(self: Pin<&mut SecondObject>);
 
         #[qinvokable]
         fn invokable_name(self: Pin<&mut SecondObject>);
+
+        #[cxx_name = "myRenamedFunction"]
+        fn my_function(self: &SecondObject);
     }
 
     extern "RustQt" {

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -163,7 +163,8 @@ public:
   ::std::int32_t const& getPropertyName() const noexcept;
   Q_SLOT void setPropertyName(::std::int32_t value) noexcept;
   Q_SIGNAL void propertyNameChanged();
-  Q_INVOKABLE void invokable_name() noexcept;
+  Q_INVOKABLE void invokableName() noexcept;
+  void myRenamedFunction() const noexcept;
   Q_SIGNAL void ready();
   explicit SecondObject(QObject* parent = nullptr);
 };

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -240,10 +240,16 @@ pub mod ffi {
         );
     }
     extern "Rust" {
-        #[cxx_name = "invokable_name"]
+        #[cxx_name = "invokableName"]
         #[namespace = "second_object"]
         #[doc(hidden)]
         fn invokable_name(self: Pin<&mut SecondObject>);
+    }
+    extern "Rust" {
+        #[cxx_name = "myRenamedFunction"]
+        #[namespace = "second_object"]
+        #[doc(hidden)]
+        fn my_function(self: &SecondObject);
     }
     unsafe extern "C++" {
         #[cxx_name = "ready"]

--- a/examples/qml_features/qml/pages/NamingPage.qml
+++ b/examples/qml_features/qml/pages/NamingPage.qml
@@ -30,5 +30,12 @@ Page {
             text: qsTr("Increment Counter")
             onClicked: renamedObject.increment()
         }
+
+        Label {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            text: qsTr("Meaning of life: %1").arg(renamedObject.getNum())
+            wrapMode: Text.Wrap
+        }
     }
 }

--- a/examples/qml_features/rust/src/naming.rs
+++ b/examples/qml_features/rust/src/naming.rs
@@ -23,6 +23,12 @@ pub mod qobject {
         #[rust_name = "plus_one"]
         fn increment_number(self: Pin<&mut NamedObject>);
     }
+
+    #[auto_cxx_name]
+    unsafe extern "RustQt" {
+        #[qinvokable]
+        fn get_num(self: &NamedObject) -> i32;
+    }
 }
 
 use std::pin::Pin;
@@ -38,5 +44,10 @@ impl qobject::NamedObject {
     pub fn plus_one(self: Pin<&mut Self>) {
         let previous = *self.num();
         self.set_num(previous + 1);
+    }
+
+    /// Method to return a greeting
+    pub fn get_num(&self) -> i32 {
+        42
     }
 }

--- a/examples/qml_features/tests/tst_naming.qml
+++ b/examples/qml_features/tests/tst_naming.qml
@@ -24,5 +24,6 @@ TestCase {
         compare(obj.numberProp, 0);
         obj.increment();
         compare(obj.numberProp, 1);
+        compare(obj.getNum(), 42);
     }
 }


### PR DESCRIPTION
Add an attribute for extern blocks which specifies all the items inside can have their names automatically converted to the correct case. 