### PR TITLE
Place all objects and passthrough items in the same block, to pass th…

### DIFF
--- a/crates/cxx-qt-gen/bat
+++ b/crates/cxx-qt-gen/bat
@@ -1,0 +1,1 @@
+/home/ben/cxx-qt/crates/cxx-qt-gen/src/generator/naming/property.rs

--- a/crates/cxx-qt-gen/bat
+++ b/crates/cxx-qt-gen/bat
@@ -1,1 +1,0 @@
-/home/ben/cxx-qt/crates/cxx-qt-gen/src/generator/naming/property.rs

--- a/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/inherit.rs
@@ -27,7 +27,7 @@ pub fn generate(
 
     for &method in inherited_methods {
         // Skip if the cfg attributes are not resolved to true
-        if !try_eval_attributes(opt.cfg_evaluator.as_ref(), &method.cfgs)? {
+        if !try_eval_attributes(opt.cfg_evaluator.as_ref(), &method.common_attrs.cfgs)? {
             continue;
         }
 

--- a/crates/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -72,8 +72,10 @@ impl GeneratedCppBlocks {
                 .iter()
                 .filter_map(|qobject| {
                     // Skip if the cfg attributes are not resolved to true
-                    match try_eval_attributes(opt.cfg_evaluator.as_ref(), &qobject.declaration.common_attrs.cfgs)
-                    {
+                    match try_eval_attributes(
+                        opt.cfg_evaluator.as_ref(),
+                        &qobject.declaration.common_attrs.cfgs,
+                    ) {
                         Ok(true) => {
                             Some(GeneratedCppQObject::from(qobject, &parser.type_names, opt))
                         }

--- a/crates/cxx-qt-gen/src/generator/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/mod.rs
@@ -72,7 +72,7 @@ impl GeneratedCppBlocks {
                 .iter()
                 .filter_map(|qobject| {
                     // Skip if the cfg attributes are not resolved to true
-                    match try_eval_attributes(opt.cfg_evaluator.as_ref(), &qobject.declaration.cfgs)
+                    match try_eval_attributes(opt.cfg_evaluator.as_ref(), &qobject.declaration.common_attrs.cfgs)
                     {
                         Ok(true) => {
                             Some(GeneratedCppQObject::from(qobject, &parser.type_names, opt))

--- a/crates/cxx-qt-gen/src/generator/cpp/qenum.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qenum.rs
@@ -39,7 +39,7 @@ pub fn generate_declaration(
     opt: &GeneratedOpt,
 ) -> Result<String> {
     // Skip if the cfg attributes are not resolved to true
-    if !try_eval_attributes(opt.cfg_evaluator.as_ref(), &qenum.cfgs)? {
+    if !try_eval_attributes(opt.cfg_evaluator.as_ref(), &qenum.common_attrs.cfgs)? {
         return Ok(String::new());
     }
 
@@ -75,7 +75,7 @@ pub fn generate_on_qobject<'a>(
 
     for qenum in qenums {
         // Skip if the cfg attributes are not resolved to true
-        if !try_eval_attributes(opt.cfg_evaluator.as_ref(), &qenum.cfgs)? {
+        if !try_eval_attributes(opt.cfg_evaluator.as_ref(), &qenum.common_attrs.cfgs)? {
             continue;
         }
 

--- a/crates/cxx-qt-gen/src/generator/cpp/signal.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/signal.rs
@@ -89,7 +89,7 @@ pub fn generate_cpp_signal(
     let mut generated = CppSignalFragment::default();
 
     // Skip if the cfg attributes are not resolved to true
-    if !try_eval_attributes(opt.cfg_evaluator.as_ref(), &signal.cfgs)? {
+    if !try_eval_attributes(opt.cfg_evaluator.as_ref(), &signal.common_attrs.cfgs)? {
         return Ok(generated);
     }
 

--- a/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
@@ -7,10 +7,9 @@ use crate::{
     generator::rust::{fragment::GeneratedRustFragment, signals::generate_rust_signal},
     naming::TypeNames,
     parser::externcxxqt::ParsedExternCxxQt,
-    syntax::path::path_compare_str,
 };
 use quote::quote;
-use syn::{parse_quote, Attribute, Item, Result};
+use syn::{parse_quote, Item, Result};
 
 impl GeneratedRustFragment {
     pub fn from_extern_cxx_qt(
@@ -60,19 +59,9 @@ impl GeneratedRustFragment {
                     #[cxx_name = #cxx_name]
                 }
             };
-            // TODO! Can we make extract_docs return references, and then use here?
-            let cfgs: Vec<&Attribute> = obj
-                .declaration
-                .attrs
-                .iter()
-                .filter(|attr| path_compare_str(attr.meta.path(), &["cfg"]))
-                .collect();
-            let docs: Vec<&Attribute> = obj
-                .declaration
-                .attrs
-                .iter()
-                .filter(|attr| path_compare_str(attr.meta.path(), &["doc"]))
-                .collect();
+            // TODO: (cfg everywhere) Can we make extract_docs return references, and then use here?
+            let cfgs = obj.common_attrs.cfgs.iter().collect::<Vec<_>>();
+            let docs = obj.common_attrs.docs.iter().collect::<Vec<_>>();
             qobject_items.push(parse_quote! {
                 #namespace
                 #cxx_name

--- a/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/externcxxqt.rs
@@ -22,7 +22,7 @@ impl GeneratedRustFragment {
         } else {
             quote! {}
         };
-        let extern_block_docs = &extern_cxxqt_block.docs;
+        let extern_block_docs = &extern_cxxqt_block.common_attrs.docs;
 
         // Add the pass through blocks
         let unsafety = &extern_cxxqt_block.unsafety;
@@ -60,6 +60,7 @@ impl GeneratedRustFragment {
                     #[cxx_name = #cxx_name]
                 }
             };
+            // TODO! Can we make extract_docs return references, and then use here?
             let cfgs: Vec<&Attribute> = obj
                 .declaration
                 .attrs

--- a/crates/cxx-qt-gen/src/generator/rust/inherit.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/inherit.rs
@@ -48,8 +48,8 @@ pub fn generate(
             if method.safe {
                 std::mem::swap(&mut unsafe_call, &mut unsafe_block);
             }
-            let doc_comments = &method.docs;
-            let cfgs = &method.cfgs;
+            let doc_comments = &method.common_attrs.docs;
+            let cfgs = &method.common_attrs.cfgs;
             let namespace = qobject_names.namespace_tokens();
 
             syn::parse2(quote_spanned! {

--- a/crates/cxx-qt-gen/src/generator/rust/qenum.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qenum.rs
@@ -16,8 +16,8 @@ pub fn generate_cxx_mod_contents(qenums: &[ParsedQEnum]) -> Vec<Item> {
             let item = &qenum.item;
             let vis = &item.vis;
             let variants = &item.variants;
-            let docs = &qenum.docs;
-            let cfgs = &qenum.cfgs;
+            let docs = &qenum.common_attrs.docs;
+            let cfgs = &qenum.common_attrs.cfgs;
 
             let cxx_namespace = if namespace.is_none() {
                 quote! {}

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -28,7 +28,7 @@ impl GeneratedRustFragment {
         let namespace_idents = NamespaceName::from(qobject);
 
         let mut generated = vec![
-            generate_qobject_definitions(&qobject_names, &qobject.cfgs, &qobject.docs)?,
+            generate_qobject_definitions(&qobject_names, &qobject.common_attrs.cfgs, &qobject.common_attrs.docs)?,
             generate_rust_properties(
                 &qobject.properties,
                 &qobject_names,
@@ -57,7 +57,7 @@ impl GeneratedRustFragment {
                 &qobject_names,
                 &namespace_idents,
                 type_names,
-                &qobject.cfgs,
+                &qobject.common_attrs.cfgs,
             )?);
         }
 
@@ -75,9 +75,9 @@ impl GeneratedRustFragment {
                 &qobject_names,
                 &namespace_idents,
                 type_names,
-                &qobject.cfgs,
+                &qobject.common_attrs.cfgs,
             )?,
-            cxxqttype::generate(&qobject_names, type_names, &qobject.cfgs)?,
+            cxxqttype::generate(&qobject_names, type_names, &qobject.common_attrs.cfgs)?,
         ]);
 
         Ok(GeneratedRustFragment::flatten(generated))

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::generator::structuring::StructuredQObject;
+use crate::parser::CommonAttrs;
 use crate::{
     generator::{
         naming::{namespace::NamespaceName, qobject::QObjectNames},
@@ -15,7 +16,7 @@ use crate::{
     naming::TypeNames,
 };
 use quote::quote;
-use syn::{parse_quote, Attribute, Result};
+use syn::{parse_quote, Result};
 
 impl GeneratedRustFragment {
     pub fn from_qobject(
@@ -28,7 +29,7 @@ impl GeneratedRustFragment {
         let namespace_idents = NamespaceName::from(qobject);
 
         let mut generated = vec![
-            generate_qobject_definitions(&qobject_names, &qobject.common_attrs.cfgs, &qobject.common_attrs.docs)?,
+            generate_qobject_definitions(&qobject_names, &qobject.common_attrs)?,
             generate_rust_properties(
                 &qobject.properties,
                 &qobject_names,
@@ -87,9 +88,11 @@ impl GeneratedRustFragment {
 /// Generate the C++ and Rust CXX definitions for the QObject
 fn generate_qobject_definitions(
     qobject_idents: &QObjectNames,
-    cfgs: &[Attribute],
-    docs: &[Attribute],
+    common_attrs: &CommonAttrs,
 ) -> Result<GeneratedRustFragment> {
+    let docs = &common_attrs.docs;
+    let cfgs = &common_attrs.cfgs;
+
     let cpp_class_name_rust = &qobject_idents.name.rust_unqualified();
     let cpp_class_name_cpp = &qobject_idents.name.cxx_unqualified();
 

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -28,7 +28,7 @@ impl GeneratedRustFragment {
         let namespace_idents = NamespaceName::from(qobject);
 
         let mut generated = vec![
-            generate_qobject_definitions(&qobject_names, &qobject.cfgs)?,
+            generate_qobject_definitions(&qobject_names, &qobject.cfgs, &qobject.docs)?,
             generate_rust_properties(
                 &qobject.properties,
                 &qobject_names,
@@ -88,6 +88,7 @@ impl GeneratedRustFragment {
 fn generate_qobject_definitions(
     qobject_idents: &QObjectNames,
     cfgs: &[Attribute],
+    docs: &[Attribute],
 ) -> Result<GeneratedRustFragment> {
     let cpp_class_name_rust = &qobject_idents.name.rust_unqualified();
     let cpp_class_name_cpp = &qobject_idents.name.cxx_unqualified();
@@ -106,6 +107,15 @@ fn generate_qobject_definitions(
         }
     };
 
+    let maybe_docs = if docs.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            #[doc = "\n"]
+            #(#docs)*
+        }
+    };
+
     Ok(GeneratedRustFragment {
         cxx_mod_contents: vec![
             parse_quote! {
@@ -116,6 +126,7 @@ fn generate_qobject_definitions(
                     #[doc = "Use this type when referring to the QObject as a pointer"]
                     #[doc = "\n"]
                     #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/concepts/generated_qobject.html>"]
+                    #maybe_docs
                     #namespace
                     #cxx_name
                     #(#cfgs)*
@@ -130,6 +141,7 @@ fn generate_qobject_definitions(
                     // but to apply it to only certain types, it is needed here too
                     #namespace
                     #(#cfgs)*
+                    #(#docs)*
                     type #rust_struct_name_rust;
                 }
             },

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -100,8 +100,8 @@ pub fn generate_rust_signal(
     } else {
         Some(quote! { unsafe })
     };
-    let doc_comments = &signal.docs;
-    let cfgs = &signal.cfgs;
+    let doc_comments = &signal.common_attrs.docs;
+    let cfgs = &signal.common_attrs.cfgs;
     let namespace = if let Some(namespace) = qobject_name.namespace() {
         quote_spanned! { span=> #[namespace = #namespace ] }
     } else {

--- a/crates/cxx-qt-gen/src/parser/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externcxxqt.rs
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::extract_docs;
 use crate::{
     parser::{
         externqobject::ParsedExternQObject, require_attributes, signals::ParsedSignal,
@@ -40,12 +39,10 @@ impl ParsedExternCxxQt {
         parent_namespace: Option<&str>,
     ) -> Result<Self> {
         // TODO: support cfg on foreign mod blocks
-        let attrs = require_attributes(
+        let (attrs, common_attrs) = require_attributes(
             &foreign_mod.attrs,
             &["namespace", "doc", "auto_cxx_name", "auto_rust_name"],
         )?;
-
-        let docs = extract_docs(&foreign_mod.attrs);
 
         let auto_case = CaseConversion::from_attrs(&attrs)?;
 
@@ -58,7 +55,7 @@ impl ParsedExternCxxQt {
 
         let mut extern_cxx_block = ParsedExternCxxQt {
             namespace,
-            docs,
+            docs: common_attrs.docs,
             unsafety: foreign_mod.unsafety,
             ..Default::default()
         };

--- a/crates/cxx-qt-gen/src/parser/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externcxxqt.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::parser::CommonAttrs;
 use crate::{
     parser::{
         externqobject::ParsedExternQObject, require_attributes, signals::ParsedSignal,
@@ -11,10 +12,8 @@ use crate::{
     syntax::{attribute::attribute_get_path, expr::expr_to_string},
 };
 use syn::{
-    spanned::Spanned, Error, ForeignItem, ForeignItemFn, Ident, ItemForeignMod, Result,
-    Token,
+    spanned::Spanned, Error, ForeignItem, ForeignItemFn, Ident, ItemForeignMod, Result, Token,
 };
-use crate::parser::CommonAttrs;
 
 /// Representation of an extern "C++Qt" block
 #[derive(Default)]
@@ -39,10 +38,10 @@ impl ParsedExternCxxQt {
         module_ident: &Ident,
         parent_namespace: Option<&str>,
     ) -> Result<Self> {
-        // TODO: support cfg on foreign mod blocks
+        // TODO: (cfg everywhere) support cfg on foreign mod blocks
         let (attrs, common_attrs) = require_attributes(
             &foreign_mod.attrs,
-            &["namespace", "doc", "auto_cxx_name", "auto_rust_name"],
+            &["doc", "namespace", "auto_cxx_name", "auto_rust_name"],
         )?;
 
         let auto_case = CaseConversion::from_attrs(&attrs)?;
@@ -72,7 +71,7 @@ impl ParsedExternCxxQt {
                 ForeignItem::Type(foreign_ty) => {
                     // Test that there is a #[qobject] attribute on any type
                     //
-                    // TODO: what happens to any docs here?
+                    // TODO: (cfg everywhere) what happens to any docs here?
                     if attribute_get_path(&foreign_ty.attrs, &["qobject"]).is_some() {
                         let extern_ty =
                             ParsedExternQObject::parse(foreign_ty, module_ident, parent_namespace)?;

--- a/crates/cxx-qt-gen/src/parser/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externcxxqt.rs
@@ -11,17 +11,18 @@ use crate::{
     syntax::{attribute::attribute_get_path, expr::expr_to_string},
 };
 use syn::{
-    spanned::Spanned, Attribute, Error, ForeignItem, ForeignItemFn, Ident, ItemForeignMod, Result,
+    spanned::Spanned, Error, ForeignItem, ForeignItemFn, Ident, ItemForeignMod, Result,
     Token,
 };
+use crate::parser::CommonAttrs;
 
 /// Representation of an extern "C++Qt" block
 #[derive(Default)]
 pub struct ParsedExternCxxQt {
     /// The namespace of the type in C++.
     pub namespace: Option<String>,
-    /// The Top level docs on the module
-    pub docs: Vec<Attribute>,
+    /// All the universal top level attributes for the block
+    pub common_attrs: CommonAttrs,
     /// Whether this block has an unsafe token
     pub unsafety: Option<Token![unsafe]>,
     /// Items which can be passed into the extern "C++Qt" block
@@ -55,7 +56,7 @@ impl ParsedExternCxxQt {
 
         let mut extern_cxx_block = ParsedExternCxxQt {
             namespace,
-            docs: common_attrs.docs,
+            common_attrs,
             unsafety: foreign_mod.unsafety,
             ..Default::default()
         };

--- a/crates/cxx-qt-gen/src/parser/externqobject.rs
+++ b/crates/cxx-qt-gen/src/parser/externqobject.rs
@@ -32,7 +32,7 @@ impl ParsedExternQObject {
         module_ident: &Ident,
         parent_namespace: Option<&str>,
     ) -> Result<ParsedExternQObject> {
-        let attributes = require_attributes(&ty.attrs, &Self::ALLOWED_ATTRS)?;
+        let (attributes, _common_attrs) = require_attributes(&ty.attrs, &Self::ALLOWED_ATTRS)?;
 
         let base_class = parse_base_type(&attributes)?;
 

--- a/crates/cxx-qt-gen/src/parser/externqobject.rs
+++ b/crates/cxx-qt-gen/src/parser/externqobject.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::naming::Name;
-use crate::parser::{parse_base_type, require_attributes, CaseConversion};
+use crate::parser::{parse_base_type, require_attributes, CaseConversion, CommonAttrs};
 use syn::{ForeignItemType, Ident, Result};
 
 /// A representation of a QObject to be generated in an extern C++ block
@@ -14,15 +14,17 @@ pub struct ParsedExternQObject {
     pub declaration: ForeignItemType,
     /// The base class of the struct
     pub base_class: Option<Ident>,
+    /// Common attrs for this object
+    pub common_attrs: CommonAttrs,
 }
 
 impl ParsedExternQObject {
     const ALLOWED_ATTRS: [&'static str; 7] = [
+        "cfg",
+        "doc",
         "cxx_name",
         "rust_name",
         "namespace",
-        "cfg",
-        "doc",
         "qobject",
         "base",
     ];
@@ -32,7 +34,8 @@ impl ParsedExternQObject {
         module_ident: &Ident,
         parent_namespace: Option<&str>,
     ) -> Result<ParsedExternQObject> {
-        let (attributes, _common_attrs) = require_attributes(&ty.attrs, &Self::ALLOWED_ATTRS)?;
+        // TODO: (cfg everywhere) should these have docs kept with them in the generated code?
+        let (attributes, common_attrs) = require_attributes(&ty.attrs, &Self::ALLOWED_ATTRS)?;
 
         let base_class = parse_base_type(&attributes)?;
 
@@ -46,6 +49,7 @@ impl ParsedExternQObject {
             )?,
             declaration: ty,
             base_class,
+            common_attrs,
         })
     }
 }

--- a/crates/cxx-qt-gen/src/parser/externrustqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externrustqt.rs
@@ -37,7 +37,7 @@ impl ParsedExternRustQt {
         module_ident: &Ident,
         parent_namespace: Option<&str>,
     ) -> Result<Self> {
-        // TODO: support cfg on foreign mod blocks
+        // TODO: (cfg everywhere) support cfg on foreign mod blocks
         let (attrs, _common_attrs) = require_attributes(
             &foreign_mod.attrs,
             &["namespace", "auto_cxx_name", "auto_rust_name"],

--- a/crates/cxx-qt-gen/src/parser/externrustqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externrustqt.rs
@@ -38,7 +38,7 @@ impl ParsedExternRustQt {
         parent_namespace: Option<&str>,
     ) -> Result<Self> {
         // TODO: support cfg on foreign mod blocks
-        let attrs = require_attributes(
+        let (attrs, _common_attrs) = require_attributes(
             &foreign_mod.attrs,
             &["namespace", "auto_cxx_name", "auto_rust_name"],
         )?;

--- a/crates/cxx-qt-gen/src/parser/inherit.rs
+++ b/crates/cxx-qt-gen/src/parser/inherit.rs
@@ -3,9 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::{
-    extract_cfgs, extract_docs, method::MethodFields, require_attributes, CaseConversion,
-};
+use crate::parser::{method::MethodFields, require_attributes, CaseConversion};
 use core::ops::Deref;
 use quote::format_ident;
 use std::ops::DerefMut;
@@ -32,14 +30,12 @@ impl ParsedInheritedMethod {
     ];
 
     pub fn parse(method: ForeignItemFn, auto_case: CaseConversion) -> Result<Self> {
-        require_attributes(&method.attrs, &Self::ALLOWED_ATTRS)?;
-        let docs = extract_docs(&method.attrs);
-        let cfgs = extract_cfgs(&method.attrs);
+        let (_attrs, common_attrs) = require_attributes(&method.attrs, &Self::ALLOWED_ATTRS)?;
 
         Ok(Self {
             method_fields: MethodFields::parse(method, auto_case)?,
-            docs,
-            cfgs,
+            docs: common_attrs.docs,
+            cfgs: common_attrs.cfgs,
         })
     }
 

--- a/crates/cxx-qt-gen/src/parser/inherit.rs
+++ b/crates/cxx-qt-gen/src/parser/inherit.rs
@@ -19,12 +19,12 @@ pub struct ParsedInheritedMethod {
 
 impl ParsedInheritedMethod {
     const ALLOWED_ATTRS: [&'static str; 6] = [
+        "cfg",
+        "doc",
         "cxx_name",
         "rust_name",
         "qinvokable",
-        "doc",
         "inherit",
-        "cfg",
     ];
 
     pub fn parse(method: ForeignItemFn, auto_case: CaseConversion) -> Result<Self> {
@@ -32,7 +32,7 @@ impl ParsedInheritedMethod {
 
         Ok(Self {
             method_fields: MethodFields::parse(method, auto_case)?,
-            common_attrs
+            common_attrs,
         })
     }
 

--- a/crates/cxx-qt-gen/src/parser/inherit.rs
+++ b/crates/cxx-qt-gen/src/parser/inherit.rs
@@ -3,20 +3,18 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::{method::MethodFields, require_attributes, CaseConversion};
+use crate::parser::{method::MethodFields, require_attributes, CaseConversion, CommonAttrs};
 use core::ops::Deref;
 use quote::format_ident;
 use std::ops::DerefMut;
-use syn::{Attribute, ForeignItemFn, Ident, Result};
+use syn::{ForeignItemFn, Ident, Result};
 
 /// Describes a method found in an extern "RustQt" with #[inherit]
 pub struct ParsedInheritedMethod {
     /// The common fields which are available on all callable types
     pub method_fields: MethodFields,
-    /// All the docs (each line) of the inherited method
-    pub docs: Vec<Attribute>,
-    /// Cfgs for the inherited method
-    pub cfgs: Vec<Attribute>,
+    /// All the universal attributes for the inherited method
+    pub common_attrs: CommonAttrs,
 }
 
 impl ParsedInheritedMethod {
@@ -34,8 +32,7 @@ impl ParsedInheritedMethod {
 
         Ok(Self {
             method_fields: MethodFields::parse(method, auto_case)?,
-            docs: common_attrs.docs,
-            cfgs: common_attrs.cfgs,
+            common_attrs
         })
     }
 

--- a/crates/cxx-qt-gen/src/parser/method.rs
+++ b/crates/cxx-qt-gen/src/parser/method.rs
@@ -5,7 +5,7 @@
 use crate::parser::CaseConversion;
 use crate::{
     naming::Name,
-    parser::{extract_cfgs, parameter::ParsedFunctionParameter, require_attributes},
+    parser::{parameter::ParsedFunctionParameter, require_attributes},
     syntax::{foreignmod, types},
 };
 use core::ops::Deref;
@@ -121,8 +121,7 @@ impl ParsedMethod {
         unsafe_block: bool,
     ) -> Result<Self> {
         let fields = MethodFields::parse(method, auto_case)?;
-        let attrs = require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
-        let cfgs = extract_cfgs(&fields.method.attrs);
+        let (attrs, common_attrs) = require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
 
         // Determine if the method is invokable
         let is_qinvokable = attrs.contains_key("qinvokable");
@@ -134,7 +133,7 @@ impl ParsedMethod {
             specifiers,
             is_qinvokable,
             is_pure,
-            cfgs,
+            cfgs: common_attrs.cfgs,
             unsafe_block,
         })
     }

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -104,7 +104,6 @@ pub fn extract_cfgs(attrs: &[Attribute]) -> Vec<Attribute> {
 /// Iterate the attributes of the method to extract Doc attributes (doc comments are parsed as this)
 pub fn extract_docs(attrs: &[Attribute]) -> Vec<Attribute> {
     extract_attr(attrs, "doc")
-
 }
 
 /// Splits a path by :: separators e.g. "cxx_qt::bridge" becomes ["cxx_qt", "bridge"]
@@ -139,8 +138,7 @@ pub fn require_attributes<'a>(
             .position(|string| path_compare_str(attr.meta.path(), &split_path(string)));
         if let Some(index) = index {
             output.insert(allowed[index], attr); // Doesn't error on duplicates
-        }
-        else {
+        } else {
             return Err(Error::new(
                 attr.span(),
                 format!(

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -87,22 +87,24 @@ impl CaseConversion {
     }
 }
 
-/// Iterate the attributes of the method to extract cfg attributes
-pub fn extract_cfgs(attrs: &[Attribute]) -> Vec<Attribute> {
+/// Helper function to extract all of a particular attribute from the slice
+fn extract_attr(attrs: &[Attribute], target: &str) -> Vec<Attribute> {
     attrs
         .iter()
-        .filter(|attr| path_compare_str(attr.meta.path(), &["cfg"]))
+        .filter(|attr| path_compare_str(attr.meta.path(), &[target]))
         .cloned()
         .collect()
 }
 
+/// Iterate the attributes of the method to extract cfg attributes
+pub fn extract_cfgs(attrs: &[Attribute]) -> Vec<Attribute> {
+    extract_attr(attrs, "cfg")
+}
+
 /// Iterate the attributes of the method to extract Doc attributes (doc comments are parsed as this)
 pub fn extract_docs(attrs: &[Attribute]) -> Vec<Attribute> {
-    attrs
-        .iter()
-        .filter(|attr| path_compare_str(attr.meta.path(), &["doc"]))
-        .cloned()
-        .collect()
+    extract_attr(attrs, "doc")
+
 }
 
 /// Splits a path by :: separators e.g. "cxx_qt::bridge" becomes ["cxx_qt", "bridge"]
@@ -116,9 +118,10 @@ fn split_path(path_str: &str) -> Vec<&str> {
 }
 
 /// Attributes which should be passed through, and are available on most things
+#[derive(Clone, Debug, Default)]
 pub struct CommonAttrs {
-    docs: Vec<Attribute>,
-    cfgs: Vec<Attribute>,
+    pub docs: Vec<Attribute>,
+    pub cfgs: Vec<Attribute>,
 }
 
 /// Collects a Map of all attributes found from the allowed list

--- a/crates/cxx-qt-gen/src/parser/qenum.rs
+++ b/crates/cxx-qt-gen/src/parser/qenum.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::{extract_cfgs, extract_docs, CaseConversion};
+use crate::parser::CaseConversion;
 use crate::{naming::Name, parser::require_attributes, syntax::path::path_compare_str};
 use quote::ToTokens;
 use syn::{Attribute, Ident, ItemEnum, Result, Variant};
@@ -60,9 +60,7 @@ impl ParsedQEnum {
         parent_namespace: Option<&str>,
         module: &Ident,
     ) -> Result<Self> {
-        require_attributes(&qenum.attrs, &Self::ALLOWED_ATTRS)?;
-        let cfgs = extract_cfgs(&qenum.attrs);
-        let docs = extract_docs(&qenum.attrs);
+        let (_attrs, common_attrs) = require_attributes(&qenum.attrs, &Self::ALLOWED_ATTRS)?;
 
         if qenum.variants.is_empty() {
             return Err(syn::Error::new_spanned(
@@ -96,8 +94,8 @@ impl ParsedQEnum {
             name,
             qobject,
             variants,
-            docs,
-            cfgs,
+            docs: common_attrs.docs,
+            cfgs: common_attrs.cfgs,
             item: qenum,
         })
     }

--- a/crates/cxx-qt-gen/src/parser/qenum.rs
+++ b/crates/cxx-qt-gen/src/parser/qenum.rs
@@ -3,10 +3,10 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::CaseConversion;
+use crate::parser::{CaseConversion, CommonAttrs};
 use crate::{naming::Name, parser::require_attributes, syntax::path::path_compare_str};
 use quote::ToTokens;
-use syn::{Attribute, Ident, ItemEnum, Result, Variant};
+use syn::{Ident, ItemEnum, Result, Variant};
 
 pub struct ParsedQEnum {
     /// The name of the QObject
@@ -17,10 +17,8 @@ pub struct ParsedQEnum {
     pub qobject: Option<Ident>,
     /// The original enum item
     pub item: ItemEnum,
-    /// Docs from the qenum
-    pub docs: Vec<Attribute>,
-    /// Cfgs from the qenum
-    pub cfgs: Vec<Attribute>,
+    /// All the universal attributes for the enum
+    pub common_attrs: CommonAttrs,
 }
 
 impl ParsedQEnum {
@@ -94,8 +92,7 @@ impl ParsedQEnum {
             name,
             qobject,
             variants,
-            docs: common_attrs.docs,
-            cfgs: common_attrs.cfgs,
+            common_attrs,
             item: qenum,
         })
     }

--- a/crates/cxx-qt-gen/src/parser/qnamespace.rs
+++ b/crates/cxx-qt-gen/src/parser/qnamespace.rs
@@ -15,7 +15,7 @@ pub struct ParsedQNamespace {
 
 impl ParsedQNamespace {
     pub fn parse(mac: ItemMacro) -> Result<Self> {
-        let attrs = require_attributes(&mac.attrs, &["qml_element"])?;
+        let (attrs, _common_attrs) = require_attributes(&mac.attrs, &["qml_element"])?;
         let namespace_literal: LitStr = syn::parse2(mac.mac.tokens)?;
         let namespace = namespace_literal.value();
         if namespace.contains(char::is_whitespace) {

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -11,6 +11,7 @@ use crate::{
 #[cfg(test)]
 use quote::format_ident;
 use syn::{Attribute, Error, Ident, Meta, Result};
+use crate::parser::CommonAttrs;
 
 /// Metadata for registering QML element
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -40,10 +41,8 @@ pub struct ParsedQObject {
     pub has_qobject_macro: bool,
     /// The original declaration entered by the user, i.e. a type alias with a list of attributes
     pub declaration: ForeignTypeIdentAlias,
-    /// Cfgs for the object
-    pub cfgs: Vec<Attribute>,
-    /// Docs for the object
-    pub docs: Vec<Attribute>,
+    /// All the universal attributes for the object
+    pub common_attrs: CommonAttrs,
 }
 
 impl ParsedQObject {
@@ -74,8 +73,10 @@ impl ParsedQObject {
                 ident_left: format_ident!("MyObject"),
                 ident_right: format_ident!("MyObjectRust"),
             },
-            cfgs: vec![],
-            docs: vec![],
+            common_attrs: CommonAttrs {
+                docs: vec![],
+                cfgs: vec![],
+            }
         }
     }
 
@@ -124,8 +125,7 @@ impl ParsedQObject {
             properties,
             qml_metadata,
             has_qobject_macro,
-            cfgs: common_attrs.cfgs,
-            docs: common_attrs.docs,
+            common_attrs
         })
     }
 

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -3,15 +3,15 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::parser::CommonAttrs;
 use crate::{
     naming::Name,
-    parser::{property::ParsedQProperty, require_attributes, parse_base_type, CaseConversion},
+    parser::{parse_base_type, property::ParsedQProperty, require_attributes, CaseConversion},
     syntax::{expr::expr_to_string, foreignmod::ForeignTypeIdentAlias, path::path_compare_str},
 };
 #[cfg(test)]
 use quote::format_ident;
 use syn::{Attribute, Error, Ident, Meta, Result};
-use crate::parser::CommonAttrs;
 
 /// Metadata for registering QML element
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -47,11 +47,11 @@ pub struct ParsedQObject {
 
 impl ParsedQObject {
     const ALLOWED_ATTRS: [&'static str; 11] = [
+        "cfg",
+        "doc",
         "cxx_name",
         "rust_name",
         "namespace",
-        "cfg",
-        "doc",
         "qobject",
         "base",
         "qml_element",
@@ -76,7 +76,7 @@ impl ParsedQObject {
             common_attrs: CommonAttrs {
                 docs: vec![],
                 cfgs: vec![],
-            }
+            },
         }
     }
 
@@ -87,7 +87,8 @@ impl ParsedQObject {
         module: &Ident,
         auto_case: CaseConversion,
     ) -> Result<Self> {
-        let (attributes, common_attrs) = require_attributes(&declaration.attrs, &Self::ALLOWED_ATTRS)?;
+        let (attributes, common_attrs) =
+            require_attributes(&declaration.attrs, &Self::ALLOWED_ATTRS)?;
 
         let has_qobject_macro = attributes.contains_key("qobject");
 
@@ -125,7 +126,7 @@ impl ParsedQObject {
             properties,
             qml_metadata,
             has_qobject_macro,
-            common_attrs
+            common_attrs,
         })
     }
 

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -11,7 +11,7 @@ use crate::{
 #[cfg(test)]
 use quote::format_ident;
 
-use crate::parser::{parse_base_type, CaseConversion};
+use crate::parser::{extract_docs, parse_base_type, CaseConversion};
 use syn::{Attribute, Error, Ident, Meta, Result};
 
 /// Metadata for registering QML element
@@ -44,6 +44,8 @@ pub struct ParsedQObject {
     pub declaration: ForeignTypeIdentAlias,
     /// Cfgs for the object
     pub cfgs: Vec<Attribute>,
+    /// Docs for the object
+    pub docs: Vec<Attribute>,
 }
 
 impl ParsedQObject {
@@ -75,6 +77,7 @@ impl ParsedQObject {
                 ident_right: format_ident!("MyObjectRust"),
             },
             cfgs: vec![],
+            docs: vec![],
         }
     }
 
@@ -86,8 +89,8 @@ impl ParsedQObject {
         auto_case: CaseConversion,
     ) -> Result<Self> {
         let attributes = require_attributes(&declaration.attrs, &Self::ALLOWED_ATTRS)?;
-        // TODO: handle docs through to generation
         let cfgs = extract_cfgs(&declaration.attrs);
+        let docs = extract_docs(&declaration.attrs);
 
         let has_qobject_macro = attributes.contains_key("qobject");
 
@@ -126,6 +129,7 @@ impl ParsedQObject {
             qml_metadata,
             has_qobject_macro,
             cfgs,
+            docs,
         })
     }
 

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use core::ops::Deref;
 use std::ops::DerefMut;
-use syn::{spanned::Spanned, Attribute, Error, ForeignItemFn, Result, Visibility};
+use syn::{spanned::Spanned, Error, ForeignItemFn, Result, Visibility};
+use crate::parser::CommonAttrs;
 
 #[derive(Clone)]
 /// Describes an individual Signal
@@ -19,10 +20,8 @@ pub struct ParsedSignal {
     pub inherit: bool,
     /// Whether the signal is private
     pub private: bool,
-    /// All the doc attributes (each line) of the signal
-    pub docs: Vec<Attribute>,
-    /// Cfgs for signal
-    pub cfgs: Vec<Attribute>,
+    /// All the universal attributes for the signal
+    pub common_attrs: CommonAttrs,
 }
 
 impl ParsedSignal {
@@ -58,8 +57,7 @@ impl ParsedSignal {
             method_fields: fields,
             inherit,
             private,
-            docs: common_attrs.docs,
-            cfgs: common_attrs.cfgs,
+            common_attrs,
         })
     }
 }

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -2,6 +2,7 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::parser::CommonAttrs;
 use crate::{
     parser::{method::MethodFields, require_attributes, CaseConversion},
     syntax::path::path_compare_str,
@@ -9,7 +10,6 @@ use crate::{
 use core::ops::Deref;
 use std::ops::DerefMut;
 use syn::{spanned::Spanned, Error, ForeignItemFn, Result, Visibility};
-use crate::parser::CommonAttrs;
 
 #[derive(Clone)]
 /// Describes an individual Signal
@@ -26,7 +26,7 @@ pub struct ParsedSignal {
 
 impl ParsedSignal {
     const ALLOWED_ATTRS: [&'static str; 6] =
-        ["cfg", "cxx_name", "rust_name", "inherit", "doc", "qsignal"];
+        ["cfg", "doc", "cxx_name", "rust_name", "inherit", "qsignal"];
 
     #[cfg(test)]
     /// Test fn for creating a mocked signal from a method body

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -2,9 +2,8 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use crate::parser::CaseConversion;
 use crate::{
-    parser::{extract_cfgs, extract_docs, method::MethodFields, require_attributes},
+    parser::{method::MethodFields, require_attributes, CaseConversion},
     syntax::path::path_compare_str,
 };
 use core::ops::Deref;
@@ -37,10 +36,8 @@ impl ParsedSignal {
     }
 
     pub fn parse(method: ForeignItemFn, auto_case: CaseConversion) -> Result<Self> {
-        let docs = extract_docs(&method.attrs);
-        let cfgs = extract_cfgs(&method.attrs);
         let fields = MethodFields::parse(method, auto_case)?;
-        let attrs = require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
+        let (attrs, common_attrs) = require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
 
         if !fields.mutable {
             return Err(Error::new(
@@ -61,8 +58,8 @@ impl ParsedSignal {
             method_fields: fields,
             inherit,
             private,
-            docs,
-            cfgs,
+            docs: common_attrs.docs,
+            cfgs: common_attrs.cfgs,
         })
     }
 }

--- a/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_inputs/passthrough_and_naming.rs
@@ -92,6 +92,7 @@ pub mod ffi {
     }
 
     #[namespace = ""]
+    /// Top level docs for a module
     unsafe extern "C++Qt" {
         #[qobject]
         type QPushButton;
@@ -102,6 +103,7 @@ pub mod ffi {
         #[namespace = "mynamespace"]
         #[cxx_name = "ExternObjectCpp"]
         #[qobject]
+        /// An external object with some docs on it
         type ExternObject;
 
         #[qsignal]
@@ -130,6 +132,7 @@ pub mod ffi {
         #[qobject]
         #[namespace = "second_object"]
         #[qproperty(i32, property_name, cxx_name = "propertyName")]
+        /// The second QObject with some different docs on it
         type SecondObject = super::SecondObjectRust;
     }
 

--- a/crates/cxx-qt-gen/test_outputs/inheritance.rs
+++ b/crates/cxx-qt-gen/test_outputs/inheritance.rs
@@ -103,8 +103,6 @@ mod inheritance {
     }
     extern "C++" {
         type QPushButton;
-    }
-    extern "C++" {
         include ! (< QtWidgets / QPushButton >);
     }
     extern "C++" {

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -201,11 +201,14 @@ pub mod ffi {
         #[doc = "Use this type when referring to the QObject as a pointer"]
         #[doc = "\n"]
         #[doc = "See the book for more information: <https://kdab.github.io/cxx-qt/book/concepts/generated_qobject.html>"]
+        #[doc = "\n"]
+        #[doc = " The second QObject with some different docs on it"]
         #[namespace = "second_object"]
         type SecondObject;
     }
     extern "Rust" {
         #[namespace = "second_object"]
+        #[doc = " The second QObject with some different docs on it"]
         type SecondObjectRust;
     }
     extern "Rust" {
@@ -381,11 +384,6 @@ pub mod ffi {
         #[namespace = "rust::cxxqt1"]
         unsafe fn cxx_qt_ffi_QPushButton_downcastPtr(base: *const QObject) -> *const QPushButton;
     }
-    #[namespace = ""]
-    unsafe extern "C++" {
-        #[namespace = "cxx_qt::multi_object"]
-        type QPushButton;
-    }
     extern "C++" {
         #[doc(hidden)]
         #[cxx_name = "upcastPtr"]
@@ -400,9 +398,13 @@ pub mod ffi {
         ) -> *const ExternObject;
     }
     #[namespace = ""]
+    #[doc = " Top level docs for a module"]
     unsafe extern "C++" {
+        #[namespace = "cxx_qt::multi_object"]
+        type QPushButton;
         #[namespace = "mynamespace"]
         #[cxx_name = "ExternObjectCpp"]
+        #[doc = " An external object with some docs on it"]
         type ExternObject;
     }
     unsafe extern "C++" {

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -196,8 +196,6 @@ mod ffi {
         #[namespace = "cxx_qt::my_object"]
         #[doc = " QTimer"]
         type QTimer;
-    }
-    unsafe extern "C++" {
         include ! (< QtCore / QTimer >);
     }
     unsafe extern "C++" {


### PR DESCRIPTION
Ultimately, it would be good to preserve the blocks things appear in, so if you place a cfg or doc attribute on the top of a block, it is preserved in the final code, but this requires significant rewriting, so work is beginning by slowly grouping things into the same extern block, and passing through docs.