### PR TITLE
MSVC: Use Qt Release runtime

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -285,6 +285,7 @@ jobs:
             clang_format_path: /home/runner/.local/bin/clang-format
             cargo_dir: ~/.cargo
             rustc_wrapper: sccache
+            build_type: Release
           - name: Ubuntu 24.04 (gcc) Qt6
             os: ubuntu-24.04
             qt_version: 6
@@ -301,6 +302,7 @@ jobs:
             clang_format_path: /home/runner/.local/bin/clang-format
             cargo_dir: ~/.cargo
             rustc_wrapper: sccache
+            build_type: Release
             packages-extra: >-
                 libgl1-mesa-dev
                 libvulkan-dev
@@ -327,6 +329,7 @@ jobs:
             cc: clang
             cxx: clang++
             rustc_wrapper: sccache
+            build_type: Release
           - name: macOS 14 (clang) Qt6
             os: macos-14
             qt_version: 6
@@ -348,6 +351,7 @@ jobs:
             cc: clang
             cxx: clang++
             rustc_wrapper: sccache
+            build_type: Release
 
           - name: Windows 2022 (MSVC) Qt5
             os: windows-2022
@@ -366,6 +370,7 @@ jobs:
             cc: cl
             cxx: cl
             rustc_wrapper: sccache
+            build_type: Release
           - name: Windows 2022 (MSVC2019) Qt6
             os: windows-2022
             qt_version: 6
@@ -383,7 +388,9 @@ jobs:
             cc: cl
             cxx: cl
             rustc_wrapper: sccache
-          - name: Windows 2022 (MSVC2022) Qt6
+            build_type: Release
+            # Use a Debug build to ensure we can build and run tests in Debug mode with MSVC
+          - name: Windows 2022 (MSVC2022) Qt6 Debug
             os: windows-2022
             qt_version: 6
             aqt_version: '6.9.0'
@@ -400,6 +407,7 @@ jobs:
             cc: cl
             cxx: cl
             rustc_wrapper: sccache
+            build_type: Debug
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}
@@ -536,7 +544,7 @@ jobs:
       run: >-
         cmake ${{ matrix.cmake_args }}
         -D USE_QT5=${{ matrix.qt_version == 5 }}
-        -D CMAKE_BUILD_TYPE=Release
+        -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -G Ninja
         -S . -B build
       env:
@@ -544,7 +552,7 @@ jobs:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
     - name: "Build"
-      run: cmake --build build --config Release --parallel ${{ matrix.cores }}
+      run: cmake --build build --config ${{ matrix.build_type }} --parallel ${{ matrix.cores }}
       env:
         RUSTC_WRAPPER: ${{ matrix.rustc_wrapper }}
 
@@ -552,7 +560,7 @@ jobs:
       run: sccache --show-stats
 
     - name: "Test"
-      run: ctest ${{ matrix.ctest_args }} -C Release -T test --output-on-failure --parallel ${{ matrix.cores }}
+      run: ctest ${{ matrix.ctest_args }} -C ${{ matrix.build_type }} -T test --output-on-failure --parallel ${{ matrix.cores }}
       working-directory: ./build
       env:
         # Use the version of clang-format from pip

--- a/examples/demo_threading/CMakeLists.txt
+++ b/examples/demo_threading/CMakeLists.txt
@@ -35,9 +35,20 @@ endif()
 
 if(NOT USE_QT5)
     find_package(Qt6 COMPONENTS ${CXXQT_QTCOMPONENTS})
+    set(Qt "Qt6")
 endif()
 if(NOT Qt6_FOUND)
     find_package(Qt5 5.15 COMPONENTS ${CXXQT_QTCOMPONENTS} REQUIRED)
+    set(Qt "Qt5")
+endif()
+
+if(MSVC)
+    # Qt also needs to link against the non-debug version of the MSVC Runtime libraries, see the previous comment.
+    # Note: The Qt:: targets are ALIAS targets that do not support setting properties directly.
+    # We therefore need to resolve the target names to either Qt5 or Qt6 directly.
+    set_property(
+        TARGET ${Qt}::Core ${Qt}::Gui ${Qt}::Qml ${Qt}::QuickControls2
+        PROPERTY MAP_IMPORTED_CONFIG_DEBUG "RELEASE")
 endif()
 
 find_package(CxxQt QUIET)

