### PR TITLE
Add AsQobject trait

### DIFF
--- a/book/src/bridge/traits.md
+++ b/book/src/bridge/traits.md
@@ -26,6 +26,8 @@ For further documentation, refer to the documentation of the individual traits:
 - [Constructor](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Constructor.html) - custom constructor
 - [Initialize](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Initialize.html) - execute Rust code when the object is constructed, or as shorthand for an empty constructor
 - [Threading](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Threading.html) - marker trait whether CXX-Qt threading should be enabled
+- [QObjectExt](https://docs.rs/cxx-qt/latest/cxx_qt_lib/trait.QObjectExt.html) - Trait which exposes some key methods of QObject
+  - This trait is automatically implemented for anything that upcasts (see below) into QObject, even transitively such as having QObject as its grandparent.
 
 > ⚠️ These traits should only be implemented if you are sure you need to, they are automatically implemented for RustQt types.
 

--- a/crates/cxx-qt/src/qobject.rs
+++ b/crates/cxx-qt/src/qobject.rs
@@ -16,10 +16,6 @@ mod ffi {
         ///
         /// Qt Documentation: [QObject](https://doc.qt.io/qt/qobject.html#details)
         type QObject;
-
-        #[cxx_name = "dumpObjectInfo"]
-        /// Dumps information about signal connections, etc. for this object to the debug output.
-        fn dump_object_info(&self);
     }
 }
 


### PR DESCRIPTION
A trait which will wrap the QObjectExt methods for types which upcast to QObject. When used in conjunction with #1252 and #1226, this will allow any type that inherits from QObject - even if this is through many levels of inheritance - to have an `as_qobject` method, and if the trait is imported, expose the methods of QObject directly on that child class. Closes #562.