### PR TITLE
Specify cxx-qt version in workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.7.1"
 # Note a version needs to be specified on dependencies of packages
 # we publish, otherwise crates.io complains as it doesn't know the version.
 [workspace.dependencies]
-cxx-qt = { path = "crates/cxx-qt" }
+cxx-qt = { path = "crates/cxx-qt", version = "0.7.1" }
 cxx-qt-macro = { path = "crates/cxx-qt-macro", version = "0.7.1" }
 cxx-qt-build = { path = "crates/cxx-qt-build", version = "0.7.1" }
 cxx-qt-gen = { path = "crates/cxx-qt-gen", version = "0.7.1" }


### PR DESCRIPTION
Otherwise cargo refuses to publish the package.