--- a/examples/qml_features/CMakeLists.txt
+++ b/examples/qml_features/CMakeLists.txt
@@ -35,9 +35,20 @@ endif()
 
 if(NOT USE_QT5)
     find_package(Qt6 COMPONENTS ${CXXQT_QTCOMPONENTS})
+    set(Qt "Qt6")
 endif()
 if(NOT Qt6_FOUND)
     find_package(Qt5 5.15 COMPONENTS ${CXXQT_QTCOMPONENTS} REQUIRED)
+    set(Qt "Qt5")
+endif()
+
+if(MSVC)
+    # Qt also needs to link against the non-debug version of the MSVC Runtime libraries, see the previous comment.
+    # Note: The Qt:: targets are ALIAS targets that do not support setting properties directly.
+    # We therefore need to resolve the target names to either Qt5 or Qt6 directly.
+    set_property(
+        TARGET ${Qt}::Core ${Qt}::Gui ${Qt}::Qml ${Qt}::Quick ${Qt}::QuickControls2 ${Qt}::QuickTest ${Qt}::Test
+        PROPERTY MAP_IMPORTED_CONFIG_DEBUG "RELEASE")
 endif()
 
 find_package(CxxQt QUIET)

--- a/examples/qml_minimal/CMakeLists.txt
+++ b/examples/qml_minimal/CMakeLists.txt
@@ -41,11 +41,23 @@ endif()
 # ANCHOR: book_cmake_setup-4
 if(NOT USE_QT5)
     find_package(Qt6 COMPONENTS ${CXXQT_QTCOMPONENTS})
+    set(Qt "Qt6")
 endif()
 if(NOT Qt6_FOUND)
     find_package(Qt5 5.15 COMPONENTS ${CXXQT_QTCOMPONENTS} REQUIRED)
+    set(Qt "Qt5")
+endif()
+
+if(MSVC)
+    # Qt also needs to link against the non-debug version of the MSVC Runtime libraries.
+    # Note: The Qt:: targets are ALIAS targets that do not support setting properties directly.
+    # We therefore need to resolve the target names to either Qt5 or Qt6 directly.
+    set_property(
+        TARGET ${Qt}::Core ${Qt}::Gui ${Qt}::Qml ${Qt}::QuickControls2 ${Qt}::QuickTest ${Qt}::Test
+        PROPERTY MAP_IMPORTED_CONFIG_DEBUG "RELEASE")
 endif()
 # ANCHOR_END: book_cmake_setup-4
+
 
 # ANCHOR: book_cmake_find_cxx_qt_start
 find_package(CxxQt QUIET)

--- a/examples/qml_multi_crates/CMakeLists.txt
+++ b/examples/qml_multi_crates/CMakeLists.txt
@@ -34,9 +34,20 @@ endif()
 
 if(NOT USE_QT5)
     find_package(Qt6 COMPONENTS ${CXXQT_QTCOMPONENTS})
+    set(Qt "Qt6")
 endif()
 if(NOT Qt6_FOUND)
     find_package(Qt5 5.15 COMPONENTS ${CXXQT_QTCOMPONENTS} REQUIRED)
+    set(Qt "Qt5")
+endif()
+
+if(MSVC)
+    # Qt also needs to link against the non-debug version of the MSVC Runtime libraries, see the previous comment.
+    # Note: The Qt:: targets are ALIAS targets that do not support setting properties directly.
+    # We therefore need to resolve the target names to either Qt5 or Qt6 directly.
+    set_property(
+        TARGET ${Qt}::Core ${Qt}::Gui ${Qt}::Qml ${Qt}::QuickControls2 ${Qt}::QuickTest ${Qt}::Test
+        PROPERTY MAP_IMPORTED_CONFIG_DEBUG "RELEASE")
 endif()
 
 find_package(CxxQt QUIET)

