### PR TITLE
cxx-qt-lib: Add binding for QQmlApplicationEngine::singletonInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.7.0...HEAD)
 
+### Added
+
+- Add binding for `singletonInstance` of `QQmlApplicationEngine`, allowing access to singleton instances registered in the QML engine.
+
 ### Fixed
 
 - Build warnings due to unused unsafe blocks since CXX 1.0.130

--- a/crates/cxx-qt-lib/include/qml/qqmlapplicationengine.h
+++ b/crates/cxx-qt-lib/include/qml/qqmlapplicationengine.h
@@ -22,6 +22,13 @@ qqmlapplicationengineNew();
 QQmlEngine&
 qqmlapplicationengineAsQQmlEngine(QQmlApplicationEngine&);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+void*
+qqmlapplicationengineSingletonInstance(QQmlApplicationEngine& engine,
+                                       QAnyStringView uri,
+                                       QAnyStringView typeName);
+#endif
+
 }
 }
 

--- a/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.cpp
+++ b/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.cpp
@@ -22,5 +22,16 @@ qqmlapplicationengineAsQQmlEngine(QQmlApplicationEngine& engine)
   return static_cast<QQmlEngine&>(engine);
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+void*
+qqmlapplicationengineSingletonInstance(QQmlApplicationEngine& engine,
+                                       QAnyStringView uri,
+                                       QAnyStringView typeName)
+{
+  return reinterpret_cast<void*>(
+    engine.singletonInstance<QObject*>(uri, typeName));
+}
+#endif
+
 }
 }


### PR DESCRIPTION
This allows accessing QObject singleton instances registered in the QML engine (using #[qml_singleton]) from the Rust side.