### PR TITLE
cxx-qt-gen: allow for unused unsafe blocks in the CXX block

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -185,6 +185,8 @@ jobs:
       - name: "Build"
         env:
           RUSTC_WRAPPER: sccache
+          # Ensure that we do not generate any exceptions in CXX
+          CXXFLAGS: "-DRUST_CXX_NO_EXCEPTIONS"
         run: cmake --build build --parallel 4
       - name: Test output files exist
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.7.0...HEAD)
 
+### Fixed
+
+- Build warnings due to unused unsafe blocks since CXX 1.0.130
+
 ## [0.7.0](https://github.com/KDAB/cxx-qt/compare/v0.6.1...v0.7.0) - 2024-10-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,8 @@ serde_json = "1.0"
 
 [workspace.lints.clippy]
 incompatible_msrv = "deny"
+
+[patch.crates-io]
+cxx = { git = 'https://github.com/ahayzen-kdab/cxx.git', branch = "trycatch-no-exceptions" }
+cxx-build = { git = 'https://github.com/ahayzen-kdab/cxx.git', branch = "trycatch-no-exceptions" }
+cxx-gen = { git = 'https://github.com/ahayzen-kdab/cxx.git', branch = "trycatch-no-exceptions" }

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -78,6 +78,10 @@ impl GeneratedRustBlocks {
         );
         let cxx_mod = parse_quote! {
             #[cxx::bridge(namespace = #namespace)]
+            // We need to allow for unused unsafe otherwise we get build failures
+            // due to changes in CXX 1.0.130
+            // https://github.com/dtolnay/cxx/commit/46fedc68464f80587057c436b4f6b6debeb9f714
+            #[allow(unused_unsafe)]
             #(#docs)*
             #module
         };

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -158,6 +158,7 @@ pub fn write_cpp_header(generated: &GeneratedCppBlocks, include_path: &str) -> S
     formatdoc! {r#"
         #pragma once
 
+        #include <cxx-qt/trycatch.h>
         {includes}
 
         {forward_declare}
@@ -255,6 +256,7 @@ mod tests {
         let expected = indoc! {r#"
 #pragma once
 
+#include <cxx-qt/trycatch.h>
 #include <cxx-qt/type.h>
 
 class MyObject;

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -336,6 +336,7 @@ mod tests {
         indoc! {r#"
         #pragma once
 
+        #include <cxx-qt/trycatch.h>
         #include <test>
 
         namespace cxx_qt::my_object {
@@ -390,6 +391,7 @@ mod tests {
         indoc! {r#"
         #pragma once
 
+        #include <cxx-qt/trycatch.h>
         #include <test>
 
         namespace cxx_qt {
@@ -469,6 +471,7 @@ mod tests {
         indoc! {r#"
         #pragma once
 
+        #include <cxx-qt/trycatch.h>
         #include <test>
 
         class MyObject;

--- a/crates/cxx-qt-gen/test_outputs/inheritance.h
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cxx-qt/trycatch.h>
 #include <cxx-qt/type.h>
 
 class MyObject;

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -1,4 +1,5 @@
 #[cxx::bridge(namespace = "")]
+#[allow(unused_unsafe)]
 mod inheritance {
     extern "C++" {
         include!("cxx-qt-lib/qmodelindex.h");

--- a/crates/cxx-qt-gen/test_outputs/invokables.h
+++ b/crates/cxx-qt-gen/test_outputs/invokables.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cxx-qt/threading.h>
+#include <cxx-qt/trycatch.h>
 #include <cxx-qt/type.h>
 
 namespace cxx_qt::my_object {

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -1,4 +1,5 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
+#[allow(unused_unsafe)]
 mod ffi {
     #[namespace = ""]
     unsafe extern "C++" {

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cxx-qt/signalhandler.h>
+#include <cxx-qt/trycatch.h>
 #include <cxx-qt/type.h>
 
 namespace cxx_qt::multi_object {

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -1,4 +1,5 @@
 #[cxx::bridge(namespace = "cxx_qt::multi_object")]
+#[allow(unused_unsafe)]
 pub mod ffi {
     const MAX: u16 = 65535;
     enum Event {

--- a/crates/cxx-qt-gen/test_outputs/properties.h
+++ b/crates/cxx-qt-gen/test_outputs/properties.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cxx-qt/signalhandler.h>
+#include <cxx-qt/trycatch.h>
 #include <cxx-qt/type.h>
 
 namespace cxx_qt::my_object {

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -1,4 +1,5 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
+#[allow(unused_unsafe)]
 mod ffi {
     #[namespace = ""]
     unsafe extern "C++" {

--- a/crates/cxx-qt-gen/test_outputs/qenum.h
+++ b/crates/cxx-qt-gen/test_outputs/qenum.h
@@ -3,6 +3,7 @@
 #include <QtCore/QObject>
 #include <QtQml/QQmlEngine>
 #include <cstdint>
+#include <cxx-qt/trycatch.h>
 #include <cxx-qt/type.h>
 
 namespace cxx_qt::my_object {

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs
@@ -1,4 +1,5 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
+#[allow(unused_unsafe)]
 mod ffi {
     unsafe extern "C++" {
         include ! (< QtCore / QObject >);

--- a/crates/cxx-qt-gen/test_outputs/signals.h
+++ b/crates/cxx-qt-gen/test_outputs/signals.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cxx-qt/signalhandler.h>
+#include <cxx-qt/trycatch.h>
 #include <cxx-qt/type.h>
 
 namespace cxx_qt::my_object {

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -1,4 +1,5 @@
 #[cxx::bridge(namespace = "cxx_qt::my_object")]
+#[allow(unused_unsafe)]
 mod ffi {
     #[namespace = ""]
     unsafe extern "C++" {

--- a/crates/cxx-qt-lib/include/core/qanystringview.h
+++ b/crates/cxx-qt-lib/include/core/qanystringview.h
@@ -27,10 +27,6 @@ namespace cxxqtlib1 {
 
 QAnyStringView
 qanystringviewInitFromRustString(::rust::Str string);
-QAnyStringView
-qanystringviewInitFromQString(const QString& string);
-::rust::String
-qanystringviewToRustString(const QAnyStringView& string);
 
 ::rust::isize
 qanystringviewLen(const QAnyStringView& string);

--- a/crates/cxx-qt-lib/src/core/qanystringview.cpp
+++ b/crates/cxx-qt-lib/src/core/qanystringview.cpp
@@ -32,12 +32,6 @@ qanystringviewInitFromRustString(::rust::Str string)
   return QAnyStringView(string.data(), string.size());
 }
 
-QAnyStringView
-qanystringviewInitFromQString(const QString& string)
-{
-  return QAnyStringView(string);
-}
-
 ::rust::isize
 qanystringviewLen(const QAnyStringView& string)
 {

--- a/crates/cxx-qt-lib/src/core/qanystringview.rs
+++ b/crates/cxx-qt-lib/src/core/qanystringview.rs
@@ -2,7 +2,7 @@
 // SPDX-FileContributor: Joshua Goins <josh@redstrate.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use crate::QString;
+use crate::{QByteArray, QString};
 use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
@@ -14,6 +14,9 @@ mod ffi {
         include!("cxx-qt-lib/qanystringview.h");
         type QAnyStringView<'a> = super::QAnyStringView<'a>;
 
+        include!("cxx-qt-lib/qbytearray.h");
+        type QByteArray = crate::QByteArray;
+
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
 
@@ -24,6 +27,10 @@ mod ffi {
         /// Returns true if this string is null; otherwise returns false.
         #[rust_name = "is_null"]
         fn isNull(self: &QAnyStringView) -> bool;
+
+        /// Returns a deep copy of this string view's data as a QString.
+        #[rust_name = "to_qstring"]
+        fn toString(self: &QAnyStringView) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -35,13 +42,16 @@ mod ffi {
         fn construct() -> QAnyStringView<'static>;
         #[doc(hidden)]
         #[rust_name = "QAnyStringView_init_from_rust_string"]
-        fn qanystringviewInitFromRustString<'a>(string: &str) -> QAnyStringView<'a>;
+        fn qanystringviewInitFromRustString<'a>(string: &'a str) -> QAnyStringView<'a>;
+        #[doc(hidden)]
+        #[rust_name = "QAnyStringView_init_from_qbytearray"]
+        fn construct<'a>(bytes: &'a QByteArray) -> QAnyStringView<'a>;
         #[doc(hidden)]
         #[rust_name = "QAnyStringView_init_from_qstring"]
-        fn qanystringviewInitFromQString<'a>(string: &QString) -> QAnyStringView<'a>;
+        fn construct<'a>(string: &'a QString) -> QAnyStringView<'a>;
         #[doc(hidden)]
         #[rust_name = "QAnyStringView_init_from_QAnyStringView"]
-        fn construct<'a>(string: &QAnyStringView) -> QAnyStringView<'a>;
+        fn construct<'a>(string: &QAnyStringView<'a>) -> QAnyStringView<'a>;
 
         #[doc(hidden)]
         #[rust_name = "QAnyStringView_eq"]
@@ -90,14 +100,21 @@ impl Eq for QAnyStringView<'_> {}
 
 impl<'a> From<&'a str> for QAnyStringView<'a> {
     /// Constructs a QAnyStringView from a Rust string
-    fn from(str: &str) -> Self {
+    fn from(str: &'a str) -> QAnyStringView<'a> {
         ffi::QAnyStringView_init_from_rust_string(str)
     }
 }
 
-impl From<&QString> for QAnyStringView<'_> {
+impl<'a> From<&'a QByteArray> for QAnyStringView<'a> {
+    /// Constructs a QAnyStringView from a QByteArray
+    fn from(bytes: &'a QByteArray) -> QAnyStringView<'a> {
+        ffi::QAnyStringView_init_from_qbytearray(bytes)
+    }
+}
+
+impl<'a> From<&'a QString> for QAnyStringView<'a> {
     /// Constructs a QAnyStringView from a QString
-    fn from(string: &QString) -> Self {
+    fn from(string: &'a QString) -> QAnyStringView<'a> {
         ffi::QAnyStringView_init_from_qstring(string)
     }
 }

--- a/crates/cxx-qt/build.rs
+++ b/crates/cxx-qt/build.rs
@@ -22,6 +22,7 @@ fn write_headers() {
         "signalhandler.h",
         "thread.h",
         "threading.h",
+        "trycatch.h",
         "type.h",
     ] {
         println!("cargo::rerun-if-changed=include/{file_path}");

--- a/crates/cxx-qt/include/thread.h
+++ b/crates/cxx-qt/include/thread.h
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #pragma once
 
+#include <iostream>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -58,8 +59,14 @@ public:
     // Ensure that we can read the pointer and it's not being written to
     const auto guard = ::std::shared_lock(m_obj->mutex);
     if (!m_obj->ptr) {
+#if defined(RUST_CXX_NO_EXCEPTIONS)
+      std::cerr << "Cannot queue function pointer as object has been destroyed"
+                << std::endl;
+      std::abort();
+#else
       throw ::std::runtime_error(
         "Cannot queue function pointer as object has been destroyed");
+#endif
       return;
     }
 
@@ -81,8 +88,15 @@ public:
     // Add the lambda to the queue
     if (!QMetaObject::invokeMethod(
           m_obj->ptr, ::std::move(lambda), Qt::QueuedConnection)) {
+#if defined(RUST_CXX_NO_EXCEPTIONS)
+      std::cerr
+        << "Cannot queue function pointer as invokeMethod on object failed"
+        << std::endl;
+      std::abort();
+#else
       throw ::std::runtime_error(
         "Cannot queue function pointer as invokeMethod on object failed");
+#endif
     }
   }
 

--- a/crates/cxx-qt/include/trycatch.h
+++ b/crates/cxx-qt/include/trycatch.h
@@ -1,0 +1,24 @@
+// clang-format off
+// SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// clang-format on
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// When building with no exceptions ensure we do not have a try catch
+// error: cannot use 'try' with exceptions disabled
+// So override the default trycatch from CXX
+#if defined(RUST_CXX_NO_EXCEPTIONS)
+namespace rust {
+namespace behavior {
+
+template<typename Try, typename Fail>
+static void
+trycatch(Try&& func, Fail&& fail) noexcept
+{
+  func();
+}
+
+} // namespace behavior
+} // namespace rust
+#endif

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -345,6 +345,7 @@ pub fn write_headers(directory: impl AsRef<Path>) {
         ),
         (include_str!("../include/thread.h"), "thread.h"),
         (include_str!("../include/threading.h"), "threading.h"),
+        (include_str!("../include/trycatch.h"), "trycatch.h"),
         (include_str!("../include/type.h"), "type.h"),
     ] {
         // Note that we do not need rerun-if-changed for these files

--- a/tests/qt_types_standalone/rust/src/qanystringview.rs
+++ b/tests/qt_types_standalone/rust/src/qanystringview.rs
@@ -20,17 +20,27 @@ mod qanystringview_cxx {
 
     extern "Rust" {
         fn construct_qanystringview(str: &str) -> QAnyStringView;
+    }
+
+    // This method must be unsafe otherwise we hit
+    // must be `unsafe fn` in order to expose explicit lifetimes to C++
+    //
+    // But then Rust complains about unused unsafe so we need to allow for this
+    #[allow(unused_unsafe)]
+    extern "Rust" {
         unsafe fn construct_qanystringview_qstring<'a>(str: &'a QString) -> QAnyStringView<'a>;
-        unsafe fn clone_qanystringview<'a>(l: &'a QAnyStringView) -> QAnyStringView<'a>;
+        unsafe fn clone_qanystringview<'a>(l: &QAnyStringView<'a>) -> QAnyStringView<'a>;
     }
 }
 
-fn construct_qanystringview(str: &str) -> QAnyStringView {
+fn construct_qanystringview<'a>(str: &'a str) -> QAnyStringView<'a> {
     QAnyStringView::from(str)
 }
-fn construct_qanystringview_qstring(str: &QString) -> QAnyStringView {
+
+fn construct_qanystringview_qstring<'a>(str: &'a QString) -> QAnyStringView<'a> {
     QAnyStringView::from(str)
 }
-fn clone_qanystringview<'a>(l: &'a QAnyStringView) -> QAnyStringView<'a> {
+
+fn clone_qanystringview<'a>(l: &QAnyStringView<'a>) -> QAnyStringView<'a> {
     l.clone()
 }


### PR DESCRIPTION
Otherwise we get build warnings as CXX has removed this attribute with changes in CXX 1.0.130