### PR TITLE
Add shorthand for cxx_qt::Initialize

### DIFF
--- a/book/src/bridge/extern_rustqt.md
+++ b/book/src/bridge/extern_rustqt.md
@@ -99,6 +99,19 @@ For more information on inheritance and how to override methods see the [Inherit
 ### Traits
 
 The [`Default` trait](https://doc.rust-lang.org/std/default/trait.Default.html) needs to be implemented for the `#[qobject]` marked struct either by hand or by using the derive macro `#[derive(Default)]`. Or the [`cxx_qt::Constructor`](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Constructor.html) trait needs to be implemented for the type.
+In order to simply implement the `Constructor` trait, the following shorthand is available:
+
+```rust,ignore
+impl cxx_qt::Initialize for x {}
+```
+
+is equivalent to writing
+
+```rust,ignore
+impl cxx_qt::Constructor<()> for x {}
+```
+
+inside the bridge.
 
 For further documentation see the [traits page](./traits.md).
 

--- a/book/src/bridge/traits.md
+++ b/book/src/bridge/traits.md
@@ -24,7 +24,7 @@ For further documentation, refer to the documentation of the individual traits:
 - [CxxQtType](https://docs.rs/cxx-qt/latest/cxx_qt/trait.CxxQtType.html) - trait to reach the Rust implementation of a `QObject`
   - This trait is automatically implemented for any `#[qobject]` type inside `extern "RustQt"` blocks.
 - [Constructor](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Constructor.html) - custom constructor
-- [Initialize](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Initialize.html) - execute Rust code when the object is constructed
+- [Initialize](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Initialize.html) - execute Rust code when the object is constructed, or as shorthand for an empty constructor
 - [Threading](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Threading.html) - marker trait whether CXX-Qt threading should be enabled
 
 > ⚠️ These traits should only be implemented if you are sure you need to, they are automatically implemented for RustQt types.

--- a/crates/cxx-qt-gen/src/parser/trait_impl.rs
+++ b/crates/cxx-qt-gen/src/parser/trait_impl.rs
@@ -3,7 +3,7 @@ use indoc::formatdoc;
 // SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use syn::{Error, Ident, ItemImpl, Path, Result, Token, Type, TypePath};
+use syn::{parse_quote, Error, Ident, ItemImpl, Path, Result, Token, Type, TypePath};
 
 use crate::{parser::constructor::Constructor, syntax::path::path_compare_str};
 
@@ -46,6 +46,13 @@ impl TraitKind {
             Self::parse_threading(not, path, imp)
         } else if path_compare_str(path, &["cxx_qt", "Constructor"]) {
             Self::parse_constructor(imp)
+        } else if path_compare_str(path, &["cxx_qt", "Initialize"]) {
+            let struct_name = &*imp.self_ty;
+            // Inside the bridge, Initialize is shorthand for the line below
+            let default_constructor: ItemImpl = parse_quote! {
+                impl cxx_qt::Constructor<()> for #struct_name {}
+            };
+            Self::parse_constructor(&default_constructor)
         } else {
             // TODO: Give suggestions on which trait might have been meant
             Err(Error::new_spanned(
@@ -55,6 +62,7 @@ impl TraitKind {
                     CXX-Qt currently only supports:
                       - cxx_qt::Threading
                       - cxx_qt::Constructor
+                      - cxx_qt::Initialize (as shorthand for Constructor<()>)
                       - (cxx_qt::Locking has been removed as of CXX-Qt 0.7)
                     Note that the trait must always be fully-qualified.
                     "},
@@ -128,6 +136,23 @@ mod tests {
         let marker = TraitImpl::parse(imp).unwrap();
         assert_eq!(marker.qobject, format_ident!("MyObject"));
         assert!(matches!(marker.kind, TraitKind::Constructor(_)))
+    }
+
+    #[test]
+    fn parse_constructor_shorthand() {
+        let imp = parse_quote! {
+            impl cxx_qt::Constructor<()> for MyObject {}
+        };
+        let marker = TraitImpl::parse(imp).unwrap();
+        assert_eq!(marker.qobject, format_ident!("MyObject"));
+        assert!(matches!(marker.kind, TraitKind::Constructor(_)));
+
+        let imp = parse_quote! {
+            impl cxx_qt::Initialize for MyObject {}
+        };
+        let shorthand = TraitImpl::parse(imp).unwrap();
+        assert_eq!(marker.kind, shorthand.kind);
+        assert_eq!(marker.qobject, shorthand.qobject);
     }
 
     use crate::tests::assert_parse_errors;

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -313,6 +313,7 @@ impl<T: Sized> Downcast for T {}
 /// To reduce the boilerplate of this use-case, CXX-Qt provides the [Initialize] trait.
 ///
 /// If a QObject implements the `Initialize` trait, and the inner Rust struct is [Default]-constructible it will automatically implement `cxx_qt::Constructor<()>`.
+/// Additionally, implementing `impl cxx_qt::Initialize` will act as shorthand for `cxx_qt::Constructor<()>`.
 pub trait Constructor<Arguments>: CxxQtType {
     /// The arguments that are passed to the [`new()`](Self::new) function to construct the inner Rust struct.
     /// This must be a tuple of CXX compatible types.
@@ -361,6 +362,7 @@ pub trait Constructor<Arguments>: CxxQtType {
 /// that calls the `initialize` function after constructing a default Rust struct.
 ///
 /// Ensure that the `impl cxx_qt::Constructor<()> for ... {}` is declared inside the CXX-Qt bridge.
+/// Alternatively, using `impl cxx_qt::Initialize for ... {}` acts as shorthand for the above line.
 ///
 /// # Example
 ///
@@ -376,6 +378,8 @@ pub trait Constructor<Arguments>: CxxQtType {
 ///
 ///     // Remember to tell the bridge about the default constructor
 ///     impl cxx_qt::Constructor<()> for MyStruct {}
+///     // or
+///     impl cxx_qt::Initialize for MyStruct {}
 /// }
 ///
 /// // Make sure the inner Rust struct implements `Default`

--- a/examples/demo_threading/rust/src/lib.rs
+++ b/examples/demo_threading/rust/src/lib.rs
@@ -51,7 +51,7 @@ pub mod qobject {
         fn sensor_power(self: Pin<&mut EnergyUsage>, uuid: &QString) -> f64;
     }
 
-    impl cxx_qt::Constructor<()> for EnergyUsage {}
+    impl cxx_qt::Initialize for EnergyUsage {}
 }
 
 use crate::{

--- a/examples/qml_features/rust/src/custom_parent_class.rs
+++ b/examples/qml_features/rust/src/custom_parent_class.rs
@@ -54,7 +54,7 @@ pub mod qobject {
         fn update(self: Pin<&mut CustomParentClass>);
     }
 
-    impl cxx_qt::Constructor<()> for CustomParentClass {}
+    impl cxx_qt::Initialize for CustomParentClass {}
 }
 
 use core::pin::Pin;

--- a/examples/qml_features/rust/src/nested_qobjects.rs
+++ b/examples/qml_features/rust/src/nested_qobjects.rs
@@ -62,7 +62,7 @@ pub mod qobject {
         fn reset(self: Pin<&mut OuterObject>);
     }
 
-    impl cxx_qt::Constructor<()> for OuterObject {}
+    impl cxx_qt::Initialize for OuterObject {}
 }
 
 use core::pin::Pin;

--- a/examples/qml_features/rust/src/properties.rs
+++ b/examples/qml_features/rust/src/properties.rs
@@ -42,7 +42,7 @@ pub mod qobject {
         fn reset_url(self: Pin<&mut RustProperties>);
     }
 
-    impl cxx_qt::Constructor<()> for RustProperties {}
+    impl cxx_qt::Initialize for RustProperties {}
 
     // Dummy constructor, added for an example in the book.
     // ANCHOR: book_constructor_new_decl

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -56,7 +56,7 @@ pub mod qobject {
     // ANCHOR_END: book_rust_obj_impl
 
     // ANCHOR: book_initialize_decl
-    impl cxx_qt::Constructor<()> for RustSignals {}
+    impl cxx_qt::Initialize for RustSignals {}
     // ANCHOR_END: book_initialize_decl
 
     // ANCHOR: book_constructor_decl

--- a/examples/qml_minimal/rust/src/cxxqt_object.rs
+++ b/examples/qml_minimal/rust/src/cxxqt_object.rs
@@ -76,6 +76,7 @@ impl qobject::MyObject {
         println!("Hi from Rust! String is '{string}' and number is {number}");
     }
 }
+
 // ANCHOR_END: book_rustobj_invokable_impl
 
 // ANCHOR_END: book_cxx_qt_module


### PR DESCRIPTION
- `impl cxx_qt::Initialize for x {}` can now be written in the bridge as shorthand
- It is shorthand for `impl cxx_qt::Constructor<()> for x {}`
- Closes #1236 