### PR TITLE
CI: Lock tool versions

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           # Note that the llvm version needs to match, see the link above
           rustup default 1.77.2
-          cargo install grcov
+          cargo install --locked --version 0.8.20 grcov
           rustup component add rustfmt
       # Ensure we do not have any existing coverage files
       - run: rm -f coverage/*.profraw
@@ -158,8 +158,8 @@ jobs:
         # cargo install --locked --no-default-features --version 0.9.1 sccache
         run: |
           cargo install --locked --no-default-features --git=https://github.com/ahayzen-kdab/sccache --branch=2092-ignore-notfound-errors sccache
-          cargo install --version 0.4.36 mdbook 
-          cargo install --version 0.7.7 mdbook-linkcheck
+          cargo install --locked --version 0.4.36 mdbook 
+          cargo install --locked --version 0.7.7 mdbook-linkcheck
       # We want our compiler cache to always update to the newest state.
       # The best way for us to achieve this is to **always** update the cache after every landed commit.
       # That way it will closely follow our development.
@@ -442,8 +442,8 @@ jobs:
       # cargo install --locked --no-default-features --version 0.9.1 sccache
       run: |
         cargo install --locked --no-default-features --git=https://github.com/ahayzen-kdab/sccache --branch=2092-ignore-notfound-errors sccache
-        cargo install --version 0.4.36 mdbook 
-        cargo install --version 0.7.7 mdbook-linkcheck
+        cargo install --locked --version 0.4.36 mdbook 
+        cargo install --locked --version 0.7.7 mdbook-linkcheck
 
     # We want our compiler cache to always update to the newest state.
     # The best way for us to achieve this is to **always** update the cache after every landed commit.


### PR DESCRIPTION
This should keep us from encounteing breakage due to rust version
changes, etc.

Closes #1212
