### PR TITLE
Fix: Rename logging_enabled property

### DIFF
--- a/examples/qml_features/qml/pages/SignalsPage.qml
+++ b/examples/qml_features/qml/pages/SignalsPage.qml
@@ -28,10 +28,10 @@ Page {
 
             ToolButton {
                 checkable: true
-                checked: rustSignals.loggingEnabled
+                checked: rustSignals.logging_enabled
                 text: qsTr("Toggle Logging")
 
-                onClicked: rustSignals.loggingEnabled = !rustSignals.loggingEnabled
+                onClicked: rustSignals.logging_enabled = !rustSignals.logging_enabled
             }
 
             Item {


### PR DESCRIPTION
Apparently we missed a rename here when removing the auto conversion.
