### PR TITLE
cxx-qt-lib: Add two more QtLogging functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `QMessageLogContext` and sending log messages to the Qt message handler.
 - Serde support for further types: `QByteArray`, `QSet`, `QStringList`, `QVector`, `QUrl`
 - Added `QEventLoop` to cxx-qt-lib-extras.
+- Support for setting Qt log message patterns with `q_set_message_pattern` and formatting log messages ith `q_format_log_message`.
 
 ### Removed
 

--- a/crates/cxx-qt-lib/src/core/mod.rs
+++ b/crates/cxx-qt-lib/src/core/mod.rs
@@ -113,7 +113,9 @@ mod qvector;
 pub use qvector::{QVector, QVectorElement};
 
 mod qtlogging;
-pub use qtlogging::{qt_message_output, QMessageLogContext, QtMsgType};
+pub use qtlogging::{
+    q_format_log_message, q_set_message_pattern, qt_message_output, QMessageLogContext, QtMsgType,
+};
 
 #[cxx::bridge]
 mod ffi {

--- a/crates/cxx-qt-lib/src/core/qtlogging.rs
+++ b/crates/cxx-qt-lib/src/core/qtlogging.rs
@@ -36,6 +36,21 @@ mod ffi {
         /// Outputs a message in the Qt message handler.
         fn qt_message_output(msgType: QtMsgType, context: &QMessageLogContext, string: &QString);
 
+        /// Generates a formatted string out of the type, context, str arguments.
+        #[cxx_name = "qFormatLogMessage"]
+        fn q_format_log_message(
+            msgType: QtMsgType,
+            context: &QMessageLogContext,
+            string: &QString,
+        ) -> QString;
+
+        /// Changes the output of the default message handler.
+        ///
+        /// # Safety
+        /// This function is marked as unsafe because it is not guaranteed to be thread-safe.
+        #[cxx_name = "qSetMessagePattern"]
+        unsafe fn q_set_message_pattern(pattern: &QString);
+
         #[cxx_name = "qmessagelogcontext_line"]
         #[doc(hidden)]
         fn line(context: &QMessageLogContext) -> i32;
@@ -131,4 +146,4 @@ unsafe impl ExternType for QMessageLogContext<'_> {
 }
 
 use crate::const_assert;
-pub use ffi::{qt_message_output, QtMsgType};
+pub use ffi::{q_format_log_message, q_set_message_pattern, qt_message_output, QtMsgType};


### PR DESCRIPTION
This adds two new global functions available in <QtLogging>: [qFormatLogMessage](https://doc.qt.io/qt-6/qtlogging.html#qFormatLogMessage) and [qSetMessagePattern](https://doc.qt.io/qt-6/qtlogging.html#qSetMessagePattern).

qFormatLogMessage is similar to qt_message_output, but actually documented. Instead of going to the default message handler though, it outputs to a QString. This is probably not useful without message handler support, but it's easy to expose.

qSetMessagePattern is very useful, as it allows CXX-Qt applications to set custom Qt message patterns for logging.