### PR TITLE
Add .gitattributes to mark generated Rust files as generated

### DIFF
--- a/crates/cxx-qt-lib/.gitattributes
+++ b/crates/cxx-qt-lib/.gitattributes
@@ -1,0 +1,4 @@
+src/core/qlist/qlist_*.rs linguist-generated=true
+src/core/qset/qset_*.rs linguist-generated=true
+src/core/qvariant/qvariant_*.rs linguist-generated=true
+src/core/qvector/qvector_*.rs linguist-generated=true


### PR DESCRIPTION
Per @redstrate's [request](https://github.com/KDAB/cxx-qt/pull/1149#discussion_r1898704744), this PR adds a .gitattributes file to [mark generated files as autogenerated](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github). That way, when one of the `generate.sh` scripts in cxx-qt-lib runs,  it will be clearly marked as generated in the corresponding PR:

![image](https://github.com/user-attachments/assets/e2ecdd77-66b3-475a-aa77-b45e1ea4b651)
