### PR TITLE
Use shorter paths in the OUT_DIR

### DIFF
--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -264,7 +264,7 @@ fn generate_cxxqt_cpp_files(
     header_dir: impl AsRef<Path>,
     include_prefix: &str,
 ) -> Vec<GeneratedCppFilePaths> {
-    let cxx_qt_dir = dir::out().join("cxx-qt-gen");
+    let cxx_qt_dir = dir::gen();
     std::fs::create_dir_all(&cxx_qt_dir).expect("Failed to create cxx-qt-gen directory!");
     std::fs::write(cxx_qt_dir.join("include-prefix.txt"), include_prefix).expect("");
 

--- a/crates/cxx-qt-lib-extras/build.rs
+++ b/crates/cxx-qt-lib-extras/build.rs
@@ -80,7 +80,7 @@ fn main() {
     });
     println!("cargo::rerun-if-changed=src/assertion_utils.h");
 
-    builder
-        .include_prefix("cxx-qt-lib-extras-internals")
-        .build();
+    // Use a short name due to the Windows file path limit!
+    // We don't re-export these headers anyway.
+    builder.include_prefix("private").build();
 }

--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -352,7 +352,9 @@ fn main() {
         .reexport_dependency("cxx-qt");
 
     let mut builder = CxxQtBuilder::library(interface)
-        .include_prefix("cxx-qt-lib-internals")
+        // Use a short name due to the Windows file path limit!
+        // We don't re-export these headers anyway
+        .include_prefix("private")
         .initializer(qt_build_utils::Initializer {
             file: Some("src/core/init.cpp".into()),
             ..qt_build_utils::Initializer::default_signature("init_cxx_qt_lib_core")


### PR DESCRIPTION
As described in #1237, on Windows we're sometimes hitting the 260 character limit
for filepaths.

This is mostly due to a lot of nesting by Qt Creator, Corrosion and
Cargo who all include the target triple and other configuration information in the
build path.

However, we can at least reduce the character count a little bit on our
part.

For example, for qqmlengine.cxxqt.h, the path length is now reduced by
~40 characters from:

out/cxx-qt-build/target/crates/cxx-qt-lib/include/cxx-qt-lib-internals/src/qml/qqmlengine.cxxqt.h

to now:

out/cxxqtbuild/include/private/src/qml/qqmlengine.cxxqt.h

Closes #1237
