### PR TITLE
On non-Unix platforms, use deep copying rather than symlinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ bindings for QWidgets APIs.
 
 ### Clone the Git repository
 
+This repository contains symbolic links, which requires some setup on Windows 10 before cloning the repository.
+First, [enable Windows Developer Mode](https://learn.microsoft.com/en-us/gaming/game-bar/guide/developer-mode)
+to avoid needing administrator privileges to create symlinks. Then, enable symlinks in Git:
+
+```shell
+git config --global core.symlinks true
+```
+
+Now clone the Git repository:
+
 ```shell
 git clone https://github.com/KDAB/cxx-qt.git
 ```

--- a/README.md
+++ b/README.md
@@ -84,16 +84,6 @@ bindings for QWidgets APIs.
 
 ### Clone the Git repository
 
-This repository contains symbolic links, which requires some setup on Windows 10 before cloning the repository.
-First, [enable Windows Developer Mode](https://learn.microsoft.com/en-us/gaming/game-bar/guide/developer-mode)
-to avoid needing administrator privileges to create symlinks. Then, enable symlinks in Git:
-
-```shell
-git config --global core.symlinks true
-```
-
-Now clone the Git repository:
-
 ```shell
 git clone https://github.com/KDAB/cxx-qt.git
 ```

--- a/crates/cxx-qt-build/src/dir.rs
+++ b/crates/cxx-qt-build/src/dir.rs
@@ -12,6 +12,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
+/// On Unix platforms, included files are symlinked into destination folders.
+/// On non-Unix platforms, due to poor support for symlinking, included files are deep copied.
+#[cfg(unix)]
+pub const INCLUDE_VERB: &str = "create symlink";
+#[cfg(not(unix))]
+pub const INCLUDE_VERB: &str = "deep copy files";
+
 // Clean a directory by removing it and recreating it.
 pub(crate) fn clean(path: impl AsRef<Path>) -> Result<()> {
     let result = std::fs::remove_dir_all(&path);

--- a/crates/cxx-qt-build/src/dir.rs
+++ b/crates/cxx-qt-build/src/dir.rs
@@ -136,6 +136,7 @@ fn deep_copy_directory(source: &Path, dest: &Path) -> Result<bool> {
     Ok(true)
 }
 
+#[cfg(not(unix))]
 fn files_conflict(source: &Path, dest: &Path) -> Result<bool> {
     use fs::File;
     use std::io::{BufRead, BufReader};

--- a/crates/cxx-qt-build/src/dir.rs
+++ b/crates/cxx-qt-build/src/dir.rs
@@ -122,9 +122,7 @@ fn deep_copy_directory(source: &Path, dest: &Path) -> Result<bool> {
         }
         if !dest_path.try_exists()? {
             fs::copy(&source_path, &dest_path)?;
-            continue;
-        }
-        if files_conflict(&source_path, &dest_path)? {
+        else if files_conflict(&source_path, &dest_path)? {
             return Ok(false);
         }
     }

--- a/crates/cxx-qt-build/src/dir.rs
+++ b/crates/cxx-qt-build/src/dir.rs
@@ -156,7 +156,8 @@ fn files_conflict(source: &Path, dest: &Path) -> Result<bool> {
             return Ok(false);
         }
         let dest_bytes = dest.fill_buf()?;
-        if source_bytes != dest_bytes {
+        let bytes_len = bytes_len.min(dest_bytes.len());
+        if source_bytes[..bytes_len] != dest_bytes[..bytes_len] {
             return Ok(true);
         }
         source.consume(bytes_len);

--- a/crates/cxx-qt-build/src/dir.rs
+++ b/crates/cxx-qt-build/src/dir.rs
@@ -15,9 +15,9 @@ use std::{
 /// On Unix platforms, included files are symlinked into destination folders.
 /// On non-Unix platforms, due to poor support for symlinking, included files are deep copied.
 #[cfg(unix)]
-pub const INCLUDE_VERB: &str = "create symlink";
+pub(crate) const INCLUDE_VERB: &str = "create symlink";
 #[cfg(not(unix))]
-pub const INCLUDE_VERB: &str = "deep copy files";
+pub(crate) const INCLUDE_VERB: &str = "deep copy files";
 
 // Clean a directory by removing it and recreating it.
 pub(crate) fn clean(path: impl AsRef<Path>) -> Result<()> {

--- a/crates/cxx-qt-build/src/dir.rs
+++ b/crates/cxx-qt-build/src/dir.rs
@@ -122,7 +122,7 @@ fn deep_copy_directory(source: &Path, dest: &Path) -> Result<bool> {
         }
         if !dest_path.try_exists()? {
             fs::copy(&source_path, &dest_path)?;
-        else if files_conflict(&source_path, &dest_path)? {
+        } else if files_conflict(&source_path, &dest_path)? {
             return Ok(false);
         }
     }

--- a/crates/cxx-qt-build/src/dir.rs
+++ b/crates/cxx-qt-build/src/dir.rs
@@ -133,8 +133,8 @@ fn deep_copy_directory(source: &Path, dest: &Path) -> Result<bool> {
 
 #[cfg(not(unix))]
 fn files_conflict(source: &Path, dest: &Path) -> Result<bool> {
-    let mut source = File::open(source)?;
-    let mut dest = File::open(dest)?;
+    let mut source = fs::File::open(source)?;
+    let mut dest = fs::File::open(dest)?;
     if source.metadata()?.len() != dest.metadata()?.len() {
         return Ok(true);
     }

--- a/crates/cxx-qt-build/src/dir.rs
+++ b/crates/cxx-qt-build/src/dir.rs
@@ -152,11 +152,11 @@ fn files_conflict(source: &Path, dest: &Path) -> Result<bool> {
     loop {
         let source_bytes = source.fill_buf()?;
         let bytes_len = source_bytes.len();
+        let dest_bytes = dest.fill_buf()?;
+        let bytes_len = bytes_len.min(dest_bytes.len());
         if bytes_len == 0 {
             return Ok(false);
         }
-        let dest_bytes = dest.fill_buf()?;
-        let bytes_len = bytes_len.min(dest_bytes.len());
         if source_bytes[..bytes_len] != dest_bytes[..bytes_len] {
             return Ok(true);
         }

--- a/crates/cxx-qt-build/src/dir.rs
+++ b/crates/cxx-qt-build/src/dir.rs
@@ -16,6 +16,8 @@ use std::{
 /// On non-Unix platforms, due to poor support for symlinking, included files are deep copied.
 #[cfg(unix)]
 pub(crate) const INCLUDE_VERB: &str = "create symlink";
+/// On Unix platforms, included files are symlinked into destination folders.
+/// On non-Unix platforms, due to poor support for symlinking, included files are deep copied.
 #[cfg(not(unix))]
 pub(crate) const INCLUDE_VERB: &str = "deep copy files";
 

--- a/crates/cxx-qt-build/src/dir.rs
+++ b/crates/cxx-qt-build/src/dir.rs
@@ -133,8 +133,10 @@ fn deep_copy_directory(source: &Path, dest: &Path) -> Result<bool> {
 
 #[cfg(not(unix))]
 fn files_conflict(source: &Path, dest: &Path) -> Result<bool> {
-    let mut source = fs::File::open(source)?;
-    let mut dest = fs::File::open(dest)?;
+    use fs::File;
+    use std::io::Read;
+    let mut source = File::open(source)?;
+    let mut dest = File::open(dest)?;
     if source.metadata()?.len() != dest.metadata()?.len() {
         return Ok(true);
     }

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -17,6 +17,7 @@ mod diagnostics;
 use diagnostics::{Diagnostic, GeneratedError};
 
 pub mod dir;
+use dir::INCLUDE_VERB;
 
 mod dependencies;
 pub use dependencies::Interface;
@@ -45,13 +46,6 @@ use cxx_qt_gen::{
     parse_qt_file, write_cpp, write_rust, CppFragment, CxxQtItem, GeneratedCppBlocks,
     GeneratedRustBlocks, Parser,
 };
-
-// On Unix platforms, included files are symlinked into destination folders.
-// On non-Unix platforms, due to poor support for symlinking, included files are deep copied.
-#[cfg(unix)]
-const INCLUDE_VERB: &str = "create symlink";
-#[cfg(not(unix))]
-const INCLUDE_VERB: &str = "deep copy files";
 
 // TODO: we need to eventually support having multiple modules defined in a single file. This
 // is currently an issue because we are using the Rust file name to derive the cpp file name

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -630,50 +630,24 @@ impl CxxQtBuilder {
         }
     }
 
-    fn symlink_directory(target: impl AsRef<Path>, link: impl AsRef<Path>) -> std::io::Result<()> {
-        #[cfg(unix)]
-        let result = std::os::unix::fs::symlink(target, link);
-
-        #[cfg(windows)]
-        let result = std::os::windows::fs::symlink_dir(target, link);
-
-        // TODO: If it's neither unix nor windows, we should probably just deep-copy the
-        // dependency headers into our own include directory.
-        #[cfg(not(any(unix, windows)))]
-        panic!("Cxx-Qt-build: Unsupported platform! Only unix and windows are currently supported! Please file a bug report in the CXX-Qt repository.");
-
-        result
-    }
-
     // A dependency can specify which of its own include paths it wants to export.
     // Set up each of these exported include paths as symlinks in our own include directory.
     fn include_dependency(&mut self, dependency: &Dependency) {
         for include_prefix in &dependency.manifest.exported_include_prefixes {
             // setup include directory
-            let target = dependency.path.join("include").join(include_prefix);
+            let source = dependency.path.join("include").join(include_prefix);
 
-            let symlink = dir::header_root().join(include_prefix);
-            if symlink.exists() {
-                // Two dependencies may be reexporting the same shared dependency, which will
-                // result in conflicting symlinks.
-                // Try detecting this by resolving the symlinks and checking whether this leads us
-                // to the same paths. If so, it's the same include path for the same prefix, which
-                // is fine.
-                let symlink =
-                    std::fs::canonicalize(symlink).expect("Failed to canonicalize symlink!");
-                let target =
-                    std::fs::canonicalize(target).expect("Failed to canonicalize symlink target!");
-                if symlink != target {
-                    panic!(
+            let dest = dir::header_root().join(include_prefix);
+            #[cfg(unix)]
+            if dir::symlinks_conflict(&dest, &source).expect("Failed to canonicalize symlink!") {
+                panic!(
                         "Conflicting include_prefixes for {include_prefix}!\nDependency {dep_name} conflicts with existing include path",
                         dep_name = dependency.manifest.name,
                     );
-                }
-            } else {
-                Self::symlink_directory(target, symlink).unwrap_or_else(|_| {
-                    panic!("Could not create symlink for include_prefix {include_prefix}!")
-                });
             }
+            dir::symlink_or_copy_directory(source, dest).unwrap_or_else(|_| {
+                panic!("Could not create symlink for include_prefix {include_prefix}!")
+            });
         }
     }
 
@@ -1020,12 +994,12 @@ impl CxxQtBuilder {
 
     fn write_interface_include_dirs(&self) {
         if let Some(interface) = &self.public_interface {
-            for (header_dir, symlink) in &interface.exported_include_directories {
-                Self::symlink_directory(header_dir, dir::header_root().join(symlink))
+            for (header_dir, dest) in &interface.exported_include_directories {
+                dir::symlink_or_copy_directory(header_dir, dir::header_root().join(dest))
                     .unwrap_or_else(|_| {
                         panic!(
                             "Failed to create symlink `{}` for export_include_directory: {}",
-                            symlink,
+                            dest,
                             header_dir.to_string_lossy()
                         )
                     });

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -638,7 +638,6 @@ impl CxxQtBuilder {
             let source = dependency.path.join("include").join(include_prefix);
 
             let dest = dir::header_root().join(include_prefix);
-            #[cfg(unix)]
             if dir::symlinks_conflict(&dest, &source).expect("Failed to canonicalize symlink!") {
                 panic!(
                         "Conflicting include_prefixes for {include_prefix}!\nDependency {dep_name} conflicts with existing include path",

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -638,6 +638,7 @@ impl CxxQtBuilder {
             let source = dependency.path.join("include").join(include_prefix);
 
             let dest = dir::header_root().join(include_prefix);
+            #[cfg(unix)]
             if dir::symlinks_conflict(&dest, &source).expect("Failed to canonicalize symlink!") {
                 panic!(
                         "Conflicting include_prefixes for {include_prefix}!\nDependency {dep_name} conflicts with existing include path",


### PR DESCRIPTION
Addresses #1120. cxx-qt-build's current symlinking works on Unix, fails on Windows unless Developer Mode is enabled, and panics on anything else. This PR modifies the non-Unix behavior to use deep file copying rather than symlinking.

I have tested this on Windows 11 and MacOS Sequoia 15.1.1.

**Note:** I'm not sure if this PR means these lines should be removed:

https://github.com/KDAB/cxx-qt/blob/f5afefecf837e199848b99d3317a623a64767c5a/README.md?plain=1#L87-L93