### PR TITLE
Add  attribute which generates wrappers for a function

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -146,6 +146,22 @@ pub fn get_params_tokens(
     }
 }
 
+/// Return the [TokenStream] of the parsed parameters, which would be used to call the fn, for use in generation
+pub fn get_call_params_tokens(parameters: &[ParsedFunctionParameter]) -> TokenStream {
+    if parameters.is_empty() {
+        quote! {}
+    } else {
+        let parameters = parameters
+            .iter()
+            .map(|parameter| {
+                let ident = &parameter.ident;
+                quote! { #ident }
+            })
+            .collect::<Vec<TokenStream>>();
+        quote! { #(#parameters),* }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cxx-qt-gen/src/parser/method.rs
+++ b/crates/cxx-qt-gen/src/parser/method.rs
@@ -57,6 +57,8 @@ pub struct ParsedMethod {
     pub is_qinvokable: bool,
     /// Whether the method is a pure virtual method
     pub is_pure: bool,
+    /// Whether to auto generate a wrapper for this method outside the bridge
+    pub wrap: bool,
     // No docs field since the docs should be on the method implementation outside the bridge
     // This means any docs on the bridge declaration would be ignored
     /// Cfgs for the method
@@ -66,7 +68,7 @@ pub struct ParsedMethod {
 }
 
 impl ParsedMethod {
-    const ALLOWED_ATTRS: [&'static str; 9] = [
+    const ALLOWED_ATTRS: [&'static str; 10] = [
         "cxx_name",
         "rust_name",
         "qinvokable",
@@ -74,6 +76,7 @@ impl ParsedMethod {
         "cxx_override",
         "cxx_virtual",
         "cxx_pure",
+        "auto_wrap",
         "doc",
         "cfg",
     ];
@@ -125,6 +128,7 @@ impl ParsedMethod {
         // Determine if the method is invokable
         let is_qinvokable = attrs.contains_key("qinvokable");
         let is_pure = attrs.contains_key("cxx_pure");
+        let wrap = attrs.contains_key("auto_wrap");
         let specifiers = ParsedQInvokableSpecifiers::from_attrs(attrs);
 
         Ok(Self {
@@ -132,6 +136,7 @@ impl ParsedMethod {
             specifiers,
             is_qinvokable,
             is_pure,
+            wrap,
             cfgs,
             unsafe_block,
         })

--- a/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
@@ -144,7 +144,8 @@ pub mod ffi {
         fn invokable_name(self: Pin<&mut SecondObject>);
 
         #[cxx_name = "myRenamedFunction"]
-        fn my_function(self: &SecondObject);
+        #[auto_wrap]
+        fn my_function(self: &SecondObject, param: i32);
     }
 
     extern "RustQt" {

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.h
@@ -165,7 +165,7 @@ public:
   Q_SLOT void setPropertyName(::std::int32_t value) noexcept;
   Q_SIGNAL void propertyNameChanged();
   Q_INVOKABLE void invokableName() noexcept;
-  void myRenamedFunction() const noexcept;
+  void myRenamedFunction(::std::int32_t param) const noexcept;
   Q_SIGNAL void ready();
   explicit SecondObject(QObject* parent = nullptr);
 };

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -263,7 +263,7 @@ pub mod ffi {
         #[cxx_name = "myRenamedFunction"]
         #[namespace = "second_object"]
         #[doc(hidden)]
-        unsafe fn my_function(self: &SecondObject);
+        unsafe fn my_function(self: &SecondObject, param: i32);
     }
     unsafe extern "C++" {
         #[cxx_name = "ready"]
@@ -780,6 +780,9 @@ cxx_qt::static_assertions::assert_eq_size!(
     cxx_qt::signalhandler::CxxQtSignalHandler<SecondObjectCxxQtSignalClosurepropertyNameChanged>,
     [usize; 2]
 );
+unsafe fn my_function(self: &SecondObject, param: i32) {
+    self.rust().my_function(param)
+}
 impl ffi::SecondObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "ready"]


### PR DESCRIPTION
Closes #1235.

Adds the `auto_wrap` attribute which will generate the wrapper function for methods defined in the bridge.