### PR TITLE
github: move to Qt 6.9.0 for CI tests

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -288,7 +288,7 @@ jobs:
           - name: Ubuntu 24.04 (gcc) Qt6
             os: ubuntu-24.04
             qt_version: 6
-            aqt_version: '6.8.0'
+            aqt_version: '6.9.0'
             aqt_arch: 'linux_gcc_64'
             aqt_host: 'linux'
             cores: 4
@@ -330,10 +330,10 @@ jobs:
           - name: macOS 14 (clang) Qt6
             os: macos-14
             qt_version: 6
-            aqt_version: '6.8.0'
+            aqt_version: '6.9.0'
             aqt_arch: 'clang_64'
             aqt_host: 'mac'
-            dyld_framework_path: /Users/runner/work/cxx-qt/Qt/6.8.0/macos/lib
+            dyld_framework_path: /Users/runner/work/cxx-qt/Qt/6.9.0/macos/lib
             # https://doc.qt.io/qt-6.7/macos.html#target-platforms
             macosx_deployment_target: '13.0'
             cores: 3
@@ -386,7 +386,7 @@ jobs:
           - name: Windows 2022 (MSVC2022) Qt6
             os: windows-2022
             qt_version: 6
-            aqt_version: '6.8.0'
+            aqt_version: '6.9.0'
             aqt_arch: 'win64_msvc2022_64'
             aqt_host: 'windows'
             cores: 4


### PR DESCRIPTION
Requires #1257 