### PR TITLE
Add a lifetime parameter to QMetaObjectConnectionGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Casting is automatically implemented for qobjects or types which have `#[base = T]` in `"RustQt"` or `"C++Qt"` blocks
 - Support for `QMessageLogContext` and sending log messages to the Qt message handler.
 - Serde support for further types: `QByteArray`, `QSet`, `QStringList`, `QVector`, `QUrl`
-
-### Changed
-
-- Add lifetime parameter to `QMetaObjectConnectionGuard`.
+- Add `QScopedMetaObjectConnectionGuard`, which is `QMetaObjectConnectionGuard` with a scoped lifetime. `QMetaObjectConnectionGuard` is now a type alias for `QScopedMetaObjectConnectionGuard<'static>`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `QMessageLogContext` and sending log messages to the Qt message handler.
 - Serde support for further types: `QByteArray`, `QSet`, `QStringList`, `QVector`, `QUrl`
 
+### Changed
+
+- Add lifetime parameter to `QMetaObjectConnectionGuard`.
+
 ### Removed
 
 - CXX-Qt-build: Interface no longer includes compiler definitions (<https://github.com/KDAB/cxx-qt/issues/1165>)

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -280,7 +280,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    type MyObjectCxxQtSignalHandlertrivialPropertyChanged = cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosuretrivialPropertyChanged>;
+                    type MyObjectCxxQtSignalHandlertrivialPropertyChanged<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosuretrivialPropertyChanged>;
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
@@ -310,7 +310,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "trivialPropertyChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_trivial_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn connect_trivial_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_trivial_property_changed(
                             self,
@@ -330,7 +330,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_trivial_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn on_trivial_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_trivial_property_changed(
                             self,
@@ -353,7 +353,7 @@ mod tests {
             parse_quote! {
                 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosuretrivialPropertyChanged {
                     type Id = cxx::type_id!("::rust::cxxqtgen1::MyObjectCxxQtSignalHandlertrivialPropertyChanged");
-                    type FnType = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + Send;
+                    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send;
                 }
             },
         );
@@ -405,7 +405,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    type MyObjectCxxQtSignalHandleropaquePropertyChanged = cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosureopaquePropertyChanged>;
+                    type MyObjectCxxQtSignalHandleropaquePropertyChanged<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosureopaquePropertyChanged>;
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
@@ -435,7 +435,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "opaquePropertyChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_opaque_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn connect_opaque_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_opaque_property_changed(
                             self,
@@ -455,7 +455,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_opaque_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn on_opaque_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_opaque_property_changed(
                             self,
@@ -478,7 +478,7 @@ mod tests {
             parse_quote! {
                 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosureopaquePropertyChanged {
                     type Id = cxx::type_id!("::rust::cxxqtgen1::MyObjectCxxQtSignalHandleropaquePropertyChanged");
-                    type FnType = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + Send;
+                    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send;
                 }
             },
         );
@@ -530,7 +530,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    type MyObjectCxxQtSignalHandlerunsafePropertyChanged = cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosureunsafePropertyChanged>;
+                    type MyObjectCxxQtSignalHandlerunsafePropertyChanged<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosureunsafePropertyChanged>;
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
@@ -560,7 +560,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "unsafePropertyChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_unsafe_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn connect_unsafe_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_property_changed(
                             self,
@@ -580,7 +580,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_unsafe_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn on_unsafe_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_property_changed(
                             self,
@@ -603,7 +603,7 @@ mod tests {
             parse_quote! {
                 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosureunsafePropertyChanged {
                     type Id = cxx::type_id!("::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerunsafePropertyChanged");
-                    type FnType = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + Send;
+                    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send;
                 }
             },
         );

--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -310,9 +310,9 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "trivialPropertyChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_trivial_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn connect_trivial_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_trivial_property_changed(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_trivial_property_changed(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosuretrivialPropertyChanged>::new(Box::new(closure)),
                             conn_type,
@@ -330,9 +330,9 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_trivial_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn on_trivial_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_trivial_property_changed(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_trivial_property_changed(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosuretrivialPropertyChanged>::new(Box::new(closure)),
                             cxx_qt::ConnectionType::AutoConnection,
@@ -435,9 +435,9 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "opaquePropertyChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_opaque_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn connect_opaque_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_opaque_property_changed(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_opaque_property_changed(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureopaquePropertyChanged>::new(Box::new(closure)),
                             conn_type,
@@ -455,9 +455,9 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_opaque_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn on_opaque_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_opaque_property_changed(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_opaque_property_changed(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureopaquePropertyChanged>::new(Box::new(closure)),
                             cxx_qt::ConnectionType::AutoConnection,
@@ -560,9 +560,9 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "unsafePropertyChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_unsafe_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn connect_unsafe_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_property_changed(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_property_changed(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureunsafePropertyChanged>::new(Box::new(closure)),
                             conn_type,
@@ -580,9 +580,9 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_unsafe_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn on_unsafe_property_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_property_changed(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_property_changed(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureunsafePropertyChanged>::new(Box::new(closure)),
                             cxx_qt::ConnectionType::AutoConnection,

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -294,7 +294,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    type MyObjectCxxQtSignalHandlerready = cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosureready>;
+                    type MyObjectCxxQtSignalHandlerready<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosureready>;
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
@@ -324,7 +324,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "ready"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_ready<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn connect_ready<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_ready(
                             self,
@@ -344,7 +344,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_ready<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn on_ready<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_ready(
                             self,
@@ -367,7 +367,7 @@ mod tests {
             quote! {
                 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosureready {
                     type Id = cxx::type_id!("::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerready");
-                    type FnType = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + Send;
+                    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send;
                 }
             },
         );
@@ -474,7 +474,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    type MyObjectCxxQtSignalHandlerdataChanged = cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosuredataChanged>;
+                    type MyObjectCxxQtSignalHandlerdataChanged<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosuredataChanged>;
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
@@ -504,7 +504,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "dataChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_data_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn connect_data_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_data_changed(
                             self,
@@ -524,7 +524,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_data_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn on_data_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_data_changed(
                             self,
@@ -547,7 +547,7 @@ mod tests {
             quote! {
                 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosuredataChanged {
                     type Id = cxx::type_id!("::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerdataChanged");
-                    type FnType = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + Send;
+                    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'a + Send;
                 }
             },
         );
@@ -616,7 +616,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    type MyObjectCxxQtSignalHandlerunsafeSignal = cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosureunsafeSignal>;
+                    type MyObjectCxxQtSignalHandlerunsafeSignal<'s> = cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosureunsafeSignal>;
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
@@ -646,7 +646,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "unsafeSignal"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_unsafe_signal<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'static +Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn connect_unsafe_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'a +Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_signal(
                             self,
@@ -666,7 +666,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_unsafe_signal<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn on_unsafe_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_signal(
                             self,
@@ -689,7 +689,7 @@ mod tests {
             quote! {
                 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosureunsafeSignal {
                     type Id = cxx::type_id!("::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerunsafeSignal");
-                    type FnType = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + Send;
+                    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'a + Send;
                 }
             },
         );
@@ -759,7 +759,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    type MyObjectCxxQtSignalHandlerbaseName = cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosurebaseName>;
+                    type MyObjectCxxQtSignalHandlerbaseName<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosurebaseName>;
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
@@ -789,7 +789,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "baseName"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_existing_signal<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn connect_existing_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_existing_signal(
                             self,
@@ -809,7 +809,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_existing_signal<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn on_existing_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_existing_signal(
                             self,
@@ -832,7 +832,7 @@ mod tests {
             quote! {
                 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosurebaseName {
                     type Id = cxx::type_id!("::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerbaseName");
-                    type FnType = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + Send;
+                    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send;
                 }
             },
         );

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -175,9 +175,9 @@ pub fn generate_rust_signal(
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = #signal_name_cpp]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn #connect_ident_rust<'a, F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'a + Send>(self: #self_type_qualified, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn #connect_ident_rust<'a, F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'a + Send>(self: #self_type_qualified, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(#module_ident::#free_connect_ident_rust(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(#module_ident::#free_connect_ident_rust(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<#closure_struct>::new(Box::new(closure)),
                             conn_type,
@@ -194,9 +194,9 @@ pub fn generate_rust_signal(
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn #on_ident_rust<'a, F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'a + Send>(self: #self_type_qualified, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn #on_ident_rust<'a, F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'a + Send>(self: #self_type_qualified, closure: F) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(#module_ident::#free_connect_ident_rust(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(#module_ident::#free_connect_ident_rust(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<#closure_struct>::new(Box::new(closure)),
                             cxx_qt::ConnectionType::AutoConnection,
@@ -324,9 +324,9 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "ready"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_ready<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn connect_ready<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_ready(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_ready(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureready>::new(Box::new(closure)),
                             conn_type,
@@ -344,9 +344,9 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_ready<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn on_ready<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_ready(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_ready(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureready>::new(Box::new(closure)),
                             cxx_qt::ConnectionType::AutoConnection,
@@ -504,9 +504,9 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "dataChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_data_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn connect_data_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_data_changed(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_data_changed(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosuredataChanged>::new(Box::new(closure)),
                             conn_type,
@@ -524,9 +524,9 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_data_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn on_data_changed<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_data_changed(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_data_changed(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosuredataChanged>::new(Box::new(closure)),
                             cxx_qt::ConnectionType::AutoConnection,
@@ -646,9 +646,9 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "unsafeSignal"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_unsafe_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'a +Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn connect_unsafe_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'a +Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_signal(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_signal(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureunsafeSignal>::new(Box::new(closure)),
                             conn_type,
@@ -666,9 +666,9 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_unsafe_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn on_unsafe_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_signal(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_signal(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureunsafeSignal>::new(Box::new(closure)),
                             cxx_qt::ConnectionType::AutoConnection,
@@ -789,9 +789,9 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "baseName"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn connect_existing_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn connect_existing_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_existing_signal(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_existing_signal(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosurebaseName>::new(Box::new(closure)),
                             conn_type,
@@ -809,9 +809,9 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn on_existing_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
+                    pub fn on_existing_signal<'a, F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'a + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a>
                     {
-                        cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_existing_signal(
+                        cxx_qt::QScopedMetaObjectConnectionGuard::from(qobject::MyObject_connect_existing_signal(
                             self,
                             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosurebaseName>::new(Box::new(closure)),
                             cxx_qt::ConnectionType::AutoConnection,

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -175,7 +175,7 @@ pub fn generate_rust_signal(
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = #signal_name_cpp]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn #connect_ident_rust<F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'static + Send>(self: #self_type_qualified, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'static>
+                    pub fn #connect_ident_rust<'a, F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'a + Send>(self: #self_type_qualified, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(#module_ident::#free_connect_ident_rust(
                             self,
@@ -194,7 +194,7 @@ pub fn generate_rust_signal(
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn #on_ident_rust<F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'static + Send>(self: #self_type_qualified, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'static>
+                    pub fn #on_ident_rust<'a, F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'a + Send>(self: #self_type_qualified, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'a>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(#module_ident::#free_connect_ident_rust(
                             self,

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -616,7 +616,7 @@ mod tests {
                 unsafe extern "C++" {
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]
-                    type MyObjectCxxQtSignalHandlerunsafeSignal<'s> = cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosureunsafeSignal>;
+                    type MyObjectCxxQtSignalHandlerunsafeSignal<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosureunsafeSignal>;
 
                     #[doc(hidden)]
                     #[namespace = "rust::cxxqtgen1"]

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -144,7 +144,7 @@ pub fn generate_rust_signal(
             unsafe extern "C++" {
                 #[doc(hidden)]
                 #[namespace = #namespace_str]
-                type #signal_handler_alias = cxx_qt::signalhandler::CxxQtSignalHandler<super::#closure_struct>;
+                type #signal_handler_alias<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::#closure_struct>;
 
                 #[doc(hidden)]
                 #[namespace = #namespace_str]
@@ -175,7 +175,7 @@ pub fn generate_rust_signal(
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = #signal_name_cpp]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-                    pub fn #connect_ident_rust<F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'static + Send>(self: #self_type_qualified, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn #connect_ident_rust<F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'static + Send>(self: #self_type_qualified, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard<'static>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(#module_ident::#free_connect_ident_rust(
                             self,
@@ -194,7 +194,7 @@ pub fn generate_rust_signal(
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
-                    pub fn #on_ident_rust<F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'static + Send>(self: #self_type_qualified, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
+                    pub fn #on_ident_rust<F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'static + Send>(self: #self_type_qualified, closure: F) -> cxx_qt::QMetaObjectConnectionGuard<'static>
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(#module_ident::#free_connect_ident_rust(
                             self,
@@ -215,7 +215,7 @@ pub fn generate_rust_signal(
                 #(#cfgs)*
                 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for #closure_struct {
                     type Id = cxx::type_id!(#signal_handler_alias_namespaced_str);
-                    type FnType = dyn FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + Send;
+                    type FnType<'a> = dyn FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'a + Send;
                 }
             },
             parse_quote_spanned! {

--- a/crates/cxx-qt-gen/test_outputs/cfgs.rs
+++ b/crates/cxx-qt-gen/test_outputs/cfgs.rs
@@ -99,8 +99,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "rust::cxxqtgen1"]
-        type QObjectEnabledCxxQtSignalHandlersignal_disabled =
+        type QObjectEnabledCxxQtSignalHandlersignal_disabled<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::QObjectEnabledCxxQtSignalClosuresignal_disabled,
             >;
         #[doc(hidden)]
@@ -134,8 +135,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "rust::cxxqtgen1"]
-        type QObjectEnabledCxxQtSignalHandlersignal_enabled =
+        type QObjectEnabledCxxQtSignalHandlersignal_enabled<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::QObjectEnabledCxxQtSignalClosuresignal_enabled,
             >;
         #[doc(hidden)]
@@ -241,8 +243,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "rust::cxxqtgen1"]
-        type QObjectDisabledCxxQtSignalHandlersignal_disabled =
+        type QObjectDisabledCxxQtSignalHandlersignal_disabled<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::QObjectDisabledCxxQtSignalClosuresignal_disabled,
             >;
         #[doc(hidden)]
@@ -276,8 +279,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "rust::cxxqtgen1"]
-        type QObjectDisabledCxxQtSignalHandlersignal_enabled =
+        type QObjectDisabledCxxQtSignalHandlersignal_enabled<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::QObjectDisabledCxxQtSignalClosuresignal_enabled,
             >;
         #[doc(hidden)]
@@ -365,8 +369,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "rust::cxxqtgen1"]
-        type QObjectExternEnabledCxxQtSignalHandlersignal_disabled1 =
+        type QObjectExternEnabledCxxQtSignalHandlersignal_disabled1<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::QObjectExternEnabledCxxQtSignalClosuresignal_disabled1,
             >;
         #[doc(hidden)]
@@ -400,8 +405,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "rust::cxxqtgen1"]
-        type QObjectExternEnabledCxxQtSignalHandlersignal_enabled1 =
+        type QObjectExternEnabledCxxQtSignalHandlersignal_enabled1<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::QObjectExternEnabledCxxQtSignalClosuresignal_enabled1,
             >;
         #[doc(hidden)]
@@ -453,8 +459,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "rust::cxxqtgen1"]
-        type QObjectExternDisabledCxxQtSignalHandlersignal_disabled2 =
+        type QObjectExternDisabledCxxQtSignalHandlersignal_disabled2<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::QObjectExternDisabledCxxQtSignalClosuresignal_disabled2,
             >;
         #[doc(hidden)]
@@ -488,8 +495,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "rust::cxxqtgen1"]
-        type QObjectExternDisabledCxxQtSignalHandlersignal_enabled2 =
+        type QObjectExternDisabledCxxQtSignalHandlersignal_enabled2<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::QObjectExternDisabledCxxQtSignalClosuresignal_enabled2,
             >;
         #[doc(hidden)]

--- a/crates/cxx-qt-gen/test_outputs/cfgs.rs
+++ b/crates/cxx-qt-gen/test_outputs/cfgs.rs
@@ -526,12 +526,13 @@ impl ffi::QObjectEnabled {
     #[doc = "signal_disabled"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_signal_disabled<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectEnabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_disabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -549,11 +550,12 @@ impl ffi::QObjectEnabled {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_signal_disabled<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectEnabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_disabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -571,7 +573,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     for QObjectEnabledCxxQtSignalClosuresignal_disabled
 {
     type Id = cxx::type_id!("::rust::cxxqtgen1::QObjectEnabledCxxQtSignalHandlersignal_disabled");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'a + Send;
 }
 #[cfg(not(enabled))]
 use core::mem::drop as drop_QObjectEnabled_signal_handler_signal_disabled;
@@ -600,12 +602,13 @@ impl ffi::QObjectEnabled {
     #[doc = "signal_enabled"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_signal_enabled<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectEnabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_enabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -622,12 +625,10 @@ impl ffi::QObjectEnabled {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_signal_enabled<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'static + Send,
-    >(
+    pub fn on_signal_enabled<'a, F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::QObjectEnabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_enabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -645,7 +646,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     for QObjectEnabledCxxQtSignalClosuresignal_enabled
 {
     type Id = cxx::type_id!("::rust::cxxqtgen1::QObjectEnabledCxxQtSignalHandlersignal_enabled");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'a + Send;
 }
 #[cfg(enabled)]
 use core::mem::drop as drop_QObjectEnabled_signal_handler_signal_enabled;
@@ -705,12 +706,13 @@ impl ffi::QObjectDisabled {
     #[doc = "signal_disabled"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_signal_disabled<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectDisabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectDisabled_connect_signal_disabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -728,11 +730,12 @@ impl ffi::QObjectDisabled {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_signal_disabled<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectDisabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectDisabled_connect_signal_disabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -750,7 +753,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     for QObjectDisabledCxxQtSignalClosuresignal_disabled
 {
     type Id = cxx::type_id!("::rust::cxxqtgen1::QObjectDisabledCxxQtSignalHandlersignal_disabled");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'a + Send;
 }
 #[cfg(not(enabled))]
 use core::mem::drop as drop_QObjectDisabled_signal_handler_signal_disabled;
@@ -779,12 +782,13 @@ impl ffi::QObjectDisabled {
     #[doc = "signal_enabled"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_signal_enabled<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectDisabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectDisabled_connect_signal_enabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -802,11 +806,12 @@ impl ffi::QObjectDisabled {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_signal_enabled<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectDisabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectDisabled_connect_signal_enabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -824,7 +829,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     for QObjectDisabledCxxQtSignalClosuresignal_enabled
 {
     type Id = cxx::type_id!("::rust::cxxqtgen1::QObjectDisabledCxxQtSignalHandlersignal_enabled");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'a + Send;
 }
 #[cfg(enabled)]
 use core::mem::drop as drop_QObjectDisabled_signal_handler_signal_enabled;
@@ -892,12 +897,13 @@ impl ffi::QObjectExternEnabled {
     #[doc = "signal_disabled1"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_signal_disabled1<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternEnabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::QObjectExternEnabled_connect_signal_disabled1(
                 self,
@@ -917,11 +923,12 @@ impl ffi::QObjectExternEnabled {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_signal_disabled1<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternEnabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::QObjectExternEnabled_connect_signal_disabled1(
                 self,
@@ -942,7 +949,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
 {
     type Id =
         cxx::type_id!("::rust::cxxqtgen1::QObjectExternEnabledCxxQtSignalHandlersignal_disabled1");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'a + Send;
 }
 #[cfg(not(enabled))]
 use core::mem::drop as drop_QObjectExternEnabled_signal_handler_signal_disabled1;
@@ -975,12 +982,13 @@ impl ffi::QObjectExternEnabled {
     #[doc = "signal_enabled1"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_signal_enabled1<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternEnabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectExternEnabled_connect_signal_enabled1(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -998,11 +1006,12 @@ impl ffi::QObjectExternEnabled {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_signal_enabled1<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternEnabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectExternEnabled_connect_signal_enabled1(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -1021,7 +1030,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
 {
     type Id =
         cxx::type_id!("::rust::cxxqtgen1::QObjectExternEnabledCxxQtSignalHandlersignal_enabled1");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'a + Send;
 }
 #[cfg(enabled)]
 use core::mem::drop as drop_QObjectExternEnabled_signal_handler_signal_enabled1;
@@ -1062,12 +1071,13 @@ impl ffi::QObjectExternDisabled {
     #[doc = "signal_disabled2"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_signal_disabled2<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternDisabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::QObjectExternDisabled_connect_signal_disabled2(
                 self,
@@ -1087,11 +1097,12 @@ impl ffi::QObjectExternDisabled {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_signal_disabled2<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternDisabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::QObjectExternDisabled_connect_signal_disabled2(
                 self,
@@ -1112,7 +1123,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
 {
     type Id =
         cxx::type_id!("::rust::cxxqtgen1::QObjectExternDisabledCxxQtSignalHandlersignal_disabled2");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'a + Send;
 }
 #[cfg(not(enabled))]
 use core::mem::drop as drop_QObjectExternDisabled_signal_handler_signal_disabled2;
@@ -1145,12 +1156,13 @@ impl ffi::QObjectExternDisabled {
     #[doc = "signal_enabled2"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_signal_enabled2<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternDisabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::QObjectExternDisabled_connect_signal_enabled2(
                 self,
@@ -1170,11 +1182,12 @@ impl ffi::QObjectExternDisabled {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_signal_enabled2<
-        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternDisabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::QObjectExternDisabled_connect_signal_enabled2(
                 self,
@@ -1195,7 +1208,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
 {
     type Id =
         cxx::type_id!("::rust::cxxqtgen1::QObjectExternDisabledCxxQtSignalHandlersignal_enabled2");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'a + Send;
 }
 #[cfg(enabled)]
 use core::mem::drop as drop_QObjectExternDisabled_signal_handler_signal_enabled2;

--- a/crates/cxx-qt-gen/test_outputs/cfgs.rs
+++ b/crates/cxx-qt-gen/test_outputs/cfgs.rs
@@ -540,8 +540,8 @@ impl ffi::QObjectEnabled {
         self: core::pin::Pin<&mut ffi::QObjectEnabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_disabled(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_disabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
                 QObjectEnabledCxxQtSignalClosuresignal_disabled,
@@ -563,8 +563,8 @@ impl ffi::QObjectEnabled {
     >(
         self: core::pin::Pin<&mut ffi::QObjectEnabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_disabled(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_disabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
                 QObjectEnabledCxxQtSignalClosuresignal_disabled,
@@ -616,8 +616,8 @@ impl ffi::QObjectEnabled {
         self: core::pin::Pin<&mut ffi::QObjectEnabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_enabled(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_enabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
                 QObjectEnabledCxxQtSignalClosuresignal_enabled,
@@ -636,8 +636,8 @@ impl ffi::QObjectEnabled {
     pub fn on_signal_enabled<'a, F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::QObjectEnabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_enabled(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::QObjectEnabled_connect_signal_enabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
                 QObjectEnabledCxxQtSignalClosuresignal_enabled,
@@ -720,14 +720,16 @@ impl ffi::QObjectDisabled {
         self: core::pin::Pin<&mut ffi::QObjectDisabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectDisabled_connect_signal_disabled(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                QObjectDisabledCxxQtSignalClosuresignal_disabled,
-            >::new(Box::new(closure)),
-            conn_type,
-        ))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::QObjectDisabled_connect_signal_disabled(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    QObjectDisabledCxxQtSignalClosuresignal_disabled,
+                >::new(Box::new(closure)),
+                conn_type,
+            ),
+        )
     }
 }
 #[cfg(not(enabled))]
@@ -743,14 +745,16 @@ impl ffi::QObjectDisabled {
     >(
         self: core::pin::Pin<&mut ffi::QObjectDisabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectDisabled_connect_signal_disabled(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                QObjectDisabledCxxQtSignalClosuresignal_disabled,
-            >::new(Box::new(closure)),
-            cxx_qt::ConnectionType::AutoConnection,
-        ))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::QObjectDisabled_connect_signal_disabled(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    QObjectDisabledCxxQtSignalClosuresignal_disabled,
+                >::new(Box::new(closure)),
+                cxx_qt::ConnectionType::AutoConnection,
+            ),
+        )
     }
 }
 #[cfg(not(enabled))]
@@ -796,8 +800,8 @@ impl ffi::QObjectDisabled {
         self: core::pin::Pin<&mut ffi::QObjectDisabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectDisabled_connect_signal_enabled(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::QObjectDisabled_connect_signal_enabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
                 QObjectDisabledCxxQtSignalClosuresignal_enabled,
@@ -819,8 +823,8 @@ impl ffi::QObjectDisabled {
     >(
         self: core::pin::Pin<&mut ffi::QObjectDisabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectDisabled_connect_signal_enabled(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::QObjectDisabled_connect_signal_enabled(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
                 QObjectDisabledCxxQtSignalClosuresignal_enabled,
@@ -911,8 +915,8 @@ impl ffi::QObjectExternEnabled {
         self: core::pin::Pin<&mut ffi::QObjectExternEnabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::QObjectExternEnabled_connect_signal_disabled1(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -936,8 +940,8 @@ impl ffi::QObjectExternEnabled {
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternEnabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::QObjectExternEnabled_connect_signal_disabled1(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -996,14 +1000,16 @@ impl ffi::QObjectExternEnabled {
         self: core::pin::Pin<&mut ffi::QObjectExternEnabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectExternEnabled_connect_signal_enabled1(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                QObjectExternEnabledCxxQtSignalClosuresignal_enabled1,
-            >::new(Box::new(closure)),
-            conn_type,
-        ))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::QObjectExternEnabled_connect_signal_enabled1(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    QObjectExternEnabledCxxQtSignalClosuresignal_enabled1,
+                >::new(Box::new(closure)),
+                conn_type,
+            ),
+        )
     }
 }
 #[cfg(enabled)]
@@ -1019,14 +1025,16 @@ impl ffi::QObjectExternEnabled {
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternEnabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QObjectExternEnabled_connect_signal_enabled1(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                QObjectExternEnabledCxxQtSignalClosuresignal_enabled1,
-            >::new(Box::new(closure)),
-            cxx_qt::ConnectionType::AutoConnection,
-        ))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::QObjectExternEnabled_connect_signal_enabled1(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    QObjectExternEnabledCxxQtSignalClosuresignal_enabled1,
+                >::new(Box::new(closure)),
+                cxx_qt::ConnectionType::AutoConnection,
+            ),
+        )
     }
 }
 #[cfg(enabled)]
@@ -1085,8 +1093,8 @@ impl ffi::QObjectExternDisabled {
         self: core::pin::Pin<&mut ffi::QObjectExternDisabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::QObjectExternDisabled_connect_signal_disabled2(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -1110,8 +1118,8 @@ impl ffi::QObjectExternDisabled {
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternDisabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::QObjectExternDisabled_connect_signal_disabled2(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -1170,8 +1178,8 @@ impl ffi::QObjectExternDisabled {
         self: core::pin::Pin<&mut ffi::QObjectExternDisabled>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::QObjectExternDisabled_connect_signal_enabled2(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -1195,8 +1203,8 @@ impl ffi::QObjectExternDisabled {
     >(
         self: core::pin::Pin<&mut ffi::QObjectExternDisabled>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::QObjectExternDisabled_connect_signal_enabled2(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -105,8 +105,9 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::multi_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlerpropertyNameChanged =
+        type MyObjectCxxQtSignalHandlerpropertyNameChanged<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::MyObjectCxxQtSignalClosurepropertyNameChanged,
             >;
         #[doc(hidden)]
@@ -226,8 +227,9 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "second_object::rust::cxxqtgen1"]
-        type SecondObjectCxxQtSignalHandlerpropertyNameChanged =
+        type SecondObjectCxxQtSignalHandlerpropertyNameChanged<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::SecondObjectCxxQtSignalClosurepropertyNameChanged,
             >;
         #[doc(hidden)]
@@ -271,8 +273,10 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "second_object::rust::cxxqtgen1"]
-        type SecondObjectCxxQtSignalHandlerready<'a> =
-            cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::SecondObjectCxxQtSignalClosureready>;
+        type SecondObjectCxxQtSignalHandlerready<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<
+            'a,
+            super::SecondObjectCxxQtSignalClosureready,
+        >;
         #[doc(hidden)]
         #[namespace = "second_object::rust::cxxqtgen1"]
         #[cxx_name = "SecondObject_readyConnect"]
@@ -409,8 +413,10 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::multi_object::rust::cxxqtgen1"]
-        type QPushButtonCxxQtSignalHandlerclicked<'a> =
-            cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::QPushButtonCxxQtSignalClosureclicked>;
+        type QPushButtonCxxQtSignalHandlerclicked<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<
+            'a,
+            super::QPushButtonCxxQtSignalClosureclicked,
+        >;
         #[doc(hidden)]
         #[namespace = "cxx_qt::multi_object::rust::cxxqtgen1"]
         #[cxx_name = "QPushButton_clickedConnect"]
@@ -439,9 +445,11 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "mynamespace::rust::cxxqtgen1"]
-        type ExternObjectCxxQtSignalHandlerdataReady = cxx_qt::signalhandler::CxxQtSignalHandler<
-            super::ExternObjectCxxQtSignalClosuredataReady,
-        >;
+        type ExternObjectCxxQtSignalHandlerdataReady<'a> =
+            cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
+                super::ExternObjectCxxQtSignalClosuredataReady,
+            >;
         #[doc(hidden)]
         #[namespace = "mynamespace::rust::cxxqtgen1"]
         #[cxx_name = "ExternObjectCpp_dataReadyConnect"]
@@ -471,8 +479,9 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "mynamespace::rust::cxxqtgen1"]
-        type ExternObjectCxxQtSignalHandlererrorOccurred =
+        type ExternObjectCxxQtSignalHandlererrorOccurred<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::ExternObjectCxxQtSignalClosureerrorOccurred,
             >;
         #[doc(hidden)]

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -718,13 +718,15 @@ impl ffi::SecondObject {
         closure: F,
         conn_type: cxx_qt::ConnectionType,
     ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
-        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::SecondObject_connect_property_name_changed(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                SecondObjectCxxQtSignalClosurepropertyNameChanged,
-            >::new(Box::new(closure)),
-            conn_type,
-        ))
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::SecondObject_connect_property_name_changed(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    SecondObjectCxxQtSignalClosurepropertyNameChanged,
+                >::new(Box::new(closure)),
+                conn_type,
+            ),
+        )
     }
 }
 impl ffi::SecondObject {
@@ -740,13 +742,15 @@ impl ffi::SecondObject {
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
     ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
-        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::SecondObject_connect_property_name_changed(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                SecondObjectCxxQtSignalClosurepropertyNameChanged,
-            >::new(Box::new(closure)),
-            cxx_qt::ConnectionType::AutoConnection,
-        ))
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::SecondObject_connect_property_name_changed(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    SecondObjectCxxQtSignalClosurepropertyNameChanged,
+                >::new(Box::new(closure)),
+                cxx_qt::ConnectionType::AutoConnection,
+            ),
+        )
     }
 }
 #[doc(hidden)]

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -541,8 +541,8 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_property_name_changed(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::MyObject_connect_property_name_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
                 MyObjectCxxQtSignalClosurepropertyNameChanged,
@@ -563,8 +563,8 @@ impl ffi::MyObject {
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_property_name_changed(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::MyObject_connect_property_name_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
                 MyObjectCxxQtSignalClosurepropertyNameChanged,
@@ -608,8 +608,8 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureready>::new(
                 Box::new(closure),
@@ -627,8 +627,8 @@ impl ffi::MyObject {
     pub fn on_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureready>::new(
                 Box::new(closure),
@@ -717,8 +717,8 @@ impl ffi::SecondObject {
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::SecondObject_connect_property_name_changed(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::SecondObject_connect_property_name_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
                 SecondObjectCxxQtSignalClosurepropertyNameChanged,
@@ -739,8 +739,8 @@ impl ffi::SecondObject {
     >(
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::SecondObject_connect_property_name_changed(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::SecondObject_connect_property_name_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
                 SecondObjectCxxQtSignalClosurepropertyNameChanged,
@@ -784,8 +784,8 @@ impl ffi::SecondObject {
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::SecondObject_connect_ready(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::SecondObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<SecondObjectCxxQtSignalClosureready>::new(
                 Box::new(closure),
@@ -803,8 +803,8 @@ impl ffi::SecondObject {
     pub fn on_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::SecondObject_connect_ready(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::SecondObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<SecondObjectCxxQtSignalClosureready>::new(
                 Box::new(closure),
@@ -918,8 +918,8 @@ impl ffi::QPushButton {
         self: core::pin::Pin<&mut ffi::QPushButton>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QPushButton_connect_clicked(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::QPushButton_connect_clicked(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<QPushButtonCxxQtSignalClosureclicked>::new(
                 Box::new(closure),
@@ -937,8 +937,8 @@ impl ffi::QPushButton {
     pub fn on_clicked<'a, F: FnMut(core::pin::Pin<&mut ffi::QPushButton>, bool) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::QPushButton>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QPushButton_connect_clicked(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::QPushButton_connect_clicked(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<QPushButtonCxxQtSignalClosureclicked>::new(
                 Box::new(closure),
@@ -979,8 +979,8 @@ impl ffi::ExternObject {
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: ExternObject_connect_data_ready (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < ExternObjectCxxQtSignalClosuredataReady > :: new (Box :: new (closure)) , conn_type ,))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt :: QScopedMetaObjectConnectionGuard :: from (ffi :: ExternObject_connect_data_ready (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < ExternObjectCxxQtSignalClosuredataReady > :: new (Box :: new (closure)) , conn_type ,))
     }
 }
 impl ffi::ExternObject {
@@ -992,8 +992,8 @@ impl ffi::ExternObject {
     pub fn on_data_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: ExternObject_connect_data_ready (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < ExternObjectCxxQtSignalClosuredataReady > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt :: QScopedMetaObjectConnectionGuard :: from (ffi :: ExternObject_connect_data_ready (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < ExternObjectCxxQtSignalClosuredataReady > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
     }
 }
 #[doc(hidden)]
@@ -1031,8 +1031,8 @@ impl ffi::ExternObject {
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::ExternObject_connect_error_occurred(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -1052,8 +1052,8 @@ impl ffi::ExternObject {
     pub fn on_error_occurred<'a, F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::ExternObject_connect_error_occurred(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -144,8 +144,8 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::multi_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlerready =
-            cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosureready>;
+        type MyObjectCxxQtSignalHandlerready<'a> =
+            cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosureready>;
         #[doc(hidden)]
         #[namespace = "cxx_qt::multi_object::rust::cxxqtgen1"]
         #[cxx_name = "MyObject_readyConnect"]
@@ -271,8 +271,8 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "second_object::rust::cxxqtgen1"]
-        type SecondObjectCxxQtSignalHandlerready =
-            cxx_qt::signalhandler::CxxQtSignalHandler<super::SecondObjectCxxQtSignalClosureready>;
+        type SecondObjectCxxQtSignalHandlerready<'a> =
+            cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::SecondObjectCxxQtSignalClosureready>;
         #[doc(hidden)]
         #[namespace = "second_object::rust::cxxqtgen1"]
         #[cxx_name = "SecondObject_readyConnect"]
@@ -409,8 +409,8 @@ pub mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::multi_object::rust::cxxqtgen1"]
-        type QPushButtonCxxQtSignalHandlerclicked =
-            cxx_qt::signalhandler::CxxQtSignalHandler<super::QPushButtonCxxQtSignalClosureclicked>;
+        type QPushButtonCxxQtSignalHandlerclicked<'a> =
+            cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::QPushButtonCxxQtSignalClosureclicked>;
         #[doc(hidden)]
         #[namespace = "cxx_qt::multi_object::rust::cxxqtgen1"]
         #[cxx_name = "QPushButton_clickedConnect"]
@@ -526,12 +526,13 @@ impl ffi::MyObject {
     #[doc = "propertyNameChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_property_name_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_property_name_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -548,11 +549,12 @@ impl ffi::MyObject {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_property_name_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_property_name_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -570,7 +572,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     type Id = cxx::type_id!(
         "::cxx_qt::multi_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerpropertyNameChanged"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_propertyNameChanged;
 fn call_MyObject_signal_handler_propertyNameChanged(
@@ -593,11 +595,11 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "ready"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-    pub fn connect_ready<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
+    pub fn connect_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureready>::new(
@@ -613,10 +615,10 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_ready<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
+    pub fn on_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureready>::new(
@@ -631,7 +633,7 @@ pub struct MyObjectCxxQtSignalClosureready {}
 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosureready {
     type Id =
         cxx::type_id!("::cxx_qt::multi_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerready");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_ready;
 fn call_MyObject_signal_handler_ready(
@@ -700,12 +702,13 @@ impl ffi::SecondObject {
     #[doc = "propertyNameChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_property_name_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::SecondObject_connect_property_name_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -722,11 +725,12 @@ impl ffi::SecondObject {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_property_name_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::SecondObject_connect_property_name_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -744,7 +748,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     type Id = cxx::type_id!(
         "::second_object::rust::cxxqtgen1::SecondObjectCxxQtSignalHandlerpropertyNameChanged"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::SecondObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'a + Send;
 }
 use core::mem::drop as drop_SecondObject_signal_handler_propertyNameChanged;
 fn call_SecondObject_signal_handler_propertyNameChanged(
@@ -767,11 +771,11 @@ impl ffi::SecondObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "ready"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-    pub fn connect_ready<F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'static + Send>(
+    pub fn connect_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::SecondObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<SecondObjectCxxQtSignalClosureready>::new(
@@ -787,10 +791,10 @@ impl ffi::SecondObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_ready<F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'static + Send>(
+    pub fn on_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::SecondObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<SecondObjectCxxQtSignalClosureready>::new(
@@ -805,7 +809,7 @@ pub struct SecondObjectCxxQtSignalClosureready {}
 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for SecondObjectCxxQtSignalClosureready {
     type Id =
         cxx::type_id!("::second_object::rust::cxxqtgen1::SecondObjectCxxQtSignalHandlerready");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::SecondObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'a + Send;
 }
 use core::mem::drop as drop_SecondObject_signal_handler_ready;
 fn call_SecondObject_signal_handler_ready(
@@ -899,12 +903,13 @@ impl ffi::QPushButton {
     #[doc = "clicked"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_clicked<
-        F: FnMut(core::pin::Pin<&mut ffi::QPushButton>, bool) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::QPushButton>, bool) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::QPushButton>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QPushButton_connect_clicked(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<QPushButtonCxxQtSignalClosureclicked>::new(
@@ -920,10 +925,10 @@ impl ffi::QPushButton {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_clicked<F: FnMut(core::pin::Pin<&mut ffi::QPushButton>, bool) + 'static + Send>(
+    pub fn on_clicked<'a, F: FnMut(core::pin::Pin<&mut ffi::QPushButton>, bool) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::QPushButton>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QPushButton_connect_clicked(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<QPushButtonCxxQtSignalClosureclicked>::new(
@@ -939,7 +944,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for QPushButtonCxxQtSignal
     type Id = cxx::type_id!(
         "::cxx_qt::multi_object::rust::cxxqtgen1::QPushButtonCxxQtSignalHandlerclicked"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::QPushButton>, bool) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::QPushButton>, bool) + 'a + Send;
 }
 use core::mem::drop as drop_QPushButton_signal_handler_clicked;
 fn call_QPushButton_signal_handler_clicked(
@@ -961,11 +966,11 @@ impl ffi::ExternObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "dataReady"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-    pub fn connect_data_ready<F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'static + Send>(
+    pub fn connect_data_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: ExternObject_connect_data_ready (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < ExternObjectCxxQtSignalClosuredataReady > :: new (Box :: new (closure)) , conn_type ,))
     }
 }
@@ -975,10 +980,10 @@ impl ffi::ExternObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_data_ready<F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'static + Send>(
+    pub fn on_data_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: ExternObject_connect_data_ready (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < ExternObjectCxxQtSignalClosuredataReady > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
     }
 }
@@ -987,7 +992,7 @@ pub struct ExternObjectCxxQtSignalClosuredataReady {}
 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for ExternObjectCxxQtSignalClosuredataReady {
     type Id =
         cxx::type_id!("::mynamespace::rust::cxxqtgen1::ExternObjectCxxQtSignalHandlerdataReady");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::ExternObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'a + Send;
 }
 use core::mem::drop as drop_ExternObject_signal_handler_dataReady;
 fn call_ExternObject_signal_handler_dataReady(
@@ -1011,12 +1016,13 @@ impl ffi::ExternObject {
     #[doc = "errorOccurred"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_error_occurred<
-        F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::ExternObject_connect_error_occurred(
                 self,
@@ -1034,10 +1040,10 @@ impl ffi::ExternObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_error_occurred<F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'static + Send>(
+    pub fn on_error_occurred<'a, F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::ExternObject_connect_error_occurred(
                 self,
@@ -1057,7 +1063,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     type Id = cxx::type_id!(
         "::mynamespace::rust::cxxqtgen1::ExternObjectCxxQtSignalHandlererrorOccurred"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::ExternObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'a + Send;
 }
 use core::mem::drop as drop_ExternObject_signal_handler_errorOccurred;
 fn call_ExternObject_signal_handler_errorOccurred(

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -609,12 +609,13 @@ impl ffi::MyObject {
     #[doc = "primitiveChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_primitive_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::MyObject_connect_primitive_changed(
                 self,
@@ -632,10 +633,10 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_primitive_changed<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
+    pub fn on_primitive_changed<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::MyObject_connect_primitive_changed(
                 self,
@@ -655,7 +656,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     type Id = cxx::type_id!(
         "::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerprimitiveChanged"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_primitiveChanged;
 fn call_MyObject_signal_handler_primitiveChanged(
@@ -678,13 +679,11 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "trivialChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-    pub fn connect_trivial_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
-    >(
+    pub fn connect_trivial_changed<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_trivial_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuretrivialChanged > :: new (Box :: new (closure)) , conn_type ,))
     }
 }
@@ -694,10 +693,10 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_trivial_changed<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
+    pub fn on_trivial_changed<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_trivial_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuretrivialChanged > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
     }
 }
@@ -707,7 +706,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClo
     type Id = cxx::type_id!(
         "::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlertrivialChanged"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_trivialChanged;
 fn call_MyObject_signal_handler_trivialChanged(
@@ -731,12 +730,13 @@ impl ffi::MyObject {
     #[doc = "propAutoCxxNameChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_prop_auto_cxx_name_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_prop_auto_cxx_name_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -753,11 +753,12 @@ impl ffi::MyObject {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_prop_auto_cxx_name_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_prop_auto_cxx_name_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -775,7 +776,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     type Id = cxx::type_id!(
         "::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerpropAutoCxxNameChanged"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_propAutoCxxNameChanged;
 fn call_MyObject_signal_handler_propAutoCxxNameChanged(
@@ -799,12 +800,13 @@ impl ffi::MyObject {
     #[doc = "customFunctionPropChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_custom_function_prop_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::MyObject_connect_custom_function_prop_changed(
                 self,
@@ -823,11 +825,12 @@ impl ffi::MyObject {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_custom_function_prop_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(
             ffi::MyObject_connect_custom_function_prop_changed(
                 self,
@@ -847,7 +850,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     type Id = cxx::type_id!(
         "::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlercustomFunctionPropChanged"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_customFunctionPropChanged;
 fn call_MyObject_signal_handler_customFunctionPropChanged(
@@ -871,12 +874,13 @@ impl ffi::MyObject {
     #[doc = "renamedPropertyChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_renamed_property_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_renamed_property_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -893,11 +897,12 @@ impl ffi::MyObject {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_renamed_property_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_renamed_property_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -915,7 +920,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     type Id = cxx::type_id!(
         "::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerrenamedPropertyChanged"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_renamedPropertyChanged;
 fn call_MyObject_signal_handler_renamedPropertyChanged(
@@ -939,12 +944,13 @@ impl ffi::MyObject {
     #[doc = "named_prop_2Changed"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_renamed_property_2_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_renamed_property_2_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -961,11 +967,12 @@ impl ffi::MyObject {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_renamed_property_2_changed<
-        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
+        'a,
+        F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_renamed_property_2_changed(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -983,7 +990,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure
     type Id = cxx::type_id!(
         "::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlernamed_prop_2Changed"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_named_prop_2Changed;
 fn call_MyObject_signal_handler_named_prop_2Changed(
@@ -1006,11 +1013,11 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "my_on_changed"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-    pub fn connect_my_on_changed<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
+    pub fn connect_my_on_changed<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_my_on_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuremy_on_changed > :: new (Box :: new (closure)) , conn_type ,))
     }
 }
@@ -1020,10 +1027,10 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_my_on_changed<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
+    pub fn on_my_on_changed<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_my_on_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuremy_on_changed > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
     }
 }
@@ -1033,7 +1040,7 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClo
     type Id = cxx::type_id!(
         "::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlermy_on_changed"
     );
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_my_on_changed;
 fn call_MyObject_signal_handler_my_on_changed(

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -625,8 +625,8 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::MyObject_connect_primitive_changed(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -646,8 +646,8 @@ impl ffi::MyObject {
     pub fn on_primitive_changed<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::MyObject_connect_primitive_changed(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -693,8 +693,8 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_trivial_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuretrivialChanged > :: new (Box :: new (closure)) , conn_type ,))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt :: QScopedMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_trivial_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuretrivialChanged > :: new (Box :: new (closure)) , conn_type ,))
     }
 }
 impl ffi::MyObject {
@@ -706,8 +706,8 @@ impl ffi::MyObject {
     pub fn on_trivial_changed<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_trivial_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuretrivialChanged > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt :: QScopedMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_trivial_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuretrivialChanged > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
     }
 }
 #[doc(hidden)]
@@ -746,14 +746,16 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_prop_auto_cxx_name_changed(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                MyObjectCxxQtSignalClosurepropAutoCxxNameChanged,
-            >::new(Box::new(closure)),
-            conn_type,
-        ))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::MyObject_connect_prop_auto_cxx_name_changed(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    MyObjectCxxQtSignalClosurepropAutoCxxNameChanged,
+                >::new(Box::new(closure)),
+                conn_type,
+            ),
+        )
     }
 }
 impl ffi::MyObject {
@@ -768,14 +770,16 @@ impl ffi::MyObject {
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_prop_auto_cxx_name_changed(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                MyObjectCxxQtSignalClosurepropAutoCxxNameChanged,
-            >::new(Box::new(closure)),
-            cxx_qt::ConnectionType::AutoConnection,
-        ))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::MyObject_connect_prop_auto_cxx_name_changed(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    MyObjectCxxQtSignalClosurepropAutoCxxNameChanged,
+                >::new(Box::new(closure)),
+                cxx_qt::ConnectionType::AutoConnection,
+            ),
+        )
     }
 }
 #[doc(hidden)]
@@ -816,8 +820,8 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::MyObject_connect_custom_function_prop_changed(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -840,8 +844,8 @@ impl ffi::MyObject {
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
             ffi::MyObject_connect_custom_function_prop_changed(
                 self,
                 cxx_qt::signalhandler::CxxQtSignalHandler::<
@@ -890,14 +894,16 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_renamed_property_changed(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                MyObjectCxxQtSignalClosurerenamedPropertyChanged,
-            >::new(Box::new(closure)),
-            conn_type,
-        ))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::MyObject_connect_renamed_property_changed(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    MyObjectCxxQtSignalClosurerenamedPropertyChanged,
+                >::new(Box::new(closure)),
+                conn_type,
+            ),
+        )
     }
 }
 impl ffi::MyObject {
@@ -912,14 +918,16 @@ impl ffi::MyObject {
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_renamed_property_changed(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                MyObjectCxxQtSignalClosurerenamedPropertyChanged,
-            >::new(Box::new(closure)),
-            cxx_qt::ConnectionType::AutoConnection,
-        ))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::MyObject_connect_renamed_property_changed(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    MyObjectCxxQtSignalClosurerenamedPropertyChanged,
+                >::new(Box::new(closure)),
+                cxx_qt::ConnectionType::AutoConnection,
+            ),
+        )
     }
 }
 #[doc(hidden)]
@@ -960,14 +968,16 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_renamed_property_2_changed(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                MyObjectCxxQtSignalClosurenamed_prop_2Changed,
-            >::new(Box::new(closure)),
-            conn_type,
-        ))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::MyObject_connect_renamed_property_2_changed(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    MyObjectCxxQtSignalClosurenamed_prop_2Changed,
+                >::new(Box::new(closure)),
+                conn_type,
+            ),
+        )
     }
 }
 impl ffi::MyObject {
@@ -982,14 +992,16 @@ impl ffi::MyObject {
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_renamed_property_2_changed(
-            self,
-            cxx_qt::signalhandler::CxxQtSignalHandler::<
-                MyObjectCxxQtSignalClosurenamed_prop_2Changed,
-            >::new(Box::new(closure)),
-            cxx_qt::ConnectionType::AutoConnection,
-        ))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(
+            ffi::MyObject_connect_renamed_property_2_changed(
+                self,
+                cxx_qt::signalhandler::CxxQtSignalHandler::<
+                    MyObjectCxxQtSignalClosurenamed_prop_2Changed,
+                >::new(Box::new(closure)),
+                cxx_qt::ConnectionType::AutoConnection,
+            ),
+        )
     }
 }
 #[doc(hidden)]
@@ -1027,8 +1039,8 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_my_on_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuremy_on_changed > :: new (Box :: new (closure)) , conn_type ,))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt :: QScopedMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_my_on_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuremy_on_changed > :: new (Box :: new (closure)) , conn_type ,))
     }
 }
 impl ffi::MyObject {
@@ -1040,8 +1052,8 @@ impl ffi::MyObject {
     pub fn on_my_on_changed<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_my_on_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuremy_on_changed > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt :: QScopedMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_my_on_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuremy_on_changed > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
     }
 }
 #[doc(hidden)]

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -146,9 +146,11 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlerprimitiveChanged = cxx_qt::signalhandler::CxxQtSignalHandler<
-            super::MyObjectCxxQtSignalClosureprimitiveChanged,
-        >;
+        type MyObjectCxxQtSignalHandlerprimitiveChanged<'a> =
+            cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
+                super::MyObjectCxxQtSignalClosureprimitiveChanged,
+            >;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
         #[cxx_name = "MyObject_primitiveChangedConnect"]
@@ -179,9 +181,11 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlertrivialChanged = cxx_qt::signalhandler::CxxQtSignalHandler<
-            super::MyObjectCxxQtSignalClosuretrivialChanged,
-        >;
+        type MyObjectCxxQtSignalHandlertrivialChanged<'a> =
+            cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
+                super::MyObjectCxxQtSignalClosuretrivialChanged,
+            >;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
         #[cxx_name = "MyObject_trivialChangedConnect"]
@@ -212,8 +216,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlerpropAutoCxxNameChanged =
+        type MyObjectCxxQtSignalHandlerpropAutoCxxNameChanged<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::MyObjectCxxQtSignalClosurepropAutoCxxNameChanged,
             >;
         #[doc(hidden)]
@@ -246,8 +251,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlercustomFunctionPropChanged =
+        type MyObjectCxxQtSignalHandlercustomFunctionPropChanged<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::MyObjectCxxQtSignalClosurecustomFunctionPropChanged,
             >;
         #[doc(hidden)]
@@ -280,8 +286,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlerrenamedPropertyChanged =
+        type MyObjectCxxQtSignalHandlerrenamedPropertyChanged<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::MyObjectCxxQtSignalClosurerenamedPropertyChanged,
             >;
         #[doc(hidden)]
@@ -314,8 +321,9 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlernamed_prop_2Changed =
+        type MyObjectCxxQtSignalHandlernamed_prop_2Changed<'a> =
             cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
                 super::MyObjectCxxQtSignalClosurenamed_prop_2Changed,
             >;
         #[doc(hidden)]
@@ -365,9 +373,11 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlermy_on_changed = cxx_qt::signalhandler::CxxQtSignalHandler<
-            super::MyObjectCxxQtSignalClosuremy_on_changed,
-        >;
+        type MyObjectCxxQtSignalHandlermy_on_changed<'a> =
+            cxx_qt::signalhandler::CxxQtSignalHandler<
+                'a,
+                super::MyObjectCxxQtSignalClosuremy_on_changed,
+            >;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
         #[cxx_name = "MyObject_my_on_changedConnect"]

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -87,7 +87,8 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlerdata_changed = cxx_qt::signalhandler::CxxQtSignalHandler<
+        type MyObjectCxxQtSignalHandlerdata_changed<'a> = cxx_qt::signalhandler::CxxQtSignalHandler<
+            'a,
             super::MyObjectCxxQtSignalClosuredata_changed,
         >;
         #[doc(hidden)]
@@ -347,7 +348,9 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClo
             cxx::UniquePtr<ffi::Opaque>,
             ffi::QPoint,
             &ffi::QPoint,
-        ) + 'a + Send;
+        )
+        + 'a
+        + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_data_changed;
 fn call_MyObject_signal_handler_data_changed(
@@ -438,7 +441,9 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClo
             cxx::UniquePtr<ffi::Opaque>,
             ffi::QPoint,
             &'a ffi::QPoint,
-        ) + 'a + Send;
+        )
+        + 'a
+        + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_newData;
 fn call_MyObject_signal_handler_newData(

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -238,8 +238,8 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureready>::new(
                 Box::new(closure),
@@ -257,8 +257,8 @@ impl ffi::MyObject {
     pub fn on_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureready>::new(
                 Box::new(closure),
@@ -308,8 +308,8 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_data_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuredata_changed > :: new (Box :: new (closure)) , conn_type ,))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt :: QScopedMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_data_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuredata_changed > :: new (Box :: new (closure)) , conn_type ,))
     }
 }
 impl ffi::MyObject {
@@ -332,8 +332,8 @@ impl ffi::MyObject {
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_data_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuredata_changed > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt :: QScopedMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_data_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuredata_changed > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
     }
 }
 #[doc(hidden)]
@@ -390,8 +390,8 @@ impl ffi::MyObject {
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_base_class_new_data(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::MyObject_connect_base_class_new_data(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosurenewData>::new(
                 Box::new(closure),
@@ -420,8 +420,8 @@ impl ffi::MyObject {
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_base_class_new_data(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::MyObject_connect_base_class_new_data(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosurenewData>::new(
                 Box::new(closure),
@@ -508,8 +508,8 @@ impl ffi::QTimer {
         self: core::pin::Pin<&mut ffi::QTimer>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QTimer_connect_timeout(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::QTimer_connect_timeout(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<QTimerCxxQtSignalClosuretimeout>::new(
                 Box::new(closure),
@@ -527,8 +527,8 @@ impl ffi::QTimer {
     pub fn on_timeout<'a, F: FnMut(core::pin::Pin<&mut ffi::QTimer>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::QTimer>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
-        cxx_qt::QMetaObjectConnectionGuard::from(ffi::QTimer_connect_timeout(
+    ) -> cxx_qt::QScopedMetaObjectConnectionGuard<'a> {
+        cxx_qt::QScopedMetaObjectConnectionGuard::from(ffi::QTimer_connect_timeout(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<QTimerCxxQtSignalClosuretimeout>::new(
                 Box::new(closure),

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -52,8 +52,8 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlerready =
-            cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosureready>;
+        type MyObjectCxxQtSignalHandlerready<'a> =
+            cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosureready>;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
         #[cxx_name = "MyObject_readyConnect"]
@@ -129,8 +129,8 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type MyObjectCxxQtSignalHandlernewData =
-            cxx_qt::signalhandler::CxxQtSignalHandler<super::MyObjectCxxQtSignalClosurenewData>;
+        type MyObjectCxxQtSignalHandlernewData<'a> =
+            cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::MyObjectCxxQtSignalClosurenewData>;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
         #[cxx_name = "MyObject_newDataConnect"]
@@ -202,8 +202,8 @@ mod ffi {
     unsafe extern "C++" {
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
-        type QTimerCxxQtSignalHandlertimeout =
-            cxx_qt::signalhandler::CxxQtSignalHandler<super::QTimerCxxQtSignalClosuretimeout>;
+        type QTimerCxxQtSignalHandlertimeout<'a> =
+            cxx_qt::signalhandler::CxxQtSignalHandler<'a, super::QTimerCxxQtSignalClosuretimeout>;
         #[doc(hidden)]
         #[namespace = "cxx_qt::my_object::rust::cxxqtgen1"]
         #[cxx_name = "QTimer_timeoutConnect"]
@@ -233,11 +233,11 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "ready"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-    pub fn connect_ready<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
+    pub fn connect_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureready>::new(
@@ -253,10 +253,10 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_ready<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
+    pub fn on_ready<'a, F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_ready(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosureready>::new(
@@ -271,7 +271,7 @@ pub struct MyObjectCxxQtSignalClosureready {}
 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosureready {
     type Id =
         cxx::type_id!("::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerready");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_ready;
 fn call_MyObject_signal_handler_ready(
@@ -293,6 +293,7 @@ impl ffi::MyObject {
     #[doc = "data_changed"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_data_changed<
+        'a,
         F: FnMut(
                 core::pin::Pin<&mut ffi::MyObject>,
                 i32,
@@ -300,13 +301,13 @@ impl ffi::MyObject {
                 ffi::QPoint,
                 &ffi::QPoint,
             )
-            + 'static
+            + 'a
             + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_data_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuredata_changed > :: new (Box :: new (closure)) , conn_type ,))
     }
 }
@@ -317,6 +318,7 @@ impl ffi::MyObject {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_data_changed<
+        'a,
         F: FnMut(
                 core::pin::Pin<&mut ffi::MyObject>,
                 i32,
@@ -324,12 +326,12 @@ impl ffi::MyObject {
                 ffi::QPoint,
                 &ffi::QPoint,
             )
-            + 'static
+            + 'a
             + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt :: QMetaObjectConnectionGuard :: from (ffi :: MyObject_connect_data_changed (self , cxx_qt :: signalhandler :: CxxQtSignalHandler :: < MyObjectCxxQtSignalClosuredata_changed > :: new (Box :: new (closure)) , cxx_qt :: ConnectionType :: AutoConnection ,))
     }
 }
@@ -339,13 +341,13 @@ impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClo
     type Id = cxx::type_id!(
         "::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlerdata_changed"
     );
-    type FnType = dyn FnMut(
+    type FnType<'a> = dyn FnMut(
             core::pin::Pin<&mut ffi::MyObject>,
             i32,
             cxx::UniquePtr<ffi::Opaque>,
             ffi::QPoint,
             &ffi::QPoint,
-        ) + Send;
+        ) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_data_changed;
 fn call_MyObject_signal_handler_data_changed(
@@ -371,6 +373,7 @@ impl ffi::MyObject {
     #[doc = "newData"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     pub fn connect_base_class_new_data<
+        'a,
         F: FnMut(
                 core::pin::Pin<&mut ffi::MyObject>,
                 i32,
@@ -378,13 +381,13 @@ impl ffi::MyObject {
                 ffi::QPoint,
                 &'a ffi::QPoint,
             )
-            + 'static
+            + 'a
             + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_base_class_new_data(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosurenewData>::new(
@@ -401,6 +404,7 @@ impl ffi::MyObject {
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
     pub fn on_base_class_new_data<
+        'a,
         F: FnMut(
                 core::pin::Pin<&mut ffi::MyObject>,
                 i32,
@@ -408,12 +412,12 @@ impl ffi::MyObject {
                 ffi::QPoint,
                 &'a ffi::QPoint,
             )
-            + 'static
+            + 'a
             + Send,
     >(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::MyObject_connect_base_class_new_data(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<MyObjectCxxQtSignalClosurenewData>::new(
@@ -428,13 +432,13 @@ pub struct MyObjectCxxQtSignalClosurenewData {}
 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for MyObjectCxxQtSignalClosurenewData {
     type Id =
         cxx::type_id!("::cxx_qt::my_object::rust::cxxqtgen1::MyObjectCxxQtSignalHandlernewData");
-    type FnType = dyn FnMut(
+    type FnType<'a> = dyn FnMut(
             core::pin::Pin<&mut ffi::MyObject>,
             i32,
             cxx::UniquePtr<ffi::Opaque>,
             ffi::QPoint,
             &'a ffi::QPoint,
-        ) + Send;
+        ) + 'a + Send;
 }
 use core::mem::drop as drop_MyObject_signal_handler_newData;
 fn call_MyObject_signal_handler_newData(
@@ -495,11 +499,11 @@ impl ffi::QTimer {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "timeout"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
-    pub fn connect_timeout<F: FnMut(core::pin::Pin<&mut ffi::QTimer>) + 'static + Send>(
+    pub fn connect_timeout<'a, F: FnMut(core::pin::Pin<&mut ffi::QTimer>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::QTimer>,
         closure: F,
         conn_type: cxx_qt::ConnectionType,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QTimer_connect_timeout(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<QTimerCxxQtSignalClosuretimeout>::new(
@@ -515,10 +519,10 @@ impl ffi::QTimer {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
-    pub fn on_timeout<F: FnMut(core::pin::Pin<&mut ffi::QTimer>) + 'static + Send>(
+    pub fn on_timeout<'a, F: FnMut(core::pin::Pin<&mut ffi::QTimer>) + 'a + Send>(
         self: core::pin::Pin<&mut ffi::QTimer>,
         closure: F,
-    ) -> cxx_qt::QMetaObjectConnectionGuard {
+    ) -> cxx_qt::QMetaObjectConnectionGuard<'a> {
         cxx_qt::QMetaObjectConnectionGuard::from(ffi::QTimer_connect_timeout(
             self,
             cxx_qt::signalhandler::CxxQtSignalHandler::<QTimerCxxQtSignalClosuretimeout>::new(
@@ -533,7 +537,7 @@ pub struct QTimerCxxQtSignalClosuretimeout {}
 impl cxx_qt::signalhandler::CxxQtSignalHandlerClosure for QTimerCxxQtSignalClosuretimeout {
     type Id =
         cxx::type_id!("::cxx_qt::my_object::rust::cxxqtgen1::QTimerCxxQtSignalHandlertimeout");
-    type FnType = dyn FnMut(core::pin::Pin<&mut ffi::QTimer>) + Send;
+    type FnType<'a> = dyn FnMut(core::pin::Pin<&mut ffi::QTimer>) + 'a + Send;
 }
 use core::mem::drop as drop_QTimer_signal_handler_timeout;
 fn call_QTimer_signal_handler_timeout(

--- a/crates/cxx-qt-lib/src/core/mod.rs
+++ b/crates/cxx-qt-lib/src/core/mod.rs
@@ -42,7 +42,9 @@ mod qmarginsf;
 pub use qmarginsf::QMarginsF;
 
 // Reexport QMetaObjectConnection and guard from cxx-qt
-pub use cxx_qt::{QMetaObjectConnection, QMetaObjectConnectionGuard};
+pub use cxx_qt::{
+    QMetaObjectConnection, QMetaObjectConnectionGuard, QScopedMetaObjectConnectionGuard,
+};
 
 mod qmodelindex;
 pub use qmodelindex::QModelIndex;

--- a/crates/cxx-qt/src/connection.rs
+++ b/crates/cxx-qt/src/connection.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use std::ffi::c_void;
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
@@ -64,7 +65,7 @@ mod ffi {
 /// that the connection should be active or call `release`.
 #[repr(C)]
 pub struct QMetaObjectConnection {
-    _space: MaybeUninit<usize>,
+    _space: MaybeUninit<*const c_void>,
 }
 
 impl Default for QMetaObjectConnection {

--- a/crates/cxx-qt/src/connectionguard.rs
+++ b/crates/cxx-qt/src/connectionguard.rs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::marker::PhantomData;
+
 use crate::QMetaObjectConnection;
 
 /// Represents a guard to a signal-slot (or signal-functor) connection.
@@ -13,24 +15,28 @@ use crate::QMetaObjectConnection;
 /// So to keep a connection active either hold onto the struct for the duration
 /// that the connection should be active or call `release`, hence the `#[must_use]`.
 #[must_use]
-pub struct QMetaObjectConnectionGuard {
+pub struct QMetaObjectConnectionGuard<'a> {
     connection: QMetaObjectConnection,
+    _phantom: PhantomData<&'a ()>,
 }
 
-impl From<QMetaObjectConnection> for QMetaObjectConnectionGuard {
+impl From<QMetaObjectConnection> for QMetaObjectConnectionGuard<'static> {
     fn from(connection: QMetaObjectConnection) -> Self {
-        Self { connection }
+        Self {
+            connection,
+            _phantom: PhantomData,
+        }
     }
 }
 
-impl Drop for QMetaObjectConnectionGuard {
+impl Drop for QMetaObjectConnectionGuard<'_> {
     /// Disconnect and deconstruct the connection
     fn drop(&mut self) {
         self.connection.disconnect();
     }
 }
 
-impl QMetaObjectConnectionGuard {
+impl QMetaObjectConnectionGuard<'static> {
     /// Release the connection without disconnecting
     pub fn release(mut self) -> QMetaObjectConnection {
         // Take the connection as our Drop implementation disconnects automatically

--- a/crates/cxx-qt/src/connectionguard.rs
+++ b/crates/cxx-qt/src/connectionguard.rs
@@ -7,20 +7,29 @@ use std::marker::PhantomData;
 
 use crate::QMetaObjectConnection;
 
-/// Represents a guard to a signal-slot (or signal-functor) connection.
+/// Represents a scoped guard to a signal-slot (or signal-functor) connection.
+///
+/// This struct can be created from a [QMetaObjectConnection].
+///
+/// Note that when this struct is dropped the connection is disconnected.
+/// So to keep a connection active hold onto the struct for the duration
+/// that the connection should be active, hence the `#[must_use]`.
+#[must_use = "If unused the connection will immediately be dropped"]
+pub struct QScopedMetaObjectConnectionGuard<'a> {
+    connection: QMetaObjectConnection,
+    _phantom: PhantomData<&'a ()>,
+}
+
+/// Represents a static guard to a signal-slot (or signal-functor) connection.
 ///
 /// This struct can be created from a [QMetaObjectConnection].
 ///
 /// Note that when this struct is dropped the connection is disconnected.
 /// So to keep a connection active either hold onto the struct for the duration
 /// that the connection should be active or call `release`, hence the `#[must_use]`.
-#[must_use]
-pub struct QMetaObjectConnectionGuard<'a> {
-    connection: QMetaObjectConnection,
-    _phantom: PhantomData<&'a ()>,
-}
+pub type QMetaObjectConnectionGuard = QScopedMetaObjectConnectionGuard<'static>;
 
-impl From<QMetaObjectConnection> for QMetaObjectConnectionGuard<'static> {
+impl From<QMetaObjectConnection> for QScopedMetaObjectConnectionGuard<'static> {
     fn from(connection: QMetaObjectConnection) -> Self {
         Self {
             connection,
@@ -29,14 +38,14 @@ impl From<QMetaObjectConnection> for QMetaObjectConnectionGuard<'static> {
     }
 }
 
-impl Drop for QMetaObjectConnectionGuard<'_> {
+impl Drop for QScopedMetaObjectConnectionGuard<'_> {
     /// Disconnect and deconstruct the connection
     fn drop(&mut self) {
         self.connection.disconnect();
     }
 }
 
-impl QMetaObjectConnectionGuard<'static> {
+impl QScopedMetaObjectConnectionGuard<'static> {
     /// Release the connection without disconnecting
     pub fn release(mut self) -> QMetaObjectConnection {
         // Take the connection as our Drop implementation disconnects automatically

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -116,7 +116,7 @@ pub use cxx_qt_macro::qobject;
 pub use qobject::QObject;
 
 pub use connection::{ConnectionType, QMetaObjectConnection};
-pub use connectionguard::QMetaObjectConnectionGuard;
+pub use connectionguard::{QMetaObjectConnectionGuard, QScopedMetaObjectConnectionGuard};
 pub use threading::{CxxQtThread, ThreadingQueueError};
 
 // Export static assertions that can then be used in cxx-qt-gen generation

--- a/crates/cxx-qt/src/signalhandler.rs
+++ b/crates/cxx-qt/src/signalhandler.rs
@@ -12,32 +12,32 @@ pub trait CxxQtSignalHandlerClosure {
     /// The Id of the CXX type
     type Id;
     /// The type of the closure
-    type FnType: ?Sized;
+    type FnType<'a>: ?Sized;
 }
 
 // A signal handler helper which is used to move a FnMut closure into C++
 #[doc(hidden)]
 #[repr(transparent)]
-pub struct CxxQtSignalHandler<T>
+pub struct CxxQtSignalHandler<'a, T>
 where
     T: CxxQtSignalHandlerClosure,
 {
-    closure: Box<T::FnType>,
+    closure: Box<T::FnType<'a>>,
 }
 
-impl<T> CxxQtSignalHandler<T>
+impl<'a, T> CxxQtSignalHandler<'a, T>
 where
     T: CxxQtSignalHandlerClosure,
 {
     /// Create a new signal handler with the given closure
     //
     // Note that we cannot use From as we cannot infer the type in the caller
-    pub fn new(closure: Box<T::FnType>) -> Self {
+    pub fn new(closure: Box<T::FnType<'a>>) -> Self {
         Self { closure }
     }
 
     /// A mutable reference to the inner closure
-    pub fn closure(&mut self) -> &mut Box<T::FnType> {
+    pub fn closure(&mut self) -> &mut Box<T::FnType<'a>> {
         &mut self.closure
     }
 }
@@ -45,7 +45,7 @@ where
 // Safety:
 //
 // Static checks on the C++ and Rust side to ensure the size is the same.
-unsafe impl<T> ExternType for CxxQtSignalHandler<T>
+unsafe impl<T> ExternType for CxxQtSignalHandler<'_, T>
 where
     T: CxxQtSignalHandlerClosure,
 {

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -65,13 +65,13 @@ pub mod qobject {
 }
 
 use core::pin::Pin;
-use cxx_qt::CxxQtType;
-use cxx_qt_lib::{ConnectionType, QMetaObjectConnectionGuard, QString, QUrl};
+use cxx_qt::{CxxQtType, QMetaObjectConnectionGuard};
+use cxx_qt_lib::{ConnectionType, QString, QUrl};
 
 /// A QObject which has Q_SIGNALs
 #[derive(Default)]
 pub struct RustSignalsRust {
-    pub(crate) connections: Option<[QMetaObjectConnectionGuard<'static>; 3]>,
+    pub(crate) connections: Option<[QMetaObjectConnectionGuard; 3]>,
 
     logging_enabled: bool,
 }

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -71,7 +71,7 @@ use cxx_qt_lib::{ConnectionType, QMetaObjectConnectionGuard, QString, QUrl};
 /// A QObject which has Q_SIGNALs
 #[derive(Default)]
 pub struct RustSignalsRust {
-    pub(crate) connections: Option<[QMetaObjectConnectionGuard; 3]>,
+    pub(crate) connections: Option<[QMetaObjectConnectionGuard<'static>; 3]>,
 
     logging_enabled: bool,
 }

--- a/tests/qt_types_standalone/rust/src/qmetaobjectconnection.rs
+++ b/tests/qt_types_standalone/rust/src/qmetaobjectconnection.rs
@@ -30,7 +30,7 @@ mod qmetaobjectconnection_cxx {
 
 // CXX doesn't support Rust alias so we need to have a new type
 struct QMetaObjectConnectionGuardWrapper {
-    guard: Option<QMetaObjectConnectionGuard>,
+    guard: Option<QMetaObjectConnectionGuard<'static>>,
 }
 
 fn create_qmetaobjectconnectionguard(

--- a/tests/qt_types_standalone/rust/src/qmetaobjectconnection.rs
+++ b/tests/qt_types_standalone/rust/src/qmetaobjectconnection.rs
@@ -30,7 +30,7 @@ mod qmetaobjectconnection_cxx {
 
 // CXX doesn't support Rust alias so we need to have a new type
 struct QMetaObjectConnectionGuardWrapper {
-    guard: Option<QMetaObjectConnectionGuard<'static>>,
+    guard: Option<QMetaObjectConnectionGuard>,
 }
 
 fn create_qmetaobjectconnectionguard(


### PR DESCRIPTION
Instead of requiring `'static` closures, connection signal handlers now accept lifetime parameters:

```rs
pub fn on_mysignal<'a, F>(self: Pin<&mut Self>, closure: F) -> QMetaObjectConnectionGuard<'a>
where
    F: FnMut(Pin<&mut Self>) + 'a + Send,
```

This makes it possible to attach callbacks to signals that use scoped variables. Only `QMetaObjectConnectionGuard<'static>` can use `.release()`, so the Drop implementation will ensure all other closures are disconnected once their lifetimes have expired.
