### PR TITLE
Implement Debug for all types that work with QDebug

### DIFF
--- a/crates/cxx-qt-lib/include/common.h
+++ b/crates/cxx-qt-lib/include/common.h
@@ -32,13 +32,6 @@ drop(T& value)
 
 template<typename T>
 QString
-toQString(const T& value)
-{
-  return value.toString();
-}
-
-template<typename T>
-QString
 toDebugQString(const T& value)
 {
   // We can't convert value directly into a string.

--- a/crates/cxx-qt-lib/include/common.h
+++ b/crates/cxx-qt-lib/include/common.h
@@ -32,6 +32,13 @@ drop(T& value)
 
 template<typename T>
 QString
+toQString(const T& value)
+{
+  return value.toString();
+}
+
+template<typename T>
+QString
 toDebugQString(const T& value)
 {
   // We can't convert value directly into a string.

--- a/crates/cxx-qt-lib/include/common.h
+++ b/crates/cxx-qt-lib/include/common.h
@@ -32,7 +32,7 @@ drop(T& value)
 
 template<typename T>
 QString
-toQString(const T& value)
+toDebugQString(const T& value)
 {
   // We can't convert value directly into a string.
   // However most Qt types are able to stream into a QDebug object such as

--- a/crates/cxx-qt-lib/include/core/qtimezone.h
+++ b/crates/cxx-qt-lib/include/core/qtimezone.h
@@ -13,6 +13,9 @@
 #include <QtCore/QList>
 #include <QtCore/QTimeZone>
 
+using QTimeZoneNameType = QTimeZone::NameType;
+using QTimeZoneTimeType = QTimeZone::TimeType;
+
 namespace rust {
 namespace cxxqtlib1 {
 
@@ -22,6 +25,8 @@ qtimezoneAvailableTimeZoneIds();
 qtimezoneClone(const QTimeZone& timezone);
 ::std::unique_ptr<QTimeZone>
 qtimezoneDefault();
+QString
+qtimezoneDisplayName(const QTimeZone &timezone, QTimeZoneTimeType timeType, QTimeZoneNameType nameType);
 ::std::unique_ptr<QTimeZone>
 qtimezoneFromOffsetSeconds(::std::int32_t offsetSeconds);
 ::std::unique_ptr<QTimeZone>

--- a/crates/cxx-qt-lib/include/core/qtimezone.h
+++ b/crates/cxx-qt-lib/include/core/qtimezone.h
@@ -26,7 +26,9 @@ qtimezoneClone(const QTimeZone& timezone);
 ::std::unique_ptr<QTimeZone>
 qtimezoneDefault();
 QString
-qtimezoneDisplayName(const QTimeZone &timezone, QTimeZoneTimeType timeType, QTimeZoneNameType nameType);
+qtimezoneDisplayName(const QTimeZone& timezone,
+                     QTimeZoneTimeType timeType,
+                     QTimeZoneNameType nameType);
 ::std::unique_ptr<QTimeZone>
 qtimezoneFromOffsetSeconds(::std::int32_t offsetSeconds);
 ::std::unique_ptr<QTimeZone>

--- a/crates/cxx-qt-lib/include/core/qurl.h
+++ b/crates/cxx-qt-lib/include/core/qurl.h
@@ -27,11 +27,6 @@ struct IsRelocatable<QUrl> : ::std::true_type
 namespace rust {
 namespace cxxqtlib1 {
 
-QUrl
-qurlInitFromString(::rust::Str string);
-::rust::String
-qurlToRustString(const QUrl& url);
-
 // Bitwise enums don't work well with Rust and CXX, so lets just use the
 // defaults for now
 QString
@@ -84,6 +79,8 @@ QString
 qurlToDisplayString(const QUrl& url);
 QByteArray
 qurlToEncoded(const QUrl& url);
+QString
+qurlToQString(const QUrl& url);
 QByteArray
 qurlToPercentEncoding(const QString& input,
                       const QByteArray& exclude,

--- a/crates/cxx-qt-lib/include/core/qurl.h
+++ b/crates/cxx-qt-lib/include/core/qurl.h
@@ -89,8 +89,6 @@ qurlToPercentEncoding(const QString& input,
                       const QByteArray& exclude,
                       const QByteArray& include);
 QString
-qurlToQString(const QUrl& url);
-QString
 qurlUserInfo(const QUrl& url);
 QString
 qurlUserName(const QUrl& url);

--- a/crates/cxx-qt-lib/include/gui/qcolor.h
+++ b/crates/cxx-qt-lib/include/gui/qcolor.h
@@ -65,8 +65,6 @@ qcolorInitFromRgb(::std::int32_t red,
                   ::std::int32_t alpha);
 QColor
 qcolorInitFromRgbF(float red, float green, float blue, float alpha);
-QColor
-qcolorInitFromRustString(::rust::Str string);
 
 // Qt 5 uses qreal and Qt 6 uses float, so cast all to floats
 float

--- a/crates/cxx-qt-lib/include/gui/qpolygon.h
+++ b/crates/cxx-qt-lib/include/gui/qpolygon.h
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #pragma once
 
+#include <QtCore/QPoint>
+#include <QtCore/QVector>
 #include <QtGui/QPolygon>
 
 #include "rust/cxx.h"
@@ -19,3 +21,14 @@ struct IsRelocatable<QPolygon> : ::std::true_type
 {};
 
 } // namespace rust
+
+namespace rust {
+namespace cxxqtlib1 {
+
+const QVector<QPoint>&
+qpolygonAsQVectorQPointRef(const QPolygon& shape);
+QVector<QPoint>&
+qpolygonAsQVectorQPointRef(QPolygon& shape);
+
+}
+}

--- a/crates/cxx-qt-lib/include/gui/qpolygonf.h
+++ b/crates/cxx-qt-lib/include/gui/qpolygonf.h
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #pragma once
 
+#include <QtCore/QPointF>
+#include <QtCore/QVector>
 #include <QtGui/QPolygonF>
 
 #include "rust/cxx.h"
@@ -19,3 +21,14 @@ struct IsRelocatable<QPolygonF> : ::std::true_type
 {};
 
 } // namespace rust
+
+namespace rust {
+namespace cxxqtlib1 {
+
+const QVector<QPointF>&
+qpolygonfAsQVectorQPointFRef(const QPolygonF& shape);
+QVector<QPointF>&
+qpolygonfAsQVectorQPointFRef(QPolygonF& shape);
+
+}
+}

--- a/crates/cxx-qt-lib/src/core/qanystringview.rs
+++ b/crates/cxx-qt-lib/src/core/qanystringview.rs
@@ -61,10 +61,6 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "QAnyStringView_len"]
         fn qanystringviewLen(string: &QAnyStringView) -> isize;
-
-        #[doc(hidden)]
-        #[rust_name = "QAnyStringView_to_qstring"]
-        fn toQString(string: &QAnyStringView) -> QString;
     }
 }
 
@@ -133,7 +129,7 @@ impl QAnyStringView<'_> {
 
 impl fmt::Display for QAnyStringView<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::QAnyStringView_to_qstring(self))
+        write!(f, "{}", self.to_qstring())
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qanystringview.rs
+++ b/crates/cxx-qt-lib/src/core/qanystringview.rs
@@ -7,6 +7,7 @@ use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 #[cxx::bridge]
 mod ffi {

--- a/crates/cxx-qt-lib/src/core/qanystringview.rs
+++ b/crates/cxx-qt-lib/src/core/qanystringview.rs
@@ -60,6 +60,10 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "QAnyStringView_len"]
         fn qanystringviewLen(string: &QAnyStringView) -> isize;
+
+        #[doc(hidden)]
+        #[rust_name = "QAnyStringView_to_qstring"]
+        fn toQString(string: &QAnyStringView) -> QString;
     }
 }
 
