### PR TITLE
Serde implementations for mappable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `QDateTime::from_string` to parse `QDateTime` from a `QString`.
+- `QSet::reserve` to reserve capacity up-front.
 - Support for further types: `QUuid`
 - New example: Basic greeter app
 - Support for further types: `qreal`, `qint64`, `qintptr`, `qsizetype`, `quint64`, `quintptr`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `#[base = T]` is now suported in `extern "C++Qt"` blocks
 - Casting is automatically implmented for qobjects or types which have `#[base = T]` in `"RustQt"` or `"C++Qt"` blocks
 - Support for `QMessageLogContext` and sending log messages to the Qt message handler.
+- Serde support for further types: `QByteArray`, `QSet`, `QStringList`, `QVector`, `QUrl`
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `QMessageLogContext` and sending log messages to the Qt message handler.
 - Serde support for further types: `QByteArray`, `QSet`, `QStringList`, `QVector`, `QUrl`
 
-
 ### Removed
 
 - CXX-Qt-build: Interface no longer includes compiler definitions (<https://github.com/KDAB/cxx-qt/issues/1165>)
@@ -149,7 +148,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not use -bundle otherwise CMake builds are missing qt-static-initalizers (note this is broken in rustc 1.69)
 - Do not import `Pin` in hidden module as invokables are outside now, resolving IDE integration
-- Rust always links against a non-debug Windows runtime with *-msvc targets, so we need to link to MultiThreadedDLL
+- Rust always links against a non-debug Windows runtime with \*-msvc targets, so we need to link to MultiThreadedDLL
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
  "qt-build-utils",
  "rgb",
  "serde",
+ "serde_json",
  "time",
  "url",
  "uuid",

--- a/crates/cxx-qt-lib/Cargo.toml
+++ b/crates/cxx-qt-lib/Cargo.toml
@@ -42,6 +42,9 @@ image-v0-25 = { version = "0.25", optional = true, package = "image", default-fe
 cxx-qt-build.workspace = true
 qt-build-utils.workspace = true
 
+[dev-dependencies]
+serde_json = "1.0.135"
+
 [features]
 full = ["qt_full", "serde", "url", "uuid", "time", "rgb", "http", "chrono", "bytes", "image-v0-24", "image-v0-25"]
 default = []

--- a/crates/cxx-qt-lib/include/core/qset/qset_private.h
+++ b/crates/cxx-qt-lib/include/core/qset/qset_private.h
@@ -58,6 +58,19 @@ qsetLen(const QSet<T>& s) noexcept
   return static_cast<::rust::isize>(s.size());
 }
 
+template<typename T>
+void
+qsetReserve(QSet<T>& s, ::rust::isize size) noexcept
+{
+  Q_ASSERT(size >= 0);
+  // Qt 5 has an int Qt 6 has a qsizetype
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+  s.reserve(static_cast<qsizetype>(size));
+#else
+  s.reserve(static_cast<int>(size));
+#endif
+}
+
 }
 }
 }

--- a/crates/cxx-qt-lib/src/core/qlist/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qlist/mod.rs
@@ -400,4 +400,11 @@ mod test {
         let qlist = QList::<u8>::from(array);
         assert_eq!(Vec::from(&qlist), array);
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn qlist_serde() {
+        let qlist = QList::<u8>::from([0, 1, 2]);
+        assert_eq!(crate::serde_impl::roundtrip(&qlist), qlist);
+    }
 }

--- a/crates/cxx-qt-lib/src/core/qset/generate.sh
+++ b/crates/cxx-qt-lib/src/core/qset/generate.sh
@@ -72,6 +72,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_$1, _: &$1);
         #[rust_name = "len_$1"]
         fn qsetLen(_: &QSet_$1) -> isize;
+        #[rust_name = "reserve_$1"]
+        fn qsetReserve(_: &mut QSet_$1, size: isize);
     }
 }
 
@@ -97,6 +99,10 @@ pub(crate) fn insert(s: &mut ffi::QSet_$1, value: &$1) {
 
 pub(crate) fn len(s: &ffi::QSet_$1) -> isize {
     ffi::len_$1(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_$1, size: isize) {
+  ffi::reserve_$1(s, size);
 }
 EOF
     rustfmt "$SCRIPTPATH/qset_$1.rs"
@@ -148,6 +154,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_$1, _: &$1);
         #[rust_name = "len_$1"]
         fn qsetLen(_: &QSet_$1) -> isize;
+        #[rust_name = "reserve_$1"]
+        fn qsetReserve(_: &mut QSet_$1, size: isize);
     }
 }
 
