### PR TITLE
Book: Drop `v` prefix from CXX-Qt-CMake GIT_TAG

### DIFF
--- a/book/src/getting-started/5-cmake-integration.md
+++ b/book/src/getting-started/5-cmake-integration.md
@@ -134,7 +134,7 @@ Download CXX-Qts CMake code with FetchContent:
 
 ```cmake,ignore
 {{#include ../../../examples/qml_minimal/CMakeLists.txt:book_cmake_find_cxx_qt_start}}
-        GIT_TAG v0.7.1
+        GIT_TAG 0.7.1
 {{#include ../../../examples/qml_minimal/CMakeLists.txt:book_cmake_find_cxx_qt_end}}
 ```
 


### PR DESCRIPTION
We're moving to a plain `0.7.1` naming scheme, as then you can use
either: `0.7` or `0.7.1` to refer to just the minor, or the exact patch
version.
