### PR TITLE
Don't set MultiThreadedDLL for MSVC Debug builds

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -285,6 +285,7 @@ jobs:
             clang_format_path: /home/runner/.local/bin/clang-format
             cargo_dir: ~/.cargo
             rustc_wrapper: sccache
+            build_type: Release
           - name: Ubuntu 24.04 (gcc) Qt6
             os: ubuntu-24.04
             qt_version: 6
@@ -301,6 +302,7 @@ jobs:
             clang_format_path: /home/runner/.local/bin/clang-format
             cargo_dir: ~/.cargo
             rustc_wrapper: sccache
+            build_type: Release
             packages-extra: >-
                 libgl1-mesa-dev
                 libvulkan-dev
@@ -327,6 +329,7 @@ jobs:
             cc: clang
             cxx: clang++
             rustc_wrapper: sccache
+            build_type: Release
           - name: macOS 14 (clang) Qt6
             os: macos-14
             qt_version: 6
@@ -348,6 +351,7 @@ jobs:
             cc: clang
             cxx: clang++
             rustc_wrapper: sccache
+            build_type: Release
 
           - name: Windows 2022 (MSVC) Qt5
             os: windows-2022
@@ -366,6 +370,7 @@ jobs:
             cc: cl
             cxx: cl
             rustc_wrapper: sccache
+            build_type: Release
           - name: Windows 2022 (MSVC2019) Qt6
             os: windows-2022
             qt_version: 6
@@ -383,7 +388,9 @@ jobs:
             cc: cl
             cxx: cl
             rustc_wrapper: sccache
-          - name: Windows 2022 (MSVC2022) Qt6
+            build_type: Release
+            # Use a Debug build to ensure we can build and run tests in Debug mode with MSVC
+          - name: Windows 2022 (MSVC2022) Qt6 Debug
             os: windows-2022
             qt_version: 6
             aqt_version: '6.8.0'
@@ -400,6 +407,7 @@ jobs:
             cc: cl
             cxx: cl
             rustc_wrapper: sccache
+            build_type: Debug
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}
@@ -536,7 +544,7 @@ jobs:
       run: >-
         cmake ${{ matrix.cmake_args }}
         -D USE_QT5=${{ matrix.qt_version == 5 }}
-        -D CMAKE_BUILD_TYPE=Release
+        -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -G Ninja
         -S . -B build
       env:
@@ -544,7 +552,7 @@ jobs:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
     - name: "Build"
-      run: cmake --build build --config Release --parallel ${{ matrix.cores }}
+      run: cmake --build build --config ${{ matrix.build_type }} --parallel ${{ matrix.cores }}
       env:
         RUSTC_WRAPPER: ${{ matrix.rustc_wrapper }}
 
@@ -552,7 +560,7 @@ jobs:
       run: sccache --show-stats
 
     - name: "Test"
-      run: ctest ${{ matrix.ctest_args }} -C Release -T test --output-on-failure --parallel ${{ matrix.cores }}
+      run: ctest ${{ matrix.ctest_args }} -C ${{ matrix.build_type }} -T test --output-on-failure --parallel ${{ matrix.cores }}
       working-directory: ./build
       env:
         # Use the version of clang-format from pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CXX-Qt-build: Interface no longer includes compiler definitions (<https://github.com/KDAB/cxx-qt/issues/1165>)
 - CXX-Qt-build: Interface no longer includes initializers
 
+### Fixed
+
+- CXX-Qt-CMake can now link to the MSVC debug runtime, setting MultiThreadedDLL is no longer recommended.
+
 ## [0.7.1](https://github.com/KDAB/cxx-qt/compare/v0.7.0...v0.7.1) - 2025-03-04
 
 ### Added

--- a/book/src/getting-started/5-cmake-integration.md
+++ b/book/src/getting-started/5-cmake-integration.md
@@ -207,6 +207,13 @@ You should now see the two Labels that display the state of our `MyObject`, as w
 
 ### Windows with MSVC
 
-If you're building CXX-Qt on Windows using MSVC generator, you need to ensure that `set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")` is set in CMake (or use the `-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL` flag) when building with the `Debug` configuration. This flag is necessary to ensure that the correct C Runtime Library is used. Then you can build using `cmake --build build --config Debug`.
+With MSVC, all parts of the build need to agree on the runtime that is linked into the executable.
 
-This issue is caused by a bug in the [cc](https://docs.rs/cc/latest/cc/index.html) crate (as described in [this pull request](https://github.com/rust-lang/cc-rs/pull/717)), which has not been merged yet. Specifically, the problem is that cc generated code always links to the MultiThreaded runtime, even when building in Debug mode. We hope that this step won't be necessary in the future, once the cc crate fix is merged and released.
+As of CXX-Qt 0.7.2, cxx-qt-cmake will automatically set the right linker flags in the debug configuration.
+
+The previous workaround of setting the CMAKE_MSVC_RUNTIME_LIBRARY to "MultiThreadedDLL" is no longer necessary or recommended!
+
+See also:
+
+- <https://corrosion-rs.github.io/corrosion/common_issues.html#linking-debug-cc-libraries-into-rust-fails-on-windows-msvc-targets>
+- <https://github.com/KDAB/cxx-qt/issues/1234>

--- a/examples/demo_threading/CMakeLists.txt
+++ b/examples/demo_threading/CMakeLists.txt
@@ -8,14 +8,6 @@ cmake_minimum_required(VERSION 3.24)
 project(demo_threading)
 set(APP_NAME ${PROJECT_NAME})
 
-# Rust always links against non-debug Windows runtime on *-msvc targets
-# Note it is best to set this on the command line to ensure all targets are consistent
-# https://github.com/corrosion-rs/corrosion/blob/master/doc/src/common_issues.md#linking-debug-cc-libraries-into-rust-fails-on-windows-msvc-targets
-# https://github.com/rust-lang/rust/issues/39016
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-endif()
-
 if(BUILD_WASM)
     # Ensure Rust build for the correct target
     set(Rust_CARGO_TARGET wasm32-unknown-emscripten)

--- a/examples/qml_features/CMakeLists.txt
+++ b/examples/qml_features/CMakeLists.txt
@@ -9,14 +9,6 @@ cmake_minimum_required(VERSION 3.24)
 project(example_qml_features)
 set(APP_NAME ${PROJECT_NAME})
 
-# Rust always links against non-debug Windows runtime on *-msvc targets
-# Note it is best to set this on the command line to ensure all targets are consistent
-# https://github.com/corrosion-rs/corrosion/blob/master/doc/src/common_issues.md#linking-debug-cc-libraries-into-rust-fails-on-windows-msvc-targets
-# https://github.com/rust-lang/rust/issues/39016
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-endif()
-
 if(BUILD_WASM)
     # Ensure Rust build for the correct target
     set(Rust_CARGO_TARGET wasm32-unknown-emscripten)

--- a/examples/qml_minimal/CMakeLists.txt
+++ b/examples/qml_minimal/CMakeLists.txt
@@ -8,14 +8,6 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(example_qml_minimal)
-
-# Rust always links against non-debug Windows runtime on *-msvc targets
-# Note it is best to set this on the command line to ensure all targets are consistent
-# https://github.com/corrosion-rs/corrosion/blob/master/doc/src/common_issues.md#linking-debug-cc-libraries-into-rust-fails-on-windows-msvc-targets
-# https://github.com/rust-lang/rust/issues/39016
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-endif()
 # ANCHOR_END: book_cmake_setup
 
 if(BUILD_WASM)

--- a/examples/qml_multi_crates/CMakeLists.txt
+++ b/examples/qml_multi_crates/CMakeLists.txt
@@ -7,14 +7,6 @@ cmake_minimum_required(VERSION 3.24)
 
 project(example_qml_multi_crates)
 
-# Rust always links against non-debug Windows runtime on *-msvc targets
-# Note it is best to set this on the command line to ensure all targets are consistent
-# https://github.com/corrosion-rs/corrosion/blob/master/doc/src/common_issues.md#linking-debug-cc-libraries-into-rust-fails-on-windows-msvc-targets
-# https://github.com/rust-lang/rust/issues/39016
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-endif()
-
 if(BUILD_WASM)
     # Ensure Rust build for the correct target
     set(Rust_CARGO_TARGET wasm32-unknown-emscripten)

--- a/tests/basic_cxx_only/CMakeLists.txt
+++ b/tests/basic_cxx_only/CMakeLists.txt
@@ -9,14 +9,6 @@ cmake_minimum_required(VERSION 3.24)
 project(tests_basic_cxx_only)
 set(APP_NAME ${PROJECT_NAME})
 
-# Rust always links against non-debug Windows runtime on *-msvc targets
-# Note it is best to set this on the command line to ensure all targets are consistent
-# https://github.com/corrosion-rs/corrosion/blob/master/doc/src/common_issues.md#linking-debug-cc-libraries-into-rust-fails-on-windows-msvc-targets
-# https://github.com/rust-lang/rust/issues/39016
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-endif()
-
 # TODO: Add a helper function to our CMake module which automatically
 # handles some of this boilerplate for a "typical" Qt application
 set(CMAKE_AUTOMOC ON)

--- a/tests/basic_cxx_qt/CMakeLists.txt
+++ b/tests/basic_cxx_qt/CMakeLists.txt
@@ -9,14 +9,6 @@ cmake_minimum_required(VERSION 3.24)
 project(tests_basic_cxx_qt)
 set(APP_NAME ${PROJECT_NAME})
 
-# Rust always links against non-debug Windows runtime on *-msvc targets
-# Note it is best to set this on the command line to ensure all targets are consistent
-# https://github.com/corrosion-rs/corrosion/blob/master/doc/src/common_issues.md#linking-debug-cc-libraries-into-rust-fails-on-windows-msvc-targets
-# https://github.com/rust-lang/rust/issues/39016
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-endif()
-
 # TODO: Add a helper function to our CMake module which automatically
 # handles some of this boilerplate for a "typical" Qt application
 set(CMAKE_AUTOMOC ON)

--- a/tests/qt_types_standalone/CMakeLists.txt
+++ b/tests/qt_types_standalone/CMakeLists.txt
@@ -9,14 +9,6 @@ cmake_minimum_required(VERSION 3.24)
 project(tests_qt_types_standalone)
 set(APP_NAME ${PROJECT_NAME})
 
-# Rust always links against non-debug Windows runtime on *-msvc targets
-# Note it is best to set this on the command line to ensure all targets are consistent
-# https://github.com/corrosion-rs/corrosion/blob/master/doc/src/common_issues.md#linking-debug-cc-libraries-into-rust-fails-on-windows-msvc-targets
-# https://github.com/rust-lang/rust/issues/39016
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-endif()
-
 # TODO: Add a helper function to our CMake module which automatically
 # handles some of this boilerplate for a "typical" Qt application
 set(CMAKE_AUTOMOC ON)


### PR DESCRIPTION
Once https://github.com/KDAB/cxx-qt-cmake/pull/12 is merged, this should
no longer be necessary.

Closes #1234
