### PR TITLE
CI: Limit concurrency to one per ref_name

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -26,7 +26,7 @@ on:
 
 # Cancel any previous runs for the same pull request
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name || github.run_id }}
   cancel-in-progress: true
 jobs:
   clang_format:


### PR DESCRIPTION
This should enable only a single workflow run per branch (including
main) to run at the same time.

If we're landing multiple commits via merge queue, it should force the
newest one to be tested only.