@@ -123,6 +127,18 @@ impl QAnyStringView<'_> {
     /// Returns the number of characters in this string.
     pub fn len(&self) -> isize {
         ffi::QAnyStringView_len(self)
+    }
+}
+
+impl fmt::Display for QAnyStringView<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::QAnyStringView_to_qstring(self))
+    }
+}
+
+impl fmt::Debug for QAnyStringView<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qbytearray.rs
+++ b/crates/cxx-qt-lib/src/core/qbytearray.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
@@ -151,9 +152,9 @@ impl std::cmp::PartialEq for QByteArray {
 
 impl std::cmp::Eq for QByteArray {}
 
-impl std::fmt::Display for QByteArray {
+impl fmt::Display for QByteArray {
     /// Convert the QByteArray to a Rust string
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Ok(string) = String::from_utf8(self.into()) {
             write!(f, "{string}")
         } else {
@@ -162,8 +163,8 @@ impl std::fmt::Display for QByteArray {
     }
 }
 
-impl std::fmt::Debug for QByteArray {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for QByteArray {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{self}")
     }
 }

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -124,9 +124,6 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qdate_to_debug_qstring"]
         fn toDebugQString(value: &QDate) -> QString;
-        #[doc(hidden)]
-        #[rust_name = "qdate_to_qstring"]
-        fn toQString(value: &QDate) -> QString;
     }
 }
 
@@ -146,7 +143,7 @@ impl Default for QDate {
 
 impl fmt::Display for QDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qdate_to_qstring(self))
+        write!(f, "{}", self.format_enum(ffi::DateFormat::TextDate))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -124,6 +124,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qdate_to_debug_qstring"]
         fn toDebugQString(value: &QDate) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qdate_to_qstring"]
+        fn toQString(value: &QDate) -> QString;
     }
 }
 
@@ -143,13 +146,13 @@ impl Default for QDate {
 
 impl fmt::Display for QDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qdate_to_debug_qstring(self))
+        write!(f, "{}", ffi::qdate_to_qstring(self))
     }
 }
 
 impl fmt::Debug for QDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self}")
+        write!(f, "{}", ffi::qdate_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -122,8 +122,8 @@ mod ffi {
         #[rust_name = "qdate_init"]
         fn construct(y: i32, m: i32, d: i32) -> QDate;
         #[doc(hidden)]
-        #[rust_name = "qdate_to_qstring"]
-        fn toQString(value: &QDate) -> QString;
+        #[rust_name = "qdate_to_debug_qstring"]
+        fn toDebugQString(value: &QDate) -> QString;
     }
 }
 
@@ -143,7 +143,7 @@ impl Default for QDate {
 
 impl fmt::Display for QDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qdate_to_qstring(self))
+        write!(f, "{}", ffi::qdate_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -140,6 +140,10 @@ mod ffi {
         #[rust_name = "to_secs_since_epoch"]
         fn toSecsSinceEpoch(self: &QDateTime) -> qint64;
 
+        /// Returns the time as a string. The format parameter determines the format of the string.
+        #[rust_name = "format_enum"]
+        fn toString(self: &QDateTime, format: DateFormat) -> QString;
+
         /// Returns a copy of this datetime converted to the given time spec.
         ///
         /// Note this method is only available with Qt < 6.8
@@ -230,9 +234,6 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qdatetime_to_debug_qstring"]
         fn toDebugQString(value: &QDateTime) -> QString;
-        #[doc(hidden)]
-        #[rust_name = "qdatetime_to_qstring"]
-        fn toQString(value: &QDateTime) -> QString;
     }
 }
 
@@ -367,7 +368,7 @@ impl Ord for QDateTime {
 
 impl fmt::Display for QDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qdatetime_to_qstring(self))
+        write!(f, "{}", self.format_enum(ffi::DateFormat::TextDate))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -228,8 +228,8 @@ mod ffi {
         #[rust_name = "qdatetime_cmp"]
         fn operatorCmp(a: &QDateTime, b: &QDateTime) -> i8;
         #[doc(hidden)]
-        #[rust_name = "qdatetime_to_qstring"]
-        fn toQString(value: &QDateTime) -> QString;
+        #[rust_name = "qdatetime_to_debug_qstring"]
+        fn toDebugQString(value: &QDateTime) -> QString;
     }
 }
 
@@ -364,7 +364,7 @@ impl Ord for QDateTime {
 
 impl fmt::Display for QDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qdatetime_to_qstring(self))
+        write!(f, "{}", ffi::qdatetime_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -230,6 +230,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qdatetime_to_debug_qstring"]
         fn toDebugQString(value: &QDateTime) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qdatetime_to_qstring"]
+        fn toQString(value: &QDateTime) -> QString;
     }
 }
 
@@ -364,13 +367,13 @@ impl Ord for QDateTime {
 
 impl fmt::Display for QDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qdatetime_to_debug_qstring(self))
+        write!(f, "{}", ffi::qdatetime_to_qstring(self))
     }
 }
 
 impl fmt::Debug for QDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self}")
+        write!(f, "{}", ffi::qdatetime_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qhash/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qhash/mod.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use core::{marker::PhantomData, mem::MaybeUninit};
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 /// The QHash class is a template class that provides a hash-table-based dictionary.
 ///
@@ -139,6 +140,17 @@ where
     /// Inserts a new item with the key and a value of value.
     pub fn insert(&mut self, key: T::Key, value: T::Value) {
         T::insert(self, key, value)
+    }
+}
+
+impl<T> fmt::Debug for QHash<T>
+where
+    T: QHashPair,
+    T::Key: fmt::Debug,
+    T::Value: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qline.rs
+++ b/crates/cxx-qt-lib/src/core/qline.rs
@@ -93,8 +93,8 @@ mod ffi {
         fn construct(pt1: QPoint, pt2: QPoint) -> QLine;
 
         #[doc(hidden)]
-        #[rust_name = "qline_to_qstring"]
-        fn toQString(value: &QLine) -> QString;
+        #[rust_name = "qline_to_debug_qstring"]
+        fn toDebugQString(value: &QLine) -> QString;
     }
 }
 
@@ -122,7 +122,7 @@ impl Default for QLine {
 
 impl fmt::Display for QLine {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qline_to_qstring(self))
+        write!(f, "{}", ffi::qline_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qlinef.rs
+++ b/crates/cxx-qt-lib/src/core/qlinef.rs
@@ -126,8 +126,8 @@ mod ffi {
         fn construct(line: &QLine) -> QLineF;
 
         #[doc(hidden)]
-        #[rust_name = "qlinef_to_qstring"]
-        fn toQString(value: &QLineF) -> QString;
+        #[rust_name = "qlinef_to_debug_qstring"]
+        fn toDebugQString(value: &QLineF) -> QString;
     }
 }
 
@@ -170,7 +170,7 @@ impl From<QLineF> for ffi::QLine {
 
 impl fmt::Display for QLineF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qlinef_to_qstring(self))
+        write!(f, "{}", ffi::qlinef_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qlist/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qlist/mod.rs
@@ -75,6 +75,15 @@ where
 
 impl<T> Eq for QList<T> where T: QListElement + Eq {}
 
+impl<T> std::fmt::Debug for QList<T>
+where
+    T: QListElement + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
 impl<T> QList<T>
 where
     T: QListElement,

--- a/crates/cxx-qt-lib/src/core/qlist/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qlist/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use core::{marker::PhantomData, mem::MaybeUninit};
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 /// The QList class is a template class that provides a dynamic array.
 ///
@@ -75,11 +76,11 @@ where
 
 impl<T> Eq for QList<T> where T: QListElement + Eq {}
 
-impl<T> std::fmt::Debug for QList<T>
+impl<T> fmt::Debug for QList<T>
 where
-    T: QListElement + std::fmt::Debug,
+    T: QListElement + fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
 }

--- a/crates/cxx-qt-lib/src/core/qmap/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qmap/mod.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use core::{marker::PhantomData, mem::MaybeUninit};
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 /// The QMap class is a template class that provides an associative array.
 ///
@@ -63,6 +64,17 @@ where
     T: QMapPair,
     T::Value: Eq,
 {
+}
+
+impl<T> fmt::Debug for QMap<T>
+where
+    T: QMapPair,
+    T::Key: fmt::Debug,
+    T::Value: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
+    }
 }
 
 impl<T> QMap<T>

