### PR TITLE
Automatically implement Upcast<Self> for all types

### DIFF
--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -267,6 +267,28 @@ pub trait Upcast<T> {
     }
 }
 
+impl<T> Upcast<T> for T {
+    unsafe fn upcast_ptr(this: *const Self) -> *const Self {
+        this
+    }
+
+    unsafe fn from_base_ptr(base: *const T) -> *const Self {
+        base
+    }
+
+    fn upcast(&self) -> &Self {
+        self
+    }
+
+    fn upcast_mut(&mut self) -> &mut Self {
+        self
+    }
+
+    fn upcast_pin(self: Pin<&mut Self>) -> Pin<&mut Self> {
+        self
+    }
+}
+
 /// This trait is automatically implemented by CXX-Qt and you most likely do not need to manually implement it.
 /// Trait for downcasting to a subclass, provided the subclass implements [Upcast] to this type.
 /// Returns `None` in cases where `Sub` isn't a child class of `Self`.

--- a/examples/cargo_without_cmake/src/main.rs
+++ b/examples/cargo_without_cmake/src/main.rs
@@ -14,8 +14,10 @@
 // ANCHOR: book_cargo_imports
 pub mod cxxqt_object;
 
+use std::pin::Pin;
+
 use cxx_qt::Upcast;
-use cxx_qt_lib::{QGuiApplication, QQmlApplicationEngine, QUrl};
+use cxx_qt_lib::{QGuiApplication, QQmlApplicationEngine, QQmlEngine, QUrl};
 // ANCHOR_END: book_cargo_imports
 
 // ANCHOR: book_cargo_rust_main
@@ -30,9 +32,9 @@ fn main() {
     }
 
     if let Some(engine) = engine.as_mut() {
+        let engine: Pin<&mut QQmlEngine> = engine.upcast_pin();
         // Listen to a signal from the QML Engine
         engine
-            .upcast_pin()
             .on_quit(|_| {
                 println!("QML Quit!");
             })

--- a/examples/qml_multi_crates/rust/main/src/main.rs
+++ b/examples/qml_multi_crates/rust/main/src/main.rs
@@ -5,8 +5,10 @@
 
 extern crate qml_multi_crates;
 
+use std::pin::Pin;
+
 use cxx_qt::Upcast;
-use cxx_qt_lib::{QGuiApplication, QQmlApplicationEngine, QUrl};
+use cxx_qt_lib::{QGuiApplication, QQmlApplicationEngine, QQmlEngine, QUrl};
 
 fn main() {
     cxx_qt::init_crate!(qml_multi_crates);
@@ -21,9 +23,9 @@ fn main() {
     }
 
     if let Some(engine) = engine.as_mut() {
+        let engine: Pin<&mut QQmlEngine> = engine.upcast_pin();
         // Listen to a signal from the QML Engine
         engine
-            .upcast_pin()
             .on_quit(|_| {
                 println!("QML Quit!");
             })


### PR DESCRIPTION
Suppose a user creates a function like this:

```rust
fn do_something<T: Upcast<MyObject>>(object: &T);
```

It should be possible to call `do_something(object)` where `object` *is* `&MyObject`.

The `Upcast<Self>` implementations are all no-ops.