### PR TITLE
Respect Formatter options in Debug and Display implementations

### DIFF
--- a/crates/cxx-qt-lib/src/core/qanystringview.rs
+++ b/crates/cxx-qt-lib/src/core/qanystringview.rs
@@ -129,13 +129,13 @@ impl QAnyStringView<'_> {
 
 impl fmt::Display for QAnyStringView<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_qstring())
+        self.to_qstring().fmt(f)
     }
 }
 
 impl fmt::Debug for QAnyStringView<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self}")
+        self.to_qstring().fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qbytearray.rs
+++ b/crates/cxx-qt-lib/src/core/qbytearray.rs
@@ -167,7 +167,7 @@ impl fmt::Display for QByteArray {
 
 impl fmt::Debug for QByteArray {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.as_slice().fmt(f)
+        fmt::Display::fmt(self, f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -143,13 +143,13 @@ impl Default for QDate {
 
 impl fmt::Display for QDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.format_enum(ffi::DateFormat::TextDate))
+        self.format_enum(ffi::DateFormat::TextDate).fmt(f)
     }
 }
 
 impl fmt::Debug for QDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qdate_to_debug_qstring(self))
+        ffi::qdate_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -368,13 +368,13 @@ impl Ord for QDateTime {
 
 impl fmt::Display for QDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.format_enum(ffi::DateFormat::TextDate))
+        self.format_enum(ffi::DateFormat::TextDate).fmt(f)
     }
 }
 
 impl fmt::Debug for QDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qdatetime_to_debug_qstring(self))
+        ffi::qdatetime_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qline.rs
+++ b/crates/cxx-qt-lib/src/core/qline.rs
@@ -122,7 +122,7 @@ impl Default for QLine {
 
 impl fmt::Display for QLine {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qline_to_debug_qstring(self))
+        ffi::qline_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qlinef.rs
+++ b/crates/cxx-qt-lib/src/core/qlinef.rs
@@ -170,7 +170,7 @@ impl From<QLineF> for ffi::QLine {
 
 impl fmt::Display for QLineF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qlinef_to_debug_qstring(self))
+        ffi::qlinef_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qmargins.rs
+++ b/crates/cxx-qt-lib/src/core/qmargins.rs
@@ -122,7 +122,7 @@ impl Default for QMargins {
 
 impl fmt::Display for QMargins {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qmargins_to_debug_qstring(self))
+        ffi::qmargins_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qmarginsf.rs
+++ b/crates/cxx-qt-lib/src/core/qmarginsf.rs
@@ -118,7 +118,7 @@ impl Default for QMarginsF {
 
 impl fmt::Display for QMarginsF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qmarginsf_to_debug_qstring(self))
+        ffi::qmarginsf_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.rs
@@ -88,13 +88,13 @@ impl std::cmp::Eq for QModelIndex {}
 
 impl fmt::Display for QModelIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self:?}")
+        ffi::qmodelindex_to_debug_qstring(self).fmt(f)
     }
 }
 
 impl fmt::Debug for QModelIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qmodelindex_to_debug_qstring(self))
+        ffi::qmodelindex_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
@@ -96,13 +96,13 @@ impl std::cmp::Eq for QPersistentModelIndex {}
 
 impl fmt::Display for QPersistentModelIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self:?}")
+        ffi::qpersistentmodelindex_to_debug_qstring(self).fmt(f)
     }
 }
 
 impl fmt::Debug for QPersistentModelIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpersistentmodelindex_to_debug_qstring(self))
+        ffi::qpersistentmodelindex_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpoint.rs
+++ b/crates/cxx-qt-lib/src/core/qpoint.rs
@@ -122,7 +122,7 @@ impl Default for QPoint {
 
 impl fmt::Display for QPoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpoint_to_debug_qstring(self))
+        ffi::qpoint_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpointf.rs
+++ b/crates/cxx-qt-lib/src/core/qpointf.rs
@@ -116,7 +116,7 @@ impl Default for QPointF {
 
 impl fmt::Display for QPointF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpointf_to_debug_qstring(self))
