### PR TITLE
Fix: Only update caches when pushed to `main`

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -181,6 +181,14 @@ jobs:
         with:
           path: /home/runner/.cache/sccache
           key: "${{ env.GITHUB_COMPILER_CACHE_KEY }}"
+
+      - name: "Start sccache server"
+        # If the compiler cache couldn't be restored, we have to create the cache path,
+        # as otherwise the server startup fails.
+        run: |
+          mkdir -p /home/runner/.cache/sccache
+          sccache --start-server
+
       - name: "emsdk cache"
         uses: actions/cache@v4
         id: emsdk-cache
@@ -458,6 +466,22 @@ jobs:
       with:
         path: ${{ matrix.compiler_cache_path }}
         key: ${{ matrix.name }}_compiler_cache
+
+    - name: "[Windows] Start sccache server"
+      # If the compiler cache couldn't be restored, we have to create the cache path,
+      # as otherwise the server startup fails.
+      if: runner.os == 'Windows'
+      run: |
+        md ${{ matrix.compiler_cache_path }} -ea 0
+        sccache --start-server
+
+    - name: "[Other] Start sccache server"
+      # If the compiler cache couldn't be restored, we have to create the cache path,
+      # as otherwise the server startup fails.
+      if: runner.os != 'Windows'
+      run: |
+        mkdir -p ${{ matrix.compiler_cache_path }}
+        sccache --start-server
 
     - name: "Install clang-format"
       # Note ensure that clang-format runner is updated too

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -238,7 +238,7 @@ jobs:
       - name: "Delete previous compiler cache"
         # Updating th cache doesn't work from forks
         # So update it once it's merged into the repo
-        if: ${{ steps.compiler-cache-restore.outputs.cache-hit &&  github.event_name == 'push' }}
+        if: ${{ steps.compiler-cache-restore.outputs.cache-hit &&  github.event_name == 'push' && github.ref_name == 'main' }}
         continue-on-error: true
         run: |
           gh extension install actions/gh-actions-cache
@@ -248,7 +248,7 @@ jobs:
       - name: "Save Compiler Cache"
         # Updating th cache doesn't work from forks
         # So update it once it's merged into the repo
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         uses: actions/cache/save@v4
         with:
           path: /home/runner/.cache/sccache
@@ -546,7 +546,7 @@ jobs:
     - name: "Delete previous compiler cache"
       # Updating th cache doesn't work from forks
       # So update it once it's merged into the repo
-      if: ${{ steps.compiler-cache-restore.outputs.cache-hit &&  github.event_name == 'push' }}
+      if: ${{ steps.compiler-cache-restore.outputs.cache-hit &&  github.event_name == 'push' && github.ref_name == 'main' }}
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache
@@ -556,7 +556,7 @@ jobs:
     - name: "Save Compiler Cache"
       # Updating th cache doesn't work from forks
       # So update it once it's merged into the repo
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       uses: actions/cache/save@v4
       with:
         path: ${{ matrix.compiler_cache_path }}


### PR DESCRIPTION
Otherwise, backports would ruin the caches for all other branches that
target `main`.
