### PR TITLE
Document types that require features

### DIFF
--- a/crates/cxx-qt-lib/Cargo.toml
+++ b/crates/cxx-qt-lib/Cargo.toml
@@ -6,12 +6,16 @@
 [package]
 name = "cxx-qt-lib"
 version.workspace = true
-authors = ["Andrew Hayzen <andrew.hayzen@kdab.com>", "Gerhard de Clercq <gerhard.declercq@kdab.com>", "Leon Matthes <leon.matthes@kdab.com>"]
+authors = [
+  "Andrew Hayzen <andrew.hayzen@kdab.com>",
+  "Gerhard de Clercq <gerhard.declercq@kdab.com>",
+  "Leon Matthes <leon.matthes@kdab.com>",
+]
 edition.workspace = true
 license.workspace = true
 description = "Qt types for integrating `cxx-qt` crate with `cxx`"
 repository.workspace = true
-exclude = [ "**/generate.sh" ]
+exclude = ["**/generate.sh"]
 
 # When creating a library with cxx-qt-build, we need to set a fake "links" key
 # to make sure the build scripts are run in the correct order and the build scripts
@@ -19,6 +23,10 @@ exclude = [ "**/generate.sh" ]
 # See also: https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key
 links = "cxx-qt-lib"
 rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 cxx.workspace = true
@@ -30,7 +38,7 @@ rgb = { version = "0.8", optional = true }
 time = { version = "0.3.20", optional = true }
 url = { version = "2.3", optional = true }
 uuid = { version = "1.1.0", optional = true }
-serde = { version = "1", features=["derive"], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 # Note: The image crate is not yet at 1.0 and a new version is released regularly.
 # To avoid a breaking change at each update, we don't specify a default version, and make the versions explicit.
 # Once 1.0 is released, we can add a dependency on `image`, which would then be `image = "1"`
@@ -46,7 +54,19 @@ qt-build-utils.workspace = true
 serde_json = "1.0.135"
 
 [features]
-full = ["qt_full", "serde", "url", "uuid", "time", "rgb", "http", "chrono", "bytes", "image-v0-24", "image-v0-25"]
+full = [
+  "qt_full",
+  "serde",
+  "url",
+  "uuid",
+  "time",
+  "rgb",
+  "http",
+  "chrono",
+  "bytes",
+  "image-v0-24",
+  "image-v0-25",
+]
 default = []
 
 qt_full = ["qt_gui", "qt_qml", "qt_quickcontrols"]

--- a/crates/cxx-qt-lib/src/lib.rs
+++ b/crates/cxx-qt-lib/src/lib.rs
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #[cfg(not(any(cxxqt_qt_version_major = "5", cxxqt_qt_version_major = "6")))]
 compile_error!("cxxqt_qt_version_major must be either \"5\" or \"6\"");
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/92a05a77-c51f-49ce-9006-88b9561275c9)

Currently, [cxx-qt-lib's docs.rs page](https://docs.rs/cxx-qt-lib/latest/cxx_qt_lib/) does not document any types that are gated behind features. This PR fixes the issue.