+        ffi::qpointf_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qrect.rs
+++ b/crates/cxx-qt-lib/src/core/qrect.rs
@@ -295,7 +295,7 @@ impl Default for QRect {
 
 impl fmt::Display for QRect {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qrect_to_debug_qstring(self))
+        ffi::qrect_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qrectf.rs
+++ b/crates/cxx-qt-lib/src/core/qrectf.rs
@@ -296,7 +296,7 @@ impl Default for QRectF {
 
 impl fmt::Display for QRectF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qrectf_to_debug_qstring(self))
+        ffi::qrectf_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qsize.rs
+++ b/crates/cxx-qt-lib/src/core/qsize.rs
@@ -138,7 +138,7 @@ impl Default for QSize {
 
 impl fmt::Display for QSize {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qsize_to_debug_qstring(self))
+        ffi::qsize_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qsizef.rs
+++ b/crates/cxx-qt-lib/src/core/qsizef.rs
@@ -141,7 +141,7 @@ impl Default for QSizeF {
 
 impl fmt::Display for QSizeF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qsizef_to_debug_qstring(self))
+        ffi::qsizef_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -249,13 +249,13 @@ impl fmt::Display for QString {
     ///
     /// Note that this converts from UTF-16 to UTF-8
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", String::from(self))
+        f.pad(&String::from(self))
     }
 }
 
 impl fmt::Debug for QString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self}")
+        f.pad(&String::from(self))
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qstringlist.rs
+++ b/crates/cxx-qt-lib/src/core/qstringlist.rs
@@ -152,13 +152,13 @@ impl std::cmp::Eq for QStringList {}
 
 impl fmt::Display for QStringList {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qstringlist_to_debug_qstring(self))
+        ffi::qstringlist_to_debug_qstring(self).fmt(f)
     }
 }
 
 impl fmt::Debug for QStringList {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", **self)
+        (**self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qtime.rs
@@ -178,13 +178,13 @@ impl Default for QTime {
 
 impl fmt::Display for QTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.format_enum(ffi::DateFormat::TextDate))
+        self.format_enum(ffi::DateFormat::TextDate).fmt(f)
     }
 }
 
 impl fmt::Debug for QTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qtime_to_debug_qstring(self))
+        ffi::qtime_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qtimezone.rs
+++ b/crates/cxx-qt-lib/src/core/qtimezone.rs
@@ -232,16 +232,16 @@ impl std::cmp::Eq for QTimeZone {}
 
 impl fmt::Display for QTimeZone {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let name = self.display_name(
+        self.display_name(
             QTimeZoneTimeType::GenericTime,
             QTimeZoneNameType::DefaultName,
-        );
-        write!(f, "{name}")
+        )
+        .fmt(f)
     }
 }
 
 impl fmt::Debug for QTimeZone {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qtimezone_to_debug_qstring(self))
+        ffi::qtimezone_to_debug_qstring(self).fmt(f)
     }
 }

--- a/crates/cxx-qt-lib/src/core/qurl.rs
+++ b/crates/cxx-qt-lib/src/core/qurl.rs
@@ -427,13 +427,13 @@ impl fmt::Display for QUrl {
     ///
     /// Note that this converts from UTF-16 to UTF-8
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qurl_to_display_string(self))
+        ffi::qurl_to_display_string(self).fmt(f)
     }
 }
 
 impl fmt::Debug for QUrl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qurl_to_debug_qstring(self))
+        ffi::qurl_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/quuid.rs
+++ b/crates/cxx-qt-lib/src/core/quuid.rs
@@ -122,13 +122,13 @@ impl Default for QUuid {
 
 impl fmt::Display for QUuid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::quuid_to_string(self))
+        ffi::quuid_to_string(self).fmt(f)
     }
 }
 
 impl fmt::Debug for QUuid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self}")
