### PR TITLE
implement Deref and DerefMut for QStringList to QList<QString>

### DIFF
--- a/crates/cxx-qt-lib/include/core/qstringlist.h
+++ b/crates/cxx-qt-lib/include/core/qstringlist.h
@@ -25,6 +25,10 @@ struct IsRelocatable<QStringList> : ::std::true_type
 namespace rust {
 namespace cxxqtlib1 {
 
+const QList<QString>&
+qstringlistAsQListQStringRef(const QStringList& list);
+QList<QString>&
+qstringlistAsQListQStringRef(QStringList& list);
 QStringList
 qstringlistFromQListQString(const QList<QString>& list);
 QList<QString>

--- a/crates/cxx-qt-lib/src/core/qstringlist.cpp
+++ b/crates/cxx-qt-lib/src/core/qstringlist.cpp
@@ -36,6 +36,18 @@ static_assert(QTypeInfo<QStringList>::isRelocatable);
 namespace rust {
 namespace cxxqtlib1 {
 
+const QList<QString>&
+qstringlistAsQListQStringRef(const QStringList& list)
+{
+  return static_cast<const QList<QString>&>(list);
+}
+
+QList<QString>&
+qstringlistAsQListQStringRef(QStringList& list)
+{
+  return static_cast<QList<QString>&>(list);
+}
+
 QStringList
 qstringlistFromQListQString(const QList<QString>& list)
 {


### PR DESCRIPTION
Per @LeonMatthesKDAB's [comment](https://github.com/KDAB/cxx-qt/pull/761#discussion_r1447611935), implements `Deref` and `DerefMut` for `QStringList` so it isn't necessary to reimplement the `QList` API.