--- a/crates/cxx-qt-lib/src/core/qmargins.rs
+++ b/crates/cxx-qt-lib/src/core/qmargins.rs
@@ -67,8 +67,8 @@ mod ffi {
         #[rust_name = "qmargins_new"]
         fn construct(left: i32, top: i32, right: i32, bottom: i32) -> QMargins;
         #[doc(hidden)]
-        #[rust_name = "qmargins_to_qstring"]
-        fn toQString(value: &QMargins) -> QString;
+        #[rust_name = "qmargins_to_debug_qstring"]
+        fn toDebugQString(value: &QMargins) -> QString;
         #[doc(hidden)]
         #[rust_name = "qmargins_plus"]
         fn operatorPlus(a: &QMargins, b: &QMargins) -> QMargins;
@@ -122,7 +122,7 @@ impl Default for QMargins {
 
 impl fmt::Display for QMargins {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qmargins_to_qstring(self))
+        write!(f, "{}", ffi::qmargins_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qmarginsf.rs
+++ b/crates/cxx-qt-lib/src/core/qmarginsf.rs
@@ -69,8 +69,8 @@ mod ffi {
         #[rust_name = "qmarginsf_new"]
         fn construct(left: f64, top: f64, right: f64, bottom: f64) -> QMarginsF;
         #[doc(hidden)]
-        #[rust_name = "qmarginsf_to_qstring"]
-        fn toQString(value: &QMarginsF) -> QString;
+        #[rust_name = "qmarginsf_to_debug_qstring"]
+        fn toDebugQString(value: &QMarginsF) -> QString;
         #[doc(hidden)]
         #[rust_name = "qmarginsf_plus"]
         fn operatorPlus(a: &QMarginsF, b: &QMarginsF) -> QMarginsF;
@@ -118,7 +118,7 @@ impl Default for QMarginsF {
 
 impl fmt::Display for QMarginsF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qmarginsf_to_qstring(self))
+        write!(f, "{}", ffi::qmarginsf_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.rs
@@ -56,8 +56,8 @@ mod ffi {
         #[rust_name = "qmodelindex_eq"]
         fn operatorEq(a: &QModelIndex, b: &QModelIndex) -> bool;
         #[doc(hidden)]
-        #[rust_name = "qmodelindex_to_qstring"]
-        fn toQString(value: &QModelIndex) -> QString;
+        #[rust_name = "qmodelindex_to_debug_qstring"]
+        fn toDebugQString(value: &QModelIndex) -> QString;
     }
 }
 
@@ -88,7 +88,7 @@ impl std::cmp::Eq for QModelIndex {}
 
 impl fmt::Display for QModelIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qmodelindex_to_qstring(self))
+        write!(f, "{}", ffi::qmodelindex_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.rs
@@ -88,13 +88,13 @@ impl std::cmp::Eq for QModelIndex {}
 
 impl fmt::Display for QModelIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qmodelindex_to_debug_qstring(self))
+        write!(f, "{self:?}")
     }
 }
 
 impl fmt::Debug for QModelIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self}")
+        write!(f, "{}", ffi::qmodelindex_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
@@ -96,13 +96,13 @@ impl std::cmp::Eq for QPersistentModelIndex {}
 
 impl fmt::Display for QPersistentModelIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpersistentmodelindex_to_debug_qstring(self))
+        write!(f, "{self:?}")
     }
 }
 
 impl fmt::Debug for QPersistentModelIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self}")
+        write!(f, "{}", ffi::qpersistentmodelindex_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
@@ -54,8 +54,8 @@ mod ffi {
         #[rust_name = "qpersistentmodelindex_eq"]
         fn operatorEq(a: &QPersistentModelIndex, b: &QPersistentModelIndex) -> bool;
         #[doc(hidden)]
-        #[rust_name = "qpersistentmodelindex_to_qstring"]
-        fn toQString(value: &QPersistentModelIndex) -> QString;
+        #[rust_name = "qpersistentmodelindex_to_debug_qstring"]
+        fn toDebugQString(value: &QPersistentModelIndex) -> QString;
     }
 }
 
@@ -96,7 +96,7 @@ impl std::cmp::Eq for QPersistentModelIndex {}
 
 impl fmt::Display for QPersistentModelIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpersistentmodelindex_to_qstring(self))
