### PR TITLE
qt-build-utils can invoke qmake when it is a script

### DIFF
--- a/crates/qt-build-utils/src/installation/qmake.rs
+++ b/crates/qt-build-utils/src/installation/qmake.rs
@@ -116,8 +116,8 @@ impl TryFrom<PathBuf> for QtInstallationQMake {
 
     fn try_from(qmake_path: PathBuf) -> anyhow::Result<Self> {
         // Attempt to read the QT_VERSION from qmake
-        let qmake_version = match Command::new(&qmake_path)
-            .args(["-query", "QT_VERSION"])
+        let mut cmd = crate::utils::qmake_query_command(&qmake_path, "QT_VERSION");
+        let qmake_version = match cmd
             // Binaries should work without environment and this prevents
             // LD_LIBRARY_PATH from causing different Qt version clashes
             .env_clear()
@@ -211,9 +211,9 @@ impl QtInstallation for QtInstallationQMake {
 
 impl QtInstallationQMake {
     fn qmake_query(&self, var_name: &str) -> String {
+        let mut cmd = crate::utils::qmake_query_command(&self.qmake_path, var_name);
         String::from_utf8_lossy(
-            &Command::new(&self.qmake_path)
-                .args(["-query", var_name])
+            &cmd
                 // Binaries should work without environment and this prevents
                 // LD_LIBRARY_PATH from causing different Qt version clashes
                 .env_clear()

--- a/crates/qt-build-utils/src/utils.rs
+++ b/crates/qt-build-utils/src/utils.rs
@@ -54,3 +54,19 @@ pub(crate) fn is_windows_target() -> bool {
 pub(crate) fn is_emscripten_target() -> bool {
     std::env::var("CARGO_CFG_TARGET_OS") == Ok("emscripten".to_owned())
 }
+
+/// Create a command to run qmake with a query.
+///
+/// On Windows, this wraps the invocation in `cmd /C` so that qmake can be a script.
+pub(crate) fn qmake_query_command(qmake_path: &Path, var_name: &str) -> Command {
+    let mut cmd;
+    if cfg!(target_os = "windows") {
+        cmd = Command::new("cmd");
+        let qmake_command = format!("\"{}\" -query {}", qmake_path.display(), var_name);
+        cmd.args(["/C", &qmake_command]);
+    } else {
+        cmd = Command::new(qmake_path);
+        cmd.args(["-query", var_name]);
+    }
+    cmd
+}


### PR DESCRIPTION
Ensure qmake is called either through `cmd` (Windows) or `sh` (Linux/MacOS).

The main change is this invocation. The rest of the code change is:

- There were two places qmake were previously invoked and they didn't share code. To prevent duplicating this shell wrapper, refactored a bit to ensure they both call the same method to query qmake.
- Due to said refactoring, also had to change the error handling a bit because the error generation moved. Added error types.