--- a/examples/qml_multi_crates/CMakeLists.txt
+++ b/examples/qml_multi_crates/CMakeLists.txt
@@ -46,7 +46,7 @@ if(MSVC)
     # Note: The Qt:: targets are ALIAS targets that do not support setting properties directly.
     # We therefore need to resolve the target names to either Qt5 or Qt6 directly.
     set_property(
-        TARGET ${Qt}::Core ${Qt}::Gui ${Qt}::Qml ${Qt}::QuickControls2 ${Qt}::QuickTest ${Qt}::Test
+        TARGET ${Qt}::Core ${Qt}::Gui ${Qt}::Qml ${Qt}::QuickControls2 ${Qt}::QuickTest ${Qt}::Test ${Qt}::Network
         PROPERTY MAP_IMPORTED_CONFIG_DEBUG "RELEASE")
 endif()
 

--- a/tests/basic_cxx_only/CMakeLists.txt
+++ b/tests/basic_cxx_only/CMakeLists.txt
@@ -24,10 +24,21 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT USE_QT5)
-    find_package(Qt6 COMPONENTS Core Gui Qml Test)
+    find_package(Qt6 COMPONENTS Core Gui Qml Test QuickControls2)
+    set(Qt "Qt6")
 endif()
 if(NOT Qt6_FOUND)
     find_package(Qt5 5.15 COMPONENTS Core Gui Qml Test QuickControls2 REQUIRED)
+    set(Qt "Qt5")
+endif()
+
+if(MSVC)
+    # Qt also needs to link against the non-debug version of the MSVC Runtime libraries, see the previous comment.
+    # Note: The Qt:: targets are ALIAS targets that do not support setting properties directly.
+    # We therefore need to resolve the target names to either Qt5 or Qt6 directly.
+    set_property(
+        TARGET ${Qt}::Core ${Qt}::Gui ${Qt}::Qml ${Qt}::Test ${Qt}::QuickControls2
+        PROPERTY MAP_IMPORTED_CONFIG_DEBUG "RELEASE")
 endif()
 
 find_package(CxxQt QUIET)

--- a/tests/basic_cxx_qt/CMakeLists.txt
+++ b/tests/basic_cxx_qt/CMakeLists.txt
@@ -24,10 +24,21 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT USE_QT5)
-    find_package(Qt6 COMPONENTS Core Gui Qml Test)
+    find_package(Qt6 COMPONENTS Core Gui Qml Test QuickControls2)
+    set(Qt "Qt6")
 endif()
 if(NOT Qt6_FOUND)
     find_package(Qt5 5.15 COMPONENTS Core Gui Qml Test QuickControls2 REQUIRED)
+    set(Qt "Qt5")
+endif()
+
+if(MSVC)
+    # Qt also needs to link against the non-debug version of the MSVC Runtime libraries, see the previous comment.
+    # Note: The Qt:: targets are ALIAS targets that do not support setting properties directly.
+    # We therefore need to resolve the target names to either Qt5 or Qt6 directly.
+    set_property(
+        TARGET ${Qt}::Core ${Qt}::Gui ${Qt}::Qml ${Qt}::Test ${Qt}::QuickControls2
+        PROPERTY MAP_IMPORTED_CONFIG_DEBUG "RELEASE")
 endif()
 
 find_package(CxxQt QUIET)

--- a/tests/qt_types_standalone/CMakeLists.txt
+++ b/tests/qt_types_standalone/CMakeLists.txt
@@ -24,10 +24,21 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT USE_QT5)
-    find_package(Qt6 COMPONENTS Core Gui Qml Test)
+    find_package(Qt6 COMPONENTS Core Gui Qml Test QuickControls2)
+    set(Qt "Qt6")
 endif()
 if(NOT Qt6_FOUND)
     find_package(Qt5 5.15 COMPONENTS Core Gui Qml Test QuickControls2 REQUIRED)
+    set(Qt "Qt5")
+endif()
+
+if(MSVC)
+    # Qt also needs to link against the non-debug version of the MSVC Runtime libraries, see the previous comment.
+    # Note: The Qt:: targets are ALIAS targets that do not support setting properties directly.
+    # We therefore need to resolve the target names to either Qt5 or Qt6 directly.
+    set_property(
+        TARGET ${Qt}::Core ${Qt}::Gui ${Qt}::Qml ${Qt}::Test ${Qt}::QuickControls2
+        PROPERTY MAP_IMPORTED_CONFIG_DEBUG "RELEASE")
 endif()
 
 find_package(CxxQt QUIET)


### PR DESCRIPTION
- **MSVC: Link Qt components to Release runtime**
- **Windows CI: Build Qt6 in Debug**
