### PR TITLE
cxx-qt-lib: standardize constructor method naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Combined and renamed the following functions:
   - `QDate::from_string` and `QDate::from_string_enum` → `QDate::from_qstring_opt`
   - `QDate::format` and `QDate::format_enum` → `QDate::to_qstring`
-  - `QDateTime::from_date_and_time_time_zone` → `QDateTime::from_date_time_timezone`
-  - `QDateTime::from_date_and_time_time_spec` → `QDateTime::from_date_time_timespec`
+  - `QDateTime::from_date_and_time_time_zone` → `QDateTime::from_qdate_qtime_qtimezone`
+  - `QDateTime::from_date_and_time_time_spec` → `QDateTime::from_qdate_qtime_timespec`
   - `QDateTime::from_string` and `QDateTime::from_string_enum` → `QDateTime::from_qstring_opt`
   - `QDateTime::format` and `QDateTime::format_enum` → `QDateTime::to_qstring`
   - `QImage::from_data` → `QImage::from_data_opt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Casting is automatically implmented for qobjects or types which have `#[base = T]` in `"RustQt"` or `"C++Qt"` blocks
 - Support for `QMessageLogContext` and sending log messages to the Qt message handler.
 
+### Changed
+
+- `QTime::from_string` and `QTime::from_string_enum` now return `Option<QTime>` rather than `QTime`, in keeping with the identical functions for `QDate` and `QDateTime`.
+- Combined and renamed the following functions:
+  - `QDate::from_string` and `QDate::from_string_enum` → `QDate::from_qstring_opt`
+  - `QDate::format` and `QDate::format_enum` → `QDate::to_qstring`
+  - `QDateTime::from_date_and_time_time_zone` → `QDateTime::from_date_time_timezone`
+  - `QDateTime::from_date_and_time_time_spec` → `QDateTime::from_date_time_timespec`
+  - `QDateTime::from_string` and `QDateTime::from_string_enum` → `QDateTime::from_qstring_opt`
+  - `QDateTime::format` and `QDateTime::format_enum` → `QDateTime::to_qstring`
+  - `QImage::from_data` → `QImage::from_data_opt`
+  - `QTime::from_string` and `QTime::from_string_enum` → `QTime::from_qstring_opt`
+  - `QTime::format` and `QTime::format_enum` → `QTime::to_qstring`
+
 ### Removed
 
 - CXX-Qt-build: Interface no longer includes compiler definitions (<https://github.com/KDAB/cxx-qt/issues/1165>)
@@ -146,7 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not use -bundle otherwise CMake builds are missing qt-static-initalizers (note this is broken in rustc 1.69)
 - Do not import `Pin` in hidden module as invokables are outside now, resolving IDE integration
-- Rust always links against a non-debug Windows runtime with *-msvc targets, so we need to link to MultiThreadedDLL
+- Rust always links against a non-debug Windows runtime with \*-msvc targets, so we need to link to MultiThreadedDLL
 
 ### Removed
 

--- a/crates/cxx-qt-lib/include/core/qdate.h
+++ b/crates/cxx-qt-lib/include/core/qdate.h
@@ -26,8 +26,6 @@ qint64
 qdateDaysTo(const QDate& date, QDate d);
 bool
 qdateIsLeapYear(::std::int32_t year);
-QString
-qdateToFormat(const QDate& date, const QString& format);
 
 }
 }

--- a/crates/cxx-qt-lib/include/core/qdate.h
+++ b/crates/cxx-qt-lib/include/core/qdate.h
@@ -18,14 +18,18 @@ namespace cxxqtlib1 {
 QDate
 qdateCurrentDate();
 QDate
-qdateFromString(const QString& string, const QString& format);
+qdateFromQString(const QString& string, const QString& format);
 QDate
-qdateFromString(const QString& string, Qt::DateFormat format);
+qdateFromQString(const QString& string, Qt::DateFormat format);
 // In Qt 5 d is const-ref, in Qt 6 it is value
 qint64
 qdateDaysTo(const QDate& date, QDate d);
 bool
 qdateIsLeapYear(::std::int32_t year);
+QString
+qdateToQString(const QDate& date, Qt::DateFormat format);
+QString
+qdateToQString(const QDate& date, const QString& format);
 
 }
 }

--- a/crates/cxx-qt-lib/include/core/qdatetime.h
+++ b/crates/cxx-qt-lib/include/core/qdatetime.h
@@ -50,5 +50,7 @@ void
 qdatetimeSetTimeZone(QDateTime& datetime, const QTimeZone& timeZone);
 QDateTime
 qdatetimeFromQString(const QString& string, Qt::DateFormat format);
+QDateTime
+qdatetimeFromQString(const QString& string, const QString& format);
 }
 }

--- a/crates/cxx-qt-lib/include/core/qdatetime.h
+++ b/crates/cxx-qt-lib/include/core/qdatetime.h
@@ -52,5 +52,9 @@ QDateTime
 qdatetimeFromQString(const QString& string, Qt::DateFormat format);
 QDateTime
 qdatetimeFromQString(const QString& string, const QString& format);
+QString
+qdatetimeToQString(const QDateTime& date, Qt::DateFormat format);
+QString
+qdatetimeToQString(const QDateTime& date, const QString& format);
 }
 }

--- a/crates/cxx-qt-lib/include/core/qtime.h
+++ b/crates/cxx-qt-lib/include/core/qtime.h
@@ -23,12 +23,16 @@ qtimeFromMSecsSinceStartOfDay(::std::int32_t msecs);
 ::std::int32_t
 qtimeMSecsTo(const QTime& time, QTime t);
 QTime
