### PR TITLE
cxx-qt-lib: Fix some doc comment syntax errors

### DIFF
--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -154,7 +154,7 @@ impl QDate {
         ffi::qdate_add_days(self, ndays)
     }
 
-    // Returns the current date, as reported by the system clock.
+    /// Returns the current date, as reported by the system clock.
     pub fn current_date() -> Self {
         ffi::qdate_current_date()
     }

--- a/crates/cxx-qt-lib/src/core/quuid.rs
+++ b/crates/cxx-qt-lib/src/core/quuid.rs
@@ -219,7 +219,7 @@ impl QUuid {
     }
 
     /// Converts self to big endian from the target’s endianness.
-    // This function is analogous to [`u8::to_be`](https://doc.rust-lang.org/src/core/num/uint_macros.rs.html#399-431).
+    /// This function is analogous to [`u8::to_be`](https://doc.rust-lang.org/src/core/num/uint_macros.rs.html#399-431).
     ///
     /// On big endian this is a no-op. On little endian the bytes are swapped.
     ///


### PR DESCRIPTION
These were using `//` instead of `///`, noticed it while adding other documentation :-)