### PR TITLE
cxx-qt-lib: Add binding for QDateTime::fromString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.7.0...HEAD)
 
+### Added
+
+- `QDateTime::from_string` to parse `QDateTime` from a `QString`.
+
 ### Fixed
 
 - Build warnings due to unused unsafe blocks since CXX 1.0.130

--- a/crates/cxx-qt-lib/include/core/qdatetime.h
+++ b/crates/cxx-qt-lib/include/core/qdatetime.h
@@ -68,5 +68,7 @@ qdatetimeToMSecsSinceEpoch(const QDateTime& datetime);
 qdatetimeToSecsSinceEpoch(const QDateTime& datetime);
 void
 qdatetimeSetTimeZone(QDateTime& datetime, const QTimeZone& timeZone);
+QDateTime
+qdatetimeFromQString(const QString& string, Qt::DateFormat format);
 }
 }

--- a/crates/cxx-qt-lib/src/core/qdatetime.cpp
+++ b/crates/cxx-qt-lib/src/core/qdatetime.cpp
@@ -154,5 +154,11 @@ qdatetimeSetTimeZone(QDateTime& datetime, const QTimeZone& timeZone)
 #endif
 }
 
+QDateTime
+qdatetimeFromQString(const QString& string, const Qt::DateFormat format)
+{
+  return QDateTime::fromString(string, format);
+}
+
 }
 }

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -14,6 +14,7 @@ mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type TimeSpec = crate::TimeSpec;
+        type DateFormat = crate::DateFormat;
     }
 
     unsafe extern "C++" {
@@ -169,6 +170,8 @@ mod ffi {
         fn qdatetimeToSecsSinceEpoch(datetime: &QDateTime) -> i64;
         #[rust_name = "qdatetime_settimezone"]
         fn qdatetimeSetTimeZone(datetime: &mut QDateTime, time_zone: &QTimeZone);
+        #[rust_name = "qdatetime_from_string"]
+        fn qdatetimeFromQString(string: &QString, format: DateFormat) -> QDateTime;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -296,6 +299,16 @@ impl QDateTime {
     /// Coordinated Universal Time (Qt::UTC) and converted to the given spec.
     pub fn from_secs_since_epoch(secs: i64, time_zone: &ffi::QTimeZone) -> Self {
         ffi::qdatetime_from_secs_since_epoch(secs, time_zone)
+    }
+
+    /// Returns the datetime represented in the string as a QDateTime using the format given, or None if this is not possible.
+    pub fn from_string(string: &ffi::QString, format: ffi::DateFormat) -> Option<Self> {
+        let date = ffi::qdatetime_from_string(string, format);
+        if date.is_valid() {
+            Some(date)
+        } else {
+            None
+        }
     }
 
     /// Returns the number of milliseconds from this datetime to the other datetime.


### PR DESCRIPTION
This gives cxx-qt users a way to parse QDateTime from a QString. This is using one of the QDateTime::fromString overloads.