+        ffi::quuid_to_string(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qvariant/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qvariant/mod.rs
@@ -139,7 +139,7 @@ impl std::cmp::PartialEq for QVariant {
 
 impl fmt::Debug for QVariant {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qvariant_to_debug_qstring(self))
+        ffi::qvariant_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qcolor.rs
+++ b/crates/cxx-qt-lib/src/gui/qcolor.rs
@@ -552,6 +552,10 @@ impl std::cmp::Eq for QColor {}
 
 impl fmt::Display for QColor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if f.width().is_some() || f.precision().is_some() {
+            #[allow(clippy::recursive_format_impl)]
+            return f.pad(&self.to_string());
+        }
         // TODO: consider the different color spec
         let r = self.red();
         let g = self.green();
@@ -667,5 +671,11 @@ mod tests {
 
         let rgba_color = rgb::RGBA8::from(&qcolor);
         assert_eq!(color, rgba_color);
+    }
+
+    #[test]
+    fn test_display_fmt() {
+        let qcolor = QColor::from_rgba(50, 100, 150, 200);
+        assert_eq!(format!("{:-<30}", qcolor), "RGBA(50, 100, 150, 200)-------");
     }
 }

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -392,13 +392,13 @@ impl Clone for QFont {
 
 impl fmt::Display for QFont {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_qstring())
+        self.to_qstring().fmt(f)
     }
 }
 
 impl fmt::Debug for QFont {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_qstring())
+        self.to_qstring().fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qimage.rs
+++ b/crates/cxx-qt-lib/src/gui/qimage.rs
@@ -339,7 +339,7 @@ impl Eq for QImage {}
 
 impl fmt::Debug for QImage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qimage_to_debug_qstring(self))
+        ffi::qimage_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpainterpath.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainterpath.rs
@@ -244,13 +244,13 @@ impl PartialEq for QPainterPath {
 
 impl fmt::Display for QPainterPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self:?}")
+        ffi::qpainterpath_to_debug_qstring(self).fmt(f)
     }
 }
 
 impl fmt::Debug for QPainterPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpainterpath_to_debug_qstring(self))
+        ffi::qpainterpath_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpen.rs
+++ b/crates/cxx-qt-lib/src/gui/qpen.rs
@@ -173,13 +173,13 @@ impl From<&ffi::PenStyle> for QPen {
 
 impl fmt::Display for QPen {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self:?}")
+        ffi::qpen_to_debug_qstring(self).fmt(f)
     }
 }
 
 impl fmt::Debug for QPen {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpen_to_debug_qstring(self))
+        ffi::qpen_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpolygon.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.rs
@@ -167,13 +167,13 @@ impl PartialEq for QPolygon {
 
 impl fmt::Display for QPolygon {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", ffi::qpolygon_to_debug_qstring(self))
+        ffi::qpolygon_to_debug_qstring(self).fmt(f)
     }
 }
 
 impl fmt::Debug for QPolygon {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", **self)
+        (**self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.rs
@@ -149,13 +149,13 @@ impl PartialEq for QPolygonF {
 
 impl fmt::Display for QPolygonF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qpolygonf_to_debug_qstring(self))
+        ffi::qpolygonf_to_debug_qstring(self).fmt(f)
     }
 }
 
 impl fmt::Debug for QPolygonF {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", **self)
+        (**self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector2d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.rs
@@ -162,7 +162,7 @@ impl Default for QVector2D {
 
 impl fmt::Display for QVector2D {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qvector2d_to_debug_qstring(self))
+        ffi::qvector2d_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector3d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.rs
@@ -185,7 +185,7 @@ impl Default for QVector3D {
 
 impl fmt::Display for QVector3D {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qvector3d_to_debug_qstring(self))
+        ffi::qvector3d_to_debug_qstring(self).fmt(f)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qvector4d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.rs
@@ -157,7 +157,7 @@ impl Default for QVector4D {
 
 impl fmt::Display for QVector4D {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ffi::qvector4d_to_debug_qstring(self))
+        ffi::qvector4d_to_debug_qstring(self).fmt(f)
     }
 }
 


### PR DESCRIPTION
Manual implementations for `fmt::Debug` and `fmt::Display` now respect formatter options, such as padding. This is a pretty simple change:

```rs
// old - formatter options are discarded
write!(f, "{}", self.to_qstring())

// new - formatter options are passed through
self.to_qstring().fmt(f)
```