@@ -173,6 +181,10 @@ pub(crate) fn insert(s: &mut ffi::QSet_$1, value: &ffi::$1) {
 
 pub(crate) fn len(s: &ffi::QSet_$1) -> isize {
     ffi::len_$1(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_$1, size: isize) {
+  ffi::reserve_$1(s, size);
 }
 EOF
     rustfmt "$SCRIPTPATH/qset_$2.rs"

--- a/crates/cxx-qt-lib/src/core/qset/qset_bool.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_bool.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_bool, _: &bool);
         #[rust_name = "len_bool"]
         fn qsetLen(_: &QSet_bool) -> isize;
+        #[rust_name = "reserve_bool"]
+        fn qsetReserve(_: &mut QSet_bool, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_bool, value: &bool) {
 
 pub(crate) fn len(s: &ffi::QSet_bool) -> isize {
     ffi::len_bool(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_bool, size: isize) {
+    ffi::reserve_bool(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_f32.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_f32.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_f32, _: &f32);
         #[rust_name = "len_f32"]
         fn qsetLen(_: &QSet_f32) -> isize;
+        #[rust_name = "reserve_f32"]
+        fn qsetReserve(_: &mut QSet_f32, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_f32, value: &f32) {
 
 pub(crate) fn len(s: &ffi::QSet_f32) -> isize {
     ffi::len_f32(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_f32, size: isize) {
+    ffi::reserve_f32(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_f64.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_f64.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_f64, _: &f64);
         #[rust_name = "len_f64"]
         fn qsetLen(_: &QSet_f64) -> isize;
+        #[rust_name = "reserve_f64"]
+        fn qsetReserve(_: &mut QSet_f64, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_f64, value: &f64) {
 
 pub(crate) fn len(s: &ffi::QSet_f64) -> isize {
     ffi::len_f64(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_f64, size: isize) {
+    ffi::reserve_f64(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_i16.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_i16.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_i16, _: &i16);
         #[rust_name = "len_i16"]
         fn qsetLen(_: &QSet_i16) -> isize;
+        #[rust_name = "reserve_i16"]
+        fn qsetReserve(_: &mut QSet_i16, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_i16, value: &i16) {
 
 pub(crate) fn len(s: &ffi::QSet_i16) -> isize {
     ffi::len_i16(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_i16, size: isize) {
+    ffi::reserve_i16(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_i32.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_i32.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_i32, _: &i32);
         #[rust_name = "len_i32"]
         fn qsetLen(_: &QSet_i32) -> isize;
+        #[rust_name = "reserve_i32"]
+        fn qsetReserve(_: &mut QSet_i32, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_i32, value: &i32) {
 
 pub(crate) fn len(s: &ffi::QSet_i32) -> isize {
     ffi::len_i32(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_i32, size: isize) {
+    ffi::reserve_i32(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_i64.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_i64.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_i64, _: &i64);
         #[rust_name = "len_i64"]
         fn qsetLen(_: &QSet_i64) -> isize;
+        #[rust_name = "reserve_i64"]
+        fn qsetReserve(_: &mut QSet_i64, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_i64, value: &i64) {
 
 pub(crate) fn len(s: &ffi::QSet_i64) -> isize {
     ffi::len_i64(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_i64, size: isize) {
+    ffi::reserve_i64(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_i8.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_i8.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_i8, _: &i8);
         #[rust_name = "len_i8"]
         fn qsetLen(_: &QSet_i8) -> isize;
+        #[rust_name = "reserve_i8"]
+        fn qsetReserve(_: &mut QSet_i8, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_i8, value: &i8) {
 
 pub(crate) fn len(s: &ffi::QSet_i8) -> isize {
     ffi::len_i8(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_i8, size: isize) {
+    ffi::reserve_i8(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_qbytearray.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_qbytearray.rs
@@ -42,6 +42,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_QByteArray, _: &QByteArray);
         #[rust_name = "len_QByteArray"]
         fn qsetLen(_: &QSet_QByteArray) -> isize;
+        #[rust_name = "reserve_QByteArray"]
+        fn qsetReserve(_: &mut QSet_QByteArray, size: isize);
     }
 }
 
@@ -67,4 +69,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_QByteArray, value: &ffi::QByteArray) {
 
 pub(crate) fn len(s: &ffi::QSet_QByteArray) -> isize {
     ffi::len_QByteArray(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_QByteArray, size: isize) {
+    ffi::reserve_QByteArray(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_qdate.rs
@@ -42,6 +42,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_QDate, _: &QDate);
         #[rust_name = "len_QDate"]
         fn qsetLen(_: &QSet_QDate) -> isize;
+        #[rust_name = "reserve_QDate"]
+        fn qsetReserve(_: &mut QSet_QDate, size: isize);
     }
 }
 
@@ -67,4 +69,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_QDate, value: &ffi::QDate) {
 
 pub(crate) fn len(s: &ffi::QSet_QDate) -> isize {
     ffi::len_QDate(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_QDate, size: isize) {
+    ffi::reserve_QDate(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_qdatetime.rs
@@ -42,6 +42,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_QDateTime, _: &QDateTime);
         #[rust_name = "len_QDateTime"]
         fn qsetLen(_: &QSet_QDateTime) -> isize;
+        #[rust_name = "reserve_QDateTime"]
+        fn qsetReserve(_: &mut QSet_QDateTime, size: isize);
     }
 }
 
@@ -67,4 +69,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_QDateTime, value: &ffi::QDateTime) {
 
 pub(crate) fn len(s: &ffi::QSet_QDateTime) -> isize {
     ffi::len_QDateTime(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_QDateTime, size: isize) {
+    ffi::reserve_QDateTime(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_qpersistentmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_qpersistentmodelindex.rs
@@ -45,6 +45,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_QPersistentModelIndex, _: &QPersistentModelIndex);
         #[rust_name = "len_QPersistentModelIndex"]
         fn qsetLen(_: &QSet_QPersistentModelIndex) -> isize;
+        #[rust_name = "reserve_QPersistentModelIndex"]
+        fn qsetReserve(_: &mut QSet_QPersistentModelIndex, size: isize);
     }
 }
 
@@ -73,4 +75,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_QPersistentModelIndex, value: &ffi::QPers
 
 pub(crate) fn len(s: &ffi::QSet_QPersistentModelIndex) -> isize {
     ffi::len_QPersistentModelIndex(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_QPersistentModelIndex, size: isize) {
+    ffi::reserve_QPersistentModelIndex(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_qstring.rs
@@ -42,6 +42,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_QString, _: &QString);
         #[rust_name = "len_QString"]
         fn qsetLen(_: &QSet_QString) -> isize;
+        #[rust_name = "reserve_QString"]
+        fn qsetReserve(_: &mut QSet_QString, size: isize);
     }
 }
 
@@ -67,4 +69,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_QString, value: &ffi::QString) {
 
 pub(crate) fn len(s: &ffi::QSet_QString) -> isize {
     ffi::len_QString(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_QString, size: isize) {
+    ffi::reserve_QString(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_qtime.rs
@@ -42,6 +42,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_QTime, _: &QTime);
         #[rust_name = "len_QTime"]
         fn qsetLen(_: &QSet_QTime) -> isize;
+        #[rust_name = "reserve_QTime"]
+        fn qsetReserve(_: &mut QSet_QTime, size: isize);
     }
 }
 
@@ -67,4 +69,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_QTime, value: &ffi::QTime) {
 
 pub(crate) fn len(s: &ffi::QSet_QTime) -> isize {
     ffi::len_QTime(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_QTime, size: isize) {
+    ffi::reserve_QTime(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_qurl.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_qurl.rs
@@ -42,6 +42,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_QUrl, _: &QUrl);
         #[rust_name = "len_QUrl"]
         fn qsetLen(_: &QSet_QUrl) -> isize;
+        #[rust_name = "reserve_QUrl"]
+        fn qsetReserve(_: &mut QSet_QUrl, size: isize);
     }
 }
 
@@ -67,4 +69,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_QUrl, value: &ffi::QUrl) {
 
 pub(crate) fn len(s: &ffi::QSet_QUrl) -> isize {
     ffi::len_QUrl(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_QUrl, size: isize) {
+    ffi::reserve_QUrl(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_quuid.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_quuid.rs
@@ -42,6 +42,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_QUuid, _: &QUuid);
         #[rust_name = "len_QUuid"]
         fn qsetLen(_: &QSet_QUuid) -> isize;
+        #[rust_name = "reserve_QUuid"]
+        fn qsetReserve(_: &mut QSet_QUuid, size: isize);
     }
 }
 
@@ -67,4 +69,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_QUuid, value: &ffi::QUuid) {
 
 pub(crate) fn len(s: &ffi::QSet_QUuid) -> isize {
     ffi::len_QUuid(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_QUuid, size: isize) {
+    ffi::reserve_QUuid(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_u16.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_u16.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_u16, _: &u16);
         #[rust_name = "len_u16"]
         fn qsetLen(_: &QSet_u16) -> isize;
+        #[rust_name = "reserve_u16"]
+        fn qsetReserve(_: &mut QSet_u16, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_u16, value: &u16) {
 
 pub(crate) fn len(s: &ffi::QSet_u16) -> isize {
     ffi::len_u16(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_u16, size: isize) {
+    ffi::reserve_u16(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_u32.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_u32.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_u32, _: &u32);
         #[rust_name = "len_u32"]
         fn qsetLen(_: &QSet_u32) -> isize;
+        #[rust_name = "reserve_u32"]
+        fn qsetReserve(_: &mut QSet_u32, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_u32, value: &u32) {
 
 pub(crate) fn len(s: &ffi::QSet_u32) -> isize {
     ffi::len_u32(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_u32, size: isize) {
+    ffi::reserve_u32(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_u64.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_u64.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_u64, _: &u64);
         #[rust_name = "len_u64"]
         fn qsetLen(_: &QSet_u64) -> isize;
+        #[rust_name = "reserve_u64"]
+        fn qsetReserve(_: &mut QSet_u64, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_u64, value: &u64) {
 
 pub(crate) fn len(s: &ffi::QSet_u64) -> isize {
     ffi::len_u64(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_u64, size: isize) {
+    ffi::reserve_u64(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qset/qset_u8.rs
+++ b/crates/cxx-qt-lib/src/core/qset/qset_u8.rs
@@ -40,6 +40,8 @@ pub mod ffi {
         fn qsetInsert(_: &mut QSet_u8, _: &u8);
         #[rust_name = "len_u8"]
         fn qsetLen(_: &QSet_u8) -> isize;
+        #[rust_name = "reserve_u8"]
+        fn qsetReserve(_: &mut QSet_u8, size: isize);
     }
 }
 
@@ -65,4 +67,8 @@ pub(crate) fn insert(s: &mut ffi::QSet_u8, value: &u8) {
 
 pub(crate) fn len(s: &ffi::QSet_u8) -> isize {
     ffi::len_u8(s)
+}
+
+pub(crate) fn reserve(s: &mut ffi::QSet_u8, size: isize) {
+    ffi::reserve_u8(s, size);
 }

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -191,15 +191,10 @@ mod ffi {
     }
 }
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 /// The QString class provides a Unicode character string.
 ///
 /// Note that QString is a UTF-16 whereas Rust strings are a UTF-8
 #[repr(C)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(from = "String", into = "String"))]
 pub struct QString {
     /// The layout has changed between Qt 5 and Qt 6
     ///
@@ -425,9 +420,54 @@ unsafe impl ExternType for QString {
     type Kind = cxx::kind::Trivial;
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for QString {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&String::from(self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QString {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::{Error as DeError, Unexpected, Visitor};
+
+        struct StringVisitor;
+
+        impl<'de> Visitor<'de> for StringVisitor {
+            type Value = QString;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string")
+            }
+
+            fn visit_str<E: DeError>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(Self::Value::from(v))
+            }
+
+            fn visit_bytes<E: DeError>(self, v: &[u8]) -> Result<Self::Value, E> {
+                match std::str::from_utf8(v) {
+                    Ok(s) => Ok(Self::Value::from(s)),
+                    Err(_) => Err(E::invalid_value(Unexpected::Bytes(v), &self)),
+                }
+            }
+        }
+
+        let visitor = StringVisitor;
+        deserializer.deserialize_string(visitor)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn qstring_serde() {
+        let qstring = QString::from("KDAB");
+        assert_eq!(crate::serde_impl::roundtrip(&qstring), qstring);
+    }
 
     #[test]
     fn test_ordering() {

--- a/crates/cxx-qt-lib/src/core/qstringlist.rs
+++ b/crates/cxx-qt-lib/src/core/qstringlist.rs
@@ -244,4 +244,13 @@ mod test {
             Some("element".to_owned())
         );
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn qstringlist_serde() {
+        let mut qstringlist = QStringList::default();
+        qstringlist.append(QString::from("element 1"));
+        qstringlist.append(QString::from("element 2"));
+        assert_eq!(crate::serde_impl::roundtrip(&qstringlist), qstringlist)
+    }
 }

--- a/crates/cxx-qt-lib/src/core/qvector/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qvector/mod.rs
@@ -400,4 +400,11 @@ mod test {
         let qvec = QVector::<u8>::from(array);
         assert_eq!(Vec::from(&qvec), array);
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn qvec_serde() {
+        let qvec = QVector::<u8>::from([0, 1, 2]);
+        assert_eq!(crate::serde_impl::roundtrip(&qvec), qvec);
+    }
 }

--- a/crates/cxx-qt-lib/src/lib.rs
+++ b/crates/cxx-qt-lib/src/lib.rs
@@ -9,6 +9,9 @@ compile_error!("cxxqt_qt_version_major must be either \"5\" or \"6\"");
 
 mod core;
 
+#[cfg(feature = "serde")]
+mod serde_impl;
+
 pub use crate::core::*;
 
 #[cfg(feature = "qt_gui")]

--- a/crates/cxx-qt-lib/src/serde_impl.rs
+++ b/crates/cxx-qt-lib/src/serde_impl.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Joshua Booth <joshua.n.booth@gmail.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::{QList, QListElement, QSet, QSetElement, QStringList, QVector, QVectorElement};
+use cxx::ExternType;
+use serde::de::{SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{self, Formatter};
+use std::marker::PhantomData;
+use std::num::NonZeroIsize;
+
+/// Serde deserializers provide an `Option<usize>` size hint, but Qt containers use signed types
+/// for size. This helper function converts between the two.
+/// It also returns `None` if the size hint is 0, because there's no need to reserve capacity of 0.
+const fn get_size_hint(size_hint: Option<usize>) -> Option<NonZeroIsize> {
+    match size_hint {
+        Some(n) if n <= isize::MAX as usize => NonZeroIsize::new(n as isize),
+        _ => None,
+    }
+}
+
+/// Serializes and deserializes a list-like container by iterating over values.
+macro_rules! seq_impl {
+    ($t:ident, $element:ident, $insert:expr) => {
+        impl<T> Serialize for $t<T>
+        where
+            T: $element + Serialize,
+        {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                serializer.collect_seq(self.iter())
+            }
+        }
+
+        impl<'de, T> Deserialize<'de> for $t<T>
+        where
+            T: $element + Deserialize<'de> + ExternType<Kind = cxx::kind::Trivial>,
+        {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                struct SeqVisitor<T: $element> {
+                    marker: PhantomData<$t<T>>,
+                }
+
+                impl<'de, T> Visitor<'de> for SeqVisitor<T>
+                where
+                    T: $element + Deserialize<'de> + ExternType<Kind = cxx::kind::Trivial>,
+                {
+                    type Value = $t<T>;
+
+                    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                        formatter.write_str("a sequence")
+                    }
+
+                    #[inline]
+                    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                    where
+                        A: SeqAccess<'de>,
+                    {
+                        let mut values = Self::Value::default();
+                        if let Some(size_hint) = get_size_hint(seq.size_hint()) {
+                            values.reserve(size_hint.get());
+                        }
+                        while let Some(value) = seq.next_element()? {
+                            $insert(&mut values, value);
+                        }
+                        Ok(values)
+                    }
+                }
+
+                let visitor = SeqVisitor {
+                    marker: PhantomData,
+                };
+                deserializer.deserialize_seq(visitor)
+            }
+        }
+    };
+}
+
+seq_impl!(QList, QListElement, QList::append);
+seq_impl!(QSet, QSetElement, QSet::insert);
+seq_impl!(QVector, QVectorElement, QVector::append);
+
+/// Like seq_impl, but for Qt classes that dereference to a container.
+macro_rules! deref_impl {
+    ($t:ty) => {
+        impl Serialize for $t {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                (**self).serialize(serializer)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $t {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                struct SeqVisitor;
+
+                impl<'de> Visitor<'de> for SeqVisitor {
+                    type Value = $t;
+
+                    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                        formatter.write_str("a sequence")
+                    }
+
+                    #[inline]
+                    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                    where
+                        A: SeqAccess<'de>,
+                    {
+                        let mut list = Self::Value::default();
+                        let values = &mut *list;
+                        if let Some(size_hint) = get_size_hint(seq.size_hint()) {
+                            values.reserve(size_hint.get());
+                        }
+                        while let Some(value) = seq.next_element()? {
+                            values.append(value);
+                        }
+                        Ok(list)
+                    }
+                }
+
+                let visitor = SeqVisitor;
+                deserializer.deserialize_seq(visitor)
+            }
+        }
+    };
+}
+
+deref_impl!(QStringList);
+
+#[cfg(test)]
+pub fn roundtrip<T>(value: &T) -> T
+where
+    T: Serialize + serde::de::DeserializeOwned,
+{
+    let serialized = serde_json::to_value(value).expect("error serializing value");
+    match serde_json::from_value(serialized) {
+        Ok(deserialized) => deserialized,
+        Err(e) => panic!(
+            "error deserializing {}: {e}",
+            serde_json::to_value(value).unwrap()
+        ),
+    }
+}


### PR DESCRIPTION
This is a subset of #1151 that only adds serde support for the following:

- QByteArray
- QList
- QVector
- QStringList
- QUrl