-qtimeFromString(const QString& string, const QString& format);
+qtimeFromQString(const QString& string, const QString& format);
 QTime
-qtimeFromString(const QString& string, Qt::DateFormat format);
+qtimeFromQString(const QString& string, Qt::DateFormat format);
 // In Qt 5 t is const-ref, in Qt 6 it is value
 ::std::int32_t
 qtimeSecsTo(const QTime& time, QTime t);
+QString
+qtimeToQString(const QTime& date, Qt::DateFormat format);
+QString
+qtimeToQString(const QTime& date, const QString& format);
 
 bool
 qtimeIsValid(int h, int m, int s, int ms);

--- a/crates/cxx-qt-lib/src/core/qdate.cpp
+++ b/crates/cxx-qt-lib/src/core/qdate.cpp
@@ -52,11 +52,5 @@ qdateIsLeapYear(::std::int32_t year)
   return QDate::isLeapYear(static_cast<int>(year));
 }
 
-QString
-qdateToFormat(const QDate& date, const QString& format)
-{
-  return date.toString(format);
-}
-
 }
 }

--- a/crates/cxx-qt-lib/src/core/qdate.cpp
+++ b/crates/cxx-qt-lib/src/core/qdate.cpp
@@ -35,13 +35,13 @@ qdateDaysTo(const QDate& date, QDate d)
 }
 
 QDate
-qdateFromString(const QString& string, const QString& format)
+qdateFromQString(const QString& string, const QString& format)
 {
   return QDate::fromString(string, format);
 }
 
 QDate
-qdateFromString(const QString& string, Qt::DateFormat format)
+qdateFromQString(const QString& string, Qt::DateFormat format)
 {
   return QDate::fromString(string, format);
 }
@@ -50,6 +50,18 @@ bool
 qdateIsLeapYear(::std::int32_t year)
 {
   return QDate::isLeapYear(static_cast<int>(year));
+}
+
+QString
+qdateToQString(const QDate& date, const QString& format)
+{
+  return date.toString(format);
+}
+
+QString
+qdateToQString(const QDate& date, Qt::DateFormat format)
+{
+  return date.toString(format);
 }
 
 }

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -78,14 +78,6 @@ mod ffi {
         #[rust_name = "set_date"]
         fn setDate(self: &mut QDate, y: i32, m: i32, d: i32) -> bool;
 
-        #[doc(hidden)]
-        #[rust_name = "format_qstring"]
-        fn toString(self: &QDate, format: &QString) -> QString;
-
-        #[doc(hidden)]
-        #[rust_name = "format_dateformat"]
-        fn toString(self: &QDate, format: DateFormat) -> QString;
-
         /// Returns the year of this date.
         fn year(self: &QDate) -> i32;
     }
@@ -102,10 +94,17 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "qdate_from_qstring_qstring"]
-        fn qdateFromString(string: &QString, format: &QString) -> QDate;
+        fn qdateFromQString(string: &QString, format: &QString) -> QDate;
         #[doc(hidden)]
         #[rust_name = "qdate_from_qstring_dateformat"]
-        fn qdateFromString(string: &QString, format: DateFormat) -> QDate;
+        fn qdateFromQString(string: &QString, format: DateFormat) -> QDate;
+
+        #[doc(hidden)]
+        #[rust_name = "qdate_to_qstring_qstring"]
+        fn qdateToQString(date: &QDate, format: &QString) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qdate_to_qstring_dateformat"]
+        fn qdateToQString(date: &QDate, format: DateFormat) -> QString;
 
         #[doc(hidden)]
         #[rust_name = "qdate_is_leap_year"]
@@ -219,8 +218,8 @@ impl QDate {
         T: Into<AnyDateFormat<'a>>,
     {
         match format.into() {
-            AnyDateFormat::DateFormat(f) => self.format_dateformat(f),
-            AnyDateFormat::QString(f) => self.format_qstring(f),
+            AnyDateFormat::DateFormat(f) => ffi::qdate_to_qstring_dateformat(self, f),
+            AnyDateFormat::QString(f) => ffi::qdate_to_qstring_qstring(self, f),
         }
     }
 }

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::{AnyDateFormat, QString};
 use cxx::{type_id, ExternType};
 use std::fmt;
 
@@ -77,8 +78,12 @@ mod ffi {
         #[rust_name = "set_date"]
         fn setDate(self: &mut QDate, y: i32, m: i32, d: i32) -> bool;
 
-        /// Returns the time as a string. The format parameter determines the format of the string.
-        #[rust_name = "format_enum"]
+        #[doc(hidden)]
+        #[rust_name = "format_qstring"]
+        fn toString(self: &QDate, format: &QString) -> QString;
+
+        #[doc(hidden)]
+        #[rust_name = "format_dateformat"]
         fn toString(self: &QDate, format: DateFormat) -> QString;
 
         /// Returns the year of this date.
@@ -96,19 +101,15 @@ mod ffi {
         fn qdateDaysTo(date: &QDate, d: QDate) -> qint64;
 
         #[doc(hidden)]
-        #[rust_name = "qdate_from_string"]
+        #[rust_name = "qdate_from_qstring_qstring"]
         fn qdateFromString(string: &QString, format: &QString) -> QDate;
         #[doc(hidden)]
-        #[rust_name = "qdate_from_string_enum"]
+        #[rust_name = "qdate_from_qstring_dateformat"]
         fn qdateFromString(string: &QString, format: DateFormat) -> QDate;
 
         #[doc(hidden)]
         #[rust_name = "qdate_is_leap_year"]
         fn qdateIsLeapYear(year: i32) -> bool;
-
-        #[doc(hidden)]
-        #[rust_name = "qdate_to_format"]
-        fn qdateToFormat(date: &QDate, format: &QString) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -143,7 +144,7 @@ impl Default for QDate {
 
 impl fmt::Display for QDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.format_enum(ffi::DateFormat::TextDate))
+        write!(f, "{}", self.to_qstring(ffi::DateFormat::TextDate))
     }
 }
 
