### PR TITLE
Fix: Constructors no longer fail silently

### DIFF
--- a/book/src/bridge/extern_rustqt.md
+++ b/book/src/bridge/extern_rustqt.md
@@ -111,7 +111,7 @@ is equivalent to writing
 impl cxx_qt::Constructor<()> for x {}
 ```
 
-inside the bridge.
+inside the bridge. You can then implement your constructors outside the bridge, using either of these traits.
 
 For further documentation see the [traits page](./traits.md).
 

--- a/book/src/bridge/traits.md
+++ b/book/src/bridge/traits.md
@@ -23,7 +23,7 @@ For further documentation, refer to the documentation of the individual traits:
 
 - [CxxQtType](https://docs.rs/cxx-qt/latest/cxx_qt/trait.CxxQtType.html) - trait to reach the Rust implementation of a `QObject`
   - This trait is automatically implemented for any `#[qobject]` type inside `extern "RustQt"` blocks.
-- [Constructor](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Constructor.html) - custom constructor
+- [Constructor](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Constructor.html) - custom constructor. This must be declared in the bridge in order for you to implement it outside the bridge
 - [Initialize](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Initialize.html) - execute Rust code when the object is constructed, or as shorthand for an empty constructor
 - [Threading](https://docs.rs/cxx-qt/latest/cxx_qt/trait.Threading.html) - marker trait whether CXX-Qt threading should be enabled
 - [QObjectExt](https://docs.rs/cxx-qt/latest/cxx_qt_lib/trait.QObjectExt.html) - Trait which exposes some key methods of QObject

--- a/crates/cxx-qt-gen/src/generator/rust/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/constructor.rs
@@ -207,6 +207,13 @@ pub fn generate(
 
     let rust_struct_name_rust = qobject_names.rust_struct.rust_unqualified();
 
+    result
+        .cxx_qt_mod_contents
+        .append(&mut vec![parse_quote_spanned! {
+            qobject_name_rust.span() => // TODO! Improve this span
+            impl ::cxx_qt::ConstructorDeclared for #qobject_name_rust_qualified {}
+        }]);
+
     for (index, constructor) in constructors.iter().enumerate() {
         let lifetime = constructor.lifetime.as_ref().map(|lifetime| {
             quote! {
@@ -599,8 +606,16 @@ mod tests {
             },
         );
 
+        // Shim impl only appears once
         assert_tokens_eq(
             &blocks.cxx_qt_mod_contents[0],
+            quote! {
+                impl ::cxx_qt::ConstructorDeclared for qobject::MyObject {}
+            },
+        );
+
+        assert_tokens_eq(
+            &blocks.cxx_qt_mod_contents[1],
             quote! {
                 #[doc(hidden)]
                 pub fn route_arguments_MyObject_0() -> qobject::CxxQtConstructorArgumentsMyObject0
@@ -619,7 +634,7 @@ mod tests {
             },
         );
         assert_tokens_eq(
-            &blocks.cxx_qt_mod_contents[1],
+            &blocks.cxx_qt_mod_contents[2],
             quote! {
                 #[doc(hidden)]
                 #[allow(unused_variables)]
@@ -633,7 +648,7 @@ mod tests {
             },
         );
         assert_tokens_eq(
-            &blocks.cxx_qt_mod_contents[2],
+            &blocks.cxx_qt_mod_contents[3],
             quote! {
                 #[doc(hidden)]
                 #[allow(unused_variables)]
@@ -725,7 +740,7 @@ mod tests {
         );
 
         assert_tokens_eq(
-            &blocks.cxx_qt_mod_contents[3],
+            &blocks.cxx_qt_mod_contents[4],
             quote! {
                 #[doc(hidden)]
                 pub fn route_arguments_MyObject_1<'lifetime>(arg0: *const QObject) -> qobject::CxxQtConstructorArgumentsMyObject1<'lifetime>
@@ -753,7 +768,7 @@ mod tests {
             },
         );
         assert_tokens_eq(
-            &blocks.cxx_qt_mod_contents[4],
+            &blocks.cxx_qt_mod_contents[5],
             quote! {
                 #[doc(hidden)]
                 #[allow(unused_variables)]
@@ -767,7 +782,7 @@ mod tests {
             },
         );
         assert_tokens_eq(
-            &blocks.cxx_qt_mod_contents[5],
+            &blocks.cxx_qt_mod_contents[6],
             quote! {
                 #[doc(hidden)]
                 #[allow(unused_variables)]
@@ -806,7 +821,7 @@ mod tests {
         ]);
 
         assert_eq!(blocks.cxx_mod_contents.len(), 10);
-        assert_eq!(blocks.cxx_qt_mod_contents.len(), 6);
+        assert_eq!(blocks.cxx_qt_mod_contents.len(), 7);
 
         let namespace_attr = quote! {
                 #[namespace = "qobject::cxx_qt_MyObject"]

--- a/crates/cxx-qt-gen/src/generator/rust/constructor.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/constructor.rs
@@ -223,6 +223,7 @@ pub fn generate(
             .cxx_qt_mod_contents
             .append(&mut vec![parse_quote_spanned! {
             constructor.imp.span() =>
+            #[allow(clippy::needless_lifetimes)]
             impl #lifetime ::cxx_qt::ConstructorDeclared<(#arguments) > for #qobject_name_rust_qualified {}
         }]);
 
@@ -616,6 +617,7 @@ mod tests {
         assert_tokens_eq(
             &blocks.cxx_qt_mod_contents[0],
             quote! {
+                #[allow(clippy::needless_lifetimes)]
                 impl ::cxx_qt::ConstructorDeclared<()> for qobject::MyObject {}
             },
         );
@@ -748,6 +750,7 @@ mod tests {
         assert_tokens_eq(
             &blocks.cxx_qt_mod_contents[4],
             quote! {
+                #[allow(clippy::needless_lifetimes)]
                 impl<'lifetime> ::cxx_qt::ConstructorDeclared<(*const QObject,)> for qobject::MyObject {}
             },
         );

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -334,7 +334,7 @@ unsafe impl ::cxx_qt::casting::Upcast<::cxx_qt::QObject> for ffi::MyObject {
         ffi::cxx_qt_ffi_MyObject_downcastPtr(base)
     }
 }
-impl ::cxx_qt::ConstructorDeclared for ffi::MyObject {}
+impl<'a> ::cxx_qt::ConstructorDeclared<(i32, &'a QString)> for ffi::MyObject {}
 #[doc(hidden)]
 pub fn route_arguments_MyObject_0<'a>(
     arg0: i32,
@@ -377,6 +377,7 @@ pub fn initialize_MyObject_0<'a>(
 ) {
     <ffi::MyObject as cxx_qt::Constructor<(i32, &'a ffi::QString)>>::initialize(qobject, ());
 }
+impl ::cxx_qt::ConstructorDeclared<()> for ffi::MyObject {}
 #[doc(hidden)]
 pub fn route_arguments_MyObject_1() -> ffi::CxxQtConstructorArgumentsMyObject1 {
     #[allow(unused_variables)]

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -334,6 +334,7 @@ unsafe impl ::cxx_qt::casting::Upcast<::cxx_qt::QObject> for ffi::MyObject {
         ffi::cxx_qt_ffi_MyObject_downcastPtr(base)
     }
 }
+impl ::cxx_qt::ConstructorDeclared for ffi::MyObject {}
 #[doc(hidden)]
 pub fn route_arguments_MyObject_0<'a>(
     arg0: i32,

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -334,6 +334,7 @@ unsafe impl ::cxx_qt::casting::Upcast<::cxx_qt::QObject> for ffi::MyObject {
         ffi::cxx_qt_ffi_MyObject_downcastPtr(base)
     }
 }
+#[allow(clippy::needless_lifetimes)]
 impl<'a> ::cxx_qt::ConstructorDeclared<(i32, &'a QString)> for ffi::MyObject {}
 #[doc(hidden)]
 pub fn route_arguments_MyObject_0<'a>(
@@ -377,6 +378,7 @@ pub fn initialize_MyObject_0<'a>(
 ) {
     <ffi::MyObject as cxx_qt::Constructor<(i32, &'a ffi::QString)>>::initialize(qobject, ());
 }
+#[allow(clippy::needless_lifetimes)]
 impl ::cxx_qt::ConstructorDeclared<()> for ffi::MyObject {}
 #[doc(hidden)]
 pub fn route_arguments_MyObject_1() -> ffi::CxxQtConstructorArgumentsMyObject1 {

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -216,6 +216,9 @@ pub trait Threading: Sized {
     fn threading_drop(cxx_qt_thread: core::pin::Pin<&mut CxxQtThread<Self>>);
 }
 
+#[doc(hidden)]
+pub trait ConstructorDeclared {}
+
 /// This trait can be implemented on any [CxxQtType] to define a
 /// custom constructor in C++ for the QObject.
 ///
@@ -307,7 +310,7 @@ pub trait Threading: Sized {
 ///
 /// If a QObject implements the `Initialize` trait, and the inner Rust struct is [Default]-constructible it will automatically implement `cxx_qt::Constructor<()>`.
 /// Additionally, implementing `impl cxx_qt::Initialize` will act as shorthand for `cxx_qt::Constructor<()>`.
-pub trait Constructor<Arguments>: CxxQtType {
+pub trait Constructor<Arguments>: CxxQtType + ConstructorDeclared {
     /// The arguments that are passed to the [`new()`](Self::new) function to construct the inner Rust struct.
     /// This must be a tuple of CXX compatible types.
     ///
@@ -394,7 +397,7 @@ pub trait Constructor<Arguments>: CxxQtType {
 /// ```
 // TODO: Once the QObject type is available in the cxx-qt crate, also auto-generate a default
 // constructor that takes QObject and passes it to the parent.
-pub trait Initialize: CxxQtType {
+pub trait Initialize: CxxQtType + ConstructorDeclared {
     /// This function is called to initialize the QObject after construction.
     fn initialize(self: core::pin::Pin<&mut Self>);
 }

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -217,6 +217,8 @@ pub trait Threading: Sized {
 }
 
 #[doc(hidden)]
+// This is implemented when using `impl cxx_qt::Constructor<...> for ... {}` and allows Constructor to be implemented.
+// This is done with a trait bound on `Constructor` which avoids declaring constructors outside the bridge which aren't actually used.
 pub trait ConstructorDeclared<Arguments> {}
 
 /// This trait can be implemented on any [CxxQtType] to define a
@@ -226,10 +228,13 @@ pub trait ConstructorDeclared<Arguments> {}
 ///
 /// If this trait is implemented for a given [CxxQtType], it must also be declared inside the
 /// [cxx_qt::bridge](bridge) macro.
+/// Under the hood, this works by implementing a shim trait called [ConstructorDeclared].
+/// If this is not present, you cannot use your constructor, so if you encounter an error regarding this trait,
+/// it is most likely you have forgotten to declare your constructor inside the bridge.
 /// See the example below.
 ///
 /// Note that declaring an implementation of this trait will stop CXX-Qt from generating a default constructor.
-/// Therefore an implementation of [Default] is no longer required for the Rust type.
+/// Therefore, an implementation of [Default] is no longer required for the Rust type.
 ///
 /// # Minimal Example
 ///
@@ -241,7 +246,9 @@ pub trait ConstructorDeclared<Arguments> {}
 ///         type MyStruct = super::MyStructRust;
 ///     }
 ///
-///     // Declare that we want to use a custom constructor
+///     // Declare that we want to use a custom constructor,
+///     // which will implement `ConstructorDeclared` for these particular args.
+///     //
 ///     // Note that the arguments must be a tuple of CXX types.
 ///     // Any associated types that aren't included here are assumed to be `()`.
 ///     impl cxx_qt::Constructor<(i32, String), NewArguments=(i32, String)> for MyStruct {}
@@ -253,6 +260,7 @@ pub trait ConstructorDeclared<Arguments> {}
 ///     pub string: String
 /// }
 ///
+/// // After declaring we want a custom constructor in the bridge, we must implement it.
 /// impl cxx_qt::Constructor<(i32, String)> for qobject::MyStruct {
 ///     type BaseArguments = (); // Will be passed to the base class constructor
 ///     type InitializeArguments = (); // Will be passed to the "initialize" function

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -217,7 +217,7 @@ pub trait Threading: Sized {
 }
 
 #[doc(hidden)]
-pub trait ConstructorDeclared {}
+pub trait ConstructorDeclared<Arguments> {}
 
 /// This trait can be implemented on any [CxxQtType] to define a
 /// custom constructor in C++ for the QObject.
@@ -310,7 +310,7 @@ pub trait ConstructorDeclared {}
 ///
 /// If a QObject implements the `Initialize` trait, and the inner Rust struct is [Default]-constructible it will automatically implement `cxx_qt::Constructor<()>`.
 /// Additionally, implementing `impl cxx_qt::Initialize` will act as shorthand for `cxx_qt::Constructor<()>`.
-pub trait Constructor<Arguments>: CxxQtType + ConstructorDeclared {
+pub trait Constructor<Arguments>: CxxQtType + ConstructorDeclared<Arguments> {
     /// The arguments that are passed to the [`new()`](Self::new) function to construct the inner Rust struct.
     /// This must be a tuple of CXX compatible types.
     ///
@@ -397,7 +397,7 @@ pub trait Constructor<Arguments>: CxxQtType + ConstructorDeclared {
 /// ```
 // TODO: Once the QObject type is available in the cxx-qt crate, also auto-generate a default
 // constructor that takes QObject and passes it to the parent.
-pub trait Initialize: CxxQtType + ConstructorDeclared {
+pub trait Initialize: CxxQtType + ConstructorDeclared<()> {
     /// This function is called to initialize the QObject after construction.
     fn initialize(self: core::pin::Pin<&mut Self>);
 }


### PR DESCRIPTION
- Closes #1233 
- A shim trait is used to check whether the user declared a constructor
- This is implemented by the bridge if you add the constructor trait in bridge
- This will then allow you to implemented constructor for your type
- This prevents constructors not being used silently