### PR TITLE
qt-build-utils: Add an option to use CMake instead of QMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `QDateTime::from_string` to parse `QDateTime` from a `QString`.
 - Support for further types: `QUuid`
+- Optional feature `cmake` to cxx-qt-build to prefer CMake instead of QMake for finding and linking to Qt.
 
 ### Fixed
 

--- a/crates/cxx-qt-build/Cargo.toml
+++ b/crates/cxx-qt-build/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0"
 
 [features]
 link_qt_object_files = ["qt-build-utils/link_qt_object_files"]
+cmake = ["qt-build-utils/cmake"]
 
 [lints]
 workspace = true

--- a/crates/qt-build-utils/Cargo.toml
+++ b/crates/qt-build-utils/Cargo.toml
@@ -17,6 +17,7 @@ rust-version.workspace = true
 cc.workspace = true
 versions = "6.3"
 thiserror.workspace = true
+cmake-package = { version = "0.1.5", optional = true }
 
 [features]
 # When Cargo links an executable, whether a bin crate or test executable,
@@ -30,6 +31,10 @@ thiserror.workspace = true
 #
 # When linking Qt dynamically, this makes no difference.
 link_qt_object_files = []
+
+# Prefer using CMake to find Qt modules, instead of using qmake.
+# This may be desirable in certain installations.
+cmake = ["dep:cmake-package"]
 
 [lints]
 workspace = true

--- a/examples/cargo_without_cmake/Cargo.toml
+++ b/examples/cargo_without_cmake/Cargo.toml
@@ -31,3 +31,6 @@ cxx-qt-lib = { workspace = true, features = ["full"] }
 # Use `cxx-qt-build = "0.7"` here instead!
 # The link_qt_object_files feature is required for statically linking Qt 6.
 cxx-qt-build = { workspace = true, features = [ "link_qt_object_files" ] }
+
+[features]
+cmake = ["cxx-qt-build/cmake"]


### PR DESCRIPTION
This is needed for scenarios where the CMake packaging for Qt is better than what QMake can handle, e.g. split Qt installations where the modules live in different directories.

A new optional feature is added to cxx-qt-build to prefer CMake for most operations related to linking/including Qt modules. QMake is still the default.

Fixes #1153.