### PR TITLE
Prevent clippy from tripping lint

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/constructor.rs
@@ -83,6 +83,7 @@ fn generate_default_constructor(
         }],
         cxx_qt_mod_contents: vec![parse_quote! {
             #[doc(hidden)]
+            #[allow(clippy::unnecessary_box_returns)]
             pub fn #create_rs_ident() -> std::boxed::Box<#rust_struct_ident> {
                 // Wrapping the call to Default::default in a Box::new call leads
                 // to a nicer error message, as it's not trying to infer trait bounds

--- a/crates/cxx-qt-gen/src/generator/rust/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/constructor.rs
@@ -406,6 +406,7 @@ pub fn generate(
             #[doc(hidden)]
             #[allow(unused_variables)]
             #[allow(clippy::extra_unused_lifetimes)]
+            #[allow(clippy::unnecessary_box_returns)]
             // If we use the lifetime here for casting to the specific Constructor type, then
             // clippy for some reason thinks that the lifetime is unused even though it is used
             // by the `as` expression.
@@ -492,6 +493,7 @@ mod tests {
             &blocks.cxx_qt_mod_contents[0],
             quote! {
                 #[doc(hidden)]
+                #[allow(clippy::unnecessary_box_returns)]
                 pub fn create_rs_MyObjectRust() -> std::boxed::Box<MyObjectRust>
                 {
                     std::boxed::Box::new(core::default::Default::default())
@@ -600,6 +602,7 @@ mod tests {
                 #[doc(hidden)]
                 #[allow(unused_variables)]
                 #[allow(clippy::extra_unused_lifetimes)]
+                #[allow(clippy::unnecessary_box_returns)]
                 pub fn new_rs_MyObject_0(new_arguments: qobject::CxxQtConstructorNewArgumentsMyObject0) -> std::boxed::Box<MyObjectRust> {
                     std::boxed::Box::new(
                         <qobject::MyObject as cxx_qt::Constructor<()> >::new(())
@@ -733,6 +736,7 @@ mod tests {
                 #[doc(hidden)]
                 #[allow(unused_variables)]
                 #[allow(clippy::extra_unused_lifetimes)]
+                #[allow(clippy::unnecessary_box_returns)]
                 pub fn new_rs_MyObject_1(new_arguments: qobject::CxxQtConstructorNewArgumentsMyObject1) -> std::boxed::Box<MyObjectRust> {
                     std::boxed::Box::new(
                         <qobject::MyObject as cxx_qt::Constructor<(*const QObject,)> >::new(

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -84,6 +84,7 @@ impl cxx_qt::Upcast<inheritance::QAbstractItemModel> for inheritance::MyObject {
 #[allow(dead_code)]
 use inheritance::QAbstractItemModel as _;
 #[doc(hidden)]
+#[allow(clippy::unnecessary_box_returns)]
 pub fn create_rs_MyObjectRust() -> std::boxed::Box<MyObjectRust> {
     std::boxed::Box::new(core::default::Default::default())
 }

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -324,6 +324,7 @@ pub fn route_arguments_MyObject_0<'a>(
 #[doc(hidden)]
 #[allow(unused_variables)]
 #[allow(clippy::extra_unused_lifetimes)]
+#[allow(clippy::unnecessary_box_returns)]
 pub fn new_rs_MyObject_0<'a>(
     new_arguments: ffi::CxxQtConstructorNewArgumentsMyObject0<'a>,
 ) -> std::boxed::Box<MyObjectRust> {
@@ -356,6 +357,7 @@ pub fn route_arguments_MyObject_1() -> ffi::CxxQtConstructorArgumentsMyObject1 {
 #[doc(hidden)]
 #[allow(unused_variables)]
 #[allow(clippy::extra_unused_lifetimes)]
+#[allow(clippy::unnecessary_box_returns)]
 pub fn new_rs_MyObject_1(
     new_arguments: ffi::CxxQtConstructorNewArgumentsMyObject1,
 ) -> std::boxed::Box<MyObjectRust> {

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -591,6 +591,7 @@ cxx_qt::static_assertions::assert_eq_size!(
     [usize; 2]
 );
 #[doc(hidden)]
+#[allow(clippy::unnecessary_box_returns)]
 pub fn create_rs_MyObjectRust() -> std::boxed::Box<MyObjectRust> {
     std::boxed::Box::new(core::default::Default::default())
 }
@@ -756,6 +757,7 @@ cxx_qt::static_assertions::assert_eq_size!(
     [usize; 2]
 );
 #[doc(hidden)]
+#[allow(clippy::unnecessary_box_returns)]
 pub fn create_rs_SecondObjectRust() -> std::boxed::Box<SecondObjectRust> {
     std::boxed::Box::new(core::default::Default::default())
 }
@@ -775,6 +777,7 @@ impl ::cxx_qt::CxxQtType for ffi::SecondObject {
     }
 }
 #[doc(hidden)]
+#[allow(clippy::unnecessary_box_returns)]
 pub fn create_rs_ThirdObjectRust() -> std::boxed::Box<ThirdObjectRust> {
     std::boxed::Box::new(core::default::Default::default())
 }

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -1038,6 +1038,7 @@ cxx_qt::static_assertions::assert_eq_size!(
     [usize; 2]
 );
 #[doc(hidden)]
+#[allow(clippy::unnecessary_box_returns)]
 pub fn create_rs_MyObjectRust() -> std::boxed::Box<MyObjectRust> {
     std::boxed::Box::new(core::default::Default::default())
 }

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs
@@ -145,6 +145,7 @@ mod ffi {
     }
 }
 #[doc(hidden)]
+#[allow(clippy::unnecessary_box_returns)]
 pub fn create_rs_MyObjectRust() -> std::boxed::Box<MyObjectRust> {
     std::boxed::Box::new(core::default::Default::default())
 }
@@ -164,6 +165,7 @@ impl ::cxx_qt::CxxQtType for ffi::MyObject {
     }
 }
 #[doc(hidden)]
+#[allow(clippy::unnecessary_box_returns)]
 pub fn create_rs_InternalObject() -> std::boxed::Box<InternalObject> {
     std::boxed::Box::new(core::default::Default::default())
 }

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -429,6 +429,7 @@ cxx_qt::static_assertions::assert_eq_size!(
     [usize; 2]
 );
 #[doc(hidden)]
+#[allow(clippy::unnecessary_box_returns)]
 pub fn create_rs_MyObjectRust() -> std::boxed::Box<MyObjectRust> {
     std::boxed::Box::new(core::default::Default::default())
 }


### PR DESCRIPTION
The following code

```rust
#[cxx_qt::bridge]
pub mod my_object {

    unsafe extern "RustQt" {
        #[qobject]
        #[qml_element]
        type Hello = super::HelloRust;
    }

    unsafe extern "RustQt" {
        #[qinvokable]
        pub fn say_hello(self: &Hello);
    }
}

#[derive(Default)]
pub struct HelloRust {}

impl my_object::Hello {
    pub fn say_hello(&self) {
        println!("Hello world!");
    }
}
```

Triggers 

```
❮ cargo clippy -- -W clippy::pedantic
   Compiling qt-test v0.0.0-development (/Users/kristof/sources/kristof-mattei/qt-test)
warning: boxed return of the sized type `cxxqt_object::HelloRust`
 --> src/cxxqt_object.rs:1:1
  |
1 | #[cxx_qt::bridge]
  | ^^^^^^^^^^^^^^^^^
  |
  = help: changing this also requires a change to the return expressions in this function
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_box_returns
  = note: `-W clippy::unnecessary-box-returns` implied by `-W clippy::pedantic`
  = help: to override `-W clippy::pedantic` add `#[allow(clippy::unnecessary_box_returns)]`
  = note: this warning originates in the attribute macro `cxx_qt::bridge` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `qt-test` (bin "qt-test") generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.27s
```

I have `clippy::pedantic` on and disable the ones I don't need, but I cannot disable this inside of the macro.

And since the macro always returns a `Box` I don't believe there is any harm in allowing it there.