@@ -166,33 +167,34 @@ impl QDate {
         ffi::qdate_days_to(self, date)
     }
 
-    /// Returns the time as a string. The format parameter determines the format of the result string.
-    pub fn format(&self, format: &ffi::QString) -> ffi::QString {
-        ffi::qdate_to_format(self, format)
-    }
-
     /// Converts the Julian day jd to a QDate.
     pub fn from_julian_day(jd: i64) -> Self {
         Self { jd }
     }
 
-    /// Returns the QTime represented by the string, using the format given, or None if the string cannot be parsed.
-    pub fn from_string(string: &ffi::QString, format: &ffi::QString) -> Option<Self> {
-        let date = ffi::qdate_from_string(string, format);
-        if date.is_valid() {
-            Some(date)
+    /// Returns the QDate represented by the string, using the format given.
+    /// If the string cannot be parsed, returns `None`.
+    pub fn from_qstring_opt<'a, T>(string: &QString, format: T) -> Option<Self>
+    where
+        T: Into<AnyDateFormat<'a>>,
+    {
+        let parsed = Self::from_qstring(string, format);
+        if parsed.is_valid() {
+            Some(parsed)
         } else {
             None
         }
     }
 
-    /// Returns the time represented in the string as a QTime using the format given, or None if this is not possible.
-    pub fn from_string_enum(string: &ffi::QString, format: ffi::DateFormat) -> Option<Self> {
-        let date = ffi::qdate_from_string_enum(string, format);
-        if date.is_valid() {
-            Some(date)
-        } else {
-            None
+    /// Returns the QDate represented by the string, using the format given.
+    /// If the string cannot be parsed, returns an invalid date.
+    fn from_qstring<'a, T>(string: &QString, format: T) -> Self
+    where
+        T: Into<AnyDateFormat<'a>>,
+    {
+        match format.into() {
+            AnyDateFormat::DateFormat(f) => ffi::qdate_from_qstring_dateformat(string, f),
+            AnyDateFormat::QString(f) => ffi::qdate_from_qstring_qstring(string, f),
         }
     }
 
@@ -209,6 +211,17 @@ impl QDate {
     /// Converts the date to a Julian day.
     pub fn to_julian_day(&self) -> i64 {
         self.jd
+    }
+
+    /// Returns the date as a string. The format parameter determines the format of the result string.
+    pub fn to_qstring<'a, T>(&self, format: T) -> QString
+    where
+        T: Into<AnyDateFormat<'a>>,
+    {
+        match format.into() {
+            AnyDateFormat::DateFormat(f) => self.format_dateformat(f),
+            AnyDateFormat::QString(f) => self.format_qstring(f),
+        }
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qdatetime.cpp
+++ b/crates/cxx-qt-lib/src/core/qdatetime.cpp
@@ -104,5 +104,17 @@ qdatetimeFromQString(const QString& string, const QString& format)
   return QDateTime::fromString(string, format);
 }
 
+QString
+qdatetimeToQString(const QDateTime& date, const QString& format)
+{
+  return date.toString(format);
+}
+
+QString
+qdatetimeToQString(const QDateTime& date, Qt::DateFormat format)
+{
+  return date.toString(format);
+}
+
 }
 }

--- a/crates/cxx-qt-lib/src/core/qdatetime.cpp
+++ b/crates/cxx-qt-lib/src/core/qdatetime.cpp
@@ -99,7 +99,7 @@ qdatetimeFromQString(const QString& string, const Qt::DateFormat format)
 }
 
 QDateTime
-qdatetimeFromQString(const QString& string, const QString &format)
+qdatetimeFromQString(const QString& string, const QString& format)
 {
   return QDateTime::fromString(string, format);
 }

--- a/crates/cxx-qt-lib/src/core/qdatetime.cpp
+++ b/crates/cxx-qt-lib/src/core/qdatetime.cpp
@@ -98,5 +98,11 @@ qdatetimeFromQString(const QString& string, const Qt::DateFormat format)
   return QDateTime::fromString(string, format);
 }
 
+QDateTime
+qdatetimeFromQString(const QString& string, const QString &format)
+{
+  return QDateTime::fromString(string, format);
+}
+
 }
 }

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -140,13 +140,6 @@ mod ffi {
         #[rust_name = "to_secs_since_epoch"]
         fn toSecsSinceEpoch(self: &QDateTime) -> qint64;
 
-        #[doc(hidden)]
-        #[rust_name = "format_qstring"]
-        fn toString(self: &QDateTime, format: &QString) -> QString;
-
-        #[doc(hidden)]
-        #[rust_name = "format_dateformat"]
-        fn toString(self: &QDateTime, format: DateFormat) -> QString;
         /// Returns a copy of this datetime converted to the given time spec.
         ///
         /// Note this method is only available with Qt < 6.8
@@ -198,12 +191,21 @@ mod ffi {
         fn qdatetimeTimeZone(datetime: &QDateTime) -> UniquePtr<QTimeZone>;
         #[rust_name = "qdatetime_settimezone"]
         fn qdatetimeSetTimeZone(datetime: &mut QDateTime, time_zone: &QTimeZone);
+
         #[doc(hidden)]
         #[rust_name = "qdatetime_from_qstring_qstring"]
         fn qdatetimeFromQString(string: &QString, format: &QString) -> QDateTime;
         #[doc(hidden)]
         #[rust_name = "qdatetime_from_qstring_dateformat"]
         fn qdatetimeFromQString(string: &QString, format: DateFormat) -> QDateTime;
+
+        #[doc(hidden)]
+        #[rust_name = "qdatetime_to_qstring_qstring"]
+        fn qdatetimeToQString(date: &QDateTime, format: &QString) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qdatetime_to_qstring_dateformat"]
+        fn qdatetimeToQString(date: &QDateTime, format: DateFormat) -> QString;
+
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -343,8 +345,8 @@ impl QDateTime {
         T: Into<AnyDateFormat<'a>>,
     {
         match format.into() {
-            AnyDateFormat::DateFormat(f) => self.format_dateformat(f),
-            AnyDateFormat::QString(f) => self.format_qstring(f),
+            AnyDateFormat::DateFormat(f) => ffi::qdatetime_to_qstring_dateformat(self, f),
+            AnyDateFormat::QString(f) => ffi::qdatetime_to_qstring_qstring(self, f),
         }
     }
 

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -217,7 +217,7 @@ mod ffi {
         #[rust_name = "qdatetime_init_default"]
         fn construct() -> QDateTime;
         #[doc(hidden)]
-        #[rust_name = "qdatetime_init_from_date_time_timezone"]
+        #[rust_name = "qdatetime_init_from_qdate_qtime_qtimezone"]
         fn construct(date: &QDate, time: &QTime, time_zone: &QTimeZone) -> QDateTime;
         #[cfg(not(cxxqt_qt_version_at_least_6_8))]
         #[doc(hidden)]
@@ -278,15 +278,19 @@ impl QDateTime {
     }
 
     /// Construct a Rust QDateTime from a given QDate, QTime, and QTimeZone
-    pub fn from_date_time_timezone(date: &QDate, time: &QTime, time_zone: &ffi::QTimeZone) -> Self {
-        ffi::qdatetime_init_from_date_time_timezone(date, time, time_zone)
+    pub fn from_qdate_qtime_qtimezone(
+        date: &QDate,
+        time: &QTime,
+        time_zone: &ffi::QTimeZone,
+    ) -> Self {
+        ffi::qdatetime_init_from_qdate_qtime_qtimezone(date, time, time_zone)
     }
 
     /// Construct a Rust QDateTime from a given QDate, QTime, Qt::TimeSpec, and offset
     ///
     /// Note this method is only available with Qt < 6.8
     #[cfg(not(cxxqt_qt_version_at_least_6_8))]
-    pub fn from_date_time_timespec(
+    pub fn from_qdate_qtime_timespec(
         date: &QDate,
         time: &QTime,
         time_spec: ffi::TimeSpec,
@@ -424,7 +428,7 @@ impl<Tz: chrono::TimeZone> TryFrom<chrono::DateTime<Tz>> for QDateTime {
 
     fn try_from(value: chrono::DateTime<Tz>) -> Result<Self, Self::Error> {
         let tz = crate::QTimeZone::from_offset_seconds(value.offset().fix().local_minus_utc());
-        Ok(QDateTime::from_date_time_timezone(
+        Ok(QDateTime::from_qdate_qtime_qtimezone(
             &QDate::from(value.date_naive()),
             &QTime::try_from(value.time())?,
             tz.as_ref().ok_or("Could not construct timezone")?,
@@ -470,7 +474,7 @@ impl TryFrom<QDateTime> for chrono::DateTime<chrono::Utc> {
 impl From<time::OffsetDateTime> for QDateTime {
     fn from(value: time::OffsetDateTime) -> Self {
         let tz = crate::QTimeZone::from_offset_seconds(value.offset().whole_seconds());
-        QDateTime::from_date_time_timezone(
+        QDateTime::from_qdate_qtime_qtimezone(
             &QDate::from(value.date()),
             &QTime::from(value.time()),
             tz.as_ref().expect("Could not construct timezone"),
@@ -482,7 +486,7 @@ impl From<time::OffsetDateTime> for QDateTime {
 impl From<time::PrimitiveDateTime> for QDateTime {
     fn from(value: time::PrimitiveDateTime) -> Self {
         let tz = crate::QTimeZone::utc();
-        QDateTime::from_date_time_timezone(
+        QDateTime::from_qdate_qtime_qtimezone(
             &QDate::from(value.date()),
             &QTime::from(value.time()),
             tz.as_ref().expect("Could not construct timezone"),
@@ -528,12 +532,12 @@ mod test {
 
     #[test]
     fn test_ordering() {
-        let qdatetime_a = QDateTime::from_date_time_timezone(
+        let qdatetime_a = QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 1, 1, 1),
             &ffi::QTimeZone::utc(),
         );
-        let qdatetime_b = QDateTime::from_date_time_timezone(
+        let qdatetime_b = QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2023, 2, 2),
             &QTime::new(2, 2, 2, 2),
             &ffi::QTimeZone::utc(),
@@ -565,7 +569,7 @@ mod test_chrono {
             )
         };
 
-        let qdatetime = QDateTime::from_date_time_timezone(
+        let qdatetime = QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2023, 1, 1),
             // Chrono adds the offset to the given time, so add the offset here to match Chrono
             &QTime::new(1 + 1 /* plus the offset */, 2, 3, 4),
@@ -589,7 +593,7 @@ mod test_chrono {
             )
         };
 
-        let qdatetime = QDateTime::from_date_time_timezone(
+        let qdatetime = QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::from_offset_seconds(60 * 60),
@@ -613,7 +617,7 @@ mod test_chrono {
             )
         };
 
-        let qdatetime = QDateTime::from_date_time_timezone(
+        let qdatetime = QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::utc(),
@@ -637,7 +641,7 @@ mod test_chrono {
             )
         };
 
-        let qdatetime = QDateTime::from_date_time_timezone(
+        let qdatetime = QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             // Should cause one hour offset when in chrono::DateTime
@@ -663,7 +667,7 @@ mod test_time {
             .unwrap()
             .assume_offset(time::UtcOffset::from_whole_seconds(60 * 60).unwrap());
 
-        let qdatetime = QDateTime::from_date_time_timezone(
+        let qdatetime = QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::from_offset_seconds(60 * 60),
@@ -681,7 +685,7 @@ mod test_time {
             .with_hms_milli(1, 2, 3, 4)
             .unwrap();
 
-        let qdatetime = QDateTime::from_date_time_timezone(
+        let qdatetime = QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::utc(),
@@ -700,7 +704,7 @@ mod test_time {
             .unwrap()
             .assume_offset(time::UtcOffset::from_whole_seconds(60 * 60).unwrap());
 
-        let qdatetime = QDateTime::from_date_time_timezone(
+        let qdatetime = QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::from_offset_seconds(60 * 60),
@@ -715,7 +719,7 @@ mod test_time {
             .with_hms_milli(1, 2, 3, 4)
             .unwrap();
 
-        let qdatetime = QDateTime::from_date_time_timezone(
+        let qdatetime = QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::utc(),

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -6,7 +6,7 @@ use cxx::{type_id, ExternType};
 use std::mem::MaybeUninit;
 use std::{cmp::Ordering, fmt};
 
-use crate::{QDate, QTime};
+use crate::{AnyDateFormat, QDate, QString, QTime};
 
 #[cxx::bridge]
 mod ffi {
@@ -140,10 +140,13 @@ mod ffi {
         #[rust_name = "to_secs_since_epoch"]
         fn toSecsSinceEpoch(self: &QDateTime) -> qint64;
 
-        /// Returns the time as a string. The format parameter determines the format of the string.
-        #[rust_name = "format_enum"]
-        fn toString(self: &QDateTime, format: DateFormat) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "format_qstring"]
+        fn toString(self: &QDateTime, format: &QString) -> QString;
 
+        #[doc(hidden)]
+        #[rust_name = "format_dateformat"]
+        fn toString(self: &QDateTime, format: DateFormat) -> QString;
         /// Returns a copy of this datetime converted to the given time spec.
         ///
         /// Note this method is only available with Qt < 6.8
@@ -195,7 +198,11 @@ mod ffi {
         fn qdatetimeTimeZone(datetime: &QDateTime) -> UniquePtr<QTimeZone>;
         #[rust_name = "qdatetime_settimezone"]
         fn qdatetimeSetTimeZone(datetime: &mut QDateTime, time_zone: &QTimeZone);
-        #[rust_name = "qdatetime_from_string"]
+        #[doc(hidden)]
+        #[rust_name = "qdatetime_from_qstring_qstring"]
+        fn qdatetimeFromQString(string: &QString, format: &QString) -> QDateTime;
+        #[doc(hidden)]
+        #[rust_name = "qdatetime_from_qstring_dateformat"]
         fn qdatetimeFromQString(string: &QString, format: DateFormat) -> QDateTime;
     }
 
@@ -210,11 +217,11 @@ mod ffi {
         #[rust_name = "qdatetime_init_default"]
         fn construct() -> QDateTime;
         #[doc(hidden)]
-        #[rust_name = "qdatetime_init_from_date_and_time_time_zone"]
+        #[rust_name = "qdatetime_init_from_date_time_timezone"]
         fn construct(date: &QDate, time: &QTime, time_zone: &QTimeZone) -> QDateTime;
         #[cfg(not(cxxqt_qt_version_at_least_6_8))]
         #[doc(hidden)]
-        #[rust_name = "qdatetime_init_from_date_and_time_time_spec"]
+        #[rust_name = "qdatetime_init_from_date_time_time_spec"]
         fn construct(
             date: &QDate,
             time: &QTime,
@@ -271,25 +278,21 @@ impl QDateTime {
     }
 
     /// Construct a Rust QDateTime from a given QDate, QTime, and QTimeZone
-    pub fn from_date_and_time_time_zone(
-        date: &QDate,
-        time: &QTime,
-        time_zone: &ffi::QTimeZone,
-    ) -> Self {
-        ffi::qdatetime_init_from_date_and_time_time_zone(date, time, time_zone)
+    pub fn from_date_time_timezone(date: &QDate, time: &QTime, time_zone: &ffi::QTimeZone) -> Self {
+        ffi::qdatetime_init_from_date_time_timezone(date, time, time_zone)
     }
 
     /// Construct a Rust QDateTime from a given QDate, QTime, Qt::TimeSpec, and offset
     ///
     /// Note this method is only available with Qt < 6.8
     #[cfg(not(cxxqt_qt_version_at_least_6_8))]
-    pub fn from_date_and_time_time_spec(
+    pub fn from_date_time_timespec(
         date: &QDate,
         time: &QTime,
         time_spec: ffi::TimeSpec,
         offset_seconds: i32,
     ) -> Self {
-        ffi::qdatetime_init_from_date_and_time_time_spec(date, time, time_spec, offset_seconds)
+        ffi::qdatetime_init_from_date_time_time_spec(date, time, time_spec, offset_seconds)
     }
 
     /// Returns a datetime whose date and time are the number of milliseconds msecs that have passed since 1970-01-01T00:00:00.000,
@@ -304,13 +307,40 @@ impl QDateTime {
         ffi::qdatetime_from_secs_since_epoch(secs, time_zone)
     }
 
-    /// Returns the datetime represented in the string as a QDateTime using the format given, or None if this is not possible.
-    pub fn from_string(string: &ffi::QString, format: ffi::DateFormat) -> Option<Self> {
-        let date = ffi::qdatetime_from_string(string, format);
-        if date.is_valid() {
-            Some(date)
+    /// Returns the QDateTime represented by the string, using the format given.
+    /// If the string cannot be parsed, returns `None`.
+    pub fn from_qstring_opt<'a, T>(string: &QString, format: T) -> Option<Self>
+    where
+        T: Into<AnyDateFormat<'a>>,
+    {
+        let parsed = Self::from_qstring(string, format);
+        if parsed.is_valid() {
+            Some(parsed)
         } else {
             None
+        }
+    }
+
+    /// Returns the QDateTime represented by the string, using the format given.
+    /// If the string cannot be parsed, returns an invalid datetime.
+    fn from_qstring<'a, T>(string: &QString, format: T) -> Self
+    where
+        T: Into<AnyDateFormat<'a>>,
+    {
+        match format.into() {
+            AnyDateFormat::DateFormat(f) => ffi::qdatetime_from_qstring_dateformat(string, f),
+            AnyDateFormat::QString(f) => ffi::qdatetime_from_qstring_qstring(string, f),
+        }
+    }
+
+    /// Returns the datetime as a string. The format parameter determines the format of the result string.
+    pub fn to_qstring<'a, T>(&self, format: T) -> QString
+    where
+        T: Into<AnyDateFormat<'a>>,
+    {
+        match format.into() {
+            AnyDateFormat::DateFormat(f) => self.format_dateformat(f),
+            AnyDateFormat::QString(f) => self.format_qstring(f),
         }
     }
 
@@ -368,7 +398,7 @@ impl Ord for QDateTime {
 
 impl fmt::Display for QDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.format_enum(ffi::DateFormat::TextDate))
+        write!(f, "{}", self.to_qstring(ffi::DateFormat::TextDate))
     }
 }
 
@@ -394,7 +424,7 @@ impl<Tz: chrono::TimeZone> TryFrom<chrono::DateTime<Tz>> for QDateTime {
 
     fn try_from(value: chrono::DateTime<Tz>) -> Result<Self, Self::Error> {
         let tz = crate::QTimeZone::from_offset_seconds(value.offset().fix().local_minus_utc());
-        Ok(QDateTime::from_date_and_time_time_zone(
+        Ok(QDateTime::from_date_time_timezone(
             &QDate::from(value.date_naive()),
             &QTime::try_from(value.time())?,
             tz.as_ref().ok_or("Could not construct timezone")?,
@@ -440,7 +470,7 @@ impl TryFrom<QDateTime> for chrono::DateTime<chrono::Utc> {
 impl From<time::OffsetDateTime> for QDateTime {
     fn from(value: time::OffsetDateTime) -> Self {
         let tz = crate::QTimeZone::from_offset_seconds(value.offset().whole_seconds());
-        QDateTime::from_date_and_time_time_zone(
+        QDateTime::from_date_time_timezone(
             &QDate::from(value.date()),
             &QTime::from(value.time()),
             tz.as_ref().expect("Could not construct timezone"),
@@ -452,7 +482,7 @@ impl From<time::OffsetDateTime> for QDateTime {
 impl From<time::PrimitiveDateTime> for QDateTime {
     fn from(value: time::PrimitiveDateTime) -> Self {
         let tz = crate::QTimeZone::utc();
-        QDateTime::from_date_and_time_time_zone(
+        QDateTime::from_date_time_timezone(
             &QDate::from(value.date()),
             &QTime::from(value.time()),
             tz.as_ref().expect("Could not construct timezone"),
@@ -498,12 +528,12 @@ mod test {
 
     #[test]
     fn test_ordering() {
-        let qdatetime_a = QDateTime::from_date_and_time_time_zone(
+        let qdatetime_a = QDateTime::from_date_time_timezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 1, 1, 1),
             &ffi::QTimeZone::utc(),
         );
-        let qdatetime_b = QDateTime::from_date_and_time_time_zone(
+        let qdatetime_b = QDateTime::from_date_time_timezone(
             &QDate::new(2023, 2, 2),
             &QTime::new(2, 2, 2, 2),
             &ffi::QTimeZone::utc(),
@@ -535,7 +565,7 @@ mod test_chrono {
             )
         };
 
-        let qdatetime = QDateTime::from_date_and_time_time_zone(
+        let qdatetime = QDateTime::from_date_time_timezone(
             &QDate::new(2023, 1, 1),
             // Chrono adds the offset to the given time, so add the offset here to match Chrono
             &QTime::new(1 + 1 /* plus the offset */, 2, 3, 4),
@@ -559,7 +589,7 @@ mod test_chrono {
             )
         };
 
-        let qdatetime = QDateTime::from_date_and_time_time_zone(
+        let qdatetime = QDateTime::from_date_time_timezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::from_offset_seconds(60 * 60),
@@ -583,7 +613,7 @@ mod test_chrono {
             )
         };
 
-        let qdatetime = QDateTime::from_date_and_time_time_zone(
+        let qdatetime = QDateTime::from_date_time_timezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::utc(),
@@ -607,7 +637,7 @@ mod test_chrono {
             )
         };
 
-        let qdatetime = QDateTime::from_date_and_time_time_zone(
+        let qdatetime = QDateTime::from_date_time_timezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             // Should cause one hour offset when in chrono::DateTime
@@ -633,7 +663,7 @@ mod test_time {
             .unwrap()
             .assume_offset(time::UtcOffset::from_whole_seconds(60 * 60).unwrap());
 
-        let qdatetime = QDateTime::from_date_and_time_time_zone(
+        let qdatetime = QDateTime::from_date_time_timezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::from_offset_seconds(60 * 60),
@@ -651,7 +681,7 @@ mod test_time {
             .with_hms_milli(1, 2, 3, 4)
             .unwrap();
 
-        let qdatetime = QDateTime::from_date_and_time_time_zone(
+        let qdatetime = QDateTime::from_date_time_timezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::utc(),
@@ -670,7 +700,7 @@ mod test_time {
             .unwrap()
             .assume_offset(time::UtcOffset::from_whole_seconds(60 * 60).unwrap());
 
-        let qdatetime = QDateTime::from_date_and_time_time_zone(
+        let qdatetime = QDateTime::from_date_time_timezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::from_offset_seconds(60 * 60),
@@ -685,7 +715,7 @@ mod test_time {
             .with_hms_milli(1, 2, 3, 4)
             .unwrap();
 
-        let qdatetime = QDateTime::from_date_and_time_time_zone(
+        let qdatetime = QDateTime::from_date_time_timezone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &ffi::QTimeZone::utc(),

--- a/crates/cxx-qt-lib/src/core/qtime.cpp
+++ b/crates/cxx-qt-lib/src/core/qtime.cpp
@@ -42,13 +42,13 @@ qtimeMSecsTo(const QTime& time, QTime t)
 }
 
 QTime
-qtimeFromString(const QString& string, const QString& format)
+qtimeFromQString(const QString& string, const QString& format)
 {
   return QTime::fromString(string, format);
 }
 
 QTime
-qtimeFromString(const QString& string, Qt::DateFormat format)
+qtimeFromQString(const QString& string, Qt::DateFormat format)
 {
   return QTime::fromString(string, format);
 }
@@ -64,6 +64,18 @@ bool
 qtimeIsValid(int h, int m, int s, int ms)
 {
   return QTime::isValid(h, m, s, ms);
+}
+
+QString
+qtimeToQString(const QTime& time, const QString& format)
+{
+  return time.toString(format);
+}
+
+QString
+qtimeToQString(const QTime& time, Qt::DateFormat format)
+{
+  return time.toString(format);
 }
 
 }

--- a/crates/cxx-qt-lib/src/core/qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qtime.rs
@@ -61,14 +61,6 @@ mod ffi {
         /// Sets the time to hour h, minute m, seconds s and milliseconds ms.
         #[rust_name = "set_hms"]
         fn setHMS(self: &mut QTime, h: i32, m: i32, s: i32, ms: i32) -> bool;
-
-        #[doc(hidden)]
-        #[rust_name = "format_qstring"]
-        fn toString(self: &QTime, format: &QString) -> QString;
-
-        #[doc(hidden)]
-        #[rust_name = "format_dateformat"]
-        fn toString(self: &QTime, format: DateFormat) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -83,10 +75,17 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "qtime_from_qstring_qstring"]
-        fn qtimeFromString(string: &QString, format: &QString) -> QTime;
+        fn qtimeFromQString(string: &QString, format: &QString) -> QTime;
         #[doc(hidden)]
         #[rust_name = "qtime_from_qstring_dateformat"]
-        fn qtimeFromString(string: &QString, format: DateFormat) -> QTime;
+        fn qtimeFromQString(string: &QString, format: DateFormat) -> QTime;
+
+        #[doc(hidden)]
+        #[rust_name = "qtime_to_qstring_qstring"]
+        fn qtimeToQString(time: &QTime, format: &QString) -> QString;
+        #[doc(hidden)]
+        #[rust_name = "qtime_to_qstring_dateformat"]
+        fn qtimeToQString(time: &QTime, format: DateFormat) -> QString;
 
         #[doc(hidden)]
         #[rust_name = "qtime_msecs_to"]
@@ -168,8 +167,8 @@ impl QTime {
         T: Into<AnyDateFormat<'a>>,
     {
         match format.into() {
-            AnyDateFormat::DateFormat(f) => self.format_dateformat(f),
-            AnyDateFormat::QString(f) => self.format_qstring(f),
+            AnyDateFormat::DateFormat(f) => ffi::qtime_to_qstring_dateformat(self, f),
+            AnyDateFormat::QString(f) => ffi::qtime_to_qstring_qstring(self, f),
         }
     }
 

--- a/crates/cxx-qt-lib/src/gui/qimage.rs
+++ b/crates/cxx-qt-lib/src/gui/qimage.rs
@@ -375,7 +375,7 @@ impl QImage {
     /// See [`QImageReader::supportedImageFormats()`](https://doc.qt.io/qt-6/qimagereader.html#supportedImageFormats) for the list of supported formats.
     ///
     /// If no `format` is provided, the format will be quessed from the image header.
-    pub fn from_data(data: &[u8], format: Option<&str>) -> Option<Self> {
+    pub fn from_data_opt(data: &[u8], format: Option<&str>) -> Option<Self> {
         let image = ffi::qimage_init_from_data(data, format.unwrap_or(""));
 
         if !image.is_null() {

--- a/crates/cxx-qt-lib/src/lib.rs
+++ b/crates/cxx-qt-lib/src/lib.rs
@@ -27,3 +27,4 @@ mod quickcontrols;
 pub use crate::quickcontrols::*;
 
 mod util;
+pub use util::AnyDateFormat;

--- a/crates/cxx-qt-lib/src/util.rs
+++ b/crates/cxx-qt-lib/src/util.rs
@@ -16,3 +16,24 @@ macro_rules! const_assert {
         const _: () = ::core::assert!($x);
     };
 }
+
+use crate::{DateFormat, QString};
+
+/// Types that can be used to format and parse dates and times.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum AnyDateFormat<'a> {
+    DateFormat(DateFormat),
+    QString(&'a QString),
+}
+
+impl From<DateFormat> for AnyDateFormat<'static> {
+    fn from(value: DateFormat) -> Self {
+        Self::DateFormat(value)
+    }
+}
+
+impl<'a> From<&'a QString> for AnyDateFormat<'a> {
+    fn from(value: &'a QString) -> Self {
+        Self::QString(value)
+    }
+}

--- a/tests/qt_types_standalone/rust/src/qdatetime.rs
+++ b/tests/qt_types_standalone/rust/src/qdatetime.rs
@@ -28,7 +28,7 @@ mod qdatetime_cxx {
 }
 
 fn construct_qdatetime(date: &QDate, time: &QTime, time_zone: &QTimeZone) -> QDateTime {
-    QDateTime::from_date_and_time_time_zone(date, time, time_zone)
+    QDateTime::from_qdate_qtime_qtimezone(date, time, time_zone)
 }
 
 fn read_qdatetime(dt: &QDateTime, date: &QDate, time: &QTime) -> bool {

--- a/tests/qt_types_standalone/rust/src/qvariant.rs
+++ b/tests/qt_types_standalone/rust/src/qvariant.rs
@@ -61,7 +61,7 @@ fn construct_qvariant(test: VariantTest) -> QVariant {
         VariantTest::QByteArray => QVariant::from(&QByteArray::from("Rust bytes")),
         VariantTest::QColor => QVariant::from(&QColor::from_rgb(255, 0, 0)),
         VariantTest::QDate => QVariant::from(&QDate::new(2022, 1, 1)),
-        VariantTest::QDateTime => QVariant::from(&QDateTime::from_date_and_time_time_zone(
+        VariantTest::QDateTime => QVariant::from(&QDateTime::from_qdate_qtime_qtimezone(
             &QDate::new(2022, 1, 1),
             &QTime::new(1, 2, 3, 4),
             &QTimeZone::from_offset_seconds(0),


### PR DESCRIPTION
Per #1203, constructor methods are now named directly after their parameters, and suffixed by `_opt` if they return `Option<Self>`. 

This PR also adds the `AnyDateFormat` type (an enum of either a `DateFormat` or a `QString`) in order to deduplicate methods for converting between date/time types and `QString`s:

```rs
// Old
QDate::from_string(mystring, &QString::from("myformat"));
QDate::from_string_enum(mystring, DateFormat::ISODate);
date.format(&QString::from("myformat"));
date.format_enum(DateFormat::ISODate);

// New
QDate::from_qstring_opt(mystring, &QString::from("myformat"));
QDate::from_qstring_opt(mystring, DateFormat::ISODate);
date.to_qstring(&QString::from("myformat"));
date.to_qstring(DateFormat::ISODate);
```

Alternatively, we could get rid of `AnyDateFormat` and use `date.to_qstring_qstring`, `QDateTime::from_qstring_dateformat_opt`, etc. I think the `AnyDateFormat` approach is slightly cleaner, but I'll get rid of it if you prefer.

These are all breaking changes. Alternatively, the old functions could be deprecated rather than removed. I didn't see any `#[deprecated]` tags in the codebase, so I defaulted to removing them.

Full list of changes (copied from the changelog):
- `QTime::from_string` and `QTime::from_string_enum` now return `Option<QTime>` rather than `QTime`, in keeping with the identical functions for `QDate` and `QDateTime`.
- Combined and renamed the following functions:
  - `QDate::from_string` and `QDate::from_string_enum` → `QDate::from_qstring_opt`
  - `QDate::format` and `QDate::format_enum` → `QDate::to_qstring`
  - `QDateTime::from_date_and_time_time_zone` → `QDateTime::from_qdate_qtime_qtimezone`
  - `QDateTime::from_date_and_time_time_spec` → `QDateTime::from_qdate_qtime_timespec`
  - `QDateTime::from_string` and `QDateTime::from_string_enum` → `QDateTime::from_qstring_opt`
  - `QDateTime::format` and `QDateTime::format_enum` → `QDateTime::to_qstring`
  - `QImage::from_data` → `QImage::from_data_opt`
  - `QTime::from_string` and `QTime::from_string_enum` → `QTime::from_qstring_opt`
  - `QTime::format` and `QTime::format_enum` → `QTime::to_qstring`