+        write!(f, "{}", ffi::qpersistentmodelindex_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpoint.rs
+++ b/crates/cxx-qt-lib/src/core/qpoint.rs
@@ -70,8 +70,8 @@ mod ffi {
         #[rust_name = "qpoint_init"]
         fn construct(x: i32, y: i32) -> QPoint;
         #[doc(hidden)]
-        #[rust_name = "qpoint_to_qstring"]
-        fn toQString(value: &QPoint) -> QString;
+        #[rust_name = "qpoint_to_debug_qstring"]
+        fn toDebugQString(value: &QPoint) -> QString;
         #[doc(hidden)]
         #[rust_name = "qpoint_plus"]
         fn operatorPlus(a: &QPoint, b: &QPoint) -> QPoint;
@@ -122,7 +122,7 @@ impl Default for QPoint {
 
 impl fmt::Display for QPoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpoint_to_qstring(self))
+        write!(f, "{}", ffi::qpoint_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpointf.rs
+++ b/crates/cxx-qt-lib/src/core/qpointf.rs
@@ -70,8 +70,8 @@ mod ffi {
         #[rust_name = "qpointf_from_qpoint"]
         fn construct(point: &QPoint) -> QPointF;
         #[doc(hidden)]
-        #[rust_name = "qpointf_to_qstring"]
-        fn toQString(value: &QPointF) -> QString;
+        #[rust_name = "qpointf_to_debug_qstring"]
+        fn toDebugQString(value: &QPointF) -> QString;
         #[doc(hidden)]
         #[rust_name = "qpointf_plus"]
         fn operatorPlus(a: &QPointF, b: &QPointF) -> QPointF;
@@ -116,7 +116,7 @@ impl Default for QPointF {
 
 impl fmt::Display for QPointF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpointf_to_qstring(self))
+        write!(f, "{}", ffi::qpointf_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qrect.rs
+++ b/crates/cxx-qt-lib/src/core/qrect.rs
@@ -257,8 +257,8 @@ mod ffi {
         #[rust_name = "qrect_init"]
         fn construct(x: i32, y: i32, width: i32, height: i32) -> QRect;
         #[doc(hidden)]
-        #[rust_name = "qrect_to_qstring"]
-        fn toQString(value: &QRect) -> QString;
+        #[rust_name = "qrect_to_debug_qstring"]
+        fn toDebugQString(value: &QRect) -> QString;
         #[doc(hidden)]
         #[rust_name = "qrect_plus"]
         fn operatorPlus(a: &QRect, b: &QMargins) -> QRect;
@@ -295,7 +295,7 @@ impl Default for QRect {
 
 impl fmt::Display for QRect {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qrect_to_qstring(self))
+        write!(f, "{}", ffi::qrect_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qrectf.rs
+++ b/crates/cxx-qt-lib/src/core/qrectf.rs
@@ -259,8 +259,8 @@ mod ffi {
         #[rust_name = "qrectf_from_qrect"]
         fn construct(rectangle: &QRect) -> QRectF;
         #[doc(hidden)]
-        #[rust_name = "qrectf_to_qstring"]
-        fn toQString(value: &QRectF) -> QString;
+        #[rust_name = "qrectf_to_debug_qstring"]
+        fn toDebugQString(value: &QRectF) -> QString;
         #[doc(hidden)]
         #[rust_name = "qrectf_plus"]
         fn operatorPlus(a: &QRectF, b: &QMarginsF) -> QRectF;
@@ -296,7 +296,7 @@ impl Default for QRectF {
 
 impl fmt::Display for QRectF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qrectf_to_qstring(self))
+        write!(f, "{}", ffi::qrectf_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qset/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qset/mod.rs
@@ -7,6 +7,7 @@ use crate::QDateTime;
 use crate::{QByteArray, QDate, QPersistentModelIndex, QString, QTime, QUrl, QUuid};
 use core::{marker::PhantomData, mem::MaybeUninit};
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 /// The QSet class is a template class that provides a hash-table-based set.
 ///
@@ -64,11 +65,11 @@ where
 
 impl<T> Eq for QSet<T> where T: QSetElement + PartialEq {}
 
-impl<T> std::fmt::Debug for QSet<T>
+impl<T> fmt::Debug for QSet<T>
 where
-    T: QSetElement + std::fmt::Debug,
+    T: QSetElement + fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
     }
 }

--- a/crates/cxx-qt-lib/src/core/qset/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qset/mod.rs
@@ -64,6 +64,15 @@ where
 
 impl<T> Eq for QSet<T> where T: QSetElement + PartialEq {}
 
+impl<T> std::fmt::Debug for QSet<T>
+where
+    T: QSetElement + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
 impl<T> QSet<T>
 where
     T: QSetElement,

--- a/crates/cxx-qt-lib/src/core/qsize.rs
+++ b/crates/cxx-qt-lib/src/core/qsize.rs
@@ -97,8 +97,8 @@ mod ffi {
         #[rust_name = "qsize_init"]
         fn construct(w: i32, h: i32) -> QSize;
         #[doc(hidden)]
-        #[rust_name = "qsize_to_qstring"]
-        fn toQString(value: &QSize) -> QString;
+        #[rust_name = "qsize_to_debug_qstring"]
+        fn toDebugQString(value: &QSize) -> QString;
         #[doc(hidden)]
         #[rust_name = "qsize_plus"]
         fn operatorPlus(a: &QSize, b: &QSize) -> QSize;
@@ -138,7 +138,7 @@ impl Default for QSize {
 
 impl fmt::Display for QSize {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qsize_to_qstring(self))
+        write!(f, "{}", ffi::qsize_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qsizef.rs
+++ b/crates/cxx-qt-lib/src/core/qsizef.rs
@@ -100,8 +100,8 @@ mod ffi {
         #[rust_name = "qsizef_from_qsize"]
         fn construct(size: &QSize) -> QSizeF;
         #[doc(hidden)]
-        #[rust_name = "qsizef_to_qstring"]
-        fn toQString(value: &QSizeF) -> QString;
+        #[rust_name = "qsizef_to_debug_qstring"]
+        fn toDebugQString(value: &QSizeF) -> QString;
         #[doc(hidden)]
         #[rust_name = "qsizef_plus"]
         fn operatorPlus(a: &QSizeF, b: &QSizeF) -> QSizeF;
@@ -141,7 +141,7 @@ impl Default for QSizeF {
 
 impl fmt::Display for QSizeF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qsizef_to_qstring(self))
+        write!(f, "{}", ffi::qsizef_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -254,7 +254,7 @@ impl fmt::Display for QString {
     ///
     /// Note that this converts from UTF-16 to UTF-8
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", <&QString as Into<String>>::into(self))
+        write!(f, "{}", String::from(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qstringlist.rs
+++ b/crates/cxx-qt-lib/src/core/qstringlist.rs
@@ -5,6 +5,7 @@
 use crate::{QList, QString};
 use core::mem::MaybeUninit;
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 #[cxx::bridge]
@@ -140,15 +141,15 @@ impl std::cmp::PartialEq for QStringList {
 
 impl std::cmp::Eq for QStringList {}
 
-impl std::fmt::Display for QStringList {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for QStringList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qstringlist_to_debug_qstring(self))
     }
 }
 
-impl std::fmt::Debug for QStringList {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        QList::fmt(self, f)
+impl fmt::Debug for QStringList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", **self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qstringlist.rs
+++ b/crates/cxx-qt-lib/src/core/qstringlist.rs
@@ -74,8 +74,8 @@ mod ffi {
         fn operatorEq(a: &QStringList, b: &QStringList) -> bool;
 
         #[doc(hidden)]
-        #[rust_name = "qstringlist_to_qstring"]
-        fn toQString(value: &QStringList) -> QString;
+        #[rust_name = "qstringlist_to_debug_qstring"]
+        fn toDebugQString(value: &QStringList) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -142,7 +142,7 @@ impl std::cmp::Eq for QStringList {}
 
 impl std::fmt::Display for QStringList {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qstringlist_to_qstring(self))
+        write!(f, "{}", ffi::qstringlist_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qstringlist.rs
+++ b/crates/cxx-qt-lib/src/core/qstringlist.rs
@@ -148,7 +148,7 @@ impl std::fmt::Display for QStringList {
 
 impl std::fmt::Debug for QStringList {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{self}")
+        QList::fmt(self, f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qtime.rs
@@ -111,8 +111,8 @@ mod ffi {
         #[rust_name = "qtime_init"]
         fn construct(h: i32, m: i32, s: i32, ms: i32) -> QTime;
         #[doc(hidden)]
-        #[rust_name = "qtime_to_qstring"]
-        fn toQString(value: &QTime) -> QString;
+        #[rust_name = "qtime_to_debug_qstring"]
+        fn toDebugQString(value: &QTime) -> QString;
     }
 }
 
@@ -178,7 +178,7 @@ impl Default for QTime {
 
 impl fmt::Display for QTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qtime_to_qstring(self))
+        write!(f, "{}", ffi::qtime_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qtime.rs
@@ -113,9 +113,6 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qtime_to_debug_qstring"]
         fn toDebugQString(value: &QTime) -> QString;
-        #[doc(hidden)]
-        #[rust_name = "qtime_to_qstring"]
-        fn toQString(value: &QTime) -> QString;
     }
 }
 
@@ -181,7 +178,7 @@ impl Default for QTime {
 
 impl fmt::Display for QTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qtime_to_qstring(self))
+        write!(f, "{}", self.format_enum(ffi::DateFormat::TextDate))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qtime.rs
@@ -113,6 +113,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qtime_to_debug_qstring"]
         fn toDebugQString(value: &QTime) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qtime_to_qstring"]
+        fn toQString(value: &QTime) -> QString;
     }
 }
 
@@ -178,13 +181,13 @@ impl Default for QTime {
 
 impl fmt::Display for QTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qtime_to_debug_qstring(self))
+        write!(f, "{}", ffi::qtime_to_qstring(self))
     }
 }
 
 impl fmt::Debug for QTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self}")
+        write!(f, "{}", ffi::qtime_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qtimezone.cpp
+++ b/crates/cxx-qt-lib/src/core/qtimezone.cpp
@@ -27,6 +27,14 @@ qtimezoneDefault()
   return ::std::make_unique<QTimeZone>();
 }
 
+QString
+qtimezoneDisplayName(const QTimeZone& timezone,
+                     QTimeZoneTimeType timeType,
+                     QTimeZoneNameType nameType)
+{
+  return timezone.displayName(timeType, nameType);
+}
+
 ::std::unique_ptr<QTimeZone>
 qtimezoneFromOffsetSeconds(::std::int32_t offsetSeconds)
 {

--- a/crates/cxx-qt-lib/src/core/qtimezone.rs
+++ b/crates/cxx-qt-lib/src/core/qtimezone.rs
@@ -6,6 +6,31 @@ use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
+    #[repr(i32)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    enum QTimeZoneNameType {
+        /// The default form of the time zone name, one of LongName, ShortName or OffsetName
+        DefaultName,
+        /// The long form of the time zone name, e.g. "Central European Time"
+        LongName,
+        /// The short form of the time zone name, usually an abbreviation, e.g. "CET", in locales
+        /// that have one for the zone, otherwise a compact GMT-ofset form, e.g. "GMT+1"
+        ShortName,
+        /// The standard ISO offset form of the time zone name, e.g. "UTC+01:00"
+        OffsetName,
+    }
+
+    #[repr(i32)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    enum QTimeZoneTimeType {
+        /// The standard time in a time zone, i.e. when Daylight-Saving is not in effect. For example when formatting a display name this will show something like "Pacific Standard Time".
+        StandardTime,
+        /// A time when Daylight-Saving is in effect. For example when formatting a display name this will show something like "Pacific daylight-saving time".
+        DaylightTime,
+        /// A time which is not specifically Standard or Daylight-Saving time, either an unknown time or a neutral form. For example when formatting a display name this will show something like "Pacific Time".
+        GenericTime,
+    }
+
     unsafe extern "C++" {
         include!("cxx-qt-lib/qbytearray.h");
         type QByteArray = crate::QByteArray;
@@ -25,6 +50,8 @@ mod ffi {
         //
         // Therefore the internal QSharedDataPointer is incremented causing a memory leak, so use an opaque type.
         type QTimeZone;
+        type QTimeZoneNameType;
+        type QTimeZoneTimeType;
 
         /// Returns the time zone abbreviation at the given atDateTime. The abbreviation may change depending on DST or even historical events.
         fn abbreviation(self: &QTimeZone, atDateTime: &QDateTime) -> QString;
@@ -79,6 +106,13 @@ mod ffi {
         #[rust_name = "qtimezone_default"]
         fn qtimezoneDefault() -> UniquePtr<QTimeZone>;
         #[doc(hidden)]
+        #[rust_name = "qtimezone_display_name"]
+        fn qtimezoneDisplayName(
+            timezone: &QTimeZone,
+            time_type: QTimeZoneTimeType,
+            name_type: QTimeZoneNameType,
+        ) -> QString;
+        #[doc(hidden)]
         #[rust_name = "qtimezone_from_offset_seconds"]
         fn qtimezoneFromOffsetSeconds(offset_seconds: i32) -> UniquePtr<QTimeZone>;
         #[doc(hidden)]
@@ -115,12 +149,36 @@ mod ffi {
     impl UniquePtr<QTimeZone> {}
 }
 
-pub use ffi::QTimeZone;
+pub use ffi::{QTimeZone, QTimeZoneNameType, QTimeZoneTimeType};
+
+impl Default for QTimeZoneNameType {
+    fn default() -> Self {
+        Self::DefaultName
+    }
+}
 
 impl QTimeZone {
     /// Returns a list of all available IANA time zone IDs on this system.
     pub fn available_time_zone_ids() -> ffi::QList_QByteArray {
         ffi::qtimezone_available_time_zone_ids()
+    }
+
+    /// Returns the localized time zone display name.
+    ///
+    /// Where the time zone display names have changed over time, the current names will be used.
+    /// If no suitably localized name of the given type is available, another name type may be
+    /// used, or an empty string may be returned.
+    ///
+    /// For custom timezones created by client code, the data supplied to the constructor are
+    /// used, as no localization data will be available for it. If this timezone is invalid, an
+    /// empty string is returned. This may also arise for the representation of local time if
+    /// determining the system time zone fails.
+    fn display_name(
+        &self,
+        time_type: QTimeZoneTimeType,
+        name_type: QTimeZoneNameType,
+    ) -> ffi::QString {
+        ffi::qtimezone_display_name(self, time_type, name_type)
     }
 
     /// Creates an instance of a time zone with the requested Offset from UTC of offsetSeconds.
@@ -169,12 +227,16 @@ impl std::cmp::Eq for QTimeZone {}
 
 impl fmt::Display for QTimeZone {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qtimezone_to_debug_qstring(self))
+        let name = self.display_name(
+            QTimeZoneTimeType::GenericTime,
+            QTimeZoneNameType::DefaultName,
+        );
+        write!(f, "{name}")
     }
 }
 
 impl fmt::Debug for QTimeZone {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self}")
+        write!(f, "{}", ffi::qtimezone_to_debug_qstring(self))
     }
 }

--- a/crates/cxx-qt-lib/src/core/qtimezone.rs
+++ b/crates/cxx-qt-lib/src/core/qtimezone.rs
@@ -103,8 +103,8 @@ mod ffi {
         #[rust_name = "qtimezone_eq"]
         fn operatorEq(a: &QTimeZone, b: &QTimeZone) -> bool;
         #[doc(hidden)]
-        #[rust_name = "qtimezone_to_qstring"]
-        fn toQString(value: &QTimeZone) -> QString;
+        #[rust_name = "qtimezone_to_debug_qstring"]
+        fn toDebugQString(value: &QTimeZone) -> QString;
     }
 
     // QTimeZone only has a copy-constructor and not a move-constructor, which means that the following is true
@@ -169,7 +169,7 @@ impl std::cmp::Eq for QTimeZone {}
 
 impl fmt::Display for QTimeZone {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qtimezone_to_qstring(self))
+        write!(f, "{}", ffi::qtimezone_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qtimezone.rs
+++ b/crates/cxx-qt-lib/src/core/qtimezone.rs
@@ -23,11 +23,16 @@ mod ffi {
     #[repr(i32)]
     #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     enum QTimeZoneTimeType {
-        /// The standard time in a time zone, i.e. when Daylight-Saving is not in effect. For example when formatting a display name this will show something like "Pacific Standard Time".
+        /// The standard time in a time zone, i.e. when Daylight-Saving is not in effect. For
+        /// example when formatting a display name this will show something like "Pacific Standard
+        /// Time".
         StandardTime,
-        /// A time when Daylight-Saving is in effect. For example when formatting a display name this will show something like "Pacific daylight-saving time".
+        /// A time when Daylight-Saving is in effect. For example when formatting a display name
+        /// this will show something like "Pacific daylight-saving time".
         DaylightTime,
-        /// A time which is not specifically Standard or Daylight-Saving time, either an unknown time or a neutral form. For example when formatting a display name this will show something like "Pacific Time".
+        /// A time which is not specifically Standard or Daylight-Saving time, either an unknown
+        /// time or a neutral form. For example when formatting a display name this will show
+        /// something like "Pacific Time".
         GenericTime,
     }
 

--- a/crates/cxx-qt-lib/src/core/qurl.cpp
+++ b/crates/cxx-qt-lib/src/core/qurl.cpp
@@ -200,12 +200,6 @@ qurlToPercentEncoding(const QString& input,
 }
 
 QString
-qurlToQString(const QUrl& url)
-{
-  return url.toString();
-}
-
-QString
 qurlUserInfo(const QUrl& url)
 {
   return url.userInfo();

--- a/crates/cxx-qt-lib/src/core/qurl.cpp
+++ b/crates/cxx-qt-lib/src/core/qurl.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #include "cxx-qt-lib/qurl.h"
-#include "cxx-qt-lib/qstring.h"
 
 #include <cxx-qt-lib/assertion_utils.h>
 
@@ -25,21 +24,6 @@ static_assert(QTypeInfo<QUrl>::isRelocatable);
 
 namespace rust {
 namespace cxxqtlib1 {
-
-QUrl
-qurlInitFromString(::rust::Str string)
-{
-  // Note that rust::Str here is borrowed
-  // and we convert back from UTF-8 to UTF-16
-  return QUrl(qstringInitFromRustString(string));
-}
-
-::rust::String
-qurlToRustString(const QUrl& url)
-{
-  // Note that this changes UTF-16 to UTF-8
-  return qstringToRustString(url.toString());
-}
 
 QString
 qurlAuthority(const QUrl& url)
@@ -189,6 +173,12 @@ QByteArray
 qurlToEncoded(const QUrl& url)
 {
   return url.toEncoded();
+}
+
+QString
+qurlToQString(const QUrl& url)
+{
+  return url.toString();
 }
 
 QByteArray

--- a/crates/cxx-qt-lib/src/core/qurl.rs
+++ b/crates/cxx-qt-lib/src/core/qurl.rs
@@ -153,9 +153,6 @@ mod ffi {
             exclude: &QByteArray,
             include: &QByteArray,
         ) -> QByteArray;
-        #[doc(hidden)]
-        #[rust_name = "qurl_to_qstring"]
-        fn qurlToQString(url: &QUrl) -> QString;
         #[rust_name = "qurl_user_info"]
         fn qurlUserInfo(url: &QUrl) -> QString;
         #[rust_name = "qurl_user_name"]
@@ -185,8 +182,11 @@ mod ffi {
         fn operatorEq(a: &QUrl, b: &QUrl) -> bool;
 
         #[doc(hidden)]
-        #[rust_name = "qurl_debug"]
+        #[rust_name = "qurl_to_debug_qstring"]
         fn toDebugQString(url: &QUrl) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qurl_to_qstring"]
+        fn toQString(url: &QUrl) -> QString;
     }
 }
 
@@ -441,7 +441,7 @@ impl fmt::Display for QUrl {
 
 impl fmt::Debug for QUrl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qurl_debug(self))
+        write!(f, "{}", ffi::qurl_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qurl.rs
+++ b/crates/cxx-qt-lib/src/core/qurl.rs
@@ -90,13 +90,6 @@ mod ffi {
     // Bitwise enums don't work well with Rust and CXX, so lets just use the defaults for now
     #[namespace = "rust::cxxqtlib1"]
     unsafe extern "C++" {
-        #[doc(hidden)]
-        #[rust_name = "qurl_init_from_string"]
-        fn qurlInitFromString(string: &str) -> QUrl;
-        #[doc(hidden)]
-        #[rust_name = "qurl_to_rust_string"]
-        fn qurlToRustString(url: &QUrl) -> String;
-
         #[rust_name = "qurl_authority"]
         fn qurlAuthority(url: &QUrl) -> QString;
         #[rust_name = "qurl_file_name"]
@@ -147,6 +140,8 @@ mod ffi {
         fn qurlToDisplayString(url: &QUrl) -> QString;
         #[rust_name = "qurl_to_encoded"]
         fn qurlToEncoded(url: &QUrl) -> QByteArray;
+        #[rust_name = "qurl_to_qstring"]
+        fn qurlToQString(url: &QUrl) -> QString;
         #[rust_name = "qurl_to_percent_encoding"]
         fn qurlToPercentEncoding(
             input: &QString,
@@ -184,9 +179,6 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qurl_to_debug_qstring"]
         fn toDebugQString(url: &QUrl) -> QString;
-        #[doc(hidden)]
-        #[rust_name = "qurl_to_qstring"]
-        fn toQString(url: &QUrl) -> QString;
     }
 }
 
@@ -435,7 +427,7 @@ impl fmt::Display for QUrl {
     ///
     /// Note that this converts from UTF-16 to UTF-8
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qurl_to_rust_string(self))
+        write!(f, "{}", ffi::qurl_to_display_string(self))
     }
 }
 
@@ -464,7 +456,7 @@ impl From<&str> for QUrl {
     ///
     /// Note that this converts from UTF-8 to UTF-16
     fn from(str: &str) -> Self {
-        ffi::qurl_init_from_string(str)
+        Self::from(&ffi::QString::from(str))
     }
 }
 
@@ -473,7 +465,7 @@ impl From<&String> for QUrl {
     ///
     /// Note that this converts from UTF-8 to UTF-16
     fn from(str: &String) -> Self {
-        ffi::qurl_init_from_string(str)
+        Self::from(str.as_str())
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qurl.rs
+++ b/crates/cxx-qt-lib/src/core/qurl.rs
@@ -186,7 +186,7 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "qurl_debug"]
-        fn toQString(url: &QUrl) -> QString;
+        fn toDebugQString(url: &QUrl) -> QString;
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/quuid.rs
+++ b/crates/cxx-qt-lib/src/core/quuid.rs
@@ -120,13 +120,13 @@ impl Default for QUuid {
 
 impl fmt::Display for QUuid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        ffi::quuid_to_string(self).fmt(f)
+        write!(f, "{}", ffi::quuid_to_string(self))
     }
 }
 
 impl fmt::Debug for QUuid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        ffi::quuid_to_string(self).fmt(f)
+        write!(f, "{self}")
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qvariant/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qvariant/mod.rs
@@ -4,11 +4,15 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
+
         include!("cxx-qt-lib/qvariant.h");
         type QVariant = super::QVariant;
 
@@ -38,6 +42,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qvariant_eq"]
         fn operatorEq(a: &QVariant, b: &QVariant) -> bool;
+        #[doc(hidden)]
+        #[rust_name = "qvariant_to_debug_qstring"]
+        fn toDebugQString(variant: &QVariant) -> QString;
     }
 }
 
@@ -127,6 +134,12 @@ impl QVariant {
 impl std::cmp::PartialEq for QVariant {
     fn eq(&self, other: &Self) -> bool {
         ffi::qvariant_eq(self, other)
+    }
+}
+
+impl fmt::Debug for QVariant {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qvariant_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qvector/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qvector/mod.rs
@@ -75,6 +75,15 @@ where
 
 impl<T> Eq for QVector<T> where T: QVectorElement + Eq {}
 
+impl<T> std::fmt::Debug for QVector<T>
+where
+    T: QVectorElement + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
 impl<T> QVector<T>
 where
     T: QVectorElement,

--- a/crates/cxx-qt-lib/src/core/qvector/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qvector/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use core::{marker::PhantomData, mem::MaybeUninit};
 use cxx::{type_id, ExternType};
+use std::fmt;
 
 /// The QVector class is a template class that provides a dynamic array.
 ///
@@ -75,11 +76,11 @@ where
 
 impl<T> Eq for QVector<T> where T: QVectorElement + Eq {}
 
-impl<T> std::fmt::Debug for QVector<T>
+impl<T> fmt::Debug for QVector<T>
 where
-    T: QVectorElement + std::fmt::Debug,
+    T: QVectorElement + fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
 }

--- a/crates/cxx-qt-lib/src/gui/qcolor.cpp
+++ b/crates/cxx-qt-lib/src/gui/qcolor.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 #include "cxx-qt-lib/qcolor.h"
-#include "cxx-qt-lib/qstring.h"
 
 #include <cxx-qt-lib/assertion_utils.h>
 
@@ -136,12 +135,6 @@ qcolorInitFromRgbF(float red, float green, float blue, float alpha)
                           static_cast<qreal>(blue),
                           static_cast<qreal>(alpha));
 #endif
-}
-
-QColor
-qcolorInitFromRustString(::rust::Str string)
-{
-  return QColor(qstringInitFromRustString(string));
 }
 
 // Qt 5 uses qreal and Qt 6 uses float, so cast all to floats

--- a/crates/cxx-qt-lib/src/gui/qcolor.rs
+++ b/crates/cxx-qt-lib/src/gui/qcolor.rs
@@ -174,9 +174,6 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qcolor_init_from_rgb_f"]
         fn qcolorInitFromRgbF(red: f32, green: f32, blue: f32, alpha: f32) -> QColor;
-        #[doc(hidden)]
-        #[rust_name = "qcolor_init_from_rust_string"]
-        fn qcolorInitFromRustString(string: &str) -> QColor;
 
         #[doc(hidden)]
         #[rust_name = "qcolor_alpha_f"]
@@ -520,12 +517,7 @@ impl TryFrom<&str> for QColor {
     type Error = &'static str;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let color = ffi::qcolor_init_from_rust_string(value);
-        if color.is_valid() {
-            Ok(color)
-        } else {
-            Err("Invalid color")
-        }
+        Self::try_from(&ffi::QString::from(value))
     }
 }
 
@@ -533,12 +525,7 @@ impl TryFrom<&String> for QColor {
     type Error = &'static str;
 
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        let color = ffi::qcolor_init_from_rust_string(value);
-        if color.is_valid() {
-            Ok(color)
-        } else {
-            Err("Invalid color")
-        }
+        Self::try_from(value.as_str())
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
@@ -357,7 +358,9 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qfont_to_debug_qstring"]
         fn toDebugQString(value: &QFont) -> QString;
-
+        #[doc(hidden)]
+        #[rust_name = "qfont_to_qstring"]
+        fn toQString(value: &QFont) -> QString;
     }
 }
 
@@ -390,8 +393,14 @@ impl Clone for QFont {
     }
 }
 
-impl std::fmt::Display for QFont {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for QFont {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qfont_to_qstring(self))
+    }
+}
+
+impl fmt::Debug for QFont {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qfont_to_debug_qstring(self))
     }
 }

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -355,8 +355,8 @@ mod ffi {
         fn operatorEq(a: &QFont, b: &QFont) -> bool;
 
         #[doc(hidden)]
-        #[rust_name = "qfont_to_qstring"]
-        fn toQString(value: &QFont) -> QString;
+        #[rust_name = "qfont_to_debug_qstring"]
+        fn toDebugQString(value: &QFont) -> QString;
 
     }
 }
@@ -392,7 +392,7 @@ impl Clone for QFont {
 
 impl std::fmt::Display for QFont {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qfont_to_qstring(self))
+        write!(f, "{}", ffi::qfont_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -358,10 +358,6 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qfont_eq"]
         fn operatorEq(a: &QFont, b: &QFont) -> bool;
-
-        #[doc(hidden)]
-        #[rust_name = "qfont_to_debug_qstring"]
-        fn toDebugQString(value: &QFont) -> QString;
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -321,6 +321,10 @@ mod ffi {
         #[rust_name = "style_strategy"]
         fn styleStrategy(self: &QFont) -> QFontStyleStrategy;
 
+        /// Returns the font as a string.
+        #[rust_name = "to_qstring"]
+        fn toString(self: &QFont) -> QString;
+
         /// Returns true if underline has been set; otherwise returns false.
         fn underline(self: &QFont) -> bool;
 
@@ -358,9 +362,6 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qfont_to_debug_qstring"]
         fn toDebugQString(value: &QFont) -> QString;
-        #[doc(hidden)]
-        #[rust_name = "qfont_to_qstring"]
-        fn toQString(value: &QFont) -> QString;
     }
 }
 
@@ -395,13 +396,13 @@ impl Clone for QFont {
 
 impl fmt::Display for QFont {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qfont_to_qstring(self))
+        write!(f, "{}", self.to_qstring())
     }
 }
 
 impl fmt::Debug for QFont {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qfont_to_debug_qstring(self))
+        write!(f, "{}", self.to_qstring())
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qimage.rs
+++ b/crates/cxx-qt-lib/src/gui/qimage.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
@@ -74,6 +75,8 @@ mod ffi {
         type QImage = super::QImage;
         include!("cxx-qt-lib/qsize.h");
         type QSize = crate::QSize;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
         include!("cxx-qt-lib/qrect.h");
         type QRect = crate::QRect;
         include!("cxx-qt-lib/qcolor.h");
@@ -263,6 +266,10 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qimage_eq"]
         fn operatorEq(a: &QImage, b: &QImage) -> bool;
+
+        #[doc(hidden)]
+        #[rust_name = "qimage_to_debug_qstring"]
+        fn toDebugQString(image: &QImage) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -329,6 +336,12 @@ impl PartialEq for QImage {
 }
 
 impl Eq for QImage {}
+
+impl fmt::Debug for QImage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qimage_to_debug_qstring(self))
+    }
+}
 
 // Safety:
 //

--- a/crates/cxx-qt-lib/src/gui/qpainterpath.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainterpath.rs
@@ -244,6 +244,12 @@ impl PartialEq for QPainterPath {
 
 impl fmt::Display for QPainterPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl fmt::Debug for QPainterPath {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qpainterpath_to_debug_qstring(self))
     }
 }

--- a/crates/cxx-qt-lib/src/gui/qpainterpath.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainterpath.rs
@@ -200,8 +200,8 @@ mod ffi {
         fn operatorEq(a: &QPainterPath, b: &QPainterPath) -> bool;
 
         #[doc(hidden)]
-        #[rust_name = "qpainterpath_to_qstring"]
-        fn toQString(value: &QPainterPath) -> QString;
+        #[rust_name = "qpainterpath_to_debug_qstring"]
+        fn toDebugQString(value: &QPainterPath) -> QString;
     }
 }
 
@@ -244,7 +244,7 @@ impl PartialEq for QPainterPath {
 
 impl fmt::Display for QPainterPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpainterpath_to_qstring(self))
+        write!(f, "{}", ffi::qpainterpath_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpen.rs
+++ b/crates/cxx-qt-lib/src/gui/qpen.rs
@@ -122,8 +122,8 @@ mod ffi {
         fn operatorEq(a: &QPen, b: &QPen) -> bool;
 
         #[doc(hidden)]
-        #[rust_name = "qpen_to_qstring"]
-        fn toQString(value: &QPen) -> QString;
+        #[rust_name = "qpen_to_debug_qstring"]
+        fn toDebugQString(value: &QPen) -> QString;
     }
 }
 
@@ -173,7 +173,7 @@ impl From<&ffi::PenStyle> for QPen {
 
 impl fmt::Display for QPen {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpen_to_qstring(self))
+        write!(f, "{}", ffi::qpen_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpen.rs
+++ b/crates/cxx-qt-lib/src/gui/qpen.rs
@@ -173,6 +173,12 @@ impl From<&ffi::PenStyle> for QPen {
 
 impl fmt::Display for QPen {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl fmt::Debug for QPen {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qpen_to_debug_qstring(self))
     }
 }

--- a/crates/cxx-qt-lib/src/gui/qpolygon.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.cpp
@@ -32,3 +32,20 @@ static_assert(!::std::is_trivially_copy_constructible<QPolygon>::value);
 static_assert(!::std::is_trivially_destructible<QPolygon>::value);
 
 static_assert(QTypeInfo<QPolygon>::isRelocatable);
+
+namespace rust {
+namespace cxxqtlib1 {
+const QVector<QPoint>&
+qpolygonAsQVectorQPointRef(const QPolygon& shape)
+{
+  return static_cast<const QVector<QPoint>&>(shape);
+}
+
+QVector<QPoint>&
+qpolygonAsQVectorQPointRefMut(QPolygon& shape)
+{
+  return static_cast<QVector<QPoint>&>(shape);
+}
+
+}
+}

--- a/crates/cxx-qt-lib/src/gui/qpolygon.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.cpp
@@ -42,7 +42,7 @@ qpolygonAsQVectorQPointRef(const QPolygon& shape)
 }
 
 QVector<QPoint>&
-qpolygonAsQVectorQPointRefMut(QPolygon& shape)
+qpolygonAsQVectorQPointRef(QPolygon& shape)
 {
   return static_cast<QVector<QPoint>&>(shape);
 }

--- a/crates/cxx-qt-lib/src/gui/qpolygon.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.rs
@@ -159,6 +159,12 @@ impl PartialEq for QPolygon {
     }
 }
 
+impl std::fmt::Debug for QPolygon {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        QVector::fmt(self, f)
+    }
+}
+
 impl std::fmt::Display for QPolygon {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", ffi::qpolygon_to_qstring(self))

--- a/crates/cxx-qt-lib/src/gui/qpolygon.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.rs
@@ -98,8 +98,8 @@ mod ffi {
         fn operatorEq(a: &QPolygon, b: &QPolygon) -> bool;
 
         #[doc(hidden)]
-        #[rust_name = "qpolygon_to_qstring"]
-        fn toQString(value: &QPolygon) -> QString;
+        #[rust_name = "qpolygon_to_debug_qstring"]
+        fn toDebugQString(value: &QPolygon) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -167,7 +167,7 @@ impl std::fmt::Debug for QPolygon {
 
 impl std::fmt::Display for QPolygon {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qpolygon_to_qstring(self))
+        write!(f, "{}", ffi::qpolygon_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpolygon.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.rs
@@ -2,9 +2,10 @@
 // SPDX-FileContributor: Laurent Montel <laurent.montel@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use crate::QRect;
+use crate::{QPoint, QRect, QVector};
 use core::mem::MaybeUninit;
 use cxx::{type_id, ExternType};
+use std::ops::{Deref, DerefMut};
 
 #[cxx::bridge]
 mod ffi {
@@ -15,6 +16,9 @@ mod ffi {
     }
 
     unsafe extern "C++" {
+        include!("cxx-qt-lib/qvector.h");
+        type QVector_QPoint = crate::QVector<QPoint>;
+
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = crate::QPoint;
         include!("cxx-qt-lib/qrect.h");
@@ -97,6 +101,15 @@ mod ffi {
         #[rust_name = "qpolygon_to_qstring"]
         fn toQString(value: &QPolygon) -> QString;
     }
+
+    #[namespace = "rust::cxxqtlib1"]
+    unsafe extern "C++" {
+        #[doc(hidden)]
+        #[rust_name = "qpolygon_as_qvector_qpoint_ref"]
+        fn qpolygonAsQVectorQPointRef(shape: &QPolygon) -> &QVector_QPoint;
+        #[rust_name = "qpolygon_as_qvector_qpoint_ref_mut"]
+        fn qpolygonAsQVectorQPointRef(shape: &mut QPolygon) -> &mut QVector_QPoint;
+    }
 }
 
 /// The QPolygon class provides a list of QPoint.
@@ -153,6 +166,20 @@ impl std::fmt::Display for QPolygon {
 }
 
 impl Eq for QPolygon {}
+
+impl Deref for QPolygon {
+    type Target = QVector<QPoint>;
+
+    fn deref(&self) -> &Self::Target {
+        ffi::qpolygon_as_qvector_qpoint_ref(self)
+    }
+}
+
+impl DerefMut for QPolygon {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        ffi::qpolygon_as_qvector_qpoint_ref_mut(self)
+    }
+}
 
 // Safety:
 //

--- a/crates/cxx-qt-lib/src/gui/qpolygon.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.rs
@@ -5,6 +5,7 @@
 use crate::{QPoint, QRect, QVector};
 use core::mem::MaybeUninit;
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 #[cxx::bridge]
@@ -159,15 +160,15 @@ impl PartialEq for QPolygon {
     }
 }
 
-impl std::fmt::Debug for QPolygon {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        QVector::fmt(self, f)
+impl fmt::Display for QPolygon {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", ffi::qpolygon_to_debug_qstring(self))
     }
 }
 
-impl std::fmt::Display for QPolygon {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qpolygon_to_debug_qstring(self))
+impl fmt::Debug for QPolygon {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", **self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.cpp
@@ -32,3 +32,20 @@ static_assert(!::std::is_trivially_copy_constructible<QPolygonF>::value);
 static_assert(!::std::is_trivially_destructible<QPolygonF>::value);
 
 static_assert(QTypeInfo<QPolygonF>::isRelocatable);
+
+namespace rust {
+namespace cxxqtlib1 {
+const QVector<QPointF>&
+qpolygonfAsQVectorQPointFRef(const QPolygonF& shape)
+{
+  return static_cast<const QVector<QPointF>&>(shape);
+}
+
+QVector<QPointF>&
+qpolygonfAsQVectorQPointFRefMut(QPolygonF& shape)
+{
+  return static_cast<QVector<QPointF>&>(shape);
+}
+
+}
+}

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.cpp
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.cpp
@@ -42,7 +42,7 @@ qpolygonfAsQVectorQPointFRef(const QPolygonF& shape)
 }
 
 QVector<QPointF>&
-qpolygonfAsQVectorQPointFRefMut(QPolygonF& shape)
+qpolygonfAsQVectorQPointFRef(QPolygonF& shape)
 {
   return static_cast<QVector<QPointF>&>(shape);
 }

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.rs
@@ -4,6 +4,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use core::mem::MaybeUninit;
 use cxx::{type_id, ExternType};
+use std::ops::{Deref, DerefMut};
+
+use crate::{QPointF, QVector};
 
 #[cxx::bridge]
 mod ffi {
@@ -14,6 +17,9 @@ mod ffi {
     }
 
     unsafe extern "C++" {
+        include!("cxx-qt-lib/qvector.h");
+        type QVector_QPointF = crate::QVector<QPointF>;
+
         include!("cxx-qt-lib/qpointf.h");
         type QPointF = crate::QPointF;
         include!("cxx-qt-lib/qrectf.h");
@@ -86,6 +92,15 @@ mod ffi {
         #[rust_name = "qpolygonf_to_qstring"]
         fn toQString(value: &QPolygonF) -> QString;
     }
+
+    #[namespace = "rust::cxxqtlib1"]
+    unsafe extern "C++" {
+        #[doc(hidden)]
+        #[rust_name = "qpolygonf_as_qvector_qpointf_ref"]
+        fn qpolygonfAsQVectorQPointFRef(shape: &QPolygonF) -> &QVector_QPointF;
+        #[rust_name = "qpolygonf_as_qvector_qpointf_ref_mut"]
+        fn qpolygonfAsQVectorQPointFRef(shape: &mut QPolygonF) -> &mut QVector_QPointF;
+    }
 }
 
 /// The QPolygonF class provides a list of QPointF.
@@ -133,6 +148,20 @@ impl std::fmt::Display for QPolygonF {
 }
 
 impl Eq for QPolygonF {}
+
+impl Deref for QPolygonF {
+    type Target = QVector<QPointF>;
+
+    fn deref(&self) -> &Self::Target {
+        ffi::qpolygonf_as_qvector_qpointf_ref(self)
+    }
+}
+
+impl DerefMut for QPolygonF {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        ffi::qpolygonf_as_qvector_qpointf_ref_mut(self)
+    }
+}
 
 // Safety:
 //

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.rs
@@ -141,6 +141,12 @@ impl PartialEq for QPolygonF {
     }
 }
 
+impl std::fmt::Debug for QPolygonF {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        QVector::fmt(self, f)
+    }
+}
+
 impl std::fmt::Display for QPolygonF {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", ffi::qpolygonf_to_qstring(self))

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.rs
@@ -89,8 +89,8 @@ mod ffi {
         fn operatorEq(a: &QPolygonF, b: &QPolygonF) -> bool;
 
         #[doc(hidden)]
-        #[rust_name = "qpolygonf_to_qstring"]
-        fn toQString(value: &QPolygonF) -> QString;
+        #[rust_name = "qpolygonf_to_debug_qstring"]
+        fn toDebugQString(value: &QPolygonF) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -149,7 +149,7 @@ impl std::fmt::Debug for QPolygonF {
 
 impl std::fmt::Display for QPolygonF {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qpolygonf_to_qstring(self))
+        write!(f, "{}", ffi::qpolygonf_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use core::mem::MaybeUninit;
 use cxx::{type_id, ExternType};
+use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 use crate::{QPointF, QVector};
@@ -141,15 +142,15 @@ impl PartialEq for QPolygonF {
     }
 }
 
-impl std::fmt::Debug for QPolygonF {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        QVector::fmt(self, f)
+impl fmt::Display for QPolygonF {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", ffi::qpolygonf_to_debug_qstring(self))
     }
 }
 
-impl std::fmt::Display for QPolygonF {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qpolygonf_to_debug_qstring(self))
+impl fmt::Debug for QPolygonF {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", **self)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector2d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.rs
@@ -107,8 +107,8 @@ mod ffi {
         #[rust_name = "qvector2d_distance_to_point"]
         fn qvector2DDistanceToPoint(vector: &QVector2D, point: QVector2D) -> f32;
         #[doc(hidden)]
-        #[rust_name = "qvector2d_to_qstring"]
-        fn toQString(value: &QVector2D) -> QString;
+        #[rust_name = "qvector2d_to_debug_qstring"]
+        fn toDebugQString(value: &QVector2D) -> QString;
         #[doc(hidden)]
         #[rust_name = "qvector2d_plus"]
         fn operatorPlus(a: &QVector2D, b: &QVector2D) -> QVector2D;
@@ -160,7 +160,7 @@ impl Default for QVector2D {
 
 impl std::fmt::Display for QVector2D {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qvector2d_to_qstring(self))
+        write!(f, "{}", ffi::qvector2d_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector2d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.rs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::fmt;
+
 use cxx::{type_id, ExternType};
 
 #[cxx::bridge]
@@ -158,8 +160,8 @@ impl Default for QVector2D {
     }
 }
 
-impl std::fmt::Display for QVector2D {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for QVector2D {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qvector2d_to_debug_qstring(self))
     }
 }

--- a/crates/cxx-qt-lib/src/gui/qvector3d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.rs
@@ -123,8 +123,8 @@ mod ffi {
         #[rust_name = "qvector3d_distance_to_point"]
         fn qvector3DDistanceToPoint(vector: &QVector3D, point: QVector3D) -> f32;
         #[doc(hidden)]
-        #[rust_name = "qvector3d_to_qstring"]
-        fn toQString(value: &QVector3D) -> QString;
+        #[rust_name = "qvector3d_to_debug_qstring"]
+        fn toDebugQString(value: &QVector3D) -> QString;
         #[doc(hidden)]
         #[rust_name = "qvector3d_plus"]
         fn operatorPlus(a: &QVector3D, b: &QVector3D) -> QVector3D;
@@ -183,7 +183,7 @@ impl Default for QVector3D {
 
 impl std::fmt::Display for QVector3D {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qvector3d_to_qstring(self))
+        write!(f, "{}", ffi::qvector3d_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector3d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.rs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::fmt;
+
 use cxx::{type_id, ExternType};
 
 #[cxx::bridge]
@@ -181,8 +183,8 @@ impl Default for QVector3D {
     }
 }
 
-impl std::fmt::Display for QVector3D {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for QVector3D {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qvector3d_to_debug_qstring(self))
     }
 }

--- a/crates/cxx-qt-lib/src/gui/qvector4d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.rs
@@ -114,8 +114,8 @@ mod ffi {
         fn construct() -> QVector4D;
 
         #[doc(hidden)]
-        #[rust_name = "qvector4d_to_qstring"]
-        fn toQString(value: &QVector4D) -> QString;
+        #[rust_name = "qvector4d_to_debug_qstring"]
+        fn toDebugQString(value: &QVector4D) -> QString;
         #[doc(hidden)]
         #[rust_name = "qvector4d_plus"]
         fn operatorPlus(a: &QVector4D, b: &QVector4D) -> QVector4D;
@@ -155,7 +155,7 @@ impl Default for QVector4D {
 
 impl std::fmt::Display for QVector4D {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qvector4d_to_qstring(self))
+        write!(f, "{}", ffi::qvector4d_to_debug_qstring(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector4d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.rs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::fmt;
+
 use cxx::{type_id, ExternType};
 
 #[cxx::bridge]
@@ -153,8 +155,8 @@ impl Default for QVector4D {
     }
 }
 
-impl std::fmt::Display for QVector4D {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for QVector4D {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ffi::qvector4d_to_debug_qstring(self))
     }
 }


### PR DESCRIPTION
This PR adds `Debug` implementations to all types that a [QDebug](https://doc.qt.io/qt-6/qdebug.html) data stream accepts.

**Note:** Some types incorrectly used QDebug output to implement `Display` instead of `Debug`. This PR does not remove those implementations because that would be a breaking change, but they probably should be removed for the next major release.