### PR TITLE
cxx-qt-lib: Add binding for QQmlApplicationEngine::loadFromModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - QObject subclasses can now inherit from other CXX-Qt generated QObject classes
 - `BUILD_WASM` CMake option to support WebAssembly builds and a book page for building for WASM
 - Add support for cxx_name and rust_name on qproperty attributes which applies to the QProperty generated as well as functions
+- Add support for loading QML files in `QQmlApplicationEngine` from modules with `loadFromModule`.
 
 ### Changed
 

--- a/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.rs
+++ b/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.rs
@@ -6,6 +6,12 @@
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
+        #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_5))]
+        include!("cxx-qt-lib/qanystringview.h");
+        type QAnyStringView<'a> = crate::QAnyStringView<'a>;
+    }
+
+    unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
         include!("cxx-qt-lib/qstringlist.h");
@@ -35,6 +41,16 @@ mod ffi {
 
         /// Loads the root QML file located at url.
         fn load(self: Pin<&mut QQmlApplicationEngine>, url: &QUrl);
+
+        /// Loads the QML type typeName from the module specified by uri.
+        /// This function was introduced in Qt 6.5.
+        #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_5))]
+        #[rust_name = "load_from_module"]
+        fn loadFromModule(
+            self: Pin<&mut QQmlApplicationEngine>,
+            uri: QAnyStringView,
+            typeName: QAnyStringView,
+        );
 
         /// This property holds the directory for storing offline user data
         #[rust_name = "offline_storage_path"]


### PR DESCRIPTION
This function was added in Qt 6.5, as an alternative from loading files by file path.