### PR TITLE
cargo: ensure version is set for all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.7.0"
 # Note a version needs to be specified on dependencies of packages
 # we publish, otherwise crates.io complains as it doesn't know the version.
 [workspace.dependencies]
-cxx-qt = { path = "crates/cxx-qt" }
+cxx-qt = { path = "crates/cxx-qt", version = "0.7.0" }
 cxx-qt-macro = { path = "crates/cxx-qt-macro", version = "0.7.0" }
 cxx-qt-build = { path = "crates/cxx-qt-build", version = "0.7.0" }
 cxx-qt-gen = { path = "crates/cxx-qt-gen", version = "0.7.0" }


### PR DESCRIPTION
Otherwise you get

```
    Updating crates.io index
error: all dependencies must have a version specified when publishing.
dependency `cxx-qt` does not specify a version
Note: The published dependency will use the version from crates.io,
the `path` specification will be removed from the dependency declaration.
```