### PR TITLE
Span inspector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 
     "tests/basic_cxx_only/rust",
     "tests/basic_cxx_qt/rust",
-    "tests/qt_types_standalone/rust",
+    "tests/qt_types_standalone/rust", "examples/span-inspector",
 ]
 resolver = "2"
 

--- a/examples/span-inspector/Cargo.toml
+++ b/examples/span-inspector/Cargo.toml
@@ -10,8 +10,10 @@ rust-version.workspace = true
 cxx.workspace = true
 cxx-qt.workspace = true
 cxx-qt-lib = { workspace = true, features = ["full"] }
+cxx-qt-macro = { workspace = true }
+cxx-qt-gen = { workspace = true }
 proc-macro2.workspace = true
-prettyplease = "0.2"
+prettyplease = { version = "0.2", features = ["verbatim"] }
 syn.workspace=true
 
 [build-dependencies]

--- a/examples/span-inspector/Cargo.toml
+++ b/examples/span-inspector/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "span-inspector"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+cxx.workspace = true
+cxx-qt.workspace = true
+cxx-qt-lib = { workspace = true, features = ["full"] }
+proc-macro2.workspace = true
+prettyplease = "0.2"
+syn.workspace=true
+
+[build-dependencies]
+cxx-qt-build = { workspace = true, features = [ "link_qt_object_files" ] }
+
+[lints]
+workspace = true

--- a/examples/span-inspector/build.rs
+++ b/examples/span-inspector/build.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use cxx_qt_build::{CxxQtBuilder, QmlModule};
+
+fn main() {
+    let qml_module: QmlModule<'static, &str, &str> = QmlModule {
+        uri: "com.kdab.cxx_qt.demo",
+        rust_files: &["src/inspector.rs"],
+        qml_files: &["qml/main.qml"],
+        ..Default::default()
+    };
+    CxxQtBuilder::new()
+        // Link Qt's Network library
+        // - Qt Core is always linked
+        // - Qt Gui is linked by enabling the qt_gui Cargo feature of cxx-qt-lib.
+        // - Qt Qml is linked by enabling the qt_qml Cargo feature of cxx-qt-lib.
+        // - Qt Qml requires linking Qt Network on macOS
+        .qt_module("Network")
+        .qt_module("Quick")
+        .qml_module(qml_module)
+        .build();
+}

--- a/examples/span-inspector/qml/main.qml
+++ b/examples/span-inspector/qml/main.qml
@@ -27,11 +27,11 @@ ApplicationWindow {
             SplitView.preferredWidth: parent.width / 2
             Component.onCompleted: {
                 inspector.input = textDocument
-                inspector.updateCursorPosition(cursorPosition)
+                inspector.rebuildOutput(cursorPosition)
             }
 
             onCursorPositionChanged: {
-                inspector.updateCursorPosition(cursorPosition)
+                inspector.rebuildOutput(cursorPosition)
             }
         }
         TextEdit {

--- a/examples/span-inspector/qml/main.qml
+++ b/examples/span-inspector/qml/main.qml
@@ -11,11 +11,13 @@ import QtQuick.Layouts
 import com.kdab.cxx_qt.demo 1.0
 
 ApplicationWindow {
+    id: appWindow
+    color: palette.window
+    property color textColor: color.lightness < 128 * "black" , "white"
     height: 480
     title: qsTr("Span Inspector")
     visible: true
     width: 640
-    color: palette.window
 
     SpanInspector {
         id: inspector
@@ -23,23 +25,39 @@ ApplicationWindow {
 
     SplitView {
         anchors.fill: parent
-        TextEdit {
+        Item {
             SplitView.preferredWidth: parent.width / 2
-            Component.onCompleted: {
-                inspector.input = textDocument
-                inspector.rebuildOutput(cursorPosition)
-            }
+            TextArea {
+                SplitView.preferredWidth: parent.width / 2
+                wrapMode: TextArea.Wrap
+                id: inputEdit
+                anchors.fill: parent
+                clip: true
+                color: appWindow.textColor
+                Component.onCompleted: {
+                    inspector.input = textDocument
+                    inspector.rebuildOutput(cursorPosition)
+                }
 
-            onCursorPositionChanged: {
-                inspector.rebuildOutput(cursorPosition)
+                onCursorPositionChanged: {
+                    inspector.rebuildOutput(cursorPosition)
+                }
+
+                onTextChanged: {
+                    inspector.rebuildOutput(cursorPosition)
+                }
             }
         }
-        TextEdit {
+
+        ScrollView {
             SplitView.preferredWidth: parent.width / 2
-            text: "Hello World"
-            readOnly: true;
-            wrapMode: TextEdit.wrap;
-            Component.onCompleted: inspector.output = textDocument
+            TextEdit {
+                clip: true
+                color: appWindow.textColor
+                text: "Hello World"
+                readOnly: true;
+                Component.onCompleted: inspector.output = textDocument
+            }
         }
     }
 }

--- a/examples/span-inspector/qml/main.qml
+++ b/examples/span-inspector/qml/main.qml
@@ -12,7 +12,7 @@ import com.kdab.cxx_qt.demo 1.0
 
 ApplicationWindow {
     height: 480
-    title: qsTr("Hello World")
+    title: qsTr("Span Inspector")
     visible: true
     width: 640
     color: palette.window
@@ -37,6 +37,8 @@ ApplicationWindow {
         TextEdit {
             SplitView.preferredWidth: parent.width / 2
             text: "Hello World"
+            readOnly: true;
+            wrapMode: TextEdit.wrap;
             Component.onCompleted: inspector.output = textDocument
         }
     }

--- a/examples/span-inspector/qml/main.qml
+++ b/examples/span-inspector/qml/main.qml
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
+import QtQuick.Layouts
+
+import com.kdab.cxx_qt.demo 1.0
+
+ApplicationWindow {
+    height: 480
+    title: qsTr("Hello World")
+    visible: true
+    width: 640
+    color: palette.window
+
+    SpanInspector {
+        id: inspector
+    }
+
+    SplitView {
+        anchors.fill: parent
+        TextEdit {
+            SplitView.preferredWidth: parent.width / 2
+            Component.onCompleted: inspector.input = textDocument
+        }
+        TextEdit {
+            SplitView.preferredWidth: parent.width / 2
+            text: "Hello World"
+            Component.onCompleted: inspector.output = textDocument
+        }
+    }
+}

--- a/examples/span-inspector/qml/main.qml
+++ b/examples/span-inspector/qml/main.qml
@@ -25,7 +25,14 @@ ApplicationWindow {
         anchors.fill: parent
         TextEdit {
             SplitView.preferredWidth: parent.width / 2
-            Component.onCompleted: inspector.input = textDocument
+            Component.onCompleted: {
+                inspector.input = textDocument
+                inspector.updateCursorPosition(cursorPosition)
+            }
+
+            onCursorPositionChanged: {
+                inspector.updateCursorPosition(cursorPosition)
+            }
         }
         TextEdit {
             SplitView.preferredWidth: parent.width / 2

--- a/examples/span-inspector/src/inspector.rs
+++ b/examples/span-inspector/src/inspector.rs
@@ -160,9 +160,12 @@ impl qobject::SpanInspector {
         let span_data: Option<Vec<bool>> = target_span.map(|target_span|
             Self::flatten_tokenstream(output_stream.clone())
                 .into_iter()
-                // prettyplease may insert extra "," tokens.
+                // prettyplease may insert extra tokens.
                 // This filter simply ignores them.
-                .filter(|token| token.to_string() != ",")
+                .filter(|token| {
+                    let string = token.to_string();
+                    !matches!(string.as_str(), "," | "}" | "{")
+                }) 
                 .map(|token| target_span.byte_range().eq(token.span().byte_range()))
                 .collect()
         );
@@ -214,9 +217,10 @@ impl qobject::SpanInspector {
             Some(span_data) => {
                 let mut token_position = span_data.len();
                 for token in flat_tokenstream.into_iter().rev() {
-                    // prettyplease may insert extra "," tokens.
+                    // prettyplease may insert extra tokens.
                     // This `if` statement simply ignores them.
-                    if !token.to_string().eq(",") { 
+                    let token_string = token.to_string();
+                    if !matches!(token_string.as_str(), "," | "{" | "}") { 
                         token_position = token_position - 1;
                     }
                     if *span_data.get(token_position).unwrap() {

--- a/examples/span-inspector/src/inspector.rs
+++ b/examples/span-inspector/src/inspector.rs
@@ -4,8 +4,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx_qt_gen::{write_rust, Parser};
-use proc_macro2::TokenStream;
-use std::str::FromStr;
+use proc_macro2::{Span, TokenStream, TokenTree};
+use std::{str::FromStr, usize};
 use syn::{parse2, ItemMod};
 
 #[cxx_qt::bridge]
@@ -24,6 +24,9 @@ mod qobject {
 
         #[cxx_name = "setPlainText"]
         fn set_plain_text(self: Pin<&mut QTextDocument>, content: &QString);
+
+        #[cxx_name = "setHtml"]
+        fn set_html(self: Pin<&mut QTextDocument>, content: &QString);
 
         #[qsignal]
         #[cxx_name = "contentsChanged"]
@@ -92,15 +95,16 @@ impl qobject::SpanInspector {
                 let qt_thread = qt_thread.clone();
                 let text = document.to_plain_text().to_string();
                 std::thread::spawn(move || {
-                    let Ok(file) = syn::parse_file(Self::expand(&text).as_str())
+                    let (expanded, span_data) = Self::expand(&text);
+                    let Ok(file) = syn::parse_file(expanded.as_str())
                         .map_err(|err| eprintln!("Parsing error: {err}"))
                     else {
                         return;
                     };
-                    let output = QString::from(prettyplease::unparse(&file));
+                    let output = QString::from(Self::build_html(prettyplease::unparse(&file), span_data));
                     qt_thread
                         .queue(move |this| {
-                            unsafe { this.output_document() }.set_plain_text(&output)
+                            unsafe { this.output_document() }.set_html(&QString::from(output))
                         })
                         .ok();
                 });
@@ -108,19 +112,23 @@ impl qobject::SpanInspector {
             .release();
     }
 
-    // Expand this code as #[cxxqt_qt::bridge] would do
-    fn expand(input: &str) -> String {
-        println!("{}", &input);
-        let stream: TokenStream = TokenStream::from_str(input).unwrap();
-
-        let mut module: ItemMod = parse2(stream).expect("could not generate ItemMod");
+    // Expand input code as #[cxxqt_qt::bridge] would do
+    fn expand(input: &str) -> (String, Vec<bool>){
+        let target: usize = 1;
+        let input_stream: TokenStream = TokenStream::from_str(input).unwrap();
+        
+        let mut module: ItemMod = parse2(input_stream.clone()).expect("could not generate ItemMod");
 
         let args = TokenStream::default();
         let args_input = format!("#[cxx_qt::bridge({args})] mod dummy;");
         let attrs = syn::parse_str::<ItemMod>(&args_input).unwrap().attrs;
         module.attrs = attrs.into_iter().chain(module.attrs).collect();
 
-        format!("{}", Self::extract_and_generate(module))
+        let output_stream = Self::extract_and_generate(module);
+        let target_span : Span = input_stream.into_iter().nth(target).map(|token| token.span()).unwrap();
+        let span_data = Self::get_span_data(output_stream.clone(), target_span);
+        
+        (format!("{}", output_stream), span_data)
     }
 
     // Take the module and C++ namespace and generate the rust code
@@ -130,5 +138,56 @@ impl qobject::SpanInspector {
             .map(|generated_rust| write_rust(&generated_rust, None))
             .unwrap_or_else(|err| err.to_compile_error())
             .into()
+    }
+
+    fn build_html(input: String, span_data: Vec<bool>) -> String{
+
+        fn highlight(token_stream: TokenStream, mut text: String, span_data: &Vec<bool>, mut token_position: usize) -> (String, usize) {
+            let token_vec: Vec<TokenTree> = token_stream.into_iter().collect();
+            for token in token_vec.into_iter().rev() {
+                match &token {
+                    TokenTree::Group(group) => {
+                    (text, token_position) = highlight(group.stream(), text, span_data, token_position);
+                    },
+                    _ => {
+                        token_position = token_position - 1;
+                        if *span_data.get(token_position).unwrap() {
+                            text.replace_range(token.span().byte_range(), format!("<span class=\"highlight\">{}</span>", token).as_str());
+                        }
+                    },
+                }
+            }
+            return (text, token_position);
+        }
+
+        let token_stream: TokenStream = TokenStream::from_str(input.as_str()).unwrap();
+        let (highlighted_string, _) = highlight(token_stream, input, &span_data, span_data.len());
+        let style: String = String::from("
+            <style> 
+                .highlight {
+                    background-color: #ff00ff;
+                    padding: 2px 6px;
+                    border-radius: 6px;
+                }
+            </style>
+        ");
+        format!("<!DOCTYPE html><html><head>{}</head><body><pre>{}</pre></body></html>", style, highlighted_string)
+    }
+
+   
+    fn get_span_data(token_stream: TokenStream, target_span: Span) -> Vec<bool> {
+        let mut vec: Vec<bool> = vec![];
+        for token in token_stream {
+            match token {
+                TokenTree::Group(group) => {
+                    vec.extend(Self::get_span_data(group.stream(), target_span));
+                }
+                _ => {
+                    vec.push(target_span.byte_range().eq(token.span().byte_range()));
+                }
+            }
+        }
+        println!("{:?}", vec);
+        vec
     }
 }

--- a/examples/span-inspector/src/inspector.rs
+++ b/examples/span-inspector/src/inspector.rs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Leon Matthes <leon.matthes@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cxx_qt::bridge]
+mod qobject {
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/qstring.h");
+        type QString = cxx_qt_lib::QString;
+    }
+    unsafe extern "C++Qt" {
+        include!(<QTextDocument>);
+        #[qobject]
+        type QTextDocument;
+
+        #[cxx_name = "toPlainText"]
+        fn to_plain_text(self: &QTextDocument) -> QString;
+
+        #[cxx_name = "setPlainText"]
+        fn set_plain_text(self: Pin<&mut QTextDocument>, content: &QString);
+
+        #[qsignal]
+        #[cxx_name = "contentsChanged"]
+        fn contents_changed(self: Pin<&mut QTextDocument>);
+    }
+
+    unsafe extern "C++Qt" {
+        include!(<QQuickTextDocument>);
+        #[qobject]
+        type QQuickTextDocument;
+
+        #[cxx_name = "textDocument"]
+        fn text_document(self: &QQuickTextDocument) -> *mut QTextDocument;
+    }
+
+    extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qproperty(*mut QQuickTextDocument, input, READ, NOTIFY, WRITE=set_input)]
+        #[qproperty(*mut QQuickTextDocument, output)]
+        type SpanInspector = super::SpanInspectorRust;
+
+        unsafe fn set_input(self: Pin<&mut SpanInspector>, input: *mut QQuickTextDocument);
+    }
+
+    impl UniquePtr<QTextDocument> {}
+    impl cxx_qt::Threading for SpanInspector {}
+}
+
+use cxx_qt::{CxxQtType, Threading};
+use qobject::{QQuickTextDocument, QString, QTextDocument};
+use std::{pin::Pin, ptr};
+
+pub struct SpanInspectorRust {
+    input: *mut QQuickTextDocument,
+    output: *mut QQuickTextDocument,
+}
+
+impl Default for SpanInspectorRust {
+    fn default() -> Self {
+        Self {
+            input: ptr::null_mut(),
+            output: ptr::null_mut(),
+        }
+    }
+}
+
+impl qobject::SpanInspector {
+    unsafe fn output_document(&self) -> Pin<&mut QTextDocument> {
+        if self.output == ptr::null_mut() {
+            panic!("Output document must be set!");
+        }
+        let output = unsafe { &*self.output };
+        unsafe { Pin::new_unchecked(&mut *output.text_document()) }
+    }
+
+    fn set_input(mut self: Pin<&mut Self>, input: *mut QQuickTextDocument) {
+        self.as_mut().rust_mut().input = input;
+        self.as_mut().input_changed();
+
+        let input = unsafe { Pin::new_unchecked(&mut *input) };
+        let document = unsafe { Pin::new_unchecked(&mut *input.text_document()) };
+        let qt_thread = self.qt_thread();
+        document
+            .on_contents_changed(move |document| {
+                let qt_thread = qt_thread.clone();
+                let text = document.to_plain_text().to_string();
+                std::thread::spawn(move || {
+                    let Ok(file) =
+                        syn::parse_file(&text).map_err(|err| eprintln!("Parsing error: {err}"))
+                    else {
+                        return;
+                    };
+                    let output = QString::from(prettyplease::unparse(&file));
+                    qt_thread
+                        .queue(move |this| {
+                            unsafe { this.output_document() }.set_plain_text(&output)
+                        })
+                        .ok();
+                });
+            })
+            .release();
+    }
+}

--- a/examples/span-inspector/src/main.rs
+++ b/examples/span-inspector/src/main.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Be Wilson <be.wilson@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+// SPDX-FileContributor: Gerhard de Clercq <gerhard.declercq@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/// A module for our Rust defined QObject
+pub mod inspector;
+
+use cxx_qt::Upcast;
+use cxx_qt_lib::{QGuiApplication, QQmlApplicationEngine, QUrl};
+
+fn main() {
+    // Create the application and engine
+    let mut app = QGuiApplication::new();
+    let mut engine = QQmlApplicationEngine::new();
+
+    // Load the QML path into the engine
+    if let Some(engine) = engine.as_mut() {
+        engine.load(&QUrl::from("qrc:/qt/qml/com/kdab/cxx_qt/demo/qml/main.qml"));
+    }
+
+    if let Some(engine) = engine.as_mut() {
+        // Listen to a signal from the QML Engine
+        engine
+            .upcast_pin()
+            .on_quit(|_| {
+                println!("QML Quit!");
+            })
+            .release();
+    }
+
+    // Start the app
+    if let Some(app) = app.as_mut() {
+        app.exec();
+    }
+}


### PR DESCRIPTION
This PR introduces a tool called span-inspector that helps analyze and visualize the spans of tokens generated from the input to a cxx-qt-bridge macro.

Details
 - Parses the input of a cxx-qt-bridge macro
 -  Expands the macro
 -  Highlights the spans of individual tokens for better inspection and debugging
 -  Differentiates between synthesized an