### PR TITLE
Add more signals to cxx_qt_lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CXX-Qt-build: Allow forcing initialization of crates/QML modules (`cxx_qt::init_crate!`/`cxx_qt::init_qml_module!`)
 - Add pure virtual function specified through the `#[cxx_pure]` attribute
 - Add wrappers for up and down casting, for all types which inherit from QObject, available for &T, &mut T and Pin<&mut T>
+- `#[base = T]` is now suported in `extern "C++Qt"` blocks
+- Casting is automatically implmented for qobjects or types which have `#[base = T]` in `"RustQt"` or `"C++Qt"` blocks
 - Support for `QMessageLogContext` and sending log messages to the Qt message handler.
 
 ### Removed

--- a/crates/cxx-qt-gen/src/naming/type_names.rs
+++ b/crates/cxx-qt-gen/src/naming/type_names.rs
@@ -119,6 +119,14 @@ impl TypeNames {
         type_names.populate_from_cxx_items(cxx_items, bridge_namespace, module_ident)?;
         type_names.populate_from_cxx_qt_data(cxx_qt_data, bridge_namespace, module_ident)?;
 
+        let qobject = Name {
+            rust: format_ident!("QObject"),
+            cxx: None,
+            module: Some(Path::from(module_ident.clone())),
+            namespace: None,
+        };
+        type_names.names.insert(qobject.rust.clone(), qobject);
+
         Ok(type_names)
     }
 

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -396,7 +396,7 @@ mod tests {
         assert_eq!(parser.passthrough_module.vis, Visibility::Inherited);
         assert_eq!(parser.cxx_qt_data.namespace, Some("cxx_qt".to_owned()));
         assert_eq!(parser.cxx_qt_data.qobjects.len(), 1);
-        assert_eq!(parser.type_names.num_types(), 18);
+        assert_eq!(parser.type_names.num_types(), 19);
         assert_eq!(
             parser
                 .type_names
@@ -501,7 +501,7 @@ mod tests {
             }
         };
         let parser = Parser::from(module).unwrap();
-        assert_eq!(parser.type_names.num_types(), 22);
+        assert_eq!(parser.type_names.num_types(), 23);
         assert_eq!(
             parser
                 .type_names

--- a/crates/cxx-qt-lib/src/core/qcoreapplication.rs
+++ b/crates/cxx-qt-lib/src/core/qcoreapplication.rs
@@ -7,7 +7,7 @@
 use crate::{QByteArray, QString, QStringList, QVector};
 use core::pin::Pin;
 
-#[cxx::bridge]
+#[cxx_qt::bridge]
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qbytearray.h");
@@ -28,6 +28,13 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qcoreapplication_new"]
         fn qcoreapplicationNew(args: &QVector_QByteArray) -> UniquePtr<QCoreApplication>;
+    }
+
+    unsafe extern "C++Qt" {
+        #[doc(hidden)]
+        #[rust_name = "about_to_quit"]
+        #[qsignal]
+        pub(self) fn aboutToQuit(self: Pin<&mut QCoreApplication>);
     }
 
     // These are all static, so we need to create bindings until CXX supports statics

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.rs
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.rs
@@ -22,7 +22,7 @@ mod ffi {
         type QFont = crate::QFont;
 
         include!("cxx-qt-lib/qcoreapplication.h");
-        type QCoreApplication;
+        type QCoreApplication = crate::QCoreApplication;
     }
 
     unsafe extern "C++Qt" {

--- a/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.rs
+++ b/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.rs
@@ -65,6 +65,16 @@ mod ffi {
         type QQmlApplicationEngine;
     }
 
+    unsafe extern "C++Qt" {
+        #[qsignal]
+        #[rust_name = "object_created"]
+        unsafe fn objectCreated(
+            self: Pin<&mut QQmlApplicationEngine>,
+            qobject: *mut QObject,
+            url: &QUrl,
+        );
+    }
+
     unsafe extern "C++" {
         include!("cxx-qt-lib/qqmlengine.h");
         type QQmlEngine = crate::QQmlEngine;


### PR DESCRIPTION
- Add objectCreated signal to QQmlApplicationEngine
- Fixed bug where type_name doesn't recognise QObject
- Fixed qualification of QCoreApplication in bridge