### PR TITLE
Use QAnyStringView for QString::arg

### DIFF
--- a/crates/cxx-qt-lib/include/core/qstring.h
+++ b/crates/cxx-qt-lib/include/core/qstring.h
@@ -30,8 +30,14 @@ qstringInitFromRustString(::rust::Str string);
 ::rust::String
 qstringToRustString(const QString& string);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+QString
+qstringArg(const QString& string, QAnyStringView a);
+#else
 QString
 qstringArg(const QString& string, const QString& a);
+#endif
+
 ::rust::isize
 qstringIndexOf(const QString& string,
                const QString& str,

--- a/crates/cxx-qt-lib/src/core/qanystringview.rs
+++ b/crates/cxx-qt-lib/src/core/qanystringview.rs
@@ -106,6 +106,13 @@ impl<'a> From<&'a str> for QAnyStringView<'a> {
     }
 }
 
+impl<'a> From<&'a String> for QAnyStringView<'a> {
+    /// Constructs a QAnyStringView from a Rust string
+    fn from(string: &'a String) -> Self {
+        ffi::QAnyStringView_init_from_rust_string(string.as_str())
+    }
+}
+
 impl<'a> From<&'a QByteArray> for QAnyStringView<'a> {
     /// Constructs a QAnyStringView from a QByteArray
     fn from(bytes: &'a QByteArray) -> Self {

--- a/crates/cxx-qt-lib/src/core/qstring.cpp
+++ b/crates/cxx-qt-lib/src/core/qstring.cpp
@@ -54,12 +54,25 @@ qstringToRustString(const QString& string)
   return ::rust::String(byteArray.constData(), byteArray.size());
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 9, 0))
+QString
+qstringArg(const QString& string, QAnyStringView a)
+{
+  return string.arg(a);
+}
+#elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+QString
+qstringArg(const QString& string, QAnyStringView a)
+{
+  return string.arg(a.toString());
+}
+#else
 QString
 qstringArg(const QString& string, const QString& a)
 {
-  // CXX can't choose between arg overloads so use C++
   return string.arg(a);
 }
+#endif
 
 ::rust::isize
 qstringIndexOf(const QString& string,

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -3,7 +3,7 @@
 // SPDX-FileContributor: Gerhard de Clercq <gerhard.declercq@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
-#[cfg(cxxqt_qt_version_at_least_6_8)]
+#[cfg(cxxqt_qt_version_major = "6")]
 use crate::QAnyStringView;
 use cxx::{type_id, ExternType};
 use std::cmp::Ordering;
@@ -19,12 +19,13 @@ mod ffi {
         type SplitBehaviorFlags = crate::SplitBehaviorFlags;
     }
 
-    unsafe extern "C++" {
-        #[cfg(cxxqt_qt_version_major = "6")]
+    #[cfg(cxxqt_qt_version_major = "6")]
+    extern "C++" {
         include!("cxx-qt-lib/qanystringview.h");
-        #[cfg(cxxqt_qt_version_major = "6")]
         type QAnyStringView<'a> = crate::QAnyStringView<'a>;
+    }
 
+    unsafe extern "C++" {
         include!("cxx-qt-lib/qbytearray.h");
         type QByteArray = crate::QByteArray;
         include!("cxx-qt-lib/qstring.h");


### PR DESCRIPTION
As of [Qt 6.9](https://doc.qt.io/qt-6/whatsnew69.html), [`QString::arg`](https://doc.qt.io/qt-6/qstring.html#arg) now accepts any parameter that can convert to `QAnyStringView`. That means we can skip unnecessary allocations:

```rs
// old (still works, but allocates a QString)
mystring.arg(&QString("myarg"));

// new (no allocation, Qt processes UTF8)
mystring.arg("myarg");

```