### PR TITLE
Base on cppqt blocks

### DIFF
--- a/book/src/concepts/casting.md
+++ b/book/src/concepts/casting.md
@@ -9,8 +9,9 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 With the [base](../bridge/attributes.md) attribute, it is possible to inherit from another type.
 In order to access this parent class, we provide an API to cast up or down.
-Currently, this is only supported for objects in `extern "RustQt"` blocks, which have either a `#[qobject]` attribute,
+Currently, this is supported for objects in both `extern "RustQt"` *and* `extern "C++Qt"` blocks, which have either a `#[qobject]` attribute,
 or a `#[base = T]` attribute. see [here](../bridge/attributes.md) for more details on these attributes.
+> Note: Types in "C++Qt" blocks are **required** to have the `#[qobject]` attribute
 
 ## Accessing the base class
 

--- a/crates/cxx-qt-gen/src/generator/naming/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/naming/qobject.rs
@@ -2,6 +2,7 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::parser::externqobject::ParsedExternQObject;
 use crate::{
     naming::{Name, TypeNames},
     parser::qobject::ParsedQObject,
@@ -26,6 +27,14 @@ impl QObjectNames {
     /// For a given QObject, create the names associated with it for generation.
     pub fn from_qobject(qobject: &ParsedQObject, type_names: &TypeNames) -> Result<Self> {
         Self::from_name_and_ident(&qobject.name, &qobject.rust_type, type_names)
+    }
+
+    /// For a given ExternQObject, create the names associated with it for generation.
+    pub fn from_extern_qobject(
+        qobject: &ParsedExternQObject,
+        type_names: &TypeNames,
+    ) -> Result<Self> {
+        Self::from_name_and_ident(&qobject.name, qobject.name.rust_unqualified(), type_names)
     }
 
     /// From the QObject name and Rust struct ident, create the names needed for generation.

--- a/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
@@ -2,13 +2,15 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::generator::naming::qobject::QObjectNames;
+use crate::naming::Name;
 use crate::{
     generator::rust::{fragment::GeneratedRustFragment, signals::generate_rust_signal},
     naming::TypeNames,
     parser::externcxxqt::ParsedExternCxxQt,
     syntax::path::path_compare_str,
 };
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{parse_quote, Attribute, Result};
 
 impl GeneratedRustFragment {
@@ -25,10 +27,59 @@ impl GeneratedRustFragment {
         // Add the pass through blocks
         let unsafety = &extern_cxxqt_block.unsafety;
         let items = &extern_cxxqt_block.passthrough_items;
-        let types = &extern_cxxqt_block
+        let mut generated = extern_cxxqt_block
             .qobjects
             .iter()
-            .map(|ty| {
+            .map(|ty| -> Result<GeneratedRustFragment> {
+                let mut generated = vec![];
+
+                let qobject_names = QObjectNames::from_extern_qobject(ty, type_names)?;
+
+                let base = ty
+                    .base_class
+                    .as_ref()
+                    .map(|name| type_names.lookup(name))
+                    .transpose()?
+                    .cloned()
+                    .unwrap_or(Name::new(format_ident!("QObject")).with_module(parse_quote! {::cxx_qt}));
+
+                let base_unqualified = base.rust_unqualified();
+                let base_qualified = base.rust_qualified();
+
+                let struct_name = ty.name.rust_qualified();
+                let struct_name_unqualified = ty.name.rust_unqualified();
+                let (upcast_fn, upcast_fn_attrs, upcast_fn_qualified) = qobject_names
+                    .cxx_qt_ffi_method("upcastPtr")
+                    .into_cxx_parts();
+                let (downcast_fn, downcast_fn_attrs, downcast_fn_qualified) = qobject_names
+                    .cxx_qt_ffi_method("downcastPtr")
+                    .into_cxx_parts();
+
+                generated.push(GeneratedRustFragment {
+                    cxx_mod_contents: vec![parse_quote! {
+                        extern "C++" {
+                            #[doc(hidden)]
+                            #(#upcast_fn_attrs)*
+                            unsafe fn #upcast_fn(thiz: *const #struct_name_unqualified) -> *const #base_unqualified;
+
+                            #[doc(hidden)]
+                            #(#downcast_fn_attrs)*
+                            unsafe fn #downcast_fn(base: *const #base_unqualified) -> *const #struct_name_unqualified;
+                        }
+                    }],
+                    cxx_qt_mod_contents: vec![parse_quote! {
+                        impl ::cxx_qt::Upcast<#base_qualified> for #struct_name {
+                            unsafe fn upcast_ptr(this: *const Self) -> *const #base_qualified {
+                                #upcast_fn_qualified(this)
+                            }
+
+                            unsafe fn from_base_ptr(base: *const #base_qualified) -> *const Self {
+                                #downcast_fn_qualified(base)
+                            }
+                        }
+                    }],
+                });
+
                 let namespace = if let Some(namespace) = &ty.name.namespace() {
                     quote! { #[namespace = #namespace ] }
                 } else {
@@ -58,24 +109,28 @@ impl GeneratedRustFragment {
                     .iter()
                     .filter(|attr| path_compare_str(attr.meta.path(), &["doc"]))
                     .collect();
-                quote! {
-                    #namespace
-                    #cxx_name
-                    #(#cfgs)*
-                    #(#docs)*
-                    #vis type #ident;
-                }
+                generated.push(GeneratedRustFragment::from_cxx_item(parse_quote! {
+                    #extern_block_namespace
+                    #unsafety extern "C++" {
+                        #namespace
+                        #cxx_name
+                        #(#cfgs)*
+                        #(#docs)*
+                        #vis type #ident;
+                    }
+                }));
+                Ok(GeneratedRustFragment::flatten(generated))
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
 
-        let mut generated = vec![GeneratedRustFragment::from_cxx_item(parse_quote! {
-            #extern_block_namespace
-            #unsafety extern "C++" {
-                #(#items)*
-
-                #(#types)*
-            }
-        })];
+        if !items.is_empty() {
+            generated.push(GeneratedRustFragment::from_cxx_item(parse_quote! {
+                #extern_block_namespace
+                #unsafety extern "C++" {
+                    #(#items)*
+                }
+            }));
+        }
 
         // Build the signals
         for signal in &extern_cxxqt_block.signals {

--- a/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
@@ -31,7 +31,6 @@ impl GeneratedRustFragment {
             .iter()
             .map(|ty| -> Result<GeneratedRustFragment> {
                 let mut generated = vec![];
-
                 let qobject_names = QObjectNames::from_extern_qobject(ty, type_names)?;
 
                 generated.push(GeneratedRustFragment::generate_casting_impl(

--- a/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
@@ -3,14 +3,13 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::generator::naming::qobject::QObjectNames;
-use crate::naming::Name;
 use crate::{
     generator::rust::{fragment::GeneratedRustFragment, signals::generate_rust_signal},
     naming::TypeNames,
     parser::externcxxqt::ParsedExternCxxQt,
     syntax::path::path_compare_str,
 };
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{parse_quote, Attribute, Result};
 
 impl GeneratedRustFragment {
@@ -35,50 +34,12 @@ impl GeneratedRustFragment {
 
                 let qobject_names = QObjectNames::from_extern_qobject(ty, type_names)?;
 
-                let base = ty
-                    .base_class
-                    .as_ref()
-                    .map(|name| type_names.lookup(name))
-                    .transpose()?
-                    .cloned()
-                    .unwrap_or(Name::new(format_ident!("QObject")).with_module(parse_quote! {::cxx_qt}));
-
-                let base_unqualified = base.rust_unqualified();
-                let base_qualified = base.rust_qualified();
-
-                let struct_name = ty.name.rust_qualified();
-                let struct_name_unqualified = ty.name.rust_unqualified();
-                let (upcast_fn, upcast_fn_attrs, upcast_fn_qualified) = qobject_names
-                    .cxx_qt_ffi_method("upcastPtr")
-                    .into_cxx_parts();
-                let (downcast_fn, downcast_fn_attrs, downcast_fn_qualified) = qobject_names
-                    .cxx_qt_ffi_method("downcastPtr")
-                    .into_cxx_parts();
-
-                generated.push(GeneratedRustFragment {
-                    cxx_mod_contents: vec![parse_quote! {
-                        extern "C++" {
-                            #[doc(hidden)]
-                            #(#upcast_fn_attrs)*
-                            unsafe fn #upcast_fn(thiz: *const #struct_name_unqualified) -> *const #base_unqualified;
-
-                            #[doc(hidden)]
-                            #(#downcast_fn_attrs)*
-                            unsafe fn #downcast_fn(base: *const #base_unqualified) -> *const #struct_name_unqualified;
-                        }
-                    }],
-                    cxx_qt_mod_contents: vec![parse_quote! {
-                        impl ::cxx_qt::Upcast<#base_qualified> for #struct_name {
-                            unsafe fn upcast_ptr(this: *const Self) -> *const #base_qualified {
-                                #upcast_fn_qualified(this)
-                            }
-
-                            unsafe fn from_base_ptr(base: *const #base_qualified) -> *const Self {
-                                #downcast_fn_qualified(base)
-                            }
-                        }
-                    }],
-                });
+                generated.push(GeneratedRustFragment::generate_casting_impl(
+                    &qobject_names,
+                    type_names,
+                    &ty.name,
+                    &ty.base_class,
+                )?);
 
                 let namespace = if let Some(namespace) = &ty.name.namespace() {
                     quote! { #[namespace = #namespace ] }

--- a/crates/cxx-qt-gen/src/generator/rust/fragment.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/fragment.rs
@@ -3,7 +3,11 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use syn::Item;
+use crate::generator::naming::qobject::QObjectNames;
+use crate::naming::{Name, TypeNames};
+use proc_macro2::Ident;
+use quote::format_ident;
+use syn::{parse_quote, Item, Result};
 
 #[derive(Default, Eq, PartialEq, Debug)]
 pub struct GeneratedRustFragment {
@@ -17,6 +21,74 @@ impl GeneratedRustFragment {
     pub fn append(&mut self, other: Self) {
         self.cxx_mod_contents.extend(other.cxx_mod_contents);
         self.cxx_qt_mod_contents.extend(other.cxx_qt_mod_contents);
+    }
+
+    pub fn qobject_import() -> Self {
+        Self {
+            cxx_mod_contents: vec![parse_quote! {
+                extern "C++" {
+                    #[doc(hidden)]
+                    #[namespace=""]
+                    type QObject = cxx_qt::QObject;
+                }
+            }],
+            cxx_qt_mod_contents: vec![],
+        }
+    }
+
+    /// Generate the required trait function implementations for casting QObjects
+    pub fn generate_casting_impl(
+        qobject_names: &QObjectNames,
+        type_names: &TypeNames,
+        type_name: &Name,
+        base_class: &Option<Ident>,
+    ) -> Result<Self> {
+        // Create name from base ident
+        let base = base_class
+            .as_ref()
+            .map(|name| type_names.lookup(name))
+            .transpose()?
+            .cloned()
+            .unwrap_or(Name::new(format_ident!("QObject")).with_module(parse_quote! {::cxx_qt}));
+
+        let base_unqualified = base.rust_unqualified();
+        let base_qualified = base.rust_qualified();
+
+        let struct_name = type_name.rust_qualified();
+        let struct_name_unqualified = type_name.rust_unqualified();
+
+        // Create ffi function names
+        let (upcast_fn, upcast_fn_attrs, upcast_fn_qualified) = qobject_names
+            .cxx_qt_ffi_method("upcastPtr")
+            .into_cxx_parts();
+        let (downcast_fn, downcast_fn_attrs, downcast_fn_qualified) = qobject_names
+            .cxx_qt_ffi_method("downcastPtr")
+            .into_cxx_parts();
+
+        Ok(Self {
+            cxx_mod_contents: vec![parse_quote! {
+                extern "C++" {
+                    #[doc(hidden)]
+                    #(#upcast_fn_attrs)*
+                    unsafe fn #upcast_fn(thiz: *const #struct_name_unqualified) -> *const #base_unqualified;
+
+                    #[doc(hidden)]
+                    #(#downcast_fn_attrs)*
+                    unsafe fn #downcast_fn(base: *const #base_unqualified) -> *const #struct_name_unqualified;
+                }
+            }],
+            cxx_qt_mod_contents: vec![parse_quote! {
+                impl ::cxx_qt::Upcast<#base_qualified> for #struct_name {
+                    unsafe fn upcast_ptr(this: *const Self) -> *const #base_qualified {
+                        #upcast_fn_qualified(this)
+                    }
+
+                    unsafe fn from_base_ptr(base: *const #base_qualified) -> *const Self {
+                        #downcast_fn_qualified(base)
+                    }
+                }
+            }],
+        })
     }
 
     // Create a singular GeneratedRustFragment from a Vector of multiple
@@ -33,9 +105,5 @@ impl GeneratedRustFragment {
             cxx_mod_contents: vec![contents],
             ..Default::default()
         }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.cxx_mod_contents.is_empty() && self.cxx_qt_mod_contents.is_empty()
     }
 }

--- a/crates/cxx-qt-gen/src/generator/rust/fragment.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/fragment.rs
@@ -34,4 +34,8 @@ impl GeneratedRustFragment {
             ..Default::default()
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.cxx_mod_contents.is_empty() && self.cxx_qt_mod_contents.is_empty()
+    }
 }

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -19,7 +19,6 @@ use quote::{format_ident, quote};
 use syn::{parse_quote, Attribute, Result};
 
 impl GeneratedRustFragment {
-    // Might need to be refactored to use a StructuredQObject instead (confirm with Leon)
     pub fn from_qobject(
         structured_qobject: &StructuredQObject,
         type_names: &TypeNames,

--- a/crates/cxx-qt-gen/src/parser/externqobject.rs
+++ b/crates/cxx-qt-gen/src/parser/externqobject.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::naming::Name;
 use crate::parser::{require_attributes, CaseConversion};
-use syn::{ForeignItemType, Ident, Result};
+use syn::{Error, Expr, ForeignItemType, Ident, Result};
 
 /// A representation of a QObject to be generated in an extern C++ block
 pub struct ParsedExternQObject {
@@ -12,17 +12,19 @@ pub struct ParsedExternQObject {
     pub name: Name,
     /// Original declaration
     pub declaration: ForeignItemType,
+    /// The base class of the struct
+    pub base_class: Option<Ident>,
 }
 
 impl ParsedExternQObject {
-    const ALLOWED_ATTRS: [&'static str; 6] = [
+    const ALLOWED_ATTRS: [&'static str; 7] = [
         "cxx_name",
         "rust_name",
         "namespace",
         "cfg",
         "doc",
         "qobject",
-        // TODO: support base, qproperty etc here?
+        "base",
     ];
 
     pub fn parse(
@@ -30,7 +32,22 @@ impl ParsedExternQObject {
         module_ident: &Ident,
         parent_namespace: Option<&str>,
     ) -> Result<ParsedExternQObject> {
-        require_attributes(&ty.attrs, &Self::ALLOWED_ATTRS)?;
+        let attributes = require_attributes(&ty.attrs, &Self::ALLOWED_ATTRS)?;
+
+        let base_class = attributes
+            .get("base")
+            .map(|attr| -> Result<Ident> {
+                let expr = &attr.meta.require_name_value()?.value;
+                if let Expr::Path(path_expr) = expr {
+                    Ok(path_expr.path.require_ident()?.clone())
+                } else {
+                    Err(Error::new_spanned(
+                        expr,
+                        "Base must be a identifier and cannot be empty!",
+                    ))
+                }
+            })
+            .transpose()?;
 
         Ok(Self {
             name: Name::from_ident_and_attrs(
@@ -41,6 +58,7 @@ impl ParsedExternQObject {
                 CaseConversion::none(),
             )?,
             declaration: ty,
+            base_class,
         })
     }
 }

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -140,6 +140,24 @@ pub fn require_attributes<'a>(
     Ok(output)
 }
 
+// Extract base identifier from attribute
+pub fn parse_base_type(attributes: &BTreeMap<&str, &Attribute>) -> Result<Option<Ident>> {
+    attributes
+        .get("base")
+        .map(|attr| -> Result<Ident> {
+            let expr = &attr.meta.require_name_value()?.value;
+            if let Expr::Path(path_expr) = expr {
+                Ok(path_expr.path.require_ident()?.clone())
+            } else {
+                Err(Error::new_spanned(
+                    expr,
+                    "Base must be a identifier and cannot be empty!",
+                ))
+            }
+        })
+        .transpose()
+}
+
 /// Struct representing the necessary components of a cxx mod to be passed through to generation
 pub struct PassthroughMod {
     pub(crate) items: Option<Vec<Item>>,

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -11,8 +11,8 @@ use crate::{
 #[cfg(test)]
 use quote::format_ident;
 
-use crate::parser::CaseConversion;
-use syn::{Attribute, Error, Expr, Ident, Meta, Result};
+use crate::parser::{parse_base_type, CaseConversion};
+use syn::{Attribute, Error, Ident, Meta, Result};
 
 /// Metadata for registering QML element
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -91,20 +91,7 @@ impl ParsedQObject {
 
         let has_qobject_macro = attributes.contains_key("qobject");
 
-        let base_class = attributes
-            .get("base")
-            .map(|attr| -> Result<Ident> {
-                let expr = &attr.meta.require_name_value()?.value;
-                if let Expr::Path(path_expr) = expr {
-                    Ok(path_expr.path.require_ident()?.clone())
-                } else {
-                    Err(Error::new_spanned(
-                        expr,
-                        "Base must be a identifier and cannot be empty!",
-                    ))
-                }
-            })
-            .transpose()?;
+        let base_class = parse_base_type(&attributes)?;
 
         // Ensure that if there is no qobject macro that a base class is specificed
         if !has_qobject_macro && base_class.is_none() {

--- a/crates/cxx-qt-gen/test_inputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_inputs/inheritance.rs
@@ -9,6 +9,12 @@ mod inheritance {
         type QAbstractItemModel;
     }
 
+    extern "C++Qt" {
+        include!(<QtWidgets/QPushButton>);
+        #[qobject]
+        type QPushButton;
+    }
+
     extern "RustQt" {
         #[qobject]
         #[base = QAbstractItemModel]

--- a/crates/cxx-qt-gen/test_inputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_inputs/inheritance.rs
@@ -15,6 +15,12 @@ mod inheritance {
         type QPushButton;
     }
 
+    extern "C++Qt" {
+        #[base = QPushButton]
+        #[qobject]
+        type QPushButtonChild;
+    }
+
     extern "RustQt" {
         #[qobject]
         #[base = QAbstractItemModel]

--- a/crates/cxx-qt-gen/test_outputs/cfgs.rs
+++ b/crates/cxx-qt-gen/test_outputs/cfgs.rs
@@ -334,6 +334,20 @@ mod ffi {
             outer: Pin<&mut QObjectDisabled>,
         ) -> Pin<&mut QObjectDisabledRust>;
     }
+    extern "C++" {
+        #[doc(hidden)]
+        #[cxx_name = "upcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QObjectExternEnabled_upcastPtr(
+            thiz: *const QObjectExternEnabled,
+        ) -> *const QObject;
+        #[doc(hidden)]
+        #[cxx_name = "downcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QObjectExternEnabled_downcastPtr(
+            base: *const QObject,
+        ) -> *const QObjectExternEnabled;
+    }
     unsafe extern "C++" {
         #[cfg(enabled)]
         type QObjectExternEnabled;
@@ -405,6 +419,20 @@ mod ffi {
             handler: &mut QObjectExternEnabledCxxQtSignalHandlersignal_enabled1,
             self_value: Pin<&mut QObjectExternEnabled>,
         );
+    }
+    extern "C++" {
+        #[doc(hidden)]
+        #[cxx_name = "upcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QObjectExternDisabled_upcastPtr(
+            thiz: *const QObjectExternDisabled,
+        ) -> *const QObject;
+        #[doc(hidden)]
+        #[cxx_name = "downcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QObjectExternDisabled_downcastPtr(
+            base: *const QObject,
+        ) -> *const QObjectExternDisabled;
     }
     unsafe extern "C++" {
         #[cfg(not(enabled))]
@@ -842,6 +870,14 @@ impl ::cxx_qt::CxxQtType for ffi::QObjectDisabled {
         ffi::cxx_qt_ffi_QObjectDisabled_unsafeRustMut(self)
     }
 }
+impl ::cxx_qt::Upcast<::cxx_qt::QObject> for ffi::QObjectExternEnabled {
+    unsafe fn upcast_ptr(this: *const Self) -> *const ::cxx_qt::QObject {
+        ffi::cxx_qt_ffi_QObjectExternEnabled_upcastPtr(this)
+    }
+    unsafe fn from_base_ptr(base: *const ::cxx_qt::QObject) -> *const Self {
+        ffi::cxx_qt_ffi_QObjectExternEnabled_downcastPtr(base)
+    }
+}
 #[cfg(not(enabled))]
 impl ffi::QObjectExternEnabled {
     #[doc = "Connect the given function pointer to the signal "]
@@ -1004,6 +1040,14 @@ cxx_qt::static_assertions::assert_eq_size!(
     >,
     [usize; 2]
 );
+impl ::cxx_qt::Upcast<::cxx_qt::QObject> for ffi::QObjectExternDisabled {
+    unsafe fn upcast_ptr(this: *const Self) -> *const ::cxx_qt::QObject {
+        ffi::cxx_qt_ffi_QObjectExternDisabled_upcastPtr(this)
+    }
+    unsafe fn from_base_ptr(base: *const ::cxx_qt::QObject) -> *const Self {
+        ffi::cxx_qt_ffi_QObjectExternDisabled_downcastPtr(base)
+    }
+}
 #[cfg(not(enabled))]
 impl ffi::QObjectExternDisabled {
     #[doc = "Connect the given function pointer to the signal "]

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -91,6 +91,27 @@ mod inheritance {
         #[namespace = "rust::cxxqt1"]
         fn cxx_qt_ffi_MyObject_unsafeRustMut(outer: Pin<&mut MyObject>) -> Pin<&mut MyObjectRust>;
     }
+    extern "C++" {
+        #[doc(hidden)]
+        #[cxx_name = "upcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QPushButton_upcastPtr(thiz: *const QPushButton) -> *const QObject;
+        #[doc(hidden)]
+        #[cxx_name = "downcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QPushButton_downcastPtr(base: *const QObject) -> *const QPushButton;
+    }
+    extern "C++" {
+        type QPushButton;
+    }
+    extern "C++" {
+        include ! (< QtWidgets / QPushButton >);
+    }
+    extern "C++" {
+        #[doc(hidden)]
+        #[namespace = ""]
+        type QObject = cxx_qt::QObject;
+    }
 }
 impl ::cxx_qt::Upcast<inheritance::QAbstractItemModel> for inheritance::MyObject {
     unsafe fn upcast_ptr(this: *const Self) -> *const inheritance::QAbstractItemModel {
@@ -118,5 +139,13 @@ impl ::cxx_qt::CxxQtType for inheritance::MyObject {
     }
     fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         inheritance::cxx_qt_ffi_MyObject_unsafeRustMut(self)
+    }
+}
+impl ::cxx_qt::Upcast<::cxx_qt::QObject> for inheritance::QPushButton {
+    unsafe fn upcast_ptr(this: *const Self) -> *const ::cxx_qt::QObject {
+        inheritance::cxx_qt_ffi_QPushButton_upcastPtr(this)
+    }
+    unsafe fn from_base_ptr(base: *const ::cxx_qt::QObject) -> *const Self {
+        inheritance::cxx_qt_ffi_QPushButton_downcastPtr(base)
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -109,6 +109,23 @@ mod inheritance {
     }
     extern "C++" {
         #[doc(hidden)]
+        #[cxx_name = "upcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QPushButtonChild_upcastPtr(
+            thiz: *const QPushButtonChild,
+        ) -> *const QPushButton;
+        #[doc(hidden)]
+        #[cxx_name = "downcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QPushButtonChild_downcastPtr(
+            base: *const QPushButton,
+        ) -> *const QPushButtonChild;
+    }
+    extern "C++" {
+        type QPushButtonChild;
+    }
+    extern "C++" {
+        #[doc(hidden)]
         #[namespace = ""]
         type QObject = cxx_qt::QObject;
     }
@@ -147,5 +164,13 @@ impl ::cxx_qt::Upcast<::cxx_qt::QObject> for inheritance::QPushButton {
     }
     unsafe fn from_base_ptr(base: *const ::cxx_qt::QObject) -> *const Self {
         inheritance::cxx_qt_ffi_QPushButton_downcastPtr(base)
+    }
+}
+impl ::cxx_qt::Upcast<inheritance::QPushButton> for inheritance::QPushButtonChild {
+    unsafe fn upcast_ptr(this: *const Self) -> *const inheritance::QPushButton {
+        inheritance::cxx_qt_ffi_QPushButtonChild_upcastPtr(this)
+    }
+    unsafe fn from_base_ptr(base: *const inheritance::QPushButton) -> *const Self {
+        inheritance::cxx_qt_ffi_QPushButtonChild_downcastPtr(base)
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -367,10 +367,36 @@ pub mod ffi {
             outer: Pin<&mut MyRustName>,
         ) -> Pin<&mut ThirdObjectRust>;
     }
+    extern "C++" {
+        #[doc(hidden)]
+        #[cxx_name = "upcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QPushButton_upcastPtr(thiz: *const QPushButton) -> *const QObject;
+        #[doc(hidden)]
+        #[cxx_name = "downcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QPushButton_downcastPtr(base: *const QObject) -> *const QPushButton;
+    }
     #[namespace = ""]
     unsafe extern "C++" {
         #[namespace = "cxx_qt::multi_object"]
         type QPushButton;
+    }
+    extern "C++" {
+        #[doc(hidden)]
+        #[cxx_name = "upcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_ExternObjectCpp_upcastPtr(thiz: *const ExternObject)
+            -> *const QObject;
+        #[doc(hidden)]
+        #[cxx_name = "downcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_ExternObjectCpp_downcastPtr(
+            base: *const QObject,
+        ) -> *const ExternObject;
+    }
+    #[namespace = ""]
+    unsafe extern "C++" {
         #[namespace = "mynamespace"]
         #[cxx_name = "ExternObjectCpp"]
         type ExternObject;
@@ -850,6 +876,22 @@ impl ::cxx_qt::CxxQtType for ffi::MyRustName {
     }
     fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         ffi::cxx_qt_ffi_MyCxxName_unsafeRustMut(self)
+    }
+}
+impl ::cxx_qt::Upcast<::cxx_qt::QObject> for ffi::QPushButton {
+    unsafe fn upcast_ptr(this: *const Self) -> *const ::cxx_qt::QObject {
+        ffi::cxx_qt_ffi_QPushButton_upcastPtr(this)
+    }
+    unsafe fn from_base_ptr(base: *const ::cxx_qt::QObject) -> *const Self {
+        ffi::cxx_qt_ffi_QPushButton_downcastPtr(base)
+    }
+}
+impl ::cxx_qt::Upcast<::cxx_qt::QObject> for ffi::ExternObject {
+    unsafe fn upcast_ptr(this: *const Self) -> *const ::cxx_qt::QObject {
+        ffi::cxx_qt_ffi_ExternObjectCpp_upcastPtr(this)
+    }
+    unsafe fn from_base_ptr(base: *const ::cxx_qt::QObject) -> *const Self {
+        ffi::cxx_qt_ffi_ExternObjectCpp_downcastPtr(base)
     }
 }
 impl ffi::QPushButton {

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -181,11 +181,23 @@ mod ffi {
         #[namespace = "rust::cxxqt1"]
         fn cxx_qt_ffi_MyObject_unsafeRustMut(outer: Pin<&mut MyObject>) -> Pin<&mut MyObjectRust>;
     }
+    extern "C++" {
+        #[doc(hidden)]
+        #[cxx_name = "upcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QTimer_upcastPtr(thiz: *const QTimer) -> *const QObject;
+        #[doc(hidden)]
+        #[cxx_name = "downcastPtr"]
+        #[namespace = "rust::cxxqt1"]
+        unsafe fn cxx_qt_ffi_QTimer_downcastPtr(base: *const QObject) -> *const QTimer;
+    }
     unsafe extern "C++" {
-        include ! (< QtCore / QTimer >);
         #[namespace = "cxx_qt::my_object"]
         #[doc = " QTimer"]
         type QTimer;
+    }
+    unsafe extern "C++" {
+        include ! (< QtCore / QTimer >);
     }
     unsafe extern "C++" {
         #[doc(hidden)]
@@ -469,6 +481,14 @@ impl ::cxx_qt::CxxQtType for ffi::MyObject {
     }
     fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         ffi::cxx_qt_ffi_MyObject_unsafeRustMut(self)
+    }
+}
+impl ::cxx_qt::Upcast<::cxx_qt::QObject> for ffi::QTimer {
+    unsafe fn upcast_ptr(this: *const Self) -> *const ::cxx_qt::QObject {
+        ffi::cxx_qt_ffi_QTimer_upcastPtr(this)
+    }
+    unsafe fn from_base_ptr(base: *const ::cxx_qt::QObject) -> *const Self {
+        ffi::cxx_qt_ffi_QTimer_downcastPtr(base)
     }
 }
 impl ffi::QTimer {

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.rs
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.rs
@@ -6,9 +6,8 @@
 
 use crate::{QByteArray, QFont, QString, QStringList, QVector};
 use core::pin::Pin;
-use cxx_qt::Upcast;
 
-#[cxx::bridge]
+#[cxx_qt::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qbytearray.h");
@@ -22,25 +21,15 @@ mod ffi {
         include!("cxx-qt-lib/qfont.h");
         type QFont = crate::QFont;
 
-        include!("cxx-qt-lib/qguiapplication.h");
-        type QGuiApplication;
-
         include!("cxx-qt-lib/qcoreapplication.h");
         type QCoreApplication;
+    }
 
-        include!("cxx-qt/casting.h");
-
-        #[doc(hidden)]
-        #[rust_name = "upcast_qguiapplication"]
-        #[cxx_name = "upcastPtr"]
-        #[namespace = "rust::cxxqt1"]
-        unsafe fn upcast(thiz: *const QGuiApplication) -> *const QCoreApplication;
-
-        #[doc(hidden)]
-        #[rust_name = "downcast_qcoreapplication"]
-        #[cxx_name = "downcastPtr"]
-        #[namespace = "rust::cxxqt1"]
-        unsafe fn downcast(base: *const QCoreApplication) -> *const QGuiApplication;
+    unsafe extern "C++Qt" {
+        include!("cxx-qt-lib/qguiapplication.h");
+        #[qobject]
+        #[base = QCoreApplication]
+        type QGuiApplication;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -116,19 +105,7 @@ mod ffi {
     impl UniquePtr<QGuiApplication> {}
 }
 
-pub use ffi::{
-    downcast_qcoreapplication, upcast_qguiapplication, QCoreApplication, QGuiApplication,
-};
-
-impl Upcast<QCoreApplication> for QGuiApplication {
-    unsafe fn upcast_ptr(this: *const Self) -> *const QCoreApplication {
-        upcast_qguiapplication(this)
-    }
-
-    unsafe fn from_base_ptr(base: *const QCoreApplication) -> *const Self {
-        downcast_qcoreapplication(base)
-    }
-}
+pub use ffi::QGuiApplication;
 
 impl QGuiApplication {
     /// Prepends path to the beginning of the library path list,

--- a/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.rs
+++ b/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#[cxx::bridge]
+#[cxx_qt::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qstring.h");
@@ -12,23 +12,6 @@ mod ffi {
         type QStringList = crate::QStringList;
         include!("cxx-qt-lib/qurl.h");
         type QUrl = crate::QUrl;
-
-        include!("cxx-qt-lib/qqmlapplicationengine.h");
-        type QQmlApplicationEngine;
-
-        include!("cxx-qt/casting.h");
-
-        #[doc(hidden)]
-        #[rust_name = "upcast_qqmlapplication_engine"]
-        #[cxx_name = "upcastPtr"]
-        #[namespace = "rust::cxxqt1"]
-        unsafe fn upcast(thiz: *const QQmlApplicationEngine) -> *const QQmlEngine;
-
-        #[doc(hidden)]
-        #[rust_name = "downcast_qqml_engine"]
-        #[cxx_name = "downcastPtr"]
-        #[namespace = "rust::cxxqt1"]
-        unsafe fn downcast(base: *const QQmlEngine) -> *const QQmlApplicationEngine;
 
         /// Adds path as a directory where the engine searches for installed modules in a URL-based directory structure.
         #[rust_name = "add_import_path"]
@@ -75,6 +58,13 @@ mod ffi {
         fn setOfflineStoragePath(self: Pin<&mut QQmlApplicationEngine>, dir: &QString);
     }
 
+    unsafe extern "C++Qt" {
+        include!("cxx-qt-lib/qqmlapplicationengine.h");
+        #[qobject]
+        #[base = QQmlEngine]
+        type QQmlApplicationEngine;
+    }
+
     unsafe extern "C++" {
         include!("cxx-qt-lib/qqmlengine.h");
         type QQmlEngine = crate::QQmlEngine;
@@ -94,20 +84,7 @@ mod ffi {
     impl UniquePtr<QQmlApplicationEngine> {}
 }
 
-use crate::QQmlEngine;
-use cxx_qt::Upcast;
-
 pub use ffi::QQmlApplicationEngine;
-
-impl Upcast<QQmlEngine> for QQmlApplicationEngine {
-    unsafe fn upcast_ptr(this: *const Self) -> *const QQmlEngine {
-        ffi::upcast_qqmlapplication_engine(this)
-    }
-
-    unsafe fn from_base_ptr(base: *const QQmlEngine) -> *const Self {
-        ffi::downcast_qqml_engine(base)
-    }
-}
 
 impl QQmlApplicationEngine {
     /// Create a new QQmlApplicationEngine

--- a/crates/cxx-qt-lib/src/quickcontrols/qquickstyle.rs
+++ b/crates/cxx-qt-lib/src/quickcontrols/qquickstyle.rs
@@ -5,9 +5,8 @@
 
 #[cxx_qt::bridge]
 mod ffi {
-    unsafe extern "C++Qt" {
+    unsafe extern "C++" {
         include!("cxx-qt-lib/qquickstyle.h");
-        #[qobject]
         type QQuickStyle;
 
         include!("cxx-qt-lib/qstring.h");


### PR DESCRIPTION
Add support for the `#[base = T]` attribute in `extern "C++Qt"` blocks, as well as casting implementations for these applicable types.