### PR TITLE
Replace handwritten documentation with Qt documentation

### DIFF
--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cxx::{type_id, ExternType};
+use cxx_qt_lib::{QString, QStringList};
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
@@ -26,22 +27,36 @@ mod ffi {
         /// Returns the names set for this option.
         fn names(self: &QCommandLineOption) -> QStringList;
 
-        /// Sets the default value used for this option to defaultValue.
+        /// Sets the default value used for this option to `default_value`.
+        ///
+        /// The default value is used if the user of the application does not specify the option on the command line.
+        ///
+        /// If `default_value` is empty, the option has no default values.
         #[rust_name = "set_default_value"]
-        fn setDefaultValue(self: &mut QCommandLineOption, value: &QString);
+        fn setDefaultValue(self: &mut QCommandLineOption, default_value: &QString);
 
-        /// Sets the list of default values used for this option to defaultValues.
+        /// Sets the list of default values used for this option to `default_values`.
+        ///
+        /// The default values are used if the user of the application does not specify the option on the command line.
         #[rust_name = "set_default_values"]
-        fn setDefaultValues(self: &mut QCommandLineOption, values: &QStringList);
+        fn setDefaultValues(self: &mut QCommandLineOption, default_values: &QStringList);
 
-        /// Sets the description used for this option to description.
+        /// Sets the description used for this option to `description`.
         /// It is customary to add a "." at the end of the description.
+        ///
+        /// The description is used by [QCommandLineParser::showHelp](https://doc.qt.io/qt/qcommandlineparser.html#showHelp)().
         #[rust_name = "set_description"]
         fn setDescription(self: &mut QCommandLineOption, description: &QString);
 
-        /// Sets the name of the expected value, for the documentation, to valueName.
+        /// Sets the name of the expected value, for the documentation, to `value_name`.
+        ///
+        /// Options without a value assigned have a boolean-like behavior: either the user specifies –option or they don't.
+        ///
+        /// Options with a value assigned need to set a name for the expected value, for the documentation of the option in the help output. An option with names `o` and `output`, and a value name of file will appear as `-o, --output <file>`.
+        ///
+        /// Call [`QCommandLineParser::value`](crate::QCommandLineParser::value) if you expect the option to be present only once, and [`QCommandLineParser::values`](crate::QCommandLineParser::values) if you expect that option to be present multiple times.
         #[rust_name = "set_value_name"]
-        fn setValueName(self: &mut QCommandLineOption, valueName: &QString);
+        fn setValueName(self: &mut QCommandLineOption, value_name: &QString);
 
         /// Returns the name of the expected value.
         #[rust_name = "value_name"]
@@ -70,35 +85,38 @@ mod ffi {
     }
 }
 
+/// The `QCommandLineOption` class defines a possible command-line option.
+///
+/// Qt Documentation: [QCommandLineOption](https://doc.qt.io/qt/qcommandlineoption.html#details)
 #[repr(C)]
 pub struct QCommandLineOption {
     _space: MaybeUninit<usize>,
 }
 
 impl Clone for QCommandLineOption {
-    /// Constructs a copy of other.
+    /// Constructs a copy of this `QCommandLineOption`.
     fn clone(&self) -> Self {
         ffi::qcommandlineoption_init_from_qcommandlineoption(self)
     }
 }
 
 impl Drop for QCommandLineOption {
-    /// Destroys the qcommandlineoption.
+    /// Destroys the `QCommandLineOption`.
     fn drop(&mut self) {
         ffi::qcommandlineoption_drop(self)
     }
 }
 
-impl From<&ffi::QString> for QCommandLineOption {
+impl From<&QString> for QCommandLineOption {
     /// Constructs a command line option object with the name name.
-    fn from(name: &ffi::QString) -> Self {
+    fn from(name: &QString) -> Self {
         ffi::qcommandlineoption_init_from_qstring(name)
     }
 }
 
-impl From<&ffi::QStringList> for QCommandLineOption {
+impl From<&QStringList> for QCommandLineOption {
     /// Constructs a command line option object with the name name.
-    fn from(names: &ffi::QStringList) -> Self {
+    fn from(names: &QStringList) -> Self {
         ffi::qcommandlineoption_init_from_qstringlist(names)
     }
 }

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.rs
@@ -50,7 +50,7 @@ mod ffi {
 
         /// Sets the name of the expected value, for the documentation, to `value_name`.
         ///
-        /// Options without a value assigned have a boolean-like behavior: either the user specifies –option or they don't.
+        /// Options without a value assigned have a boolean-like behavior: either the user specifies `–option` or they don't.
         ///
         /// Options with a value assigned need to set a name for the expected value, for the documentation of the option in the help output. An option with names `o` and `output`, and a value name of file will appear as `-o, --output <file>`.
         ///

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.rs
@@ -3,32 +3,36 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
+use cxx_qt_lib::{QString, QStringList};
 use std::mem::MaybeUninit;
 
 #[cxx::bridge]
 mod ffi {
-    /// The type of image format available in Qt.
+    /// This enum describes the way the parser interprets options that occur after positional arguments.
     #[repr(i32)]
     #[namespace = "rust::cxxqtlib1"]
     #[derive(Debug)]
     enum QCommandLineParserOptionsAfterPositionalArgumentsMode {
-        /// application argument --opt -t is interpreted as setting the options opt and t,
-        /// just like application --opt -t argument would do. This is the default parsing mode.
-        /// In order to specify that --opt and -t are positional arguments instead, the user can use --,
-        /// as in application argument -- --opt -t.
+        /// `application argument --opt -t` is interpreted as setting the options `opt` and `t`,
+        /// just like `application --opt -t argument` would do. This is the default parsing mode.
+        /// In order to specify that `--opt` and `-t` are positional arguments instead, the user can use `--`,
+        /// as in `application argument -- --opt -t`.
         ParseAsOptions,
-        /// application argument --opt is interpreted as having two positional arguments, argument and --opt.
+        /// `application argument --opt` is interpreted as having two positional arguments, `argument` and `--opt`.
         /// This mode is useful for executables that aim to launch other executables (e.g. wrappers, debugging tools, etc.)
         /// or that support internal commands followed by options for the command. argument is the name of the command,
         /// and all options occurring after it can be collected and parsed by another command line parser, possibly in another executable.
         ParseAsPositionalArguments,
     }
 
+    /// This enum describes the way the parser interprets command-line options that use a single dash followed by multiple letters, as `-abc`.
     #[repr(i32)]
     #[namespace = "rust::cxxqtlib1"]
     #[derive(Debug)]
     enum QCommandLineParserSingleDashWordOptionMode {
+        /// `-abc` is interpreted as `-a -b -c`, i.e. as three short options that have been compacted on the command-line, if none of the options take a value. If `a` takes a value, then it is interpreted as `-a bc`, i.e. the short option a followed by the value `bc`. This is typically used in tools that behave like compilers, in order to handle options such as `-DDEFINE=VALUE` or `-I/include/path`. This is the default parsing mode. New applications are recommended to use this mode.
         ParseAsCompactedShortOptions,
+        /// `-abc` is interpreted as `--abc`, i.e. as the long option named `abc`. This is how Qt's own tools (uic, rcc...) have always been parsing arguments. This mode should be used for preserving compatibility in applications that were parsing arguments in such a way. There is an exception if the `a` option has the [`QCommandLineOption::ShortOptionStyle`] flag set, in which case it is still interpreted as `-a bc`.
         ParseAsLongOptions,
     }
 
@@ -44,18 +48,24 @@ mod ffi {
         type QStringList = cxx_qt_lib::QStringList;
 
         /// Adds help options to the command-line parser.
+        ///
+        /// The options specified for this command-line are described by `-h` or `--help`. On Windows, the alternative `-?` is also supported. The option `--help-all` extends that to include generic Qt options, not defined by this command, in the output.
+        ///
+        /// These options are handled automatically by `QCommandLineParser`.
         #[rust_name = "add_help_option"]
         fn addHelpOption(self: &mut QCommandLineParser) -> QCommandLineOption;
 
-        /// Adds the option option to look for while parsing.
-        /// Returns true if adding the option was successful; otherwise returns false.
+        /// Adds the option `option` to look for while parsing.
+        /// Returns `true` if adding the option was successful; otherwise returns `false`.
+        ///
         /// Adding the option fails if there is no name attached to the option,
         /// or the option has a name that clashes with an option name added before.
         #[rust_name = "add_option"]
         fn addOption(self: &mut QCommandLineParser, option: &QCommandLineOption) -> bool;
 
-        /// Adds the -v / --version option, which displays the version string of the application.
-        /// This option is handled automatically by QCommandLineParser.
+        /// Adds the `-v` / `--version` option, which displays the version string of the application.
+        ///
+        /// This option is handled automatically by `QCommandLineParser`.
         #[rust_name = "add_version_option"]
         fn addVersionOption(self: &mut QCommandLineParser) -> QCommandLineOption;
 
@@ -67,7 +77,7 @@ mod ffi {
         #[rust_name = "clear_positional_arguments"]
         fn clearPositionalArguments(self: &mut QCommandLineParser);
 
-        /// Returns a translated error text for the user. This should only be called when parse() returns false.
+        /// Returns a translated error text for the user. This should only be called when [`parse`](Self::parse) returns `false`.
         #[rust_name = "error_text"]
         fn errorText(self: &QCommandLineParser) -> QString;
 
@@ -76,42 +86,75 @@ mod ffi {
         fn helpText(self: &QCommandLineParser) -> QString;
 
         /// Returns a list of option names that were found.
+        ///
+        /// This returns a list of all the recognized option names found by the parser, in the order in which they were found. For any long options that were in the form {–option=value}, the value part will have been dropped.
+        ///
+        /// The names in this list do not include the preceding dash characters. Names may appear more than once in this list if they were encountered more than once by the parser.
+        ///
+        /// Any entry in the list can be used with [`value`](Self::value) or with [`values`](Self::values) to get any relevant option values.
         #[rust_name = "option_names"]
         fn optionNames(self: &QCommandLineParser) -> QStringList;
 
         /// Parses the command line arguments.
+        ///
+        /// Most programs don't need to call this, a simple call to [`process`] is enough.
+        ///
+        /// This function is more low-level, and only does the parsing. The application will have to take care of the error handling, using [`error_text`] if this function returns `false`. This can be useful for instance to show a graphical error message in graphical programs.
+        ///
+        /// Calling this function instead of [`process`] can also be useful in order to ignore unknown options temporarily, because more option definitions will be provided later on (depending on one of the arguments), before calling [`process`].
+        ///
+        /// Don't forget that arguments must start with the name of the executable (ignored, though).
+        ///
+        /// Returns `false` in case of a parse error (unknown option or missing value); returns `true` otherwise.
+        ///
+        /// [`process`]: Self::process
+        /// [`error_text`]: Self::error_text
         fn parse(self: &mut QCommandLineParser, arguments: &QStringList) -> bool;
 
         /// Returns a list of positional arguments.
+        ///
+        /// These are all of the arguments that were not recognized as part of an option.
         #[rust_name = "positional_arguments"]
         fn positionalArguments(self: &QCommandLineParser) -> QStringList;
 
         /// Processes the command line arguments.
+        ///
+        /// In addition to parsing the options (like [`parse`](Self::parse)), this function also handles the builtin options and handles errors.
+        ///
+        /// The builtin options are `--version` if [`add_version_option`](Self::add_version_option) was called and `--help` / `--help-all` if [`add_help_option`](Self::add_help_option) was called.
+        ///
+        /// When invoking one of these options, or when an error happens (for instance an unknown option was passed), the current process will then stop, using the [exit](https://doc.qt.io/qt/qcoreapplication.html#exit)() function.
         fn process(self: &mut QCommandLineParser, arguments: &QStringList);
 
-        /// Sets the application description shown by helpText().
+        /// Sets the application description shown by [`help_text`](Self::help_text).
         #[rust_name = "set_application_description"]
         fn setApplicationDescription(self: &mut QCommandLineParser, description: &QString);
 
-        /// Sets the parsing mode to parsingMode. This must be called before process() or parse().
+        /// Sets the parsing mode to `single_dash_word_option_mode`. This must be called before [`process`](Self::process) or [`parse`](Self::parse).
         #[rust_name = "set_single_dash_word_option_mode"]
         fn setSingleDashWordOptionMode(
             self: &mut QCommandLineParser,
-            singleDashWordOptionMode: QCommandLineParserSingleDashWordOptionMode,
+            single_dash_word_option_mode: QCommandLineParserSingleDashWordOptionMode,
         );
 
-        /// Sets the parsing mode to parsingMode. This must be called before process() or parse().
+        /// Sets the parsing mode to `parsing_mode`. This must be called before [`process`](Self::process) or [`parse`](Self::parse).
         #[rust_name = "set_options_after_positional_arguments_mode"]
         fn setOptionsAfterPositionalArgumentsMode(
             self: &mut QCommandLineParser,
-            parsingMode: QCommandLineParserOptionsAfterPositionalArgumentsMode,
+            parsing_mode: QCommandLineParserOptionsAfterPositionalArgumentsMode,
         );
 
-        /// Displays the version information from QCoreApplication::applicationVersion(), and exits the application.
+        /// Displays the version information from [`QCoreApplication::application_version`](cxx_qt_lib::QCoreApplication::application_version), and exits the application.
+        ///
+        ///  This is automatically triggered by the `–version` option, but can also be used to display the version when not using [`process`](Self::process). The exit code is set to `EXIT_SUCCESS` (0).
         #[rust_name = "show_version"]
         fn showVersion(self: &mut QCommandLineParser);
 
         /// Returns a list of unknown option names.
+        ///
+        /// This list will include both long and short name options that were not recognized. For any long options that were in the form {–option=value}, the value part will have been dropped and only the long name is added.
+        ///
+        /// The names in this list do not include the preceding dash characters. Names may appear more than once in this list if they were encountered more than once by the parser.
         #[rust_name = "unknown_option_names"]
         fn unknownOptionNames(self: &QCommandLineParser) -> QStringList;
     }
@@ -146,8 +189,9 @@ mod ffi {
     }
 }
 
-/// QCoreApplication provides the command-line arguments as a simple list of strings.
-/// QCommandLineParser provides the ability to define a set of options, parse the command-line arguments, and store which options have actually been used, as well as option values.
+/// The QCommandLineParser class provides a means for handling the command line options.
+///
+/// Qt Documentation: [QCommandLineParser](https://doc.qt.io/qt/qcommandlineparser.html#details)
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct QCommandLineParser {
@@ -155,18 +199,34 @@ pub struct QCommandLineParser {
 }
 
 impl QCommandLineParser {
-    /// Returns the option value found for the given option name optionName, or an empty string if not found.
-    pub fn value(&self, option_name: &ffi::QString) -> ffi::QString {
+    /// Returns the option value found for the given option name `option_name`, or an empty string if not found.
+    ///
+    /// The name provided can be any long or short name of any option that was added with [`add_option`](Self::add_option). All the option names are treated as being equivalent. If the name is not recognized or that option was not present, an empty string is returned.
+    ///
+    /// For options found by the parser, the last value found for that option is returned. If the option wasn't specified on the command line, the default value is returned.
+    ///
+    /// If the option does not take a value, a warning is printed, and an empty string is returned.
+    pub fn value(&self, option_name: &QString) -> QString {
         ffi::qcommandlineparser_value(self, option_name)
     }
 
-    /// Returns a list of option values found for the given option name optionName, or an empty list if not found.
-    pub fn values(&self, option_name: &ffi::QString) -> ffi::QStringList {
+    /// Returns a list of option values found for the given option name `option_name`, or an empty list if not found.
+    ///
+    /// The name provided can be any long or short name of any option that was added with [`add_option`](Self::add_option). All the options names are treated as being equivalent. If the name is not recognized or that option was not present, an empty list is returned.
+    ///
+    /// For options found by the parser, the list will contain an entry for each time the option was encountered by the parser. If the option wasn't specified on the command line, the default values are returned.
+    ///
+    /// An empty list is returned if the option does not take a value.
+    pub fn values(&self, option_name: &QString) -> QStringList {
         ffi::qcommandlineparser_values(self, option_name)
     }
 
-    /// Checks whether the option name was passed to the application.
-    pub fn is_set(&self, name: &ffi::QString) -> bool {
+    /// Checks whether the option `name` was passed to the application.
+    ///
+    /// Returns `true` if the option `name` was set, `false` otherwise.
+    ///
+    /// The name provided can be any long or short name of any option that was added with [`add_option`](Self::add_option). All the options names are treated as being equivalent. If the name is not recognized or that option was not present, `false` is returned.
+    pub fn is_set(&self, name: &QString) -> bool {
         ffi::is_set_from_qstring(self, name)
     }
 }

--- a/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.rs
@@ -11,14 +11,18 @@ mod ffi {
         include!("cxx-qt-lib-extras/qelapsedtimer.h");
         type QElapsedTimer = crate::QElapsedTimer;
 
-        /// Returns false if the timer has never been started or invalidated by a call to invalidate().
+        /// Returns `false` if the timer has never been started or invalidated by a call to [`invalidate`](Self::invalidate).
         #[rust_name = "is_valid"]
         fn isValid(self: &QElapsedTimer) -> bool;
 
-        /// Marks this QElapsedTimer object as invalid.
+        /// Marks this `QElapsedTimer` object as invalid.
+        ///
+        /// An invalid object can be checked with [`is_valid`](Self::is_valid). Calculations of timer elapsed since invalid data are undefined and will likely produce bizarre results.
         fn invalidate(self: &mut QElapsedTimer);
 
-        /// Starts this timer. Once started, a timer value can be checked with elapsed() or msecsSinceReference().
+        /// Starts this timer. Once started, a timer value can be checked with [elapsed](https://doc.qt.io/qt/qelapsedtimer.html#elapsed)() or [msecsSinceReference](https://doc.qt.io/qt/qelapsedtimer.html#msecsSinceReference)().
+        ///
+        /// Also, starting a timer makes it valid again.
         fn start(self: &mut QElapsedTimer);
     }
 
@@ -39,7 +43,9 @@ mod ffi {
     }
 }
 
-/// The QElapsedTimer struct provides a fast way to calculate elapsed times.
+/// The `QElapsedTimer` class provides a fast way to calculate elapsed times.
+///
+/// Qt Documentation: [QElapsedTimer](https://doc.qt.io/qt/qelapsedtimer.html#details)
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct QElapsedTimer {
@@ -48,7 +54,7 @@ pub struct QElapsedTimer {
 }
 
 impl Default for QElapsedTimer {
-    /// Constructs an invalid QElapsedTimer. A timer becomes valid once it has been started.
+    /// Constructs an invalid `QElapsedTimer`. A timer becomes valid once it has been started.
     fn default() -> Self {
         ffi::qelapsedtimer_init_default()
     }
@@ -56,8 +62,10 @@ impl Default for QElapsedTimer {
 
 impl QElapsedTimer {
     /// Restarts the timer and returns the number of milliseconds elapsed since the previous start.
-    /// This function is equivalent to obtaining the elapsed time with elapsed() and then starting the timer again with start(),
+    /// This function is equivalent to obtaining the elapsed time with [elapsed](https://doc.qt.io/qt/qelapsedtimer.html#elapsed)() and then starting the timer again with [`start`](Self::start),
     /// but it does so in one single operation, avoiding the need to obtain the clock value twice.
+    ///
+    /// Calling this function on a `QElapsedTimer` that is invalid results in undefined behavior.
     pub fn restart(mut self) -> i64 {
         ffi::qelapsedtimer_restart(&mut self)
     }

--- a/crates/cxx-qt-lib-extras/src/core/qeventloop.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qeventloop.rs
@@ -11,14 +11,14 @@ use cxx_qt_lib::{QFlag, QFlags};
 
 #[cxx_qt::bridge]
 mod ffi {
-    /// This enum controls the types of events processed by [`QEventLoop::process_filtered_events`].
+    /// This enum controls the types of events processed by [`QEventLoop::process_events`].
     #[repr(i32)]
     enum QEventLoopProcessEventsFlag {
-        /// All events. Note that [`QEventType::DeferredDelete`](https://doc.qt.io/qt-6/qevent.html#Type-enum) events are processed specially. See [`QObject::delete_later`](https://doc.qt.io/qt-6/qobject.html#deleteLater) for more details.
+        /// All events. Note that [QEvent::DeferredDelete](https://doc.qt.io/qt/qevent.html#Type-enum) events are processed specially. See [QObject::deleteLater](https://doc.qt.io/qt/qobject.html#deleteLater)() for more details.
         AllEvents = 0x00,
-        /// Do not process user input events, such as [QEventType::MouseButtonPress](https://doc.qt.io/qt-6/qevent.html#Type-enum) and [QEventType::KeyPress](https://doc.qt.io/qt-6/qevent.html#Type-enum). Note that the events are not discarded; they will be delivered the next time [`QEventLoop::process_filtered_events`] is called without this flag.
+        /// Do not process user input events, such as [QEvent::MouseButtonPress](https://doc.qt.io/qt/qevent.html#Type-enum) and [QEvent::KeyPress](https://doc.qt.io/qt/qevent.html#Type-enum). Note that the events are not discarded; they will be delivered the next time [`QEventLoop::process_events`] is called without this flag.
         ExcludeUserInputEvents = 0x01,
-        /// Do not process socket notifier events. Note that the events are not discarded; they will be delivered the next time [`QEventLoop::process_filtered_events`] is called without this flag.
+        /// Do not process socket notifier events. Note that the events are not discarded; they will be delivered the next time [`QEventLoop::process_events`] is called without this flag.
         ExcludeSocketNotifiers = 0x02,
         /// Wait for events if no pending events are available.
         WaitForMoreEvents = 0x04,
@@ -37,24 +37,24 @@ mod ffi {
     unsafe extern "C++Qt" {
         /// The `QEventLoop` class provides a means of entering and leaving an event loop.
         ///
-        /// Qt Documentation: [QEventLoop](https://doc.qt.io/qt-6/qeventloop.html#details)
+        /// Qt Documentation: [QEventLoop](https://doc.qt.io/qt/qeventloop.html#details)
         #[qobject]
         type QEventLoop;
 
-        /// Enters the main event loop and waits until [`exit`](QEventLoop::exit) is called. Returns the value that was passed to [`exit`](QEventLoop::exit).
+        /// Enters the main event loop and waits until [`exit`](Self::exit) is called. Returns the value that was passed to [`exit`](Self::exit).
         ///
         /// Only events of the types allowed by `flags` will be processed.
         ///
         /// It is necessary to call this function to start event handling. The main event loop receives events from the window system and dispatches these to the application widgets.
         ///
-        /// Generally speaking, no user interaction can take place before calling this function. As a special case, modal widgets like [`QMessageBox`](https://doc.qt.io/qt-6/qmessagebox.html) can be used before calling this function, because modal widgets use their own local event loop.
+        /// Generally speaking, no user interaction can take place before calling this function. As a special case, modal widgets like [QMessageBox](https://doc.qt.io/qt/qmessagebox.html) can be used before calling this function, because modal widgets use their own local event loop.
         ///
-        /// To make your application perform idle processing (i.e. executing a special function whenever there are no pending events), use a [`QChronoTimer`](https://doc.qt.io/qt-6/qchronotimer.html) with 0ns timeout. More sophisticated idle processing schemes can be achieved using [`process_events`](QEventLoop::process_events).
+        /// To make your application perform idle processing (i.e. executing a special function whenever there are no pending events), use a [QChronoTimer](https://doc.qt.io/qt/qchronotimer.html) with 0ns timeout. More sophisticated idle processing schemes can be achieved using [`process_events`](QEventLoop::process_events).
         fn exec(self: Pin<&mut QEventLoop>, flags: QEventLoopProcessEventsFlags) -> i32;
 
         /// Tells the event loop to exit with a return code.
         ///
-        /// After this function has been called, the event loop returns from the call to [`exec`](QeventLoop::exec) or [`exec_all`](QeventLoop::exec_all). The call returns `return_code`.
+        /// After this function has been called, the event loop returns from the call to [`exec`](Self::exec) or [`exec_all`](Self::exec_all). The call returns `return_code`.
         ///
         /// By convention, a `return_code` of 0 means success, and any non-zero value indicates an error.
         ///
@@ -65,7 +65,7 @@ mod ffi {
         ///
         /// This function is especially useful if you have a long running operation and want to show its progress without allowing user input; i.e. by using the [`QEventLoopProcessEventsFlag::ExcludeUserInputEvents`] flag.
         ///
-        /// This function is simply a wrapper for [QAbstractEventDispatcher::process_events`](https://doc.qt.io/qt-6/qabstracteventdispatcher.html#processEvents). See the documentation for that function for details.
+        /// This function is simply a wrapper for [QAbstractEventDispatcher::processEvents](https://doc.qt.io/qt/qabstracteventdispatcher.html#processEvents)(). See the documentation for that function for details.
         #[rust_name = "process_events"]
         fn processEvents(self: Pin<&mut QEventLoop>, flags: QEventLoopProcessEventsFlags) -> bool;
 
@@ -79,7 +79,7 @@ mod ffi {
 
         /// Tells the event loop to exit normally.
         ///
-        /// Same as [`self.exit(0)`](QEventLoop::exit).
+        /// Same as [`self.exit(0)`](Self::exit).
         fn quit(self: Pin<&mut QEventLoop>);
 
         /// Wakes up the event loop.
@@ -130,13 +130,13 @@ impl QEventLoop {
         ffi::qeventloop_init_default()
     }
 
-    /// Enters the main event loop and waits until [`exit`](QEventLoop::exit) is called. Returns the value that was passed to [`exit`](QEventLoop::exit).
+    /// Enters the main event loop and waits until [`exit`](Self::exit) is called. Returns the value that was passed to [`exit`](Self::exit).
     ///
     /// It is necessary to call this function to start event handling. The main event loop receives events from the window system and dispatches these to the application widgets.
     ///
-    /// Generally speaking, no user interaction can take place before calling this function. As a special case, modal widgets like [`QMessageBox`](https://doc.qt.io/qt-6/qmessagebox.html) can be used before calling this function, because modal widgets use their own local event loop.
+    /// Generally speaking, no user interaction can take place before calling this function. As a special case, modal widgets like [QMessageBox](https://doc.qt.io/qt/qmessagebox.html) can be used before calling this function, because modal widgets use their own local event loop.
     ///
-    /// To make your application perform idle processing (i.e. executing a special function whenever there are no pending events), use a [`QChronoTimer`](https://doc.qt.io/qt-6/qchronotimer.html) with 0ns timeout. More sophisticated idle processing schemes can be achieved using [`process_all_events`](QEventLoop::process_all_events).
+    /// To make your application perform idle processing (i.e. executing a special function whenever there are no pending events), use a [QChronoTimer](https://doc.qt.io/qt/qchronotimer.html) with 0ns timeout. More sophisticated idle processing schemes can be achieved using [`process_all_events`](Self::process_all_events).
     pub fn exec_all(self: Pin<&mut Self>) -> i32 {
         self.exec(QEventLoopProcessEventsFlag::AllEvents.into())
     }
@@ -156,7 +156,7 @@ impl QEventLoop {
 
     /// Processes some pending events. Returns `true` if pending events were handled; otherwise returns `false`.
     ///
-    /// This function is simply a wrapper for [`QAbstractEventDispatcher::process_events`](https://doc.qt.io/qt-6/qabstracteventdispatcher.html#processEvents). See the documentation for that function for details.
+    /// This function is simply a wrapper for [QAbstractEventDispatcher::processEvents](https://doc.qt.io/qt/qabstracteventdispatcher.html#processEvents)(). See the documentation for that function for details.
     pub fn process_all_events(self: Pin<&mut QEventLoop>) -> bool {
         self.process_events(QEventLoopProcessEventsFlag::AllEvents.into())
     }

--- a/crates/cxx-qt-lib-extras/src/gui/qapplication.rs
+++ b/crates/cxx-qt-lib-extras/src/gui/qapplication.rs
@@ -21,6 +21,9 @@ mod ffi {
         type QFont = cxx_qt_lib::QFont;
 
         include!("cxx-qt-lib-extras/qapplication.h");
+        /// The `QApplication` class manages the GUI application's control flow and main settings.
+        ///
+        /// Qt Documentation: [QApplication](https://doc.qt.io/qt/qapplication.html#details)
         type QApplication;
     }
 
@@ -94,25 +97,28 @@ mod ffi {
 pub use ffi::QApplication;
 
 impl QApplication {
-    /// Prepends path to the beginning of the library path list,
+    /// Prepends `path` to the beginning of the library path list,
     /// ensuring that it is searched for libraries first.
-    /// If path is empty or already in the path list, the path list is not changed.
+    /// If `path` is empty or already in the path list, the path list is not changed.
     pub fn add_library_path(self: Pin<&mut Self>, path: &QString) {
         ffi::qapplication_add_library_path(self, path);
     }
 
-    /// The name of this application
+    /// Returns the name of this application.
     pub fn application_name(&self) -> QString {
         ffi::qapplication_application_name(self)
     }
 
-    /// The version of this application
+    /// Returns the version of this application.
     pub fn application_version(&self) -> QString {
         ffi::qapplication_application_version(self)
     }
 
-    /// Enters the main event loop and waits until exit() is called,
-    /// and then returns the value that was set to exit() (which is 0 if exit() is called via quit()).
+    /// Enters the main event loop and waits until [exit]\() is called,
+    /// and then returns the value that was set to [exit]\() (which is 0 if [exit]\() is called via [quit]\()).
+    ///
+    /// [exit]: https://doc.qt.io/qt/qcoreapplication.html#exit
+    /// [quit]: https://doc.qt.io/qt/qcoreapplication.html#quit
     pub fn exec(self: Pin<&mut Self>) -> i32 {
         ffi::qapplication_exec(self)
     }
@@ -128,7 +134,7 @@ impl QApplication {
     }
 
     /// Initializes the window system and constructs an application object.
-    /// Standard [Qt command line arguments](https://doc.qt.io/qt-6/qapplication.html#supported-command-line-options) are handled automatically.
+    /// Standard [Qt command line arguments](https://doc.qt.io/qt/qguiapplication.html#supported-command-line-options) are handled automatically.
     pub fn new() -> cxx::UniquePtr<Self> {
         let mut vector = QVector::<QByteArray>::default();
 
@@ -152,48 +158,48 @@ impl QApplication {
         ffi::qapplication_new(&vector)
     }
 
-    /// The Internet domain of the organization that wrote this application
+    /// Returns the Internet domain of the organization that wrote this application.
     pub fn organization_domain(&self) -> QString {
         ffi::qapplication_organization_domain(self)
     }
 
-    /// The name of the organization that wrote this application
+    /// Returns the name of the organization that wrote this application.
     pub fn organization_name(&self) -> QString {
         ffi::qapplication_organization_name(self)
     }
 
-    /// Set the name of this application
+    /// Set the `name` of this application.
     pub fn set_application_name(self: Pin<&mut Self>, name: &QString) {
         ffi::qapplication_set_application_name(self, name);
     }
 
-    /// Removes path from the library path list. If path is empty or not in the path list, the list is not changed.
+    /// Removes `path` from the library path list. If `path` is empty or not in the path list, the list is not changed.
     pub fn remove_library_path(&self, path: &QString) {
         ffi::qapplication_remove_library_path(self, path)
     }
 
-    /// Set the version of this application
+    /// Set the `version` of this application.
     pub fn set_application_version(self: Pin<&mut Self>, version: &QString) {
         ffi::qapplication_set_application_version(self, version);
     }
 
-    /// Changes the default application font to font.
+    /// Changes the default application font to `font`.
     pub fn set_application_font(self: Pin<&mut Self>, font: &QFont) {
         ffi::qapplication_set_font(self, font);
     }
 
-    /// Sets the list of directories to search when loading plugins with QLibrary to paths.
-    /// All existing paths will be deleted and the path list will consist of the paths given in paths and the path to the application.
+    /// Sets the list of directories to search when loading plugins with [QLibrary](https://doc.qt.io/qt/qlibrary.html) to `paths`.
+    /// All existing paths will be deleted and the path list will consist of the paths given in `paths` and the path to the application.
     pub fn set_library_paths(self: Pin<&mut Self>, paths: &QStringList) {
         ffi::qapplication_set_library_paths(self, paths);
     }
 
-    /// Sets the Internet domain of the organization that wrote this application
+    /// Sets the Internet `domain` of the organization that wrote this application.
     pub fn set_organization_domain(self: Pin<&mut Self>, domain: &QString) {
         ffi::qapplication_set_organization_domain(self, domain);
     }
 
-    /// Sets the name of the organization that wrote this application
+    /// Sets the `name` of the organization that wrote this application.
     pub fn set_organization_name(self: Pin<&mut Self>, name: &QString) {
         ffi::qapplication_set_organization_name(self, name);
     }

--- a/crates/cxx-qt-lib/include/gui/qfont.h
+++ b/crates/cxx-qt-lib/include/gui/qfont.h
@@ -25,6 +25,7 @@ using QFontCapitalization = QFont::Capitalization;
 using QFontSpacingType = QFont::SpacingType;
 using QFontStyleStrategy = QFont::StyleStrategy;
 using QFontStyleHint = QFont::StyleHint;
+using QFontWeight = QFont::Weight;
 
 } // namespace cxxqtlib1
 } // namespace rust

--- a/crates/cxx-qt-lib/src/core/qanystringview.rs
+++ b/crates/cxx-qt-lib/src/core/qanystringview.rs
@@ -21,11 +21,11 @@ mod ffi {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
 
-        /// Returns true if the string has no characters; otherwise returns false.
+        /// Returns `true` if the string has no characters; otherwise returns `false`.
         #[rust_name = "is_empty"]
         fn isEmpty(self: &QAnyStringView) -> bool;
 
-        /// Returns true if this string is null; otherwise returns false.
+        /// Returns `true` if this string is null; otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QAnyStringView) -> bool;
 
@@ -64,10 +64,14 @@ mod ffi {
     }
 }
 
-/// The QAnyStringView class provides a unified view of a Latin-1, UTF-8, or UTF-16 string.
+/// The `QAnyStringView` class provides a unified view of a Latin-1, UTF-8, or UTF-16 string.
+///
+/// Introduced in Qt 6.0.
+///
+/// Qt Documentation: [QAnyStringView](https://doc.qt.io/qt/qanystringview.html#details)
 #[repr(C)]
 pub struct QAnyStringView<'a> {
-    /// QAnyStringView has two members, a pointer and a size_t
+    /// `QAnyStringView` has two members, a pointer and a `size_t`
     _space: MaybeUninit<[usize; 1]>,
     _space2: MaybeUninit<[c_void; 1]>,
 
@@ -76,16 +80,16 @@ pub struct QAnyStringView<'a> {
 }
 
 impl<'a> Clone for QAnyStringView<'a> {
-    /// Constructs a copy of other.
+    /// Constructs a copy of `self`.
     ///
-    /// This operation takes constant time, because QAnyStringView is a view-only string.
+    /// This operation takes constant time, because `QAnyStringView` is a view-only string.
     fn clone(&self) -> QAnyStringView<'a> {
         ffi::QAnyStringView_init_from_QAnyStringView(self)
     }
 }
 
 impl Default for QAnyStringView<'_> {
-    /// Constructs a null string. Null strings are also empty.
+    /// Constructs a null string view.
     fn default() -> Self {
         ffi::QAnyStringView_init_default()
     }
@@ -100,28 +104,28 @@ impl PartialEq for QAnyStringView<'_> {
 impl Eq for QAnyStringView<'_> {}
 
 impl<'a> From<&'a str> for QAnyStringView<'a> {
-    /// Constructs a QAnyStringView from a Rust string
+    /// Constructs a `QAnyStringView` from a Rust string.
     fn from(str: &'a str) -> Self {
         ffi::QAnyStringView_init_from_rust_string(str)
     }
 }
 
 impl<'a> From<&'a QByteArray> for QAnyStringView<'a> {
-    /// Constructs a QAnyStringView from a QByteArray
+    /// Constructs a `QAnyStringView` from a `QByteArray`.
     fn from(bytes: &'a QByteArray) -> Self {
         ffi::QAnyStringView_init_from_qbytearray(bytes)
     }
 }
 
 impl<'a> From<&'a QString> for QAnyStringView<'a> {
-    /// Constructs a QAnyStringView from a QString
+    /// Constructs a `QAnyStringView` from a `QString`.
     fn from(string: &'a QString) -> Self {
         ffi::QAnyStringView_init_from_qstring(string)
     }
 }
 
 impl QAnyStringView<'_> {
-    /// Returns the number of characters in this string.
+    /// Returns the size of this string view, in the encoding's code points.
     pub fn len(&self) -> isize {
         ffi::QAnyStringView_len(self)
     }

--- a/crates/cxx-qt-lib/src/core/qbytearray.rs
+++ b/crates/cxx-qt-lib/src/core/qbytearray.rs
@@ -16,16 +16,16 @@ mod ffi {
 
         /// Clears the contents of the byte array and makes it null.
         fn clear(self: &mut Self);
-        /// Returns true if the byte array has size 0; otherwise returns false.
+        /// Returns `true` if the byte array has size 0; otherwise returns `false`.
         #[rust_name = "is_empty"]
         fn isEmpty(self: &Self) -> bool;
-        /// Returns true if this byte array is lowercase, that is, if it's identical to its toLower() folding.
+        /// Returns `true` if this byte array is lowercase, that is, if it's identical to its [`to_lower`](Self::to_lower) folding.
         #[rust_name = "is_lower"]
         fn isLower(self: &Self) -> bool;
-        /// Returns true if this byte array is null; otherwise returns false.
+        /// Returns `true` if this byte array is null; otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &Self) -> bool;
-        /// Returns true if this byte array is uppercase, that is, if it's identical to its toUpper() folding.
+        /// Returns `true` if this byte array is uppercase, that is, if it's identical to its [`to_upper`](Self::to_upper) folding.
         #[rust_name = "is_upper"]
         fn isUpper(self: &Self) -> bool;
         /// Releases any memory not required to store the array's data.
@@ -107,7 +107,9 @@ mod ffi {
     }
 }
 
-/// The QByteArray class provides an array of bytes.
+/// The `QByteArray` class provides an array of bytes.
+///
+/// Qt Documentation: [QByteArray](https://doc.qt.io/qt/qbytearray.html#details)
 #[repr(C)]
 pub struct QByteArray {
     /// The layout has changed between Qt 5 and Qt 6
@@ -121,17 +123,17 @@ pub struct QByteArray {
 }
 
 impl AsRef<[u8]> for QByteArray {
-    /// Construct a slice of u8 from a QByteArray
+    /// Construct a slice of `u8` from a `QByteArray`.
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
     }
 }
 
 impl Clone for QByteArray {
-    /// Constructs a copy of other.
+    /// Constructs a copy of `self`.
     ///
-    /// This operation takes constant time, because QByteArray is implicitly shared similar to a [std::borrow::Cow].
-    /// This makes returning a QByteArray from a function very fast.
+    /// This operation takes constant time, because `QByteArray` is implicitly shared similar to a [`Cow`](std::borrow::Cow).
+    /// This makes returning a `QByteArray` from a function very fast.
     /// If a shared instance is modified, it will be copied (copy-on-write), and that takes linear time.
     fn clone(&self) -> Self {
         ffi::qbytearray_clone(self)
@@ -154,7 +156,7 @@ impl std::cmp::PartialEq for QByteArray {
 impl std::cmp::Eq for QByteArray {}
 
 impl fmt::Display for QByteArray {
-    /// Convert the QByteArray to a Rust string
+    /// Convert the `QByteArray` to a Rust string.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let slice = self.as_slice();
         if let Ok(string) = str::from_utf8(slice) {
@@ -179,28 +181,28 @@ impl Drop for QByteArray {
 }
 
 impl From<&str> for QByteArray {
-    /// Constructs a QByteArray from a Rust string slice. This makes a deep copy of the data.
+    /// Constructs a `QByteArray` from a Rust string slice. This makes a deep copy of the data.
     fn from(str: &str) -> Self {
         ffi::qbytearray_from_slice_u8(str.as_bytes())
     }
 }
 
 impl From<&String> for QByteArray {
-    /// Constructs a QByteArray from a Rust string. This makes a deep copy of the data.
+    /// Constructs a `QByteArray` from a Rust string. This makes a deep copy of the data.
     fn from(str: &String) -> Self {
         ffi::qbytearray_from_slice_u8(str.as_bytes())
     }
 }
 
 impl From<&[u8]> for QByteArray {
-    /// Constructs a QByteArray from a `&[u8]`. This makes a deep copy of the data.
+    /// Constructs a `QByteArray` from a `&[u8]`. This makes a deep copy of the data.
     fn from(bytes: &[u8]) -> Self {
         ffi::qbytearray_from_slice_u8(bytes)
     }
 }
 
 impl From<&QByteArray> for Vec<u8> {
-    /// Convert the QByteArray to a `Vec<u8>`. This makes a deep copy of the data.
+    /// Convert the `QByteArray` to a `Vec<u8>`. This makes a deep copy of the data.
     fn from(bytearray: &QByteArray) -> Self {
         ffi::qbytearray_to_vec_u8(bytearray)
     }
@@ -208,7 +210,7 @@ impl From<&QByteArray> for Vec<u8> {
 
 #[cfg(feature = "bytes")]
 impl From<&bytes::Bytes> for QByteArray {
-    /// Convert `bytes::Bytes` to a QByteArray. This makes a deep copy of the data.
+    /// Convert `bytes::Bytes` to a `QByteArray`. This makes a deep copy of the data.
     fn from(value: &bytes::Bytes) -> Self {
         Self::from(value.as_ref())
     }
@@ -216,93 +218,106 @@ impl From<&bytes::Bytes> for QByteArray {
 
 #[cfg(feature = "bytes")]
 impl From<&QByteArray> for bytes::Bytes {
-    /// Convert QByteArray to a `bytes::Bytes`. This makes a deep copy of the data.
+    /// Convert `QByteArray` to a `bytes::Bytes`. This makes a deep copy of the data.
     fn from(value: &QByteArray) -> Self {
         Self::copy_from_slice(value.as_ref())
     }
 }
 
 impl QByteArray {
-    /// Inserts value at the end of the list.
+    /// Inserts `value` at the end of the list.
     pub fn append(&mut self, ch: u8) {
         ffi::qbytearray_append(self, ch);
     }
 
-    /// Construct a mutable slice of u8 from a QByteArray
+    /// Extracts a mutable slice of the entire vector.
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         ffi::qbytearray_as_mut_slice(self)
     }
 
-    /// Construct a slice of u8 from a QByteArray
+    /// Extracts a slice containing the entire byte array.
     pub fn as_slice(&self) -> &[u8] {
         ffi::qbytearray_as_slice(self)
     }
 
-    /// Sets every byte in the byte array to ch.
-    /// If size is different from -1 (the default),
-    /// the byte array is resized to size size beforehand.
+    /// Sets every byte in the byte array to `ch`.
+    /// If `size` is different from -1,
+    /// the byte array is resized to size `size` beforehand.
     pub fn fill(&mut self, ch: u8, size: isize) {
         ffi::qbytearray_fill(self, ch, size)
     }
 
-    /// Construct a QByteArray from a `bytes::Bytes` without a deep copy
+    /// Construct a `QByteArray` from a `bytes::Bytes` without a deep copy
     ///
     /// # Safety
     ///
-    /// The caller must ensure that the original `bytes::Bytes` outlives the QByteArray
-    /// and that the QByteArray is not modified
+    /// The caller must ensure that the original `bytes::Bytes` outlives the `QByteArray`
+    /// and that the `QByteArray` is not modified
     #[cfg(feature = "bytes")]
     pub unsafe fn from_raw_bytes(bytes: &bytes::Bytes) -> Self {
         Self::from_raw_data(bytes.as_ref())
     }
 
-    /// Construct a QByteArray from a `&[u8]` without a deep copy
+    /// Construct a `QByteArray` from a `&[u8]` without a deep copy
     ///
     /// # Safety
     ///
-    /// The caller must ensure that the original slice outlives the QByteArray
-    /// and that the QByteArray is not modified
+    /// The caller must ensure that the original slice outlives the `QByteArray`
+    /// and that the `QByteArray` is not modified
     pub unsafe fn from_raw_data(bytes: &[u8]) -> Self {
         ffi::qbytearray_from_raw_data(bytes)
     }
 
-    /// Inserts item value into the list at the given position.
+    /// Inserts byte `ch` at index position `pos` in the byte array.
+    ///
+    /// This array grows to accommodate the insertion. If `pos` is beyond the end of the array, the array is first extended with space characters to reach this `pos`.
     pub fn insert(&mut self, pos: isize, ch: u8) {
         ffi::qbytearray_insert(self, pos, ch);
     }
 
-    /// Returns the number of items in the QByteArray.
+    /// Returns the number of bytes in this byte array.
     pub fn len(&self) -> isize {
         ffi::qbytearray_len(self)
     }
 
-    /// Inserts value at the start of the list.
+    /// Prepends the byte `ch` to this byte array.
     pub fn prepend(&mut self, ch: u8) {
         ffi::qbytearray_prepend(self, ch);
     }
 
-    /// Removes len bytes from the array, starting at index position pos.
+    /// Removes `len` bytes from the array, starting at index position `pos`.
+    ///
+    /// If `pos` is out of range, nothing happens. If `pos` is valid, but `pos + len` is larger than the size of the array, the array is truncated at position `pos`.
     pub fn remove(&mut self, pos: isize, len: isize) {
         ffi::qbytearray_remove(self, pos, len);
     }
 
-    /// Reserve the specified capacity to prevent repeated allocations
-    /// when the maximum size is known.
+    /// Attempts to allocate memory for at least `size` bytes.
+    ///
+    /// If you know in advance how large the byte array will be, you can call this function, and if you call [`resize`](Self::resize) often you are likely to get better performance.
+    ///
+    /// If in doubt about how much space shall be needed, it is usually better to use an upper bound as `size`, or a high estimate of the most likely size, if a strict upper bound would be much bigger than this. If `size` is an underestimate, the array will grow as needed once the reserved size is exceeded, which may lead to a larger allocation than your best overestimate would have and will slow the operation that triggers it.
+    ///
+    /// The sole purpose of this function is to provide a means of fine tuning `QByteArray`'s memory usage. In general, you will rarely ever need to call this function.
     pub fn reserve(&mut self, size: isize) {
         ffi::qbytearray_reserve(self, size);
     }
 
-    /// Sets the size of the byte array to size bytes.
+    /// Sets the size of the byte array to `size` bytes.
     ///
-    /// If size is greater than the current size, the byte array is extended to make it size bytes with the extra bytes added to the end. The new bytes are uninitialized.
+    /// If `size` is greater than the current size, the byte array is extended to make it `size` bytes with the extra bytes added to the end. **The new bytes are uninitialized.**
     ///
-    /// If size is less than the current size, bytes beyond position size are excluded from the byte array.
+    /// If `size` is less than the current size, bytes beyond position `size` are excluded from the byte array.
+    ///
+    /// **Note:** While `resize` will grow the capacity if needed, it never shrinks capacity.
     pub fn resize(&mut self, size: isize) {
         ffi::qbytearray_resize(self, size);
     }
 
     /// Returns a copy of this byte array that has spacing characters removed from the start and end,
     /// and in which each sequence of internal spacing characters is replaced with a single space.
+    ///
+    /// The spacing characters are the ASCII characters tabulation `'\t'`, line feed `'\n'`, carriage return `'\r'`, vertical tabulation `'\x08'` (`'\v'` in C), form feed `'\x0C'` (`'\f'` in C), and space `' '`.
     pub fn simplified(&self) -> Self {
         ffi::qbytearray_simplified(self)
     }
@@ -318,6 +333,8 @@ impl QByteArray {
     }
 
     /// Returns a copy of this byte array with spacing characters removed from the start and end.
+    ///
+    /// The spacing characters are the ASCII characters tabulation `'\t'`, line feed `'\n'`, carriage return `'\r'`, vertical tabulation `'\x08'` (`'\v'` in C), form feed `'\x0C'` (`'\f'` in C), and space `' '`.
     pub fn trimmed(&self) -> Self {
         ffi::qbytearray_trimmed(self)
     }

--- a/crates/cxx-qt-lib/src/core/qcoreapplication.rs
+++ b/crates/cxx-qt-lib/src/core/qcoreapplication.rs
@@ -20,6 +20,9 @@ mod ffi {
         type QVector_QByteArray = crate::QVector<QByteArray>;
 
         include!("cxx-qt-lib/qcoreapplication.h");
+        /// The `QCoreApplication` class provides an event loop for Qt applications without UI.
+        ///
+        /// Qt Documentation: [QCoreApplication](https://doc.qt.io/qt/qcoreapplication.html#details)
         type QCoreApplication;
     }
 
@@ -91,25 +94,28 @@ mod ffi {
 pub use ffi::QCoreApplication;
 
 impl QCoreApplication {
-    /// Prepends path to the beginning of the library path list,
+    /// Prepends `path` to the beginning of the library path list,
     /// ensuring that it is searched for libraries first.
-    /// If path is empty or already in the path list, the path list is not changed.
+    /// If `path` is empty or already in the path list, the path list is not changed.
     pub fn add_library_path(self: Pin<&mut Self>, path: &QString) {
         ffi::qcoreapplication_add_library_path(self, path);
     }
 
-    /// The name of this application
+    /// Returns the name of this application.
     pub fn application_name(&self) -> QString {
         ffi::qcoreapplication_application_name(self)
     }
 
-    /// The version of this application
+    /// Returns the version of this application.
     pub fn application_version(&self) -> QString {
         ffi::qcoreapplication_application_version(self)
     }
 
-    /// Enters the main event loop and waits until exit() is called,
-    /// and then returns the value that was set to exit() (which is 0 if exit() is called via quit()).
+    /// Enters the main event loop and waits until [exit]\() is called,
+    /// and then returns the value that was set to [exit]\() (which is 0 if [exit]\() is called via [quit]\()).
+    ///
+    /// [exit]: https://doc.qt.io/qt/qcoreapplication.html#exit
+    /// [quit]: https://doc.qt.io/qt/qcoreapplication.html#quit
     pub fn exec(self: Pin<&mut Self>) -> i32 {
         ffi::qcoreapplication_exec(self)
     }
@@ -119,7 +125,7 @@ impl QCoreApplication {
         ffi::qcoreapplication_library_paths(self)
     }
 
-    /// Initializes the window system and constructs an application object with command line arguments in args.
+    /// Constructs a Qt core application using the arguments from [`std::env::args_os()`]. Core applications are applications without a graphical user interface. Such applications are used at the console or as server processes.
     pub fn new() -> cxx::UniquePtr<Self> {
         let mut vector = QVector::<QByteArray>::default();
 
@@ -143,43 +149,43 @@ impl QCoreApplication {
         ffi::qcoreapplication_new(&vector)
     }
 
-    /// The Internet domain of the organization that wrote this application
+    /// Returns the Internet domain of the organization that wrote this application.
     pub fn organization_domain(&self) -> QString {
         ffi::qcoreapplication_organization_domain(self)
     }
 
-    /// The name of the organization that wrote this application
+    /// Returns the name of the organization that wrote this application.
     pub fn organization_name(&self) -> QString {
         ffi::qcoreapplication_organization_name(self)
     }
 
-    /// Removes path from the library path list. If path is empty or not in the path list, the list is not changed.
+    /// Removes `path` from the library path list. If `path` is empty or not in the path list, the list is not changed.
     pub fn remove_library_path(&self, path: &QString) {
         ffi::qcoreapplication_remove_library_path(self, path)
     }
 
-    /// Set the name of this application
+    /// Set the `name` of this application.
     pub fn set_application_name(self: Pin<&mut Self>, name: &QString) {
         ffi::qcoreapplication_set_application_name(self, name);
     }
 
-    /// Set the version of this application
+    /// Set the `version` of this application.
     pub fn set_application_version(self: Pin<&mut Self>, version: &QString) {
         ffi::qcoreapplication_set_application_version(self, version);
     }
 
-    /// Sets the list of directories to search when loading plugins with QLibrary to paths.
-    /// All existing paths will be deleted and the path list will consist of the paths given in paths and the path to the application.
+    /// Sets the list of directories to search when loading plugins with [QLibrary](https://doc.qt.io/qt/qlibrary.html) to `paths`.
+    /// All existing paths will be deleted and the path list will consist of the paths given in `paths` and the path to the application.
     pub fn set_library_paths(self: Pin<&mut Self>, paths: &QStringList) {
         ffi::qcoreapplication_set_library_paths(self, paths);
     }
 
-    /// Sets the Internet domain of the organization that wrote this application
+    /// Sets the Internet `domain` of the organization that wrote this application.
     pub fn set_organization_domain(self: Pin<&mut Self>, domain: &QString) {
         ffi::qcoreapplication_set_organization_domain(self, domain);
     }
 
-    /// Sets the name of the organization that wrote this application
+    /// Sets the `name` of the organization that wrote this application.
     pub fn set_organization_name(self: Pin<&mut Self>, name: &QString) {
         ffi::qcoreapplication_set_organization_name(self, name);
     }

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -6,6 +6,9 @@
 use cxx::{type_id, ExternType};
 use std::fmt;
 
+use crate::DateFormat;
+use crate::QString;
+
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
@@ -30,56 +33,70 @@ mod ffi {
         #[rust_name = "add_days_qint64"]
         fn addDays(self: &QDate, ndays: qint64) -> QDate;
 
-        /// Returns a QDate object containing a date nmonths later than the date of this object (or earlier if nmonths is negative).
+        /// Returns a `QDate` object containing a date `nmonths` later than the date of this object (or earlier if `nmonths` is negative).
         #[rust_name = "add_months"]
         fn addMonths(self: &QDate, nmonths: i32) -> QDate;
 
-        /// Returns a QDate object containing a date nyears later than the date of this object (or earlier if nyears is negative).
+        /// Returns a `QDate` object containing a date `nyears` later than the date of this object (or earlier if `nyears` is negative).
+        ///
+        /// **Note:** If the ending day/month combination does not exist in the resulting year (e.g., for the Gregorian calendar, if the date was Feb 29 and the final year is not a leap year), this function will return a date that is the latest valid date in the given month (in the example, Feb 28).
         #[rust_name = "add_years"]
         fn addYears(self: &QDate, nyears: i32) -> QDate;
 
         /// Returns the day of the month for this date.
+        ///
+        /// Uses the Gregorian calendar (for which the return ranges from 1 to 31). Returns 0 if the date is invalid.
         fn day(self: &QDate) -> i32;
 
         /// Returns the weekday (1 = Monday to 7 = Sunday) for this date.
+        ///
+        /// Uses the Gregorian calendar. Returns 0 if the date is invalid.
         #[rust_name = "day_of_week"]
         fn dayOfWeek(self: &QDate) -> i32;
 
         /// Returns the day of the year (1 for the first day) for this date.
+        ///
+        /// Uses the Gregorian calendar. Returns 0 if either the date or the first day of its year is invalid.
         #[rust_name = "day_of_year"]
         fn dayOfYear(self: &QDate) -> i32;
 
         /// Returns the number of days in the month for this date.
+        ///
+        /// Uses the Gregorian calendar (for which the result ranges from 28 to 31). Returns 0 if the date is invalid.
         #[rust_name = "days_in_monyth"]
         fn daysInMonth(self: &QDate) -> i32;
 
         /// Returns the number of days in the year for this date.
+        ///
+        /// Uses the Gregorian calendar (for which the result is 365 or 366). Returns 0 if the date is invalid.
         #[rust_name = "days_in_year"]
         fn daysInYear(self: &QDate) -> i32;
 
-        /// Returns true if the date is null; otherwise returns false. A null date is invalid.
+        /// Returns `true` if the date is null; otherwise returns `false`. A null date is invalid.
         #[rust_name = "is_null"]
         fn isNull(self: &QDate) -> bool;
 
-        /// Returns true if this date is valid; otherwise returns false.
+        /// Returns `true` if this date is valid; otherwise returns `false`.
         #[rust_name = "is_valid"]
         fn isValid(self: &QDate) -> bool;
 
         /// Returns the month-number for the date.
         ///
-        /// Numbers the months of the year starting with 1 for the first
+        /// Uses the Gregorian calendar (for which the result ranges from 1 to 12). Returns 0 if the date is invalid.
         fn month(self: &QDate) -> i32;
 
-        /// Sets this to represent the date, in the Gregorian calendar, with the given year, month and day numbers.
-        /// Returns true if the resulting date is valid, otherwise it sets this to represent an invalid date and returns false.
+        /// Sets this date to represent the date, in the Gregorian calendar, with the given `year`, `month` and `day` numbers.
+        /// Returns `true` if the resulting date is valid, otherwise it sets this date to represent an invalid date and returns `false`.
         #[rust_name = "set_date"]
         fn setDate(self: &mut QDate, y: i32, m: i32, d: i32) -> bool;
 
-        /// Returns the time as a string. The format parameter determines the format of the string.
+        /// Returns the date as a string. The `format` parameter determines the format of the string.
         #[rust_name = "format_enum"]
         fn toString(self: &QDate, format: DateFormat) -> QString;
 
         /// Returns the year of this date.
+        ///
+        /// Uses the Gregorian calendar. Returns 0 if the date is invalid.
         fn year(self: &QDate) -> i32;
     }
 
@@ -125,7 +142,9 @@ mod ffi {
     }
 }
 
-/// The QDate class provides date functions.
+/// The `QDate` class provides date functions.
+///
+/// Qt Documentation: [QDate](https://doc.qt.io/qt/qdate.html#details)
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(C)]
 pub struct QDate {
@@ -141,7 +160,7 @@ impl Default for QDate {
 
 impl fmt::Display for QDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.format_enum(ffi::DateFormat::TextDate).fmt(f)
+        self.format_enum(DateFormat::TextDate).fmt(f)
     }
 }
 
@@ -152,37 +171,37 @@ impl fmt::Debug for QDate {
 }
 
 impl QDate {
-    /// Returns a QDate object containing a date ndays later than the date of this object (or earlier if ndays is negative).
+    /// Returns a `QDate` object containing a date `ndays` later than the date of this object (or earlier if `ndays` is negative).
     ///
     /// Returns a null date if the current date is invalid or the new date is out of range.
     pub fn add_days(self: &QDate, ndays: i64) -> QDate {
         self.add_days_qint64(ndays.into())
     }
 
-    /// Returns the current date, as reported by the system clock.
+    /// Returns the system clock's current date.
     pub fn current_date() -> Self {
         ffi::qdate_current_date()
     }
 
-    /// Returns the number of days from this date to d (which is negative if d is earlier than this date).
+    /// Returns the number of days from this date to `date` (which is negative if `date` is earlier than this date).
     ///
     /// Returns 0 if either date is invalid.
     pub fn days_to(&self, date: Self) -> i64 {
         ffi::qdate_days_to(self, date).into()
     }
 
-    /// Returns the time as a string. The format parameter determines the format of the result string.
-    pub fn format(&self, format: &ffi::QString) -> ffi::QString {
+    /// Returns the date as a string. The `format` parameter determines the format of the string.
+    pub fn format(&self, format: &QString) -> QString {
         ffi::qdate_to_format(self, format)
     }
 
-    /// Converts the Julian day jd to a QDate.
+    /// Converts the Julian day `jd` to a `QDate`.
     pub fn from_julian_day(jd: i64) -> Self {
         Self { jd }
     }
 
-    /// Returns the QTime represented by the string, using the format given, or None if the string cannot be parsed.
-    pub fn from_string(string: &ffi::QString, format: &ffi::QString) -> Option<Self> {
+    /// Returns the `QDate` represented by the string `string`, using the `format` given, or `None` if the string cannot be parsed.
+    pub fn from_string(string: &QString, format: &QString) -> Option<Self> {
         let date = ffi::qdate_from_string(string, format);
         if date.is_valid() {
             Some(date)
@@ -191,8 +210,10 @@ impl QDate {
         }
     }
 
-    /// Returns the time represented in the string as a QTime using the format given, or None if this is not possible.
-    pub fn from_string_enum(string: &ffi::QString, format: ffi::DateFormat) -> Option<Self> {
+    /// Returns the `QDate` represented in the string `string`, using the `format` given, or `None` if the string cannot be parsed.
+    ///
+    /// Note for [`DateFormat::TextDate`]: only English month names (e.g. "Jan" in short form or "January" in long form) are recognized.
+    pub fn from_string_enum(string: &QString, format: DateFormat) -> Option<Self> {
         let date = ffi::qdate_from_string_enum(string, format);
         if date.is_valid() {
             Some(date)
@@ -201,12 +222,16 @@ impl QDate {
         }
     }
 
-    /// Returns true if the specified year is a leap year in the Gregorian calendar; otherwise returns false.
+    /// Returns `true` if the specified `year` is a leap year in the Gregorian calendar; otherwise returns `false`.
     pub fn is_leap_year(year: i32) -> bool {
         ffi::qdate_is_leap_year(year)
     }
 
-    /// Constructs a date with year y, month m and day d.
+    /// Constructs a date with year `y`, month `m` and day `d`.
+    ///
+    /// The date is understood in terms of the Gregorian calendar. If the specified date is invalid, the date is not set and [`is_valid`](Self::is_valid) returns `false`.
+    ///
+    /// **Warning:** Years 1 to 99 are interpreted as is. Year 0 is invalid.
     pub fn new(y: i32, m: i32, d: i32) -> Self {
         ffi::qdate_init(y, m, d)
     }

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -6,7 +6,9 @@ use cxx::{type_id, ExternType};
 use std::mem::MaybeUninit;
 use std::{cmp::Ordering, fmt};
 
-use crate::{QDate, QTime};
+#[allow(unused)]
+use crate::TimeSpec;
+use crate::{DateFormat, QDate, QString, QTime, QTimeZone};
 
 #[cxx::bridge]
 mod ffi {
@@ -38,7 +40,9 @@ mod ffi {
         #[rust_name = "add_days_qint64"]
         fn addDays(self: &QDateTime, ndays: qint64) -> QDateTime;
 
-        /// Returns a QDateTime object containing a datetime nmonths months later than the datetime of this object (or earlier if nmonths is negative).
+        /// Returns a QDateTime object containing a datetime `nmonths` months later than the datetime of this object (or earlier if `nmonths` is negative).
+        ///
+        /// If [`time_spec`](Self::time_spec) is [`TimeSpec::LocalTime`] or [`TimeSpec::TimeZone`] and the resulting date and time fall in the Standard Time to Daylight-Saving Time transition hour then the result will be just beyond this gap, in the direction of change. If the transition is at 2am and the clock goes forward to 3am, the result of aiming between 2am and 3am will be adjusted to fall before 2am (if `nmonths` is negative) or after 3am (otherwise).
         #[rust_name = "add_months"]
         fn addMonths(self: &QDateTime, nmonths: i32) -> QDateTime;
 
@@ -50,7 +54,9 @@ mod ffi {
         #[rust_name = "add_secs_qint64"]
         fn addSecs(self: &QDateTime, secs: qint64) -> QDateTime;
 
-        /// Returns a QDateTime object containing a datetime nyears years later than the datetime of this object (or earlier if nyears is negative).
+        /// Returns a QDateTime object containing a datetime `nyears` years later than the datetime of this object (or earlier if `nyears` is negative).
+        ///
+        /// If [`time_spec`](Self::time_spec) is [`TimeSpec::LocalTime`] or [`TimeSpec::TimeZone`] and the resulting date and time fall in the Standard Time to Daylight-Saving Time transition hour then the result will be just beyond this gap, in the direction of change. If the transition is at 2am and the clock goes forward to 3am, the result of aiming between 2am and 3am will be adjusted to fall before 2am (if `nyears` is negative) or after 3am (otherwise).
         #[rust_name = "add_years"]
         fn addYears(self: &QDateTime, nyears: i32) -> QDateTime;
 
@@ -61,19 +67,21 @@ mod ffi {
         #[rust_name = "days_to_qint64"]
         fn daysTo(self: &QDateTime, other: &QDateTime) -> qint64;
 
-        /// Returns if this datetime falls in Daylight-Saving Time.
+        /// Returns `true` if this datetime falls in Daylight-Saving Time, otherwise `false`.
+        ///
+        /// If [`time_spec`](Self::time_spec) is not [`TimeSpec::LocalTime`] or [`TimeSpec::TimeZone`] then this will always return `false`.
         #[rust_name = "is_daylight_time"]
         fn isDaylightTime(self: &QDateTime) -> bool;
 
-        /// Returns true if both the date and the time are null; otherwise returns false. A null datetime is invalid.
+        /// Returns `true` if both the date and the time are null; otherwise returns `false`. A null datetime is invalid.
         #[rust_name = "is_null"]
         fn isNull(self: &QDateTime) -> bool;
 
-        /// Returns true if both the date and the time are valid and they are valid in the current Qt::TimeSpec, otherwise returns false.
+        /// Returns `true` if both the `date` and the `time` are valid and they are valid in the current [`TimeSpec`](TimeSpec), otherwise returns `false`.
         #[rust_name = "is_valid"]
         fn isValid(self: &QDateTime) -> bool;
 
-        /// Returns this date-time's Offset From UTC in seconds.
+        /// Returns this date-time's offset from UTC in seconds.
         #[rust_name = "offset_from_utc"]
         fn offsetFromUtc(self: &QDateTime) -> i32;
 
@@ -89,9 +97,9 @@ mod ffi {
         #[rust_name = "set_msecs_since_epoch_qint64"]
         fn setMSecsSinceEpoch(self: &mut QDateTime, msecs: qint64);
 
-        /// Sets the timeSpec() to Qt::OffsetFromUTC and the offset to offsetSeconds.
+        /// Sets the [`time_spec`](Self::time_spec) to [`TimeSpec::OffsetFromUTC`] and the offset to `offset_seconds`.
         ///
-        /// Note this method is only available with Qt < 6.8
+        /// **Note:** This method is only available with Qt < 6.8.
         #[cfg(not(cxxqt_qt_version_at_least_6_8))]
         #[rust_name = "set_offset_from_utc"]
         fn setOffsetFromUtc(self: &mut QDateTime, offset_seconds: i32);
@@ -100,9 +108,9 @@ mod ffi {
         #[rust_name = "set_secs_since_epoch_qint64"]
         fn setSecsSinceEpoch(self: &mut QDateTime, secs: qint64);
 
-        /// Sets the time specification used in this datetime to spec. The datetime will refer to a different point in time.
+        /// Sets the time specification used in this datetime to `spec`. The datetime will refer to a different point in time.
         ///
-        /// Note this method is only available with Qt < 6.8
+        /// **Note:** This method is only available with Qt < 6.8.
         #[cfg(not(cxxqt_qt_version_at_least_6_8))]
         #[rust_name = "set_time_spec"]
         fn setTimeSpec(self: &mut QDateTime, spec: TimeSpec);
@@ -118,7 +126,9 @@ mod ffi {
         #[rust_name = "time_zone_abbreviation"]
         fn timeZoneAbbreviation(self: &QDateTime) -> QString;
 
-        /// Returns a datetime containing the date and time information in this datetime, but specified using the Qt::LocalTime definition.
+        /// Returns a copy of this datetime converted to local time.
+        ///
+        /// The result represents the same moment in time as, and is equal to, this datetime.
         #[rust_name = "to_local_time"]
         fn toLocalTime(self: &QDateTime) -> QDateTime;
 
@@ -126,7 +136,11 @@ mod ffi {
         #[rust_name = "to_msecs_since_epoch_qint64"]
         fn toMSecsSinceEpoch(self: &QDateTime) -> qint64;
 
-        /// Returns a copy of this datetime converted to a spec of Qt::OffsetFromUTC with the given offsetSeconds.
+        /// Returns a copy of this datetime converted to a spec of [`TimeSpec::OffsetFromUTC`] with the given `offset_seconds`.
+        ///
+        /// If the `offset_seconds` equals 0 then a UTC datetime will be returned.
+        ///
+        /// The result represents the same moment in time as, and is equal to, this datetime.
         #[rust_name = "to_offset_from_utc"]
         fn toOffsetFromUtc(self: &QDateTime, offset_seconds: i32) -> QDateTime;
 
@@ -134,22 +148,28 @@ mod ffi {
         #[rust_name = "to_secs_since_epoch_qint64"]
         fn toSecsSinceEpoch(self: &QDateTime) -> qint64;
 
-        /// Returns the time as a string. The format parameter determines the format of the string.
+        /// Returns the time as a string in the `format` given.
         #[rust_name = "format_enum"]
         fn toString(self: &QDateTime, format: DateFormat) -> QString;
 
-        /// Returns a copy of this datetime converted to the given time spec.
+        /// Returns a copy of this datetime converted to the given time `spec`.
         ///
         /// Note this method is only available with Qt < 6.8
         #[cfg(not(cxxqt_qt_version_at_least_6_8))]
         #[rust_name = "to_time_spec"]
         fn toTimeSpec(self: &QDateTime, spec: TimeSpec) -> QDateTime;
 
-        /// Returns a copy of this datetime converted to the given timeZone
+        /// Returns a copy of this datetime converted to the given `time_zone`.
+        ///
+        /// The result represents the same moment in time as, and is equal to, this datetime.
+        ///
+        /// If `time_zone` is invalid then the datetime will be invalid.
         #[rust_name = "to_time_zone"]
-        fn toTimeZone(self: &QDateTime, timeZone: &QTimeZone) -> QDateTime;
+        fn toTimeZone(self: &QDateTime, time_zone: &QTimeZone) -> QDateTime;
 
-        /// Returns a datetime containing the date and time information in this datetime, but specified using the Qt::UTC definition.
+        /// Returns a copy of this datetime converted to UTC.
+        ///
+        /// The result represents the same moment in time as, and is equal to, this datetime.
         #[rust_name = "to_utc"]
         fn toUTC(self: &QDateTime) -> QDateTime;
     }
@@ -231,97 +251,124 @@ mod ffi {
     }
 }
 
-/// The QDateTime class provides date and time functions.
+/// The `QDateTime` class provides date and time functions.
+///
+/// Qt Documentation: [QDateTime](https://doc.qt.io/qt/qdatetime.html#details)
 #[repr(C)]
 pub struct QDateTime {
     _space: MaybeUninit<usize>,
 }
 
 impl QDateTime {
-    /// Sets the time zone used in this datetime to toZone. The datetime will refer to a different point in time.
-    pub fn set_time_zone(&mut self, time_zone: &ffi::QTimeZone) {
+    /// Sets the time zone used in this datetime to `time_zone`.
+    ///
+    /// The datetime may refer to a different point in time. It uses the time representation of `time_zone`, which may change the meaning of its unchanged [`date`](Self::date) and [`time`](Self::time).
+    ///
+    /// If `time_zone` is invalid then the datetime will be invalid.
+    pub fn set_time_zone(&mut self, time_zone: &QTimeZone) {
         ffi::qdatetime_settimezone(self, time_zone)
     }
 
-    /// Returns a QDateTime object containing a datetime ndays days later than the datetime of this object (or earlier if ndays is negative).
+    /// Returns a `QDateTime` object containing a datetime `ndays` days later than the datetime of this object (or earlier if `ndays` is negative).
+    ///
+    /// If [`time_spec`](Self::time_spec) is [`TimeSpec::LocalTime`] or [`TimeSpec::TimeZone`] and the resulting date and time fall in the Standard Time to Daylight-Saving Time transition hour then the result will be just beyond this gap, in the direction of change. If the transition is at 2am and the clock goes forward to 3am, the result of aiming between 2am and 3am will be adjusted to fall before 2am (if `ndays` is negative) or after 3am (otherwise).
     pub fn add_days(self: &QDateTime, ndays: i64) -> QDateTime {
         self.add_days_qint64(ndays.into())
     }
 
-    /// Returns a QDateTime object containing a datetime msecs milliseconds later than the datetime of this object (or earlier if msecs is negative).
+    /// Returns a `QDateTime` object containing a datetime `msecs` milliseconds later than the datetime of this object (or earlier if `msecs` is negative).
+    ///
+    /// If this datetime is invalid, an invalid datetime will be returned.
     pub fn add_msecs(self: &QDateTime, msecs: i64) -> QDateTime {
         self.add_msecs_qint64(msecs.into())
     }
 
-    /// Returns a QDateTime object containing a datetime s seconds later than the datetime of this object (or earlier if s is negative).
+    /// Returns a `QDateTime` object containing a datetime `secs` seconds later than the datetime of this object (or earlier if `secs` is negative).
+    ///
+    /// If this datetime is invalid, an invalid datetime will be returned.
     pub fn add_secs(self: &QDateTime, secs: i64) -> QDateTime {
         self.add_secs_qint64(secs.into())
     }
 
-    /// Returns the current datetime, as reported by the system clock, in the local time zone.
+    /// Returns the system clock's current datetime, using local time.
     pub fn current_date_time() -> Self {
         ffi::qdatetime_current_date_time()
     }
 
-    /// Returns the current datetime, as reported by the system clock, in UTC.
+    /// Returns the system clock's current datetime, expressed in terms of UTC.
     pub fn current_date_time_utc() -> Self {
         ffi::qdatetime_current_date_time_utc()
     }
 
-    /// Returns the number of milliseconds since 1970-01-01T00:00:00 Universal Coordinated Time.
-    /// This number is like the POSIX time_t variable, but expressed in milliseconds instead.
+    /// Returns the current number of milliseconds since the start, in UTC, of the year 1970.
+    ///
+    /// This number is like the POSIX `time_t` variable, but expressed in milliseconds instead.
     pub fn current_msecs_since_epoch() -> i64 {
         ffi::qdatetime_current_msecs_since_epoch().into()
     }
 
-    /// Returns the number of seconds since 1970-01-01T00:00:00 Universal Coordinated Time.
+    /// Returns the number of seconds since the start, in UTC, of the year 1970.
+    ///
+    /// This number is like the POSIX `time_t` variable.
     pub fn current_secs_since_epoch() -> i64 {
         ffi::qdatetime_current_secs_since_epoch().into()
     }
 
-    /// Returns the number of days from this datetime to the other datetime.
+    /// Returns the number of days from this datetime to the `other` datetime.
     /// The number of days is counted as the number of times midnight is reached between this datetime to the other datetime.
     /// This means that a 10 minute difference from 23:55 to 0:05 the next day counts as one day.
+    ///
+    /// If the `other` datetime is earlier than this datetime, the value returned is negative.
     pub fn days_to(&self, other: &Self) -> i64 {
         self.days_to_qint64(other).into()
     }
 
-    /// Construct a Rust QDateTime from a given QDate, QTime, and QTimeZone
-    pub fn from_date_and_time_time_zone(
-        date: &QDate,
-        time: &QTime,
-        time_zone: &ffi::QTimeZone,
-    ) -> Self {
+    /// Constructs a datetime with the given `date` and `time`, using the time representation described by `time_zone`.
+    ///
+    /// If `date` is valid and `time` is not, the time will be set to midnight. If `time_zone` is invalid then the datetime will be invalid.
+    pub fn from_date_and_time_time_zone(date: &QDate, time: &QTime, time_zone: &QTimeZone) -> Self {
         ffi::qdatetime_init_from_date_and_time_time_zone(date, time, time_zone)
     }
 
-    /// Construct a Rust QDateTime from a given QDate, QTime, Qt::TimeSpec, and offset
+    /// Constructs a datetime with the given `date` and `time`, using the time specification defined by `spec` and `offset_seconds` seconds.
     ///
-    /// Note this method is only available with Qt < 6.8
+    /// If `date` is valid and `time` is not, the time will be set to midnight.
+    ///
+    /// If the spec is not [`TimeSpec::OffsetFromUTC`] then `offset_seconds` will be ignored.
+    ///
+    /// If the spec is [`TimeSpec::OffsetFromUTC`] and `offset_seconds` is 0 then the time spec will be set to [`TimeSpec::UTC`], i.e. an offset of 0 seconds.
+    ///
+    /// If spec is [`TimeSpec:TimeZone`] then the spec will be set to [`TimeSpec::LocalTime`], i.e. the current system time zone.
+    ///
+    /// **Note:** This method is only available with Qt < 6.8.
     #[cfg(not(cxxqt_qt_version_at_least_6_8))]
     pub fn from_date_and_time_time_spec(
         date: &QDate,
         time: &QTime,
-        time_spec: ffi::TimeSpec,
+        time_spec: TimeSpec,
         offset_seconds: i32,
     ) -> Self {
         ffi::qdatetime_init_from_date_and_time_time_spec(date, time, time_spec, offset_seconds)
     }
 
-    /// Returns a datetime whose date and time are the number of milliseconds msecs that have passed since 1970-01-01T00:00:00.000,
-    /// Coordinated Universal Time (Qt::UTC) and with the given timeZone.
-    pub fn from_msecs_since_epoch(msecs: i64, time_zone: &ffi::QTimeZone) -> Self {
+    /// Returns a datetime representing a moment the given number `msecs` of milliseconds after the start, in UTC, of the year 1970, described as specified by `time_zone`.
+    ///
+    /// Note that there are possible values for `msecs` that lie outside the valid range of `QDateTime`, both negative and positive. The behavior of this function is undefined for those values.
+    pub fn from_msecs_since_epoch(msecs: i64, time_zone: &QTimeZone) -> Self {
         ffi::qdatetime_from_msecs_since_epoch(msecs.into(), time_zone)
     }
 
-    /// Returns a datetime whose date and time are the number of seconds secs that have passed since 1970-01-01T00:00:00.000,
-    /// Coordinated Universal Time (Qt::UTC) and converted to the given spec.
-    pub fn from_secs_since_epoch(secs: i64, time_zone: &ffi::QTimeZone) -> Self {
+    /// Returns a datetime representing a moment the given number `secs` of seconds after the start, in UTC, of the year 1970, described as specified by `time_zone`.
+    ///
+    /// Note that there are possible values for `secs` that lie outside the valid range of `QDateTime`, both negative and positive. The behavior of this function is undefined for those values.
+    pub fn from_secs_since_epoch(secs: i64, time_zone: &QTimeZone) -> Self {
         ffi::qdatetime_from_secs_since_epoch(secs.into(), time_zone)
     }
 
-    /// Returns the datetime represented in the string as a QDateTime using the format given, or None if this is not possible.
-    pub fn from_string(string: &ffi::QString, format: ffi::DateFormat) -> Option<Self> {
+    /// Returns the datetime represented by the `string`, using the `format` given, or `None` if this is not possible.
+    ///
+    /// Note for [`DateFormat::TextDate`]: only English month names (e.g. "Jan" in short form or "January" in long form) are recognized.
+    pub fn from_string(string: &QString, format: DateFormat) -> Option<Self> {
         let date = ffi::qdatetime_from_string(string, format);
         if date.is_valid() {
             Some(date)
@@ -330,53 +377,69 @@ impl QDateTime {
         }
     }
 
-    /// Returns the number of milliseconds from this datetime to the other datetime.
-    /// If the other datetime is earlier than this datetime, the value returned is negative.
+    /// Returns the number of milliseconds from this datetime to the `other` datetime.
+    /// If the `other` datetime is earlier than this datetime, the value returned is negative.
+    ///
+    /// Returns 0 if either datetime is invalid.
     pub fn msecs_to(self: &QDateTime, other: &QDateTime) -> i64 {
         self.msecs_to_qint64(other).into()
     }
 
-    /// Returns the number of seconds from this datetime to the other datetime.
-    /// If the other datetime is earlier than this datetime, the value returned is negative.
+    /// Returns the number of seconds from this datetime to the `other` datetime.
+    /// If the `other` datetime is earlier than this datetime, the value returned is negative.
+    ///
+    /// Returns 0 if either datetime is invalid.
     pub fn secs_to(self: &QDateTime, other: &QDateTime) -> i64 {
         self.secs_to_qint64(other).into()
     }
 
-    /// Sets the date part of this datetime to date. If no time is set yet, it is set to midnight.
-    /// If date is invalid, this QDateTime becomes invalid.
+    /// Sets the date part of this datetime to `date`. If no time is set yet, it is set to midnight.
+    /// If `date` is invalid, this `QDateTime` becomes invalid.
     pub fn set_date(&mut self, date: QDate) {
         ffi::qdatetime_set_date(self, date);
     }
 
-    /// Sets the date and time given the number of milliseconds msecs that have passed since 1970-01-01T00:00:00.000,
-    /// Coordinated Universal Time (Qt::UTC). On systems that do not support time zones this function will behave as if local time were Qt::UTC.
+    /// Sets the datetime to represent a moment a given number, `msecs`, of milliseconds after the start, in UTC, of the year 1970.
+    ///
+    /// On systems that do not support time zones, this function will behave as if local time were UTC.
+    ///
+    /// Note that passing `i64::MIN` to `msecs` will result in undefined behavior.
     pub fn set_msecs_since_epoch(self: &mut QDateTime, msecs: i64) {
         self.set_msecs_since_epoch_qint64(msecs.into());
     }
 
-    /// Sets the date and time given the number of seconds secs that have passed since 1970-01-01T00:00:00.000,
-    /// Coordinated Universal Time (Qt::UTC). On systems that do not support time zones this function will behave as if local time were Qt::UTC.
+    /// Sets the datetime to represent a moment a given number, `secs`, of seconds after the start, in UTC, of the year 1970.
+    ///
+    /// On systems that do not support time zones, this function will behave as if local time were UTC.
     pub fn set_secs_since_epoch(self: &mut QDateTime, secs: i64) {
         self.set_secs_since_epoch_qint64(secs.into());
     }
 
-    /// Sets the time part of this datetime to time. If time is not valid, this function sets it to midnight.
-    /// Therefore, it's possible to clear any set time in a QDateTime by setting it to a default QTime.
+    /// Sets the time part of this datetime to `time`. If `time` is not valid, this function sets it to midnight.
+    /// Therefore, it's possible to clear any set time in a `QDateTime` by setting it to [`QTime::default()`].
     pub fn set_time(&mut self, time: QTime) {
         ffi::qdatetime_set_time(self, time);
     }
 
     /// Returns the time zone of the datetime.
-    pub fn time_zone(&self) -> cxx::UniquePtr<ffi::QTimeZone> {
+    pub fn time_zone(&self) -> cxx::UniquePtr<QTimeZone> {
         ffi::qdatetime_time_zone(self)
     }
 
-    /// Returns the datetime as the number of milliseconds that have passed since 1970-01-01T00:00:00.000, Coordinated Universal Time (Qt::UTC).
+    /// Returns the datetime as a number of milliseconds after the start, in UTC, of the year 1970.
+    ///
+    /// On systems that do not support time zones, this function will behave as if local time were UTC.
+    ///
+    /// The behavior for this function is undefined if the datetime stored in this object is not valid. However, for all valid dates, this function returns a unique value.
     pub fn to_msecs_since_epoch(self: &QDateTime) -> i64 {
         self.to_msecs_since_epoch_qint64().into()
     }
 
-    /// Returns the datetime as the number of seconds that have passed since 1970-01-01T00:00:00.000, Coordinated Universal Time (Qt::UTC).
+    /// Returns the datetime as a number of seconds after the start, in UTC, of the year 1970.
+    ///
+    /// On systems that do not support time zones, this function will behave as if local time were UTC.
+    ///
+    /// The behavior for this function is undefined if the datetime stored in this object is not valid. However, for all valid dates, this function returns a unique value.
     pub fn to_secs_since_epoch(self: &QDateTime) -> i64 {
         self.to_secs_since_epoch_qint64().into()
     }
@@ -418,7 +481,7 @@ impl Ord for QDateTime {
 
 impl fmt::Display for QDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.format_enum(ffi::DateFormat::TextDate).fmt(f)
+        self.format_enum(DateFormat::TextDate).fmt(f)
     }
 }
 
@@ -551,12 +614,12 @@ mod test {
         let qdatetime_a = QDateTime::from_date_and_time_time_zone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 1, 1, 1),
-            &ffi::QTimeZone::utc(),
+            &QTimeZone::utc(),
         );
         let qdatetime_b = QDateTime::from_date_and_time_time_zone(
             &QDate::new(2023, 2, 2),
             &QTime::new(2, 2, 2, 2),
-            &ffi::QTimeZone::utc(),
+            &QTimeZone::utc(),
         );
 
         assert!(qdatetime_a < qdatetime_b);
@@ -589,7 +652,7 @@ mod test_chrono {
             &QDate::new(2023, 1, 1),
             // Chrono adds the offset to the given time, so add the offset here to match Chrono
             &QTime::new(1 + 1 /* plus the offset */, 2, 3, 4),
-            &ffi::QTimeZone::from_offset_seconds(60 * 60),
+            &QTimeZone::from_offset_seconds(60 * 60),
         );
         assert_eq!(QDateTime::try_from(datetime_east).unwrap(), qdatetime);
     }
@@ -612,7 +675,7 @@ mod test_chrono {
         let qdatetime = QDateTime::from_date_and_time_time_zone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
-            &ffi::QTimeZone::from_offset_seconds(60 * 60),
+            &QTimeZone::from_offset_seconds(60 * 60),
         );
         assert_eq!(
             chrono::DateTime::<chrono::FixedOffset>::try_from(qdatetime).unwrap(),
@@ -636,7 +699,7 @@ mod test_chrono {
         let qdatetime = QDateTime::from_date_and_time_time_zone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
-            &ffi::QTimeZone::utc(),
+            &QTimeZone::utc(),
         );
         assert_eq!(
             chrono::DateTime::<chrono::Utc>::try_from(qdatetime).unwrap(),
@@ -661,7 +724,7 @@ mod test_chrono {
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
             // Should cause one hour offset when in chrono::DateTime
-            &ffi::QTimeZone::from_offset_seconds(60 * 60),
+            &QTimeZone::from_offset_seconds(60 * 60),
         );
         assert_eq!(
             chrono::DateTime::<chrono::Utc>::try_from(qdatetime).unwrap(),
@@ -686,7 +749,7 @@ mod test_time {
         let qdatetime = QDateTime::from_date_and_time_time_zone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
-            &ffi::QTimeZone::from_offset_seconds(60 * 60),
+            &QTimeZone::from_offset_seconds(60 * 60),
         );
         assert_eq!(
             time::OffsetDateTime::try_from(qdatetime).unwrap(),
@@ -704,7 +767,7 @@ mod test_time {
         let qdatetime = QDateTime::from_date_and_time_time_zone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
-            &ffi::QTimeZone::utc(),
+            &QTimeZone::utc(),
         );
         assert_eq!(
             time::PrimitiveDateTime::try_from(qdatetime).unwrap(),
@@ -723,7 +786,7 @@ mod test_time {
         let qdatetime = QDateTime::from_date_and_time_time_zone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
-            &ffi::QTimeZone::from_offset_seconds(60 * 60),
+            &QTimeZone::from_offset_seconds(60 * 60),
         );
         assert_eq!(QDateTime::from(time_offsetdatetime), qdatetime);
     }
@@ -738,7 +801,7 @@ mod test_time {
         let qdatetime = QDateTime::from_date_and_time_time_zone(
             &QDate::new(2023, 1, 1),
             &QTime::new(1, 2, 3, 4),
-            &ffi::QTimeZone::utc(),
+            &QTimeZone::utc(),
         );
         assert_eq!(QDateTime::from(time_offsetdatetime), qdatetime);
     }

--- a/crates/cxx-qt-lib/src/core/qflags/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qflags/mod.rs
@@ -17,8 +17,10 @@ pub use repr::QFlagRepr;
 
 mod util;
 
-/// The `QFlags<T>` class is a template class, where T is an enum type.
+/// The `QFlags<T>` class is a template class, where `T` is an enum type.
 /// QFlags are used throughout Qt for storing combinations of enum values.
+///
+/// Qt Documentation: [QFlags](https://doc.qt.io/qt/qflags.html#details)
 #[repr(transparent)]
 pub struct QFlags<T: QFlag> {
     repr: <T::Repr as QFlagRepr>::Int,
@@ -65,7 +67,7 @@ impl<T: QFlag> Hash for QFlags<T> {
 }
 
 impl<T: QFlag> From<T> for QFlags<T> {
-    /// Returns the value stored in the QFlags object as an integer.
+    /// Returns the value stored in the `QFlags` object as an integer.
     fn from(value: T) -> Self {
         Self {
             repr: value.to_int(),
@@ -74,35 +76,35 @@ impl<T: QFlag> From<T> for QFlags<T> {
 }
 
 impl<T: QFlag> Default for QFlags<T> {
-    /// Constructs an empty QFlags object.
+    /// Constructs an empty `QFlags` object.
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl<T: QFlag> QFlags<T> {
-    /// Constructs an empty QFlags object.
+    /// Constructs an empty `QFlags` object.
     pub const fn new() -> Self {
         Self::from_int(T::Repr::ZERO)
     }
 
-    /// Constructs a QFlags object representing the integer value *i*.
+    /// Constructs a `QFlags` object representing the integer value `i`.
     pub const fn from_int(i: <T::Repr as QFlagRepr>::Int) -> Self {
         Self { repr: i }
     }
 
-    /// Returns the value stored in the QFlags object as an integer.
+    /// Returns the value stored in the `QFlags` object as an integer.
     pub const fn to_int(self) -> <T::Repr as QFlagRepr>::Int {
         self.repr
     }
 
-    /// Returns `true` if no flag is set (i.e., if the value stored by the QFlags object is 0);
+    /// Returns `true` if no flag is set (i.e., if the value stored by the `QFlags` object is 0);
     /// otherwise returns `false`.
     pub fn is_empty(self) -> bool {
         self.repr == T::Repr::ZERO
     }
 
-    /// Sets the flag *flag* if *on* is `true` or unsets it if *on* is `false`.
+    /// Sets the flag `flag` if `on` is `true` or unsets it if `on` is `false`.
     /// Returns a mutable reference to this object.
     pub fn set_flag(&mut self, flag: T, on: bool) -> &mut Self {
         if on {
@@ -113,21 +115,21 @@ impl<T: QFlag> QFlags<T> {
         self
     }
 
-    /// Returns `true` if the flag `flag` is set, otherwise false.
+    /// Returns `true` if the flag `flag` is set, otherwise `false`.
     ///
-    /// Note: if *flag* contains multiple bits set to 1 (for instance, if it's an enumerator equal
+    /// Note: if `flag` contains multiple bits set to 1 (for instance, if it's an enumerator equal
     /// to the bitwise-OR of other enumerators) then this function will return `true` if and only if
-    /// all the bits are set in this flags object. On the other hand, if *flag* contains no bits set
+    /// all the bits are set in this flags object. On the other hand, if `flag` contains no bits set
     /// to 1 (that is, its value as a integer is 0), then this function will return `true` if and
     /// only if this flags object also has no bits set to 1.
     pub fn test_flag(self, flag: T) -> bool {
         self.test_flags(Self::from(flag))
     }
 
-    /// Returns `true` if this *flags* object matches the given flags.
+    /// Returns `true` if this flags object matches the given `flags`.
     ///
-    /// If *flags* has any flags set, this flags object matches precisely if all flags set in
-    /// *flags* are also set in this flags object. Otherwise, when *flags* has no flags set, this
+    /// If `flags` has any flags set, this flags object matches precisely if all flags set in
+    /// `flags` are also set in this flags object. Otherwise, when `flags` has no flags set, this
     /// flags object only matches if it also has no flags set.
     pub fn test_flags(self, flags: Self) -> bool {
         if flags.is_empty() {
@@ -137,14 +139,14 @@ impl<T: QFlag> QFlags<T> {
         }
     }
 
-    /// Returns `true` if any flag set in *flag* is also set in this flags object, otherwise
-    /// `false`. If *flag* has no flags set, the return will always be `false`.
+    /// Returns `true` if any flag set in `flag` is also set in this flags object, otherwise
+    /// `false`. If `flag` has no flags set, the return will always be `false`.
     pub fn test_any_flag(self, flag: T) -> bool {
         self.test_any_flags(Self::from(flag))
     }
 
-    /// Returns `true` if any flag set in *flags* is also set in this flags object, otherwise
-    /// `false`. If *flags* has no flags set, the return will always be `false`.
+    /// Returns `true` if any flag set in `flags` is also set in this flags object, otherwise
+    /// `false`. If `flags` has no flags set, the return will always be `false`.
     pub fn test_any_flags(self, flags: Self) -> bool {
         (self.repr & flags.repr) != T::Repr::ZERO
     }
@@ -153,7 +155,7 @@ impl<T: QFlag> QFlags<T> {
 impl<T: QFlag> Not for QFlags<T> {
     type Output = Self;
 
-    /// Returns a QFlags object that contains the bitwise negation of this object.
+    /// Returns a `QFlags` object that contains the bitwise negation of this object.
     fn not(self) -> Self::Output {
         Self { repr: !self.repr }
     }
@@ -162,7 +164,7 @@ impl<T: QFlag> Not for QFlags<T> {
 impl<T: QFlag> BitAnd for QFlags<T> {
     type Output = Self;
 
-    /// Returns a QFlags object containing the result of the bitwise AND operation on this object
+    /// Returns a `QFlags` object containing the result of the bitwise AND operation on this object
     /// and `mask`.
     fn bitand(self, mask: Self) -> Self::Output {
         Self {
@@ -173,7 +175,7 @@ impl<T: QFlag> BitAnd for QFlags<T> {
 impl<T: QFlag> BitAnd<T> for QFlags<T> {
     type Output = Self;
 
-    /// Returns a QFlags object containing the result of the bitwise AND operation on this object
+    /// Returns a `QFlags` object containing the result of the bitwise AND operation on this object
     /// and `mask`.
     fn bitand(self, mask: T) -> Self::Output {
         Self {
@@ -182,13 +184,13 @@ impl<T: QFlag> BitAnd<T> for QFlags<T> {
     }
 }
 impl<T: QFlag> BitAndAssign for QFlags<T> {
-    /// Performs a bitwise AND operation with mask and stores the result in this QFlags object.
+    /// Performs a bitwise AND operation with mask and stores the result in this `QFlags` object.
     fn bitand_assign(&mut self, mask: Self) {
         self.repr &= mask.repr;
     }
 }
 impl<T: QFlag> BitAndAssign<T> for QFlags<T> {
-    /// Performs a bitwise AND operation with mask and stores the result in this QFlags object.
+    /// Performs a bitwise AND operation with mask and stores the result in this `QFlags` object.
     fn bitand_assign(&mut self, mask: T) {
         self.repr &= mask.to_int();
     }
@@ -197,7 +199,7 @@ impl<T: QFlag> BitAndAssign<T> for QFlags<T> {
 impl<T: QFlag> BitXor for QFlags<T> {
     type Output = Self;
 
-    /// Returns a QFlags object containing the result of the bitwise XOR operation on this object
+    /// Returns a `QFlags` object containing the result of the bitwise XOR operation on this object
     /// and `other`.
     fn bitxor(self, other: Self) -> Self::Output {
         Self {
@@ -208,7 +210,7 @@ impl<T: QFlag> BitXor for QFlags<T> {
 impl<T: QFlag> BitXor<T> for QFlags<T> {
     type Output = Self;
 
-    /// Returns a QFlags object containing the result of the bitwise XOR operation on this object
+    /// Returns a `QFlags` object containing the result of the bitwise XOR operation on this object
     /// and `other`.
     fn bitxor(self, other: T) -> Self::Output {
         Self {
@@ -217,13 +219,13 @@ impl<T: QFlag> BitXor<T> for QFlags<T> {
     }
 }
 impl<T: QFlag> BitXorAssign for QFlags<T> {
-    /// Performs a bitwise XOR operation with `other` and stores the result in this QFlags object.
+    /// Performs a bitwise XOR operation with `other` and stores the result in this `QFlags` object.
     fn bitxor_assign(&mut self, other: Self) {
         self.repr ^= other.repr;
     }
 }
 impl<T: QFlag> BitXorAssign<T> for QFlags<T> {
-    /// Performs a bitwise XOR operation with `other` and stores the result in this QFlags object.
+    /// Performs a bitwise XOR operation with `other` and stores the result in this `QFlags` object.
     fn bitxor_assign(&mut self, other: T) {
         self.repr ^= other.to_int();
     }
@@ -232,7 +234,7 @@ impl<T: QFlag> BitXorAssign<T> for QFlags<T> {
 impl<T: QFlag> BitOr for QFlags<T> {
     type Output = Self;
 
-    /// Returns a QFlags object containing the result of the bitwise OR operation on this object and
+    /// Returns a `QFlags` object containing the result of the bitwise OR operation on this object and
     /// `other`.
     fn bitor(self, other: Self) -> Self::Output {
         Self {
@@ -243,7 +245,7 @@ impl<T: QFlag> BitOr for QFlags<T> {
 impl<T: QFlag> BitOr<T> for QFlags<T> {
     type Output = Self;
 
-    /// Returns a QFlags object containing the result of the bitwise OR operation on this object and
+    /// Returns a `QFlags` object containing the result of the bitwise OR operation on this object and
     /// `other`.
     fn bitor(self, other: T) -> Self::Output {
         Self {
@@ -252,13 +254,13 @@ impl<T: QFlag> BitOr<T> for QFlags<T> {
     }
 }
 impl<T: QFlag> BitOrAssign for QFlags<T> {
-    /// Performs a bitwise OR operation with `other` and stores the result in this QFlags object.
+    /// Performs a bitwise OR operation with `other` and stores the result in this `QFlags` object.
     fn bitor_assign(&mut self, other: Self) {
         self.repr |= other.repr;
     }
 }
 impl<T: QFlag> BitOrAssign<T> for QFlags<T> {
-    /// Performs a bitwise OR operation with `other` and stores the result in this QFlags object.
+    /// Performs a bitwise OR operation with `other` and stores the result in this `QFlags` object.
     fn bitor_assign(&mut self, mask: T) {
         self.repr |= mask.to_int();
     }

--- a/crates/cxx-qt-lib/src/core/qflags/qflag.rs
+++ b/crates/cxx-qt-lib/src/core/qflags/qflag.rs
@@ -7,6 +7,8 @@ use super::QFlagRepr;
 
 use cxx::ExternType;
 
+/// Trait implementation for an element in a [`QFlags`](crate::QFlags).
+///
 /// # Safety
 ///
 /// By writing the unsafe `QFlag` impl, the programmer asserts that the C++ namespace and type name

--- a/crates/cxx-qt-lib/src/core/qflags/util.rs
+++ b/crates/cxx-qt-lib/src/core/qflags/util.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 #[macro_export]
+#[doc(hidden)]
 macro_rules! unsafe_impl_qflag {
     ( $typeName:ty, $typeId:literal, $repr:ident ) => {
         unsafe impl $crate::QFlag for $typeName {

--- a/crates/cxx-qt-lib/src/core/qhash/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qhash/mod.rs
@@ -6,12 +6,14 @@ use core::{marker::PhantomData, mem::MaybeUninit};
 use cxx::{type_id, ExternType};
 use std::fmt;
 
-/// The QHash class is a template class that provides a hash-table-based dictionary.
+/// The `QHash` class is a template class that provides a hash-table-based dictionary.
 ///
 /// Note that this means that T needs to have a C++ global
 /// [`qHash()` function](https://doc.qt.io/qt-6/qhash.html#qhash).
 ///
 /// To use QHash with a custom pair, implement the [`QHashPair`] trait for T.
+///
+/// Qt Documentation: [QHash]("https://doc.qt.io/qt/qhash.html#details")
 #[repr(C)]
 pub struct QHash<T>
 where
@@ -25,7 +27,7 @@ impl<T> Clone for QHash<T>
 where
     T: QHashPair,
 {
-    /// Constructs a copy of other.
+    /// Constructs a copy of the hash.
     fn clone(&self) -> Self {
         T::clone(self)
     }
@@ -72,17 +74,17 @@ impl<T> QHash<T>
 where
     T: QHashPair,
 {
-    /// Removes all items from the hash.
+    /// Removes all items from the hash and frees up all memory used by it.
     pub fn clear(&mut self) {
         T::clear(self)
     }
 
-    /// Returns true if the hash contains an item with the key; otherwise returns false.
+    /// Returns `true` if the hash contains an item with the key; otherwise returns `false`.
     pub fn contains(&self, key: &T::Key) -> bool {
         T::contains(self, key)
     }
 
-    /// Returns the value associated with the key if it exists.
+    /// Returns the value associated with the `key` or `None` if it does not exist.
     pub fn get(&self, key: &T::Key) -> Option<T::Value> {
         if self.contains(key) {
             Some(T::get_or_default(self, key))
@@ -91,12 +93,16 @@ where
         }
     }
 
-    /// Returns the value associated with the key or a default value.
+    /// Returns the value associated with the `key`, or a default-constructed value if it does not exist.
+    ///
+    /// For most value types, a default-constructed value simply means that a value is created using the default constructor (e.g. an empty string for [`QString`](crate::QString)). Primitive types like `i32` and `f64` are initialized to 0.
     pub fn get_or_default(&self, key: &T::Key) -> T::Value {
         T::get_or_default(self, key)
     }
 
-    /// Inserts a new item with the key and a value of value.
+    /// Inserts a new item with the `key` and a value of `value`.
+    ///
+    /// If there is already an item with the `key`, that item's value is replaced with `value`.
     ///
     /// The key and value is a reference here so it can be opaque or trivial but
     /// note that the key and value is copied when being inserted into the hash.
@@ -104,13 +110,13 @@ where
         T::insert_clone(self, key, value)
     }
 
-    /// Returns true if the hash contains no items; otherwise returns false.
+    /// Returns `true` if the hash contains no items; otherwise returns `false`.
     pub fn is_empty(&self) -> bool {
         T::len(self) == 0
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order.
-    /// The iterator element type is (&'a T::Key, &'a T::Value).
+    /// The iterator element type is `(&'a T::Key, &'a T::Value)`.
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             hash: self,
@@ -123,9 +129,9 @@ where
         T::len(self)
     }
 
-    /// Removes all the items that have the key from the hash.
+    /// Removes the item that has the `key` from the hash.
     ///
-    /// Returns true if at least one item was removed, otherwise returns false.
+    /// Returns `true` if the key exists in the hash and the item has been removed, and `false` otherwise.
     pub fn remove(&mut self, key: &T::Key) -> bool {
         T::remove(self, key)
     }
@@ -137,7 +143,7 @@ where
     T::Key: ExternType<Kind = cxx::kind::Trivial>,
     T::Value: ExternType<Kind = cxx::kind::Trivial>,
 {
-    /// Inserts a new item with the key and a value of value.
+    /// Inserts a new item with the `key` and a value of `value`.
     pub fn insert(&mut self, key: T::Key, value: T::Value) {
         T::insert(self, key, value)
     }

--- a/crates/cxx-qt-lib/src/core/qline.rs
+++ b/crates/cxx-qt-lib/src/core/qline.rs
@@ -38,7 +38,7 @@ mod ffi {
         /// Returns the y-coordinate of the line's end point.
         fn y2(self: &QLine) -> i32;
 
-        /// Returns the center point of this line. This is equivalent to (p1() + p2()) / 2, except it will never overflow.
+        /// Returns the center point of this line. This is equivalent to `(self.p1() + self.p2()) / 2`, except it will never overflow.
         fn center(self: &QLine) -> QPoint;
 
         /// Returns the horizontal component of the line's vector.
@@ -47,36 +47,37 @@ mod ffi {
         /// Returns the vertical component of the line's vector.
         fn dy(self: &QLine) -> i32;
 
-        /// Returns true if the line does not have distinct start and end points; otherwise returns false.
+        /// Returns `true` if the line does not have distinct start and end points; otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QLine) -> bool;
 
-        /// Sets the starting point of this line to p1.
+        /// Sets the starting point of this line to `p1`.
         #[rust_name = "set_p1"]
         fn setP1(self: &mut QLine, p1: &QPoint);
 
-        /// Sets the end point of this line to p2.
+        /// Sets the end point of this line to `p2`.
         #[rust_name = "set_p2"]
         fn setP2(self: &mut QLine, p1: &QPoint);
 
-        /// Sets this line to the start in x1, y1 and end in x2, y2.
+        /// Sets this line to the start in `x1`, `y1` and end in `x2`, `y2`.
         #[rust_name = "set_line"]
         fn setLine(self: &mut QLine, x1: i32, y1: i32, x2: i32, y2: i32);
 
-        /// Sets the start point of this line to p1 and the end point of this line to p2.
+        /// Sets the start point of this line to `p1` and the end point of this line to `p2`.
         #[rust_name = "set_points"]
         fn setPoints(self: &mut QLine, p1: &QPoint, p2: &QPoint);
 
         /// Returns this line as a line with floating point accuracy.
-        /// since Qt 6.4.
+        ///
+        /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_linef"]
         fn toLineF(self: &QLine) -> QLineF;
 
-        /// Translates this line by the given offset.
+        /// Translates this line by the given `offset`.
         fn translate(self: &mut QLine, offset: &QPoint);
 
-        /// Returns this line translated by the given offset.
+        /// Returns this line translated by the given `offset`.
         fn translated(self: &QLine, offset: &QPoint) -> QLine;
     }
 
@@ -98,7 +99,9 @@ mod ffi {
     }
 }
 
-/// The QLine class provides a two-dimensional vector using integer precision
+/// The `QLine` class provides a two-dimensional vector using integer precision.
+///
+/// Qt Documentation: [QLine](https://doc.qt.io/qt/qline.html#details)
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct QLine {
@@ -107,7 +110,7 @@ pub struct QLine {
 }
 
 impl QLine {
-    /// Constructs a line object that represents the line between p1 and p2.
+    /// Constructs a line object that represents the line between `p1` and `p2`.
     pub fn new(pt1: QPoint, pt2: QPoint) -> Self {
         ffi::qline_new(pt1, pt2)
     }

--- a/crates/cxx-qt-lib/src/core/qlinef.rs
+++ b/crates/cxx-qt-lib/src/core/qlinef.rs
@@ -23,8 +23,10 @@ mod ffi {
         /// Returns the angle of the line in degrees.
         fn angle(self: &QLineF) -> f64;
 
-        /// Returns the angle (in degrees) from this line to the given line, taking the direction of the lines into account.
-        /// If the lines do not intersect within their range, it is the intersection point of the extended lines that serves as origin (see QLineF::UnboundedIntersection).
+        /// Returns the angle (in degrees) from this line to the given `line`, taking the direction of the lines into account.
+        /// If the lines do not intersect within their range, it is the intersection point of the extended lines that serves as origin.
+        ///
+        /// The returned value represents the number of degrees you need to add to this line to make it have the same angle as the given `line`, going counter-clockwise.
         #[rust_name = "angle_to"]
         fn angleTo(self: &QLineF, line: &QLineF) -> f64;
 
@@ -46,7 +48,7 @@ mod ffi {
         /// Returns the y-coordinate of the line's end point.
         fn y2(self: &QLineF) -> f64;
 
-        /// Returns the center point of this line. This is equivalent to (p1() + p2()) / 2, except it will never overflow.
+        /// Returns the center point of this line. This is equivalent to `(self.p1() + self.p2()) / 2`, except it will never overflow.
         fn center(self: &QLineF) -> QPointF;
 
         /// Returns the horizontal component of the line's vector.
@@ -55,7 +57,7 @@ mod ffi {
         /// Returns the vertical component of the line's vector.
         fn dy(self: &QLineF) -> f64;
 
-        /// Returns true if the line does not have distinct start and end points; otherwise returns false.
+        /// Returns `true` if the line does not have distinct start and end points; otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QLineF) -> bool;
 
@@ -66,43 +68,47 @@ mod ffi {
         #[rust_name = "normal_vector"]
         fn normalVector(self: &QLineF) -> QLineF;
 
-        /// Returns the point at the parameterized position specified by t. The function returns the line's start point if t = 0, and its end point if t = 1.
+        /// Returns the point at the parameterized position specified by `t`. The function returns the line's start point if `t` = 0, and its end point if `t` = 1.
         #[rust_name = "point_at"]
         fn pointAt(self: &QLineF, t: f64) -> QPointF;
 
-        /// Sets the angle of the line to the given angle (in degrees). This will change the position of the second point of the line such that the line has the given angle.
+        /// Sets the angle of the line to the given `angle` (in degrees). This will change the position of the second point of the line such that the line has the given angle.
+        ///
+        /// Positive values for the angles mean counter-clockwise while negative values mean the clockwise direction. Zero degrees is at the 3 o'clock position.
         #[rust_name = "set_angle"]
         fn setAngle(self: &mut QLineF, angle: f64);
 
-        /// Sets the length of the line to the given length. QLineF will move the end point - p2() - of the line to give the line its new length, unless length() was previously zero, i
+        /// Sets the length of the line to the given length. `QLineF` will move the end point ([`p2`](QLineF::p2)) of the line to give the line its new length, unless [`length`](Self::length) was previously zero,
         /// in which case no scaling is attempted. For lines with very short lengths (represented by denormal floating-point values), results may be imprecise.
         #[rust_name = "set_length"]
         fn setLength(self: &mut QLineF, length: f64);
 
-        /// Sets the starting point of this line to p1.
+        /// Sets the starting point of this line to `p1`.
         #[rust_name = "set_p1"]
         fn setP1(self: &mut QLineF, p1: &QPointF);
 
-        /// Sets the end point of this line to p2.
+        /// Sets the end point of this line to `p2`.
         #[rust_name = "set_p2"]
         fn setP2(self: &mut QLineF, p1: &QPointF);
 
-        /// Sets this line to the start in x1, y1 and end in x2, y2.
+        /// Sets this line to the start in `x1`, `y1` and end in `x2`, `y2`.
         #[rust_name = "set_line"]
         fn setLine(self: &mut QLineF, x1: f64, y1: f64, x2: f64, y2: f64);
 
-        /// Sets the start point of this line to p1 and the end point of this line to p2.
+        /// Sets the start point of this line to `p1` and the end point of this line to `p2`.
         #[rust_name = "set_points"]
         fn setPoints(self: &mut QLineF, p1: &QPointF, p2: &QPointF);
 
         /// Returns an integer based copy of this line.
+        ///
+        /// Note that the returned line's start and end points are rounded to the nearest integer.
         #[rust_name = "to_line"]
         fn toLine(self: &QLineF) -> QLine;
 
-        /// Translates this line by the given offset.
+        /// Translates this line by the given `offset`.
         fn translate(self: &mut QLineF, offset: &QPointF);
 
-        /// Returns this line translated by the given offset.
+        /// Returns this line translated by the given `offset`.
         fn translated(self: &QLineF, offset: &QPointF) -> QLineF;
 
         /// Returns the unit vector for this line, i.e a line starting at the same point as this line with a length of 1.0, provided the line is non-null.
@@ -131,7 +137,9 @@ mod ffi {
     }
 }
 
-/// The QLineF class provides a two-dimensional vector using floating point precision.
+/// The `QLineF` class provides a two-dimensional vector using floating point precision.
+///
+/// Qt Documentation: [QLineF](https://doc.qt.io/qt/qlinef.html#details)
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QLineF {
@@ -140,27 +148,27 @@ pub struct QLineF {
 }
 
 impl QLineF {
-    /// Constructs a line object that represents the line between pt1 and pt2.
+    /// Constructs a line object that represents the line between `pt1` and `pt2`.
     pub fn new(pt1: QPointF, pt2: QPointF) -> Self {
         ffi::qlinef_new(pt1, pt2)
     }
 }
 
 impl Default for QLineF {
-    /// Constructs a default qlinef
+    /// Constructs a null line.
     fn default() -> Self {
         ffi::qlinef_default()
     }
 }
 
-impl From<&ffi::QLine> for QLineF {
-    /// Construct a QLineF object from the given integer-based line.
+impl From<&QLine> for QLineF {
+    /// Construct a `QLineF` object from the given integer-based line.
     fn from(line: &QLine) -> Self {
         ffi::qlinef_from_qline(line)
     }
 }
 
-impl From<QLineF> for ffi::QLine {
+impl From<QLineF> for QLine {
     /// Returns an integer-based copy of this line.
     /// Note that the returned line's start and end points are rounded to the nearest integer.
     fn from(value: QLineF) -> Self {

--- a/crates/cxx-qt-lib/src/core/qmap/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qmap/mod.rs
@@ -6,9 +6,11 @@ use core::{marker::PhantomData, mem::MaybeUninit};
 use cxx::{type_id, ExternType};
 use std::fmt;
 
-/// The QMap class is a template class that provides an associative array.
+/// The `QMap` class is a template class that provides an associative array.
 ///
-/// To use QMap with a custom pair, implement the [`QMapPair`] trait for T.
+/// To use `QMap` with a custom pair, implement the [`QMapPair`] trait for `T`.
+///
+/// Qt Documentation: [QMap]("https://doc.qt.io/qt/qmap.html#details")
 #[repr(C)]
 pub struct QMap<T>
 where
@@ -22,7 +24,7 @@ impl<T> Clone for QMap<T>
 where
     T: QMapPair,
 {
-    /// Constructs a copy of other.
+    /// Constructs a copy of `self`.
     fn clone(&self) -> Self {
         T::clone(self)
     }
@@ -53,7 +55,7 @@ where
     T: QMapPair,
     T::Value: PartialEq,
 {
-    /// Returns true if both maps contain the same key value pairs
+    /// Returns `true` if both maps contain the same (key, value) pairs, otherwise `false`.
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().all(|(k, v)| other.get(k).as_ref() == Some(v))
     }
@@ -86,12 +88,12 @@ where
         T::clear(self)
     }
 
-    /// Returns true if the map contains an item with the key; otherwise returns false.
+    /// Returns `true` if the map contains an item with key `key`; otherwise returns `false`.
     pub fn contains(&self, key: &T::Key) -> bool {
         T::contains(self, key)
     }
 
-    /// Returns the value associated with the key if it exists.
+    /// Returns the value associated with the key `key` if it exists, otherwise returns `None`.
     pub fn get(&self, key: &T::Key) -> Option<T::Value> {
         if self.contains(key) {
             Some(T::get_or_default(self, key))
@@ -100,12 +102,14 @@ where
         }
     }
 
-    /// Returns the value associated with the key or a default value.
+    /// Returns the value associated with the key `key`, or a default-constructed value if it does not exist.
+    ///
+    /// For most value types, a default-constructed value simply means that a value is created using the default constructor (e.g. an empty string for [`QString`](crate::QString)). Primitive types like `i32` and `f64` are initialized to 0.
     pub fn get_or_default(&self, key: &T::Key) -> T::Value {
         T::get_or_default(self, key)
     }
 
-    /// Inserts a new item with the key and a value of value.
+    /// Inserts a new item with the key `key` and a value of `value`.
     ///
     /// The key and value are references here so they can be opaque or trivial.
     /// Note that the key and value are cloned before inserting into the map.
@@ -113,13 +117,13 @@ where
         T::insert_clone(self, key, value)
     }
 
-    /// Returns true if the map contains no items; otherwise returns false.
+    /// Returns `true` if the map contains no items; otherwise returns `false`.
     pub fn is_empty(&self) -> bool {
         T::len(self) == 0
     }
 
     /// An iterator visiting all key-value pairs in an arbitrary order.
-    /// The iterator element type is (&T::Key, &T::Value).
+    /// The iterator element type is `(&T::Key, &T::Value)`.
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             map: self,
@@ -127,12 +131,14 @@ where
         }
     }
 
-    /// Returns the number of items in the map.
+    /// Returns the number of (key, value) pairs in the map.
     pub fn len(&self) -> isize {
         T::len(self)
     }
 
-    /// Removes all the items that have the key from the map.
+    /// Removes all the items that have the key `key` from the map.
+    ///
+    /// Returns `true` if the key exists in the map, otherwise `false`.
     pub fn remove(&mut self, key: &T::Key) -> bool {
         T::remove(self, key)
     }
@@ -144,7 +150,7 @@ where
     T::Key: ExternType<Kind = cxx::kind::Trivial>,
     T::Value: ExternType<Kind = cxx::kind::Trivial>,
 {
-    /// Inserts a new item with the key and a value of value.
+    /// Inserts a new item with the key `key` and a value of `value`.
     pub fn insert(&mut self, key: T::Key, value: T::Value) {
         T::insert(self, key, value)
     }

--- a/crates/cxx-qt-lib/src/core/qmargins.rs
+++ b/crates/cxx-qt-lib/src/core/qmargins.rs
@@ -20,7 +20,7 @@ mod ffi {
         /// Returns the bottom margin.
         fn bottom(self: &QMargins) -> i32;
 
-        /// Returns true if all margins are is 0; otherwise returns false.
+        /// Returns `true` if all margins are is 0; otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QMargins) -> bool;
 
@@ -30,24 +30,25 @@ mod ffi {
         /// Returns the right margin.
         fn right(self: &QMargins) -> i32;
 
-        /// Sets the bottom margin to bottom.
+        /// Sets the bottom margin to `bottom`.
         #[rust_name = "set_bottom"]
         fn setBottom(self: &mut QMargins, bottom: i32);
 
-        /// Sets the left margin to left.
+        /// Sets the left margin to `left`.
         #[rust_name = "set_left"]
         fn setLeft(self: &mut QMargins, left: i32);
 
-        /// Sets the right margin to right.
+        /// Sets the right margin to `right`.
         #[rust_name = "set_right"]
         fn setRight(self: &mut QMargins, right: i32);
 
-        /// Sets the Top margin to Top.
+        /// Sets the top margin to `top`.
         #[rust_name = "set_top"]
         fn setTop(self: &mut QMargins, top: i32);
 
         /// Returns these margins as margins with floating point accuracy.
-        /// since Qt6.4
+        ///
+        /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_marginsf"]
         fn toMarginsF(self: &QMargins) -> QMarginsF;
@@ -96,7 +97,9 @@ mod ffi {
     }
 }
 
-/// The QMargins class defines the four margins of a rectangle.
+/// The `QMargins` class defines the four margins of a rectangle.
+///
+/// Qt Documentation: [QMargins](https://doc.qt.io/qt/qmargins.html#details)
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct QMargins {
@@ -107,7 +110,7 @@ pub struct QMargins {
 }
 
 impl QMargins {
-    /// Constructs margins with the given left, top, right, and bottom
+    /// Constructs margins with the given `left`, `top`, `right`, and `bottom`.
     pub fn new(left: i32, top: i32, right: i32, bottom: i32) -> Self {
         ffi::qmargins_new(left, top, right, bottom)
     }

--- a/crates/cxx-qt-lib/src/core/qmarginsf.rs
+++ b/crates/cxx-qt-lib/src/core/qmarginsf.rs
@@ -6,6 +6,8 @@
 use cxx::{type_id, ExternType};
 use std::fmt;
 
+use crate::QMargins;
+
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
@@ -19,7 +21,7 @@ mod ffi {
         /// Returns the bottom margin.
         fn bottom(self: &QMarginsF) -> f64;
 
-        /// Returns true if all margins are very close to 0; otherwise returns false.
+        /// Returns `true` if all margins are very close to 0; otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QMarginsF) -> bool;
 
@@ -29,21 +31,21 @@ mod ffi {
         /// Returns the right margin.
         fn right(self: &QMarginsF) -> f64;
 
-        /// Sets the bottom margin to abottom (which must be finite).
+        /// Sets the bottom margin to `abottom` (which must be finite).
         #[rust_name = "set_bottom"]
-        fn setBottom(self: &mut QMarginsF, bottom: f64);
+        fn setBottom(self: &mut QMarginsF, abottom: f64);
 
-        /// Sets the left margin to aleft (which must be finite).
+        /// Sets the left margin to `aleft` (which must be finite).
         #[rust_name = "set_left"]
-        fn setLeft(self: &mut QMarginsF, left: f64);
+        fn setLeft(self: &mut QMarginsF, aleft: f64);
 
-        /// Sets the right margin to aright (which must be finite).
+        /// Sets the right margin to `aright` (which must be finite).
         #[rust_name = "set_right"]
-        fn setRight(self: &mut QMarginsF, right: f64);
+        fn setRight(self: &mut QMarginsF, aright: f64);
 
-        /// Sets the top margin to atop (which must be finite).
+        /// Sets the top margin to `atop` (which must be finite).
         #[rust_name = "set_top"]
-        fn setTop(self: &mut QMarginsF, top: f64);
+        fn setTop(self: &mut QMarginsF, atop: f64);
 
         /// Returns an integer-based copy of this margins object.
         ///
@@ -92,7 +94,9 @@ mod ffi {
     }
 }
 
-/// The QMarginsF class defines the four margins of a rectangle.
+/// The `QMarginsF` class defines the four margins of a rectangle.
+///
+/// Qt Documentation: [QMarginsF](https://doc.qt.io/qt/qmarginsf.html#details)
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QMarginsF {
@@ -103,7 +107,7 @@ pub struct QMarginsF {
 }
 
 impl QMarginsF {
-    /// Constructs margins with the given left, top, right, and bottom. All parameters must be finite.
+    /// Constructs margins with the given `left`, `top`, `right`, and `bottom`. All parameters must be finite.
     pub fn new(left: f64, top: f64, right: f64, bottom: f64) -> Self {
         ffi::qmarginsf_new(left, top, right, bottom)
     }
@@ -164,19 +168,19 @@ impl std::ops::Div<f64> for QMarginsF {
     }
 }
 
-impl From<&ffi::QMargins> for QMarginsF {
-    /// Constructs margins copied from the given margins.
-    fn from(margins: &ffi::QMargins) -> Self {
+impl From<&QMargins> for QMarginsF {
+    /// Constructs margins copied from the given `margins`.
+    fn from(margins: &QMargins) -> Self {
         ffi::qmarginsf_from_qmargin(margins)
     }
 }
 
-impl From<&QMarginsF> for ffi::QMargins {
-    /// Returns an integer-based copy of this margins object.
+impl From<&QMarginsF> for QMargins {
+    /// Returns an integer-based copy of `margins`.
     ///
     /// Note that the components in the returned margins will be rounded to the nearest integer.
-    fn from(value: &QMarginsF) -> Self {
-        value.to_margins()
+    fn from(margins: &QMarginsF) -> Self {
+        margins.to_margins()
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.rs
@@ -18,21 +18,21 @@ mod ffi {
 
         /// Returns the column this model index refers to.
         fn column(self: &QModelIndex) -> i32;
-        /// Returns true if this model index is valid; otherwise returns false.
+        /// Returns `true` if this model index is valid; otherwise returns `false`.
         ///
         /// A valid index belongs to a model, and has non-negative row and column numbers.
         #[rust_name = "is_valid"]
         fn isValid(self: &QModelIndex) -> bool;
-        /// Returns the parent of the model index, or QModelIndex() if it has no parent.
+        /// Returns the parent of the model index, or an invalid `QModelIndex` if it has no parent.
         fn parent(self: &QModelIndex) -> QModelIndex;
         /// Returns the row this model index refers to.
         fn row(self: &QModelIndex) -> i32;
-        /// Returns the sibling at row and column. If there is no sibling at this position, an invalid QModelIndex is returned.
+        /// Returns the sibling at `row` and `column`. If there is no sibling at this position, an invalid `QModelIndex` is returned.
         fn sibling(self: &QModelIndex, row: i32, column: i32) -> QModelIndex;
-        /// Returns the sibling at column for the current row. If there is no sibling at this position, an invalid QModelIndex is returned.
+        /// Returns the sibling at `column` for the current row. If there is no sibling at this position, an invalid `QModelIndex` is returned.
         #[rust_name = "sibling_at_column"]
         fn siblingAtColumn(self: &QModelIndex, column: i32) -> QModelIndex;
-        /// Returns the sibling at row for the current column. If there is no sibling at this position, an invalid QModelIndex is returned.
+        /// Returns the sibling at `row` for the current column. If there is no sibling at this position, an invalid `QModelIndex` is returned.
         #[rust_name = "sibling_at_row"]
         fn siblingAtRow(self: &QModelIndex, row: i32) -> QModelIndex;
 
@@ -61,7 +61,9 @@ mod ffi {
     }
 }
 
-/// The QModelIndex class is used to locate data in a data model.
+/// The `QModelIndex` class is used to locate data in a data model.
+///
+/// Qt Documentation: [QModelIndex](https://doc.qt.io/qt/qmodelindex.html#details)
 #[derive(Clone)]
 #[repr(C)]
 pub struct QModelIndex {

--- a/crates/cxx-qt-lib/src/core/qobject.rs
+++ b/crates/cxx-qt-lib/src/core/qobject.rs
@@ -41,16 +41,30 @@ use ffi::{QObjectExternal, QString};
 /// Trait which exposes methods available on a `QObject`.
 /// Exposes some basic signals and methods for now, more to be added.
 pub trait QObjectExt {
+    /// If `block` is `true`, signals emitted by this object are blocked (i.e., emitting a signal will not invoke anything connected to it). If `block` is `false`, no such blocking will occur.
+    ///
+    /// The return value is the previous value of [`signals_blocked`](Self::signals_blocked).
+    ///
+    /// Note that the [destroyed](https://doc.qt.io/qt/qobject.html#destroyed)() signal will be emitted even if the signals for this object have been blocked.
+    ///
+    /// Signals emitted while being blocked are not buffered.
     fn block_signals(self: Pin<&mut Self>, block: bool) -> bool;
 
+    /// Returns `true` if signals are blocked; otherwise returns `false`.
+    ///
+    /// Signals are not blocked by default.
     fn signals_blocked(&self) -> bool;
 
+    /// Sets the object's name to `name`.
     fn set_object_name(self: Pin<&mut Self>, name: &QString);
 
+    /// Returns the name of this object.
     fn object_name(&self) -> QString;
 
+    /// Returns a mutable pointer to the parent object.
     fn parent(&self) -> *mut Self;
 
+    /// Makes the object a child of `parent`.
     fn set_parent(self: Pin<&mut Self>, parent: &Self);
 }
 

--- a/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
@@ -20,19 +20,19 @@ mod ffi {
 
         /// Returns the column this persistent model index refers to.
         fn column(self: &QPersistentModelIndex) -> i32;
-        /// Returns true if this persistent model index is valid; otherwise returns false.
+        /// Returns `true` if this persistent model index is valid; otherwise returns `false`.
         ///
         /// A valid index belongs to a model, and has non-negative row and column numbers.
         #[rust_name = "is_valid"]
         fn isValid(self: &QPersistentModelIndex) -> bool;
-        /// Returns the parent QModelIndex for this persistent index, or an invalid QModelIndex if it has no parent.
+        /// Returns the parent `QModelIndex` for this persistent index, or an invalid `QModelIndex` if it has no parent.
         fn parent(self: &QPersistentModelIndex) -> QModelIndex;
         /// Returns the row this persistent model index refers to.
         fn row(self: &QPersistentModelIndex) -> i32;
-        /// Returns the sibling at row and column or an invalid QModelIndex if there is no sibling at this position.
+        /// Returns the sibling at `row` and `column` or an invalid `QModelIndex` if there is no sibling at this position.
         fn sibling(self: &QPersistentModelIndex, row: i32, column: i32) -> QModelIndex;
 
-        /// Swaps this persistent modelindex with other. This function is very fast and never fails.
+        /// Swaps this persistent modelindex with `other`. This function is very fast and never fails.
         fn swap(self: &mut QPersistentModelIndex, other: &mut QPersistentModelIndex);
     }
 
@@ -59,14 +59,16 @@ mod ffi {
     }
 }
 
-/// The QPersistentModelIndex class is used to locate data in a data model.
+/// The `QPersistentModelIndex` class is used to locate data in a data model.
+///
+/// Qt Documentation: [QPersistentModelIndex](https://doc.qt.io/qt/qpersistentmodelindex.html#details)
 #[repr(C)]
 pub struct QPersistentModelIndex {
     _space: MaybeUninit<usize>,
 }
 
 impl Clone for QPersistentModelIndex {
-    /// Creates a new QPersistentModelIndex that is a copy of the other persistent model index.
+    /// Creates a new `QPersistentModelIndex` that is a copy of the other persistent model index.
     fn clone(&self) -> Self {
         ffi::qpersistentmodelindex_clone(self)
     }
@@ -80,7 +82,7 @@ impl Drop for QPersistentModelIndex {
 }
 
 impl From<&crate::QModelIndex> for QPersistentModelIndex {
-    /// Creates a new QPersistentModelIndex that is a copy of the model index.
+    /// Creates a new `QPersistentModelIndex` that is a copy of the model `index`.
     fn from(index: &crate::QModelIndex) -> Self {
         ffi::qpersistentmodelindex_from_qmodelindex(index)
     }

--- a/crates/cxx-qt-lib/src/core/qpoint.rs
+++ b/crates/cxx-qt-lib/src/core/qpoint.rs
@@ -19,30 +19,31 @@ mod ffi {
         #[allow(dead_code)]
         type QPointF = crate::QPointF;
 
-        /// Returns true if both the x and y coordinates are set to 0, otherwise returns false.
+        /// Returns `true` if both the x and y coordinates are set to 0, otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QPoint) -> bool;
 
-        /// Returns the sum of the absolute values of x() and y(),
+        /// Returns the sum of the absolute values of [`x`](Self::x) and [`y`](Self::y),
         /// traditionally known as the "Manhattan length" of the vector from the origin to the point.
         #[rust_name = "manhattan_length"]
         fn manhattanLength(self: &QPoint) -> i32;
 
-        /// Sets the x coordinate of this point to the given x coordinate.
+        /// Sets the x coordinate of this point to the given `x` coordinate.
         #[rust_name = "set_x"]
         fn setX(self: &mut QPoint, x: i32);
 
-        /// Sets the y coordinate of this point to the given y coordinate.
+        /// Sets the y coordinate of this point to the given `y` coordinate.
         #[rust_name = "set_y"]
         fn setY(self: &mut QPoint, y: i32);
 
         /// Returns this point as a point with floating point accuracy.
+        ///
         /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_pointf"]
         fn toPointF(self: &QPoint) -> QPointF;
 
-        /// Returns a point with x and y coordinates exchanged
+        /// Returns a point with x and y coordinates exchanged.
         fn transposed(self: &QPoint) -> QPoint;
 
         /// Returns the x coordinate of this point.
@@ -93,7 +94,9 @@ mod ffi {
     }
 }
 
-/// The QPoint struct defines a point in the plane using integer precision.
+/// The `QPoint` class defines a point in the plane using integer precision.
+///
+/// Qt Documentation: [QPoint](https://doc.qt.io/qt/qpoint.html#details)
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct QPoint {
@@ -102,19 +105,19 @@ pub struct QPoint {
 }
 
 impl QPoint {
-    /// Returns the dot product of p1 and p2.
+    /// Returns the dot product of `p1` and `p2`.
     pub fn dot_product(p1: &QPoint, p2: &QPoint) -> i32 {
         ffi::qpoint_dot_product(p1, p2)
     }
 
-    /// Constructs a point with the given coordinates (x, y).
-    pub fn new(x: i32, y: i32) -> Self {
-        ffi::qpoint_init(x, y)
+    /// Constructs a point with the given coordinates (`xpos`, `ypos`).
+    pub fn new(xpos: i32, ypos: i32) -> Self {
+        ffi::qpoint_init(xpos, ypos)
     }
 }
 
 impl Default for QPoint {
-    /// Constructs a null point, i.e. with coordinates (0, 0)
+    /// Constructs a null point, i.e. with coordinates (0, 0).
     fn default() -> Self {
         ffi::qpoint_init_default()
     }

--- a/crates/cxx-qt-lib/src/core/qpointf.rs
+++ b/crates/cxx-qt-lib/src/core/qpointf.rs
@@ -7,6 +7,8 @@
 use cxx::{type_id, ExternType};
 use std::fmt;
 
+use crate::QPoint;
+
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
@@ -17,29 +19,29 @@ mod ffi {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
 
-        /// Returns true if both the x and y coordinates are set to 0.0 (ignoring the sign); otherwise returns false.
+        /// Returns `true` if both the x and y coordinates are set to 0.0 (ignoring the sign); otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QPointF) -> bool;
 
-        /// Returns the sum of the absolute values of x() and y(),
+        /// Returns the sum of the absolute values of `self.x()` and `self.y()`,
         /// traditionally known as the "Manhattan length" of the vector from the origin to the point.
         #[rust_name = "manhattan_length"]
         fn manhattanLength(self: &QPointF) -> f64;
 
-        /// Sets the x coordinate of this point to the given finite x coordinate.
+        /// Sets the x coordinate of this point to the given finite `x` coordinate.
         #[rust_name = "set_x"]
         fn setX(self: &mut QPointF, x: f64);
 
-        /// Sets the y coordinate of this point to the given finite y coordinate.
+        /// Sets the y coordinate of this point to the given finite `y` coordinate.
         #[rust_name = "set_y"]
         fn setY(self: &mut QPointF, y: f64);
 
         /// Rounds the coordinates of this point to the nearest integer,
-        /// and returns a QPoint object with the rounded coordinates.
+        /// and returns a `QPoint` object with the rounded coordinates.
         #[rust_name = "to_point"]
         fn toPoint(self: &QPointF) -> QPoint;
 
-        /// Returns a point with x and y coordinates exchanged
+        /// Returns a point with x and y coordinates exchanged.
         fn transposed(self: &QPointF) -> QPointF;
 
         /// Returns the x coordinate of this point.
@@ -87,7 +89,9 @@ mod ffi {
     }
 }
 
-/// The QPointF struct defines a point in the plane using floating point precision.
+/// The `QPointF` class defines a point in the plane using floating point precision.
+///
+/// Qt Documentation: [QPointF](https://doc.qt.io/qt/qpointf.html#details)
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QPointF {
@@ -96,19 +100,19 @@ pub struct QPointF {
 }
 
 impl QPointF {
-    /// Returns the dot product of p1 and p2.
+    /// Returns the dot product of `p1` and `p2`.
     pub fn dot_product(p1: &QPointF, p2: &QPointF) -> f64 {
         ffi::qpointf_dot_product(p1, p2)
     }
 
-    /// Constructs a point with the given coordinates (x, y).
-    pub fn new(x: f64, y: f64) -> Self {
-        ffi::qpointf_init(x, y)
+    /// Constructs a point with the given coordinates (`xpos`, `ypos`).
+    pub fn new(xpos: f64, ypos: f64) -> Self {
+        ffi::qpointf_init(xpos, ypos)
     }
 }
 
 impl Default for QPointF {
-    /// Constructs a null point, i.e. with coordinates (0.0, 0.0)
+    /// Constructs a null point, i.e. with coordinates (0.0, 0.0).
     fn default() -> Self {
         ffi::qpointf_init_default()
     }
@@ -120,18 +124,18 @@ impl fmt::Display for QPointF {
     }
 }
 
-impl From<&ffi::QPoint> for QPointF {
-    /// Constructs a copy of the given point.
-    fn from(point: &ffi::QPoint) -> Self {
+impl From<&QPoint> for QPointF {
+    /// Constructs a copy of the given `point`.
+    fn from(point: &QPoint) -> Self {
         ffi::qpointf_from_qpoint(point)
     }
 }
 
-impl From<QPointF> for ffi::QPoint {
-    /// Rounds the coordinates of this point to the nearest integer,
-    /// and returns a QPoint object with the rounded coordinates.
-    fn from(value: QPointF) -> Self {
-        value.to_point()
+impl From<QPointF> for QPoint {
+    /// Rounds the coordinates of `point` to the nearest integer,
+    /// and returns a `QPoint` object with the rounded coordinates.
+    fn from(point: QPointF) -> Self {
+        point.to_point()
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qrect.rs
+++ b/crates/cxx-qt-lib/src/core/qrect.rs
@@ -6,6 +6,8 @@
 use cxx::{type_id, ExternType};
 use std::fmt;
 
+use crate::QMargins;
+
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
@@ -23,111 +25,111 @@ mod ffi {
         #[allow(dead_code)]
         type QRectF = crate::QRectF;
 
-        /// Adds dx1, dy1, dx2 and dy2 respectively to the existing coordinates of the rectangle.
+        /// Adds `dx1`, `dy1`, `dx2` and `dy2` respectively to the existing coordinates of the rectangle.
         fn adjust(self: &mut QRect, dx1: i32, dy1: i32, dx2: i32, dy2: i32);
 
-        /// Returns a new rectangle with dx1, dy1, dx2 and dy2 added respectively to the existing coordinates of this rectangle.
+        /// Returns a new rectangle with `dx1`, `dy1`, `dx2` and `dy2` added respectively to the existing coordinates of this rectangle.
         fn adjusted(self: &QRect, dx1: i32, dy1: i32, dx2: i32, dy2: i32) -> QRect;
 
         /// Returns the y-coordinate of the rectangle's bottom edge.
         ///
-        /// Note that for historical reasons this function returns top() + height() - 1; use y() + height() to retrieve the true y-coordinate.
+        /// Note that for historical reasons this function returns `self.top() + self.height() - 1`; use `self.y() + self.height()` to retrieve the true y-coordinate.
         fn bottom(self: &QRect) -> i32;
 
         /// Returns the position of the rectangle's bottom-left corner.
         ///
-        /// Note that for historical reasons this function returns QPoint(left(), top() + height() - 1).
+        /// Note that for historical reasons this function returns `QPoint::new(self.left(), self.top() + self.height() - 1)`.
         #[rust_name = "bottom_left"]
         fn bottomLeft(self: &QRect) -> QPoint;
 
         /// Returns the position of the rectangle's bottom-right corner.
         ///
-        /// Note that for historical reasons this function returns QPoint(left() + width() -1, top() + height() - 1).
+        /// Note that for historical reasons this function returns `QPoint::new(self.left() + width() - 1, self.top() + self.height() - 1)`.
         #[rust_name = "bottom_right"]
         fn bottomRight(self: &QRect) -> QPoint;
 
         /// Returns the center point of the rectangle.
         fn center(self: &QRect) -> QPoint;
 
-        /// Returns true if the given point is inside or on the edge of the rectangle, otherwise returns false.
-        /// If proper is true, this function only returns true if the given point is inside the rectangle (i.e., not on the edge).
+        /// Returns `true` if the given point is inside or on the edge of the rectangle, otherwise returns `false`.
+        /// If `proper` is `true`, this function only returns `true` if the given point is inside the rectangle (i.e., not on the edge).
         fn contains(self: &QRect, point: &QPoint, proper: bool) -> bool;
 
-        /// Returns the height of the rectangle.
+        /// Returns the `height` of the rectangle.
         fn height(self: &QRect) -> i32;
 
-        /// Returns the intersection of this rectangle and the given rectangle. Note that r.intersected(s) is equivalent to r & s.
+        /// Returns the intersection of this rectangle and the given rectangle. Note that `r.intersected(s)` is equivalent to `r & s`.
         fn intersected(self: &QRect, rectangle: &QRect) -> QRect;
 
-        /// Returns true if this rectangle intersects with the given rectangle (i.e., there is at least one pixel that is within both rectangles), otherwise returns false.
+        /// Returns `true` if this rectangle intersects with the given rectangle (i.e., there is at least one pixel that is within both rectangles), otherwise returns `false`.
         fn intersects(self: &QRect, rectangle: &QRect) -> bool;
 
-        /// Returns true if the rectangle is empty, otherwise returns false.
+        /// Returns `true` if the rectangle is empty, otherwise returns `false`.
         ///
-        /// An empty rectangle has a left() > right() or top() > bottom(). An empty rectangle is not valid (i.e., isEmpty() == !isValid()).
+        /// An empty rectangle has `self.left() > self.right()` or `self.top() > self.bottom()`. An empty rectangle is not valid (i.e., `self.is_empty() == !self.is_valid()`).
         #[rust_name = "is_empty"]
         fn isEmpty(self: &QRect) -> bool;
 
-        /// Returns true if the rectangle is a null rectangle, otherwise returns false.
+        /// Returns `true` if the rectangle is a null rectangle, otherwise returns `false`.
         ///
-        /// A null rectangle has both the width and the height set to 0 (i.e., right() == left() - 1 and bottom() == top() - 1). A null rectangle is also empty, and hence is not valid.
+        /// A null rectangle has both the width and the height set to 0 (i.e., `self.right() == self.left() - 1` and `self.bottom() == self.top() - 1)`. A null rectangle is also empty, and hence is not valid.
         #[rust_name = "is_null"]
         fn isNull(self: &QRect) -> bool;
 
-        /// Returns true if the rectangle is valid, otherwise returns false.
+        /// Returns `true` if the rectangle is valid, otherwise returns `false`.
         ///
-        /// A valid rectangle has a left() <= right() and top() <= bottom(). Note that non-trivial operations like intersections are not defined for invalid rectangles. A valid rectangle is not empty (i.e., isValid() == !isEmpty()).
+        /// A valid rectangle has `self.left() <= self.right()` and `self.top() <= self.bottom()`. Note that non-trivial operations like intersections are not defined for invalid rectangles. A valid rectangle is not empty (i.e., `self.is_valid() == !self.is_empty()`).
         #[rust_name = "is_valid"]
         fn isValid(self: &QRect) -> bool;
 
-        /// Returns the x-coordinate of the rectangle's left edge. Equivalent to x().
+        /// Returns the x-coordinate of the rectangle's left edge. Equivalent to `self.x()`.
         fn left(self: &QRect) -> i32;
 
-        /// Returns a rectangle grown by the margins.
+        /// Returns a rectangle grown by the `margins`.
         #[rust_name = "margins_added"]
         fn marginsAdded(self: &QRect, margins: &QMargins) -> QRect;
 
-        /// Removes the margins from the rectangle, shrinking it.
+        /// Removes the `margins` from the rectangle, shrinking it.
         #[rust_name = "margins_removed"]
         fn marginsRemoved(self: &QRect, margins: &QMargins) -> QRect;
 
-        /// Moves the rectangle vertically, leaving the rectangle's bottom edge at the given y coordinate. The rectangle's size is unchanged.
+        /// Moves the rectangle vertically, leaving the rectangle's bottom edge at the given `y` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_bottom"]
         fn moveBottom(self: &mut QRect, y: i32);
 
-        /// Moves the rectangle, leaving the bottom-left corner at the given position. The rectangle's size is unchanged.
+        /// Moves the rectangle, leaving the bottom-left corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_bottom_left"]
         fn moveBottomLeft(self: &mut QRect, position: &QPoint);
 
-        /// Moves the rectangle, leaving the bottom-right corner at the given position. The rectangle's size is unchanged.
+        /// Moves the rectangle, leaving the bottom-right corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_bottom_right"]
         fn moveBottomRight(self: &mut QRect, position: &QPoint);
 
-        /// Moves the rectangle, leaving the center point at the given position. The rectangle's size is unchanged.
+        /// Moves the rectangle, leaving the center point at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_center"]
         fn moveCenter(self: &mut QRect, position: &QPoint);
 
-        /// Moves the rectangle horizontally, leaving the rectangle's left edge at the given x coordinate. The rectangle's size is unchanged.
+        /// Moves the rectangle horizontally, leaving the rectangle's left edge at the given `x` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_left"]
         fn moveLeft(self: &mut QRect, x: i32);
 
-        /// Moves the rectangle horizontally, leaving the rectangle's right edge at the given x coordinate. The rectangle's size is unchanged.
+        /// Moves the rectangle horizontally, leaving the rectangle's right edge at the given `x` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_right"]
         fn moveRight(self: &mut QRect, x: i32);
 
-        /// Moves the rectangle, leaving the top-left corner at the given position.
+        /// Moves the rectangle, leaving the top-left corner at the given `position`.
         #[rust_name = "move_to"]
         fn moveTo(self: &mut QRect, position: &QPoint);
 
-        /// Moves the rectangle vertically, leaving the rectangle's top edge at the given y coordinate. The rectangle's size is unchanged.
+        /// Moves the rectangle vertically, leaving the rectangle's top edge at the given `y` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_top"]
         fn moveTop(self: &mut QRect, y: i32);
 
-        /// Moves the rectangle, leaving the top-left corner at the given position. The rectangle's size is unchanged.
+        /// Moves the rectangle, leaving the top-left corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_top_left"]
         fn moveTopLeft(self: &mut QRect, position: &QPoint);
 
-        /// Moves the rectangle, leaving the top-right corner at the given position. The rectangle's size is unchanged.
+        /// Moves the rectangle, leaving the top-right corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_top_right"]
         fn moveTopRight(self: &mut QRect, position: &QPoint);
 
@@ -136,69 +138,69 @@ mod ffi {
 
         /// Returns the x-coordinate of the rectangle's right edge.
         ///
-        /// Note that for historical reasons this function returns left() + width() - 1; use x() + width() to retrieve the true x-coordinate.
+        /// Note that for historical reasons this function returns `self.left() + width() - 1`; use `self.x() + width()` to retrieve the true x-coordinate.
         fn right(self: &QRect) -> i32;
 
-        /// Sets the bottom edge of the rectangle to the given y coordinate.
+        /// Sets the bottom edge of the rectangle to the given `y` coordinate.
         /// May change the height, but will never change the top edge of the rectangle.
         #[rust_name = "set_bottom"]
         fn setBottom(self: &mut QRect, y: i32);
 
-        /// Set the bottom-left corner of the rectangle to the given position.
+        /// Set the bottom-left corner of the rectangle to the given `position`.
         /// May change the size, but will never change the top-right corner of the rectangle.
         #[rust_name = "set_bottom_left"]
         fn setBottomLeft(self: &mut QRect, position: &QPoint);
 
-        /// Set the bottom-right corner of the rectangle to the given position.
+        /// Set the bottom-right corner of the rectangle to the given `position`.
         /// May change the size, but will never change the top-left corner of the rectangle.
         #[rust_name = "set_bottom_right"]
         fn setBottomRight(self: &mut QRect, position: &QPoint);
 
-        /// Sets the coordinates of the rectangle's top-left corner to (x1, y1), and the coordinates of its bottom-right corner to (x2, y2).
+        /// Sets the coordinates of the rectangle's top-left corner to (`x1`, `y1`), and the coordinates of its bottom-right corner to (`x2`, `y2`).
         #[rust_name = "set_coords"]
         fn setCoords(self: &mut QRect, x1: i32, y1: i32, x2: i32, y2: i32);
 
-        /// Sets the height of the rectangle to the given height. The bottom edge is changed, but not the top one.
+        /// Sets the height of the rectangle to the given `height`. The bottom edge is changed, but not the top one.
         #[rust_name = "set_height"]
         fn setHeight(self: &mut QRect, h: i32);
 
-        /// Sets the left edge of the rectangle to the given x coordinate. May change the width, but will never change the right edge of the rectangle.
+        /// Sets the left edge of the rectangle to the given `x` coordinate. May change the width, but will never change the right edge of the rectangle.
         #[rust_name = "set_left"]
         fn setLeft(self: &mut QRect, x: i32);
 
-        /// Sets the coordinates of the rectangle's top-left corner to (x, y), and its size to the given width and height.
+        /// Sets the coordinates of the rectangle's top-left corner to (`x`, `y`), and its size to the given `width` and `height`.
         #[rust_name = "set_rect"]
         fn setRect(self: &mut QRect, x: i32, y: i32, width: i32, height: i32);
 
-        /// Sets the right edge of the rectangle to the given x coordinate. May change the width, but will never change the left edge of the rectangle.
+        /// Sets the right edge of the rectangle to the given `x` coordinate. May change the width, but will never change the left edge of the rectangle.
         #[rust_name = "set_right"]
         fn setRight(self: &mut QRect, x: i32);
 
-        /// Sets the size of the rectangle to the given size. The top-left corner is not moved.
+        /// Sets the size of the rectangle to the given `size`. The top-left corner is not moved.
         #[rust_name = "set_size"]
         fn setSize(self: &mut QRect, size: &QSize);
 
-        /// Sets the top edge of the rectangle to the given y coordinate. May change the height, but will never change the bottom edge of the rectangle.
+        /// Sets the top edge of the rectangle to the given `y` coordinate. May change the height, but will never change the bottom edge of the rectangle.
         #[rust_name = "set_top"]
         fn setTop(self: &mut QRect, y: i32);
 
-        /// Set the top-left corner of the rectangle to the given position. May change the size, but will never change the bottom-right corner of the rectangle.
+        /// Set the top-left corner of the rectangle to the given `position`. May change the size, but will never change the bottom-right corner of the rectangle.
         #[rust_name = "set_top_left"]
         fn setTopLeft(self: &mut QRect, position: &QPoint);
 
-        /// Set the top-right corner of the rectangle to the given position. May change the size, but will never change the bottom-left corner of the rectangle.
+        /// Set the top-right corner of the rectangle to the given `position`. May change the size, but will never change the bottom-left corner of the rectangle.
         #[rust_name = "set_top_right"]
         fn setTopRight(self: &mut QRect, position: &QPoint);
 
-        /// Sets the width of the rectangle to the given width. The right edge is changed, but not the left one.
+        /// Sets the width of the rectangle to the given `width`. The right edge is changed, but not the left one.
         #[rust_name = "set_width"]
         fn setWidth(self: &mut QRect, w: i32);
 
-        /// Sets the left edge of the rectangle to the given x coordinate. May change the width, but will never change the right edge of the rectangle.
+        /// Sets the left edge of the rectangle to the given `x` coordinate. May change the width, but will never change the right edge of the rectangle.
         #[rust_name = "set_x"]
         fn setX(self: &mut QRect, x: i32);
 
-        /// Sets the top edge of the rectangle to the given y coordinate. May change the height, but will never change the bottom edge of the rectangle.
+        /// Sets the top edge of the rectangle to the given `y` coordinate. May change the height, but will never change the bottom edge of the rectangle.
         #[rust_name = "set_y"]
         fn setY(self: &mut QRect, y: i32);
 
@@ -206,12 +208,13 @@ mod ffi {
         fn size(self: &QRect) -> QSize;
 
         /// Returns this rectangle as a rectangle with floating point accuracy.
+        ///
         /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_rectf"]
         fn toRectF(self: &QRect) -> QRectF;
 
-        /// Returns the y-coordinate of the rectangle's top edge. Equivalent to y().
+        /// Returns the y-coordinate of the rectangle's top edge. Equivalent to `self.y()`.
         fn top(self: &QRect) -> i32;
 
         /// Returns the position of the rectangle's top-left corner.
@@ -220,20 +223,20 @@ mod ffi {
 
         /// Returns the position of the rectangle's top-right corner.
         ///
-        /// Note that for historical reasons this function returns QPoint(left() + width() -1, top()).
+        /// Note that for historical reasons this function returns `QPoint::new(self.left() + width() -1, self.top())`.
         #[rust_name = "top_right"]
         fn topRight(self: &QRect) -> QPoint;
 
-        /// Moves the rectangle offset.x() along the x axis and offset.y() along the y axis, relative to the current position.
+        /// Moves the rectangle `offset.x()` along the x axis and `offset.y()` along the y axis, relative to the current position.
         fn translate(self: &mut QRect, offset: &QPoint);
 
-        /// Returns a copy of the rectangle that is translated offset.x() along the x axis and offset.y() along the y axis, relative to the current position.
+        /// Returns a copy of the rectangle that is translated `offset.x()` along the x axis and `offset.y()` along the y axis, relative to the current position.
         fn translated(self: &QRect, offset: &QPoint) -> QRect;
 
         /// Returns a copy of the rectangle that has its width and height exchanged.
         fn transposed(self: &QRect) -> QRect;
 
-        /// Returns the bounding rectangle of this rectangle and the given rectangle.
+        /// Returns the bounding rectangle of this rectangle and the given `rectangle`.
         fn united(self: &QRect, rectangle: &QRect) -> QRect;
 
         /// Returns the width of the rectangle.
@@ -268,7 +271,9 @@ mod ffi {
     }
 }
 
-/// The QRect struct defines a rectangle in the plane using integer precision.
+/// The `QRect` class defines a rectangle in the plane using integer precision.
+///
+/// Qt Documentation: [QRect](https://doc.qt.io/qt/qrect.html#details)
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct QRect {
@@ -280,7 +285,7 @@ pub struct QRect {
 }
 
 impl QRect {
-    /// Constructs a rectangle with (x, y) as its top-left corner and the given width and height.
+    /// Constructs a rectangle with (`x`, `y`) as its top-left corner and the given `width` and `height`.
     pub fn new(x: i32, y: i32, width: i32, height: i32) -> Self {
         ffi::qrect_init(x, y, width, height)
     }
@@ -299,16 +304,16 @@ impl fmt::Display for QRect {
     }
 }
 
-impl std::ops::Add<ffi::QMargins> for QRect {
+impl std::ops::Add<QMargins> for QRect {
     type Output = Self;
-    fn add(self, other: ffi::QMargins) -> Self {
+    fn add(self, other: QMargins) -> Self {
         ffi::qrect_plus(&self, &other)
     }
 }
 
-impl std::ops::Sub<ffi::QMargins> for QRect {
+impl std::ops::Sub<QMargins> for QRect {
     type Output = Self;
-    fn sub(self, other: ffi::QMargins) -> Self {
+    fn sub(self, other: QMargins) -> Self {
         ffi::qrect_minus(&self, &other)
     }
 }

--- a/crates/cxx-qt-lib/src/core/qrectf.rs
+++ b/crates/cxx-qt-lib/src/core/qrectf.rs
@@ -6,6 +6,8 @@
 use cxx::{type_id, ExternType};
 use std::fmt;
 
+use crate::{QMarginsF, QRect};
+
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
@@ -22,10 +24,10 @@ mod ffi {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
 
-        /// Adds dx1, dy1, dx2 and dy2 respectively to the existing coordinates of the rectangle. All parameters must be finite.
+        /// Adds `dx1`, `dy1`, `dx2` and `dy2` respectively to the existing coordinates of the rectangle. All parameters must be finite.
         fn adjust(self: &mut QRectF, dx1: f64, dy1: f64, dx2: f64, dy2: f64);
 
-        /// Returns a new rectangle with dx1, dy1, dx2 and dy2 added respectively to the existing coordinates of this rectangle. All parameters must be finite.
+        /// Returns a new rectangle with `dx1`, `dy1`, `dx2` and `dy2` added respectively to the existing coordinates of this rectangle. All parameters must be finite.
         fn adjusted(self: &QRectF, dx1: f64, dy1: f64, dx2: f64, dy2: f64) -> QRectF;
 
         /// Returns the y-coordinate of the rectangle's bottom edge.
@@ -42,84 +44,84 @@ mod ffi {
         /// Returns the center point of the rectangle.
         fn center(self: &QRectF) -> QPointF;
 
-        /// Returns true if the given point is inside or on the edge of the rectangle; otherwise returns false.
+        /// Returns `true` if the given point is inside or on the edge of the rectangle; otherwise returns `false`.
         fn contains(self: &QRectF, point: &QPointF) -> bool;
 
         /// Returns the height of the rectangle.
         fn height(self: &QRectF) -> f64;
 
-        /// Returns the intersection of this rectangle and the given rectangle. Note that r.intersected(s) is equivalent to r & s.
+        /// Returns the intersection of this rectangle and the given rectangle. Note that `r.intersected(s)` is equivalent to `r & s`.
         fn intersected(self: &QRectF, rectangle: &QRectF) -> QRectF;
 
-        /// Returns true if this rectangle intersects with the given rectangle (i.e. there is a non-empty area of overlap between them), otherwise returns false.
+        /// Returns `true` if this rectangle intersects with the given rectangle (i.e. there is a non-empty area of overlap between them), otherwise returns `false`.
         fn intersects(self: &QRectF, rectangle: &QRectF) -> bool;
 
-        /// Returns true if the rectangle is empty, otherwise returns false.
+        /// Returns `true` if the rectangle is empty, otherwise returns `false`.
         ///
-        /// An empty rectangle has width() <= 0 or height() <= 0. An empty rectangle is not valid (i.e., isEmpty() == !isValid()).
+        /// An empty rectangle has `self.width() <= 0` or `self.height() <= 0`. An empty rectangle is not valid (i.e., `self.is_empty() == !self.is_valid()`).
         #[rust_name = "is_empty"]
         fn isEmpty(self: &QRectF) -> bool;
 
-        /// Returns true if the rectangle is a null rectangle, otherwise returns false.
+        /// Returns `true` if the rectangle is a null rectangle, otherwise returns `false`.
         ///
         /// A null rectangle has both the width and the height set to 0. A null rectangle is also empty, and hence not valid.
         #[rust_name = "is_null"]
         fn isNull(self: &QRectF) -> bool;
 
-        /// Returns true if the rectangle is valid, otherwise returns false.
+        /// Returns `true` if the rectangle is valid, otherwise returns `false`.
         ///
-        /// A valid rectangle has a width() > 0 and height() > 0. Note that non-trivial operations like intersections are not defined for invalid rectangles. A valid rectangle is not empty (i.e., isValid() == !isEmpty()).
+        /// A valid rectangle has a `self.width() > 0` and `self.height() > 0`. Note that non-trivial operations like intersections are not defined for invalid rectangles. A valid rectangle is not empty (i.e., `self.is_valid() == !self.is_empty()`).
         #[rust_name = "is_valid"]
         fn isValid(self: &QRectF) -> bool;
 
-        /// Returns the x-coordinate of the rectangle's left edge. Equivalent to x().
+        /// Returns the x-coordinate of the rectangle's left edge. Equivalent to `self.x()`.
         fn left(self: &QRectF) -> f64;
 
-        /// Returns a rectangle grown by the margins.
+        /// Returns a rectangle grown by the `margins`.
         #[rust_name = "margins_added"]
         fn marginsAdded(self: &QRectF, margins: &QMarginsF) -> QRectF;
 
-        /// Removes the margins from the rectangle, shrinking it.
+        /// Removes the `margins` from the rectangle, shrinking it.
         #[rust_name = "margins_removed"]
         fn marginsRemoved(self: &QRectF, margins: &QMarginsF) -> QRectF;
 
-        /// Moves the rectangle vertically, leaving the rectangle's bottom edge at the given finite y coordinate. The rectangle's size is unchanged.
+        /// Moves the rectangle vertically, leaving the rectangle's bottom edge at the given finite `y` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_bottom"]
         fn moveBottom(self: &mut QRectF, y: f64);
 
-        /// Moves the rectangle, leaving the bottom-left corner at the given position. The rectangle's size is unchanged.
+        /// Moves the rectangle, leaving the bottom-left corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_bottom_left"]
         fn moveBottomLeft(self: &mut QRectF, position: &QPointF);
 
-        /// Moves the rectangle, leaving the bottom-right corner at the given position. The rectangle's size is unchanged.
+        /// Moves the rectangle, leaving the bottom-right corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_bottom_right"]
         fn moveBottomRight(self: &mut QRectF, position: &QPointF);
 
-        /// Moves the rectangle, leaving the center point at the given position. The rectangle's size is unchanged.
+        /// Moves the rectangle, leaving the center point at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_center"]
         fn moveCenter(self: &mut QRectF, position: &QPointF);
 
-        /// Moves the rectangle horizontally, leaving the rectangle's left edge at the given finite x coordinate. The rectangle's size is unchanged.
+        /// Moves the rectangle horizontally, leaving the rectangle's left edge at the given finite `x` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_left"]
         fn moveLeft(self: &mut QRectF, x: f64);
 
-        /// Moves the rectangle horizontally, leaving the rectangle's right edge at the given finite x coordinate. The rectangle's size is unchanged.
+        /// Moves the rectangle horizontally, leaving the rectangle's right edge at the given finite `x` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_right"]
         fn moveRight(self: &mut QRectF, x: f64);
 
-        /// Moves the rectangle, leaving the top-left corner at the given position.
+        /// Moves the rectangle, leaving the top-left corner at the given `position`.
         #[rust_name = "move_to"]
         fn moveTo(self: &mut QRectF, position: &QPointF);
 
-        /// Moves the rectangle vertically, leaving the rectangle's top line at the given finite y coordinate. The rectangle's size is unchanged.
+        /// Moves the rectangle vertically, leaving the rectangle's top line at the given finite `y` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_top"]
         fn moveTop(self: &mut QRectF, y: f64);
 
-        /// Moves the rectangle, leaving the top-left corner at the given position. The rectangle's size is unchanged.
+        /// Moves the rectangle, leaving the top-left corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_top_left"]
         fn moveTopLeft(self: &mut QRectF, position: &QPointF);
 
-        /// Moves the rectangle, leaving the top-right corner at the given position. The rectangle's size is unchanged.
+        /// Moves the rectangle, leaving the top-right corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_top_right"]
         fn moveTopRight(self: &mut QRectF, position: &QPointF);
 
@@ -129,73 +131,73 @@ mod ffi {
         /// Returns the x-coordinate of the rectangle's right edge.
         fn right(self: &QRectF) -> f64;
 
-        /// Sets the bottom edge of the rectangle to the given finite y coordinate.
+        /// Sets the bottom edge of the rectangle to the given finite `y` coordinate.
         /// May change the height, but will never change the top edge of the rectangle.
         #[rust_name = "set_bottom"]
         fn setBottom(self: &mut QRectF, y: f64);
 
-        /// Set the bottom-left corner of the rectangle to the given position.
+        /// Set the bottom-left corner of the rectangle to the given `position`.
         /// May change the size, but will never change the top-right corner of the rectangle.
         #[rust_name = "set_bottom_left"]
         fn setBottomLeft(self: &mut QRectF, position: &QPointF);
 
-        /// Set the bottom-right corner of the rectangle to the given position.
+        /// Set the bottom-right corner of the rectangle to the given `position`.
         /// May change the size, but will never change the top-left corner of the rectangle.
         #[rust_name = "set_bottom_right"]
         fn setBottomRight(self: &mut QRectF, position: &QPointF);
 
-        /// Sets the coordinates of the rectangle's top-left corner to (x1, y1),
-        /// and the coordinates of its bottom-right corner to (x2, y2). All parameters must be finite.
+        /// Sets the coordinates of the rectangle's top-left corner to (`x1`, `y1`),
+        /// and the coordinates of its bottom-right corner to (`x2`, `y2`). All parameters must be finite.
         #[rust_name = "set_coords"]
         fn setCoords(self: &mut QRectF, x1: f64, y1: f64, x2: f64, y2: f64);
 
-        /// Sets the height of the rectangle to the given finite height. The bottom edge is changed, but not the top one.
+        /// Sets the height of the rectangle to the given finite `height`. The bottom edge is changed, but not the top one.
         #[rust_name = "set_height"]
         fn setHeight(self: &mut QRectF, h: f64);
 
-        /// Sets the left edge of the rectangle to the given finite x coordinate.
+        /// Sets the left edge of the rectangle to the given finite `x` coordinate.
         /// May change the width, but will never change the right edge of the rectangle.
         #[rust_name = "set_left"]
         fn setLeft(self: &mut QRectF, x: f64);
 
-        /// Sets the coordinates of the rectangle's top-left corner to (x, y), and its size to the given width and height. All parameters must be finite.
+        /// Sets the coordinates of the rectangle's top-left corner to (`x`, `y`), and its size to the given `width` and `height`. All parameters must be finite.
         #[rust_name = "set_rect"]
         fn setRect(self: &mut QRectF, x: f64, y: f64, width: f64, height: f64);
 
-        /// Sets the right edge of the rectangle to the given finite x coordinate.
+        /// Sets the right edge of the rectangle to the given finite `x` coordinate.
         /// May change the width, but will never change the left edge of the rectangle.
         #[rust_name = "set_right"]
         fn setRight(self: &mut QRectF, x: f64);
 
-        /// Sets the size of the rectangle to the given finite size. The top-left corner is not moved.
+        /// Sets the size of the rectangle to the given finite `size`. The top-left corner is not moved.
         #[rust_name = "set_size"]
         fn setSize(self: &mut QRectF, size: &QSizeF);
 
-        /// Sets the top edge of the rectangle to the given finite y coordinate.
+        /// Sets the top edge of the rectangle to the given finite `y` coordinate.
         /// May change the height, but will never change the bottom edge of the rectangle.
         #[rust_name = "set_top"]
         fn setTop(self: &mut QRectF, y: f64);
 
-        /// Set the top-left corner of the rectangle to the given position.
+        /// Set the top-left corner of the rectangle to the given `position`.
         /// May change the size, but will never change the bottom-right corner of the rectangle.
         #[rust_name = "set_top_left"]
         fn setTopLeft(self: &mut QRectF, position: &QPointF);
 
-        /// Set the top-right corner of the rectangle to the given position.
+        /// Set the top-right corner of the rectangle to the given `position`.
         /// May change the size, but will never change the bottom-left corner of the rectangle.
         #[rust_name = "set_top_right"]
         fn setTopRight(self: &mut QRectF, position: &QPointF);
 
-        /// Sets the width of the rectangle to the given finite width. The right edge is changed, but not the left one.
+        /// Sets the width of the rectangle to the given finite `width`. The right edge is changed, but not the left one.
         #[rust_name = "set_width"]
         fn setWidth(self: &mut QRectF, w: f64);
 
-        /// Sets the left edge of the rectangle to the given finite x coordinate.
+        /// Sets the left edge of the rectangle to the given finite `x` coordinate.
         /// May change the width, but will never change the right edge of the rectangle.
         #[rust_name = "set_x"]
         fn setX(self: &mut QRectF, x: f64);
 
-        /// Sets the top edge of the rectangle to the given finite y coordinate.
+        /// Sets the top edge of the rectangle to the given finite `y` coordinate.
         /// May change the height, but will never change the bottom edge of the rectangle.
         #[rust_name = "set_y"]
         fn setY(self: &mut QRectF, y: f64);
@@ -203,16 +205,16 @@ mod ffi {
         /// Returns the size of the rectangle.
         fn size(self: &QRectF) -> QSizeF;
 
-        /// Returns a QRect based on the values of this rectangle that is the smallest possible integer rectangle that completely contains this rectangle.
+        /// Returns a `QRect` based on the values of this rectangle that is the smallest possible integer rectangle that completely contains this rectangle.
         #[rust_name = "to_aligned_rect"]
         fn toAlignedRect(self: &QRectF) -> QRect;
 
-        /// Returns a QRect based on the values of this rectangle.
+        /// Returns a `QRect` based on the values of this rectangle.
         /// Note that the coordinates in the returned rectangle are rounded to the nearest integer.
         #[rust_name = "to_rect"]
         fn toRect(self: &QRectF) -> QRect;
 
-        /// Returns the y-coordinate of the rectangle's top edge. Equivalent to y().
+        /// Returns the y-coordinate of the rectangle's top edge. Equivalent to `self.y()`.
         fn top(self: &QRectF) -> f64;
 
         /// Returns the position of the rectangle's top-left corner.
@@ -223,16 +225,16 @@ mod ffi {
         #[rust_name = "top_right"]
         fn topRight(self: &QRectF) -> QPointF;
 
-        /// Moves the rectangle offset.x() along the x axis and offset.y() along the y axis, relative to the current position.
+        /// Moves the rectangle `offset.x()` along the x axis and `offset.y()` along the y axis, relative to the current position.
         fn translate(self: &mut QRectF, offset: &QPointF);
 
-        /// Returns a copy of the rectangle that is translated offset.x() along the x axis and offset.y() along the y axis, relative to the current position.
+        /// Returns a copy of the rectangle that is translated `offset.x()` along the x axis and `offset.y()` along the y axis, relative to the current position.
         fn translated(self: &QRectF, offset: &QPointF) -> QRectF;
 
         /// Returns a copy of the rectangle that has its width and height exchanged.
         fn transposed(self: &QRectF) -> QRectF;
 
-        /// Returns the bounding rectangle of this rectangle and the given rectangle.
+        /// Returns the bounding rectangle of this rectangle and the given `rectangle`.
         fn united(self: &QRectF, rectangle: &QRectF) -> QRectF;
 
         /// Returns the width of the rectangle.
@@ -270,7 +272,9 @@ mod ffi {
     }
 }
 
-/// The QRectF struct defines a rectangle in the plane using floating point precision.
+/// The `QRectF` class defines a rectangle in the plane using floating point precision.
+///
+/// Qt Documentation: [QRectF](https://doc.qt.io/qt/qrectf.html#details)
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QRectF {
@@ -281,7 +285,7 @@ pub struct QRectF {
 }
 
 impl QRectF {
-    /// Constructs a rectangle with (x, y) as its top-left corner and the given width and height.
+    /// Constructs a rectangle with (`x`, `y`) as its top-left corner and the given `width` and `height`.
     pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
         ffi::qrectf_init(x, y, width, height)
     }
@@ -300,31 +304,31 @@ impl fmt::Display for QRectF {
     }
 }
 
-impl From<&ffi::QRect> for QRectF {
-    /// Constructs a QRectF rectangle from the given QRect rectangle.
-    fn from(rectangle: &ffi::QRect) -> Self {
+impl From<&QRect> for QRectF {
+    /// Constructs a `QRectF` rectangle from the given `QRect` rectangle.
+    fn from(rectangle: &QRect) -> Self {
         ffi::qrectf_from_qrect(rectangle)
     }
 }
 
-impl From<&QRectF> for ffi::QRect {
-    /// Returns a QRect based on the values of this rectangle.
+impl From<&QRectF> for QRect {
+    /// Returns a `QRect` based on the values of this rectangle.
     /// Note that the coordinates in the returned rectangle are rounded to the nearest integer.
     fn from(value: &QRectF) -> Self {
         value.to_rect()
     }
 }
 
-impl std::ops::Add<ffi::QMarginsF> for QRectF {
+impl std::ops::Add<QMarginsF> for QRectF {
     type Output = Self;
-    fn add(self, other: ffi::QMarginsF) -> Self {
+    fn add(self, other: QMarginsF) -> Self {
         ffi::qrectf_plus(&self, &other)
     }
 }
 
-impl std::ops::Sub<ffi::QMarginsF> for QRectF {
+impl std::ops::Sub<QMarginsF> for QRectF {
     type Output = Self;
-    fn sub(self, other: ffi::QMarginsF) -> Self {
+    fn sub(self, other: QMarginsF) -> Self {
         ffi::qrectf_minus(&self, &other)
     }
 }

--- a/crates/cxx-qt-lib/src/core/qset/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qset/mod.rs
@@ -9,11 +9,13 @@ use core::{marker::PhantomData, mem::MaybeUninit};
 use cxx::{type_id, ExternType};
 use std::fmt;
 
-/// The QSet class is a template class that provides a hash-table-based set.
+/// The `QSet` class is a template class that provides a hash-table-based set.
 ///
-/// Note that this means that T needs to have a global `qHash()` function.
+/// Note that this means that `T` needs to have a global [`qHash()`](https://doc.qt.io/qt/qhash.html#qHash) function.
 ///
-/// To use QSet with a custom type, implement the [`QSetElement`] trait for T.
+/// To use `QSet` with a custom type, implement the [`QSetElement`] trait for `T`.
+///
+/// Qt Documentation: [QSet]("https://doc.qt.io/qt/qset.html#details")
 #[repr(C)]
 pub struct QSet<T>
 where
@@ -27,7 +29,7 @@ impl<T> Clone for QSet<T>
 where
     T: QSetElement,
 {
-    /// Constructs a copy of the QSet.
+    /// Constructs a copy of the `QSet`.
     fn clone(&self) -> Self {
         T::clone(self)
     }
@@ -47,7 +49,7 @@ impl<T> Drop for QSet<T>
 where
     T: QSetElement,
 {
-    /// Destroys the QSet.
+    /// Destroys the `QSet`.
     fn drop(&mut self) {
         T::drop(self);
     }
@@ -57,7 +59,7 @@ impl<T> PartialEq for QSet<T>
 where
     T: QSetElement + PartialEq,
 {
-    /// Returns true if both sets contain the same elements
+    /// Returns `true` if the sets contain the same (key, value) pairs, otherwise `false`.
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().all(|x| other.contains(x))
     }
@@ -83,13 +85,12 @@ where
         T::clear(self);
     }
 
-    /// Returns true if the set contains item value; otherwise returns false.
+    /// Returns `true` if the set contains item `value`; otherwise returns `false`.
     pub fn contains(&self, value: &T) -> bool {
         T::contains(self, value)
     }
 
-    /// Inserts item value into the set, if value isn't already in the set,
-    /// and returns an iterator pointing at the inserted item.
+    /// Inserts item `value` into the set, if `value` isn't already in the set.
     ///
     /// The value is a reference here so it can be opaque or trivial but
     /// note that the value is copied when being inserted into the set.
@@ -97,13 +98,13 @@ where
         T::insert_clone(self, value);
     }
 
-    /// Returns true if the set contains no elements; otherwise returns false.
+    /// Returns `true` if the set contains no elements; otherwise returns `false`.
     pub fn is_empty(&self) -> bool {
         T::len(self) == 0
     }
 
     /// An iterator visiting all elements in arbitrary order.
-    /// The iterator element type is &'a T.
+    /// The iterator element type is `&'a T`.
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             set: self,
@@ -116,14 +117,19 @@ where
         T::len(self)
     }
 
-    /// Removes any occurrence of item value from the set.
-    /// Returns true if an item was actually removed; otherwise returns false.
+    /// Removes any occurrence of item `value` from the set.
+    /// Returns `true` if an item was actually removed; otherwise returns `false`.
     pub fn remove(&mut self, value: &T) -> bool {
         T::remove(self, value)
     }
 
-    /// Reserve the specified capacity to prevent repeated allocations
-    /// when the maximum size is known.
+    /// Ensures that the set's internal hash table consists of at least `size` buckets.
+    ///
+    /// This function is useful for code that needs to build a huge set and wants to avoid repeated reallocation.
+    ///
+    /// Ideally, `size` should be slightly more than the maximum number of elements expected in the set. `size` doesn't have to be prime, because `QSet` will use a prime number internally anyway. If `size` is an underestimate, the worst that will happen is that the `QSet` will be a bit slower.
+    ///
+    /// In general, you will rarely ever need to call this function. `QSet`'s internal hash table automatically shrinks or grows to provide good performance without wasting too much memory.
     pub fn reserve(&mut self, size: isize) {
         T::reserve(self, size);
     }
@@ -140,8 +146,7 @@ impl<T> QSet<T>
 where
     T: QSetElement + ExternType<Kind = cxx::kind::Trivial>,
 {
-    /// Inserts item value into the set, if value isn't already in the set,
-    /// and returns an iterator pointing at the inserted item.
+    /// Inserts item `value` into the set, if `value` isn't already in the set.
     pub fn insert(&mut self, value: T) {
         T::insert(self, value);
     }

--- a/crates/cxx-qt-lib/src/core/qsize.rs
+++ b/crates/cxx-qt-lib/src/core/qsize.rs
@@ -25,53 +25,54 @@ mod ffi {
         #[allow(dead_code)]
         type QSizeF = crate::QSizeF;
 
-        /// Returns a size holding the minimum width and height of this size and the given otherSize.
+        /// Returns a size holding the minimum width and height of this size and the given `other_size`.
         #[rust_name = "bounded_to"]
         fn boundedTo(self: &QSize, other_size: &QSize) -> QSize;
 
-        /// Returns a size holding the maximum width and height of this size and the given otherSize.
+        /// Returns a size holding the maximum width and height of this size and the given `other_size`.
         #[rust_name = "expanded_to"]
         fn expandedTo(self: &QSize, other_size: &QSize) -> QSize;
 
         /// Returns the height.
         fn height(self: &QSize) -> i32;
 
-        /// Returns true if either of the width and height is less than or equal to 0; otherwise returns false.
+        /// Returns `true` if either of the width and height is less than or equal to 0; otherwise returns `false`.
         #[rust_name = "is_empty"]
         fn isEmpty(self: &QSize) -> bool;
 
-        /// Returns true if both the width and height is 0; otherwise returns false.
+        /// Returns `true` if both the width and height is 0; otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QSize) -> bool;
 
-        /// Returns true if both the width and height is equal to or greater than 0; otherwise returns false.
+        /// Returns `true` if both the width and height is equal to or greater than 0; otherwise returns `false`.
         #[rust_name = "is_valid"]
         fn isValid(self: &QSize) -> bool;
 
-        /// Returns the size that results from growing this size by margins.
+        /// Returns the size that results from growing this size by `margins`.
         #[rust_name = "grown_by"]
         fn grownBy(self: &QSize, margins: QMargins) -> QSize;
 
-        /// Scales the size to a rectangle with the given size, according to the specified mode.
+        /// Scales the size to a rectangle with the given `size`, according to the specified `mode`.
         fn scale(self: &mut QSize, size: &QSize, mode: AspectRatioMode);
 
-        /// Return a size scaled to a rectangle with the given size s, according to the specified mode.
+        /// Return a size scaled to a rectangle with the given size `s`, according to the specified `mode`.
         fn scaled(self: &QSize, s: &QSize, mode: AspectRatioMode) -> QSize;
 
-        /// Sets the height to the given height.
+        /// Sets the height to the given `height`.
         #[rust_name = "set_height"]
         fn setHeight(self: &mut QSize, height: i32);
 
-        /// Sets the width to the given width.
+        /// Sets the width to the given `width`.
         #[rust_name = "set_width"]
         fn setWidth(self: &mut QSize, width: i32);
 
-        /// Returns the size that results from shrinking this size by margins.
+        /// Returns the size that results from shrinking this size by `margins`.
         #[rust_name = "shrunk_by"]
         fn shrunkBy(self: &QSize, margins: QMargins) -> QSize;
 
         /// Returns this size as a size with floating point accuracy.
-        /// since 6.4
+        ///
+        /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_sizef"]
         fn toSizeF(self: &QSize) -> QSizeF;
@@ -79,7 +80,7 @@ mod ffi {
         /// Swaps the width and height values.
         fn transpose(self: &mut QSize);
 
-        /// Returns a QSize with width and height swapped.
+        /// Returns a `QSize` with width and height swapped.
         fn transposed(self: &QSize) -> QSize;
 
         /// Returns the width.
@@ -114,7 +115,9 @@ mod ffi {
     }
 }
 
-/// The QSize struct defines the size of a two-dimensional object using integer point precision.
+/// The `QSize` class defines the size of a two-dimensional object using integer point precision.
+///
+/// Qt Documentation: [QSize](https://doc.qt.io/qt/qsize.html#details)
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct QSize {
@@ -123,14 +126,14 @@ pub struct QSize {
 }
 
 impl QSize {
-    /// Constructs a size with the given width and height.
+    /// Constructs a size with the given `width` and `height`.
     pub fn new(width: i32, height: i32) -> Self {
         ffi::qsize_init(width, height)
     }
 }
 
 impl Default for QSize {
-    /// Constructs a size with an invalid width and height
+    /// Constructs a size with an invalid width and height.
     fn default() -> Self {
         ffi::qsize_init_default()
     }

--- a/crates/cxx-qt-lib/src/core/qsizef.rs
+++ b/crates/cxx-qt-lib/src/core/qsizef.rs
@@ -7,6 +7,8 @@
 use cxx::{type_id, ExternType};
 use std::fmt;
 
+use crate::QSize;
+
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
@@ -25,48 +27,48 @@ mod ffi {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
 
-        /// Returns a size holding the minimum width and height of this size and the given otherSize.
+        /// Returns a size holding the minimum width and height of this size and the given `other_size`.
         #[rust_name = "bounded_to"]
         fn boundedTo(self: &QSizeF, other_size: &QSizeF) -> QSizeF;
 
-        /// Returns a size holding the maximum width and height of this size and the given otherSize.
+        /// Returns a size holding the maximum width and height of this size and the given `other_size`.
         #[rust_name = "expanded_to"]
         fn expandedTo(self: &QSizeF, other_size: &QSizeF) -> QSizeF;
 
         /// Returns the height.
         fn height(self: &QSizeF) -> f64;
 
-        /// Returns true if either of the width and height is less than or equal to 0; otherwise returns false.
+        /// Returns `true` if either of the width and height is less than or equal to 0; otherwise returns `false`.
         #[rust_name = "is_empty"]
         fn isEmpty(self: &QSizeF) -> bool;
 
-        /// Returns true if both the width and height are 0.0 (ignoring the sign); otherwise returns false.
+        /// Returns `true` if both the width and height are 0.0 (ignoring the sign); otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QSizeF) -> bool;
 
-        /// Returns true if both the width and height are equal to or greater than 0; otherwise returns false.
+        /// Returns `true` if both the width and height are equal to or greater than 0; otherwise returns `false`.
         #[rust_name = "is_valid"]
         fn isValid(self: &QSizeF) -> bool;
 
-        /// Returns the size that results from growing this size by margins.
+        /// Returns the size that results from growing this size by `margins`.
         #[rust_name = "grown_by"]
         fn grownBy(self: &QSizeF, margins: QMarginsF) -> QSizeF;
 
-        /// Scales the size to a rectangle with the given size, according to the specified mode.
+        /// Scales the size to a rectangle with the given `size`, according to the specified `mode`.
         fn scale(self: &mut QSizeF, size: &QSizeF, mode: AspectRatioMode);
 
-        /// Returns a size scaled to a rectangle with the given size s, according to the specified mode.
+        /// Returns a size scaled to a rectangle with the given size `s`, according to the specified `mode`.
         fn scaled(self: &QSizeF, s: &QSizeF, mode: AspectRatioMode) -> QSizeF;
 
-        /// Sets the height to the given finite height.
+        /// Sets the height to the given finite `height`.
         #[rust_name = "set_height"]
         fn setHeight(self: &mut QSizeF, height: f64);
 
-        /// Sets the width to the given finite width.
+        /// Sets the width to the given finite `width`.
         #[rust_name = "set_width"]
         fn setWidth(self: &mut QSizeF, width: f64);
 
-        /// Returns the size that results from shrinking this size by margins.
+        /// Returns the size that results from shrinking this size by `margins`.
         #[rust_name = "shrunk_by"]
         fn shrunkBy(self: &QSizeF, margins: QMarginsF) -> QSizeF;
 
@@ -117,7 +119,9 @@ mod ffi {
     }
 }
 
-/// The QSizeF class defines the size of a two-dimensional object using floating point precision.
+/// The `QSizeF` class defines the size of a two-dimensional object using floating point precision.
+///
+/// Qt Documentation: [QSizeF](https://doc.qt.io/qt/qsizef.html#details)
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QSizeF {
@@ -126,9 +130,9 @@ pub struct QSizeF {
 }
 
 impl QSizeF {
-    /// Constructs a size with the given width and height.
-    pub fn new(w: f64, h: f64) -> Self {
-        ffi::qsizef_init(w, h)
+    /// Constructs a size with the given `width` and `height`.
+    pub fn new(width: f64, height: f64) -> Self {
+        ffi::qsizef_init(width, height)
     }
 }
 
@@ -145,14 +149,14 @@ impl fmt::Display for QSizeF {
     }
 }
 
-impl From<&ffi::QSize> for QSizeF {
-    /// Constructs a size with floating point accuracy from the given size.
-    fn from(size: &ffi::QSize) -> Self {
+impl From<&QSize> for QSizeF {
+    /// Constructs a size with floating point accuracy from the given `size`.
+    fn from(size: &QSize) -> Self {
         ffi::qsizef_from_qsize(size)
     }
 }
 
-impl From<QSizeF> for ffi::QSize {
+impl From<QSizeF> for QSize {
     /// Returns an integer based copy of this size.
     ///
     /// Note that the coordinates in the returned size will be rounded to the nearest integer.

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -8,6 +8,8 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::mem::MaybeUninit;
 
+use crate::{CaseSensitivity, QByteArray, QStringList, SplitBehaviorFlags};
+
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
@@ -25,7 +27,7 @@ mod ffi {
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = crate::QStringList;
 
-        /// Appends the string str onto the end of this string.
+        /// Appends the string `str` onto the end of this string.
         fn append<'a>(self: &'a mut QString, str: &QString) -> &'a mut QString;
 
         /// Clears the contents of the string and makes it null.
@@ -36,57 +38,67 @@ mod ffi {
         #[rust_name = "compare_i32"]
         fn compare(self: &QString, other: &QString, cs: CaseSensitivity) -> i32;
 
-        /// Returns true if this string contains an occurrence of the string str; otherwise returns false.
+        /// Returns `true` if this string contains an occurrence of the string `str`; otherwise returns `false`.
+        ///
+        /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the search is case-insensitive.
         fn contains(self: &QString, str: &QString, cs: CaseSensitivity) -> bool;
 
-        /// Returns true if the string ends with s; otherwise returns false.
+        /// Returns `true` if the string ends with `s`; otherwise returns `false`.
+        ///
+        /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the search is case-insensitive.
         #[rust_name = "ends_with"]
         fn endsWith(self: &QString, s: &QString, cs: CaseSensitivity) -> bool;
 
-        /// Returns true if the string has no characters; otherwise returns false.
+        /// Returns `true` if the string has no characters; otherwise returns `false`.
         #[rust_name = "is_empty"]
         fn isEmpty(self: &QString) -> bool;
 
-        /// Returns true if the string is lowercase, that is, it's identical to its toLower() folding.
+        /// Returns `true` if the string is lowercase, that is, it's identical to its [`to_lower`](Self::to_lower) folding.
         #[rust_name = "is_lower"]
         fn isLower(self: &QString) -> bool;
 
-        /// Returns true if this string is null; otherwise returns false.
+        /// Returns `true` if this string is null; otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QString) -> bool;
 
-        /// Returns true if the string is read right to left.
+        /// Returns `true` if the string is read right to left.
         #[rust_name = "is_right_to_left"]
         fn isRightToLeft(self: &QString) -> bool;
 
-        /// Returns true if the string is uppercase, that is, it's identical to its toUpper() folding.
+        /// Returns `true` if the string is uppercase, that is, it's identical to its [`to_upper`](Self::to_upper) folding.
         #[rust_name = "is_upper"]
         fn isUpper(self: &QString) -> bool;
 
-        /// Returns true if the string contains valid UTF-16 encoded data, or false otherwise.
+        /// Returns `true` if the string contains valid UTF-16 encoded data, or `false` otherwise.
         #[rust_name = "is_valid_utf16"]
         fn isValidUtf16(self: &QString) -> bool;
 
-        /// Prepends the string str to the beginning of this string and returns a reference to this string.
+        /// Prepends the string `str` to the beginning of this string and returns a mutable reference to this string.
         fn prepend<'a>(self: &'a mut QString, str: &QString) -> &'a mut QString;
 
-        /// Removes every occurrence of the given str string in this string, and returns a reference to this string.
+        /// Removes every occurrence of the given `str` string in this string, and returns a mutable reference to this string.
+        ///
+        /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the search is case-insensitive.
         fn remove<'a>(self: &'a mut QString, str: &QString, cs: CaseSensitivity)
             -> &'a mut QString;
 
         /// Removes the first character in this string. If the string is empty, this function does nothing.
+        ///
         /// This function was introduced in Qt 6.5.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_5))]
         #[rust_name = "remove_first"]
         fn removeFirst(self: &mut QString) -> &mut QString;
 
         /// Removes the last character in this string. If the string is empty, this function does nothing.
+        ///
         /// This function was introduced in Qt 6.5.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_5))]
         #[rust_name = "remove_last"]
         fn removeLast(self: &mut QString) -> &mut QString;
 
-        /// Replaces every occurrence of the string before with the string after and returns a reference to this string.
+        /// Replaces every occurrence of the string `before` with the string `after` and returns a mutable reference to this string.
+        ///
+        /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the search is case-insensitive.
         fn replace<'a>(
             self: &'a mut QString,
             before: &QString,
@@ -94,11 +106,11 @@ mod ffi {
             cs: CaseSensitivity,
         ) -> &'a mut QString;
 
-        /// Returns true if the string starts with s; otherwise returns false.
+        /// Returns `true` if the string starts with `s`; otherwise returns `false`.
         #[rust_name = "starts_with"]
         fn startsWith(self: &QString, s: &QString, cs: CaseSensitivity) -> bool;
 
-        /// Converts a plain text string to an HTML string with HTML metacharacters <, >, &, and " replaced by HTML entities.
+        /// Converts a plain text string to an HTML string with HTML metacharacters `<`, `>`, `&`, and `"` replaced by HTML entities.
         #[rust_name = "to_html_escaped"]
         fn toHtmlEscaped(self: &QString) -> QString;
     }
@@ -191,9 +203,11 @@ mod ffi {
     }
 }
 
-/// The QString class provides a Unicode character string.
+/// The `QString` class provides a Unicode character string.
 ///
-/// Note that QString is a UTF-16 whereas Rust strings are a UTF-8
+/// Note that `QString` is encoded in UTF-16, whereas Rust's [`String`] is encoded in UTF-8.
+///
+/// Qt Documentation: [QString](https://doc.qt.io/qt/qstring.html#details)
 #[repr(C)]
 pub struct QString {
     /// The layout has changed between Qt 5 and Qt 6
@@ -207,10 +221,10 @@ pub struct QString {
 }
 
 impl Clone for QString {
-    /// Constructs a copy of other.
+    /// Constructs a copy of this string.
     ///
-    /// This operation takes constant time, because QString is implicitly shared.
-    /// This makes returning a QString from a function very fast.
+    /// This operation takes constant time, because `QString` is implicitly shared.
+    /// This makes returning a `QString` from a function very fast.
     /// If a shared instance is modified, it will be copied (copy-on-write), and that takes linear time.
     fn clone(&self) -> Self {
         ffi::qstring_init_from_qstring(self)
@@ -245,9 +259,9 @@ impl Ord for QString {
 }
 
 impl fmt::Display for QString {
-    /// Convert the QString to a Rust string
+    /// Format the `QString` as a Rust string.
     ///
-    /// Note that this converts from UTF-16 to UTF-8
+    /// Note that this converts from UTF-16 to UTF-8.
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.pad(&String::from(self))
     }
@@ -276,74 +290,81 @@ impl Drop for QString {
 }
 
 impl From<&str> for QString {
-    /// Constructs a QString from a Rust string
+    /// Constructs a `QString` from a string slice.
     ///
-    /// Note that this converts from UTF-8 to UTF-16
+    /// Note that this converts from UTF-8 to UTF-16.
     fn from(str: &str) -> Self {
         ffi::qstring_init_from_rust_string(str)
     }
 }
 
 impl From<&String> for QString {
-    /// Constructs a QString from a Rust string
+    /// Constructs a `QString` from a Rust `String` reference.
     ///
-    /// Note that this converts from UTF-8 to UTF-16
+    /// Note that this converts from UTF-8 to UTF-16.
     fn from(str: &String) -> Self {
         ffi::qstring_init_from_rust_string(str)
     }
 }
 
 impl From<String> for QString {
-    /// Constructs a QString from a Rust string
+    /// Constructs a `QString` from a Rust `String`.
     ///
-    /// Note that this converts from UTF-8 to UTF-16
+    /// Note that this converts from UTF-8 to UTF-16.
     fn from(str: String) -> Self {
         ffi::qstring_init_from_rust_string(&str)
     }
 }
 
 impl From<&QString> for String {
-    /// Convert the QString to a Rust string
+    /// Constructs a Rust `String` from a `QString` reference.
     ///
-    /// Note that this converts from UTF-16 to UTF-8
+    /// Note that this converts from UTF-16 to UTF-8.
     fn from(qstring: &QString) -> Self {
         ffi::qstring_to_rust_string(qstring)
     }
 }
 
 impl From<QString> for String {
-    /// Convert the QString to a Rust string
+    /// Constructs a Rust `String` from a `QString`.
     ///
-    /// Note that this converts from UTF-16 to UTF-8
+    /// Note that this converts from UTF-16 to UTF-8.
     fn from(qstring: QString) -> Self {
         ffi::qstring_to_rust_string(&qstring)
     }
 }
 
 impl QString {
-    /// Returns a copy of this string with the lowest numbered place marker replaced by string a, i.e., %1, %2, ..., %99.
+    /// Returns a copy of this string with the lowest numbered place marker replaced by string `a`, i.e., %1, %2, ..., %99.
+    ///
+    /// If there is no unreplaced place-marker remaining, a warning message is printed and the result is undefined. Place-marker numbers must be in the range 1 to 99.
     pub fn arg(&self, a: &QString) -> Self {
         ffi::qstring_arg(self, a)
     }
 
-    /// Lexically compares this string with the other string and
-    /// returns if this string is less than, equal to, or greater than the other string.
-    pub fn compare(&self, other: &QString, cs: ffi::CaseSensitivity) -> Ordering {
+    /// Lexically compares this string with the `other` string.
+    ///
+    /// If `cs` is [`CaseSensitivity::CaseSensitive`], the comparison is case-sensitive; otherwise the comparison is case-insensitive.
+    ///
+    /// Case sensitive comparison is based exclusively on the numeric Unicode values of the characters and is very fast, but is not what a human would expect.
+    pub fn compare(&self, other: &QString, cs: CaseSensitivity) -> Ordering {
         self.compare_i32(other, cs).cmp(&0)
     }
 
-    /// Returns the index position of the first occurrence of the string str in this string,
-    /// searching forward from index position from. Returns -1 if str is not found.
-    pub fn index_of(&self, str: &QString, from: isize, cs: ffi::CaseSensitivity) -> isize {
+    /// Returns the index position of the first occurrence of the string `str` in this string,
+    /// searching forward from index position `from`. Returns -1 if `str` is not found.
+    ///
+    /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the comparison is case-insensitive.
+    pub fn index_of(&self, str: &QString, from: isize, cs: CaseSensitivity) -> isize {
         ffi::qstring_index_of(self, str, from, cs)
     }
 
-    /// Inserts the string str at the given index position and returns a mutable reference to this string.
-    pub fn insert<'a>(&'a mut self, pos: isize, str: &Self) -> &'a mut Self {
-        ffi::qstring_insert(self, pos, str)
+    /// Inserts the string `str` at the given index `position` and returns a mutable reference to this string.
+    pub fn insert<'a>(&'a mut self, position: isize, str: &Self) -> &'a mut Self {
+        ffi::qstring_insert(self, position, str)
     }
 
-    /// Returns a substring that contains the n leftmost characters of the string.
+    /// Returns a substring that contains the `n` leftmost characters of the string.
     pub fn left(&self, n: isize) -> Self {
         ffi::qstring_left(self, n)
     }
@@ -353,41 +374,50 @@ impl QString {
         ffi::qstring_len(self)
     }
 
-    /// Returns a string that contains n characters of this string, starting at the specified position index.
+    /// Returns a string that contains `n` characters of this string, starting at the specified `position` index.
     pub fn mid(&self, position: isize, n: isize) -> Self {
         ffi::qstring_mid(self, position, n)
     }
 
-    /// Returns a substring that contains the n rightmost characters of the string.
+    /// Returns a substring that contains the `n` rightmost characters of the string.
     pub fn right(&self, n: isize) -> Self {
         ffi::qstring_right(self, n)
     }
 
     /// Returns a string that has whitespace removed from the start and the end,
     /// and that has each sequence of internal whitespace replaced with a single space.
+    ///
+    /// Whitespace characters are the ASCII characters tabulation `'\t'`, line feed `'\n'`, carriage return `'\r'`, vertical tabulation `'\x08'` (`'\v'` in C), form feed `'\x0C'` (`'\f'` in C), and space `' '`.
     pub fn simplified(&self) -> Self {
         ffi::qstring_simplified(self)
     }
 
-    /// Splits the string into substrings wherever sep occurs, and returns the list of those strings.
-    /// If sep does not match anywhere in the string, split() returns a single-element list containing this string.
+    /// Splits the string into substrings wherever `sep` occurs, and returns the list of those strings.
+    /// If `sep` does not match anywhere in the string, this function returns a single-element list containing this string.
+    ///
+    /// `cs` specifies whether `sep` should be matched case sensitively or case insensitively.
+    ///
+    /// If `behavior` is [`SplitBehaviorFlags::SkipEmptyParts`], empty entries don't appear in the result.
     pub fn split(
         &self,
         sep: &QString,
-        behavior: ffi::SplitBehaviorFlags,
-        cs: ffi::CaseSensitivity,
-    ) -> ffi::QStringList {
+        behavior: SplitBehaviorFlags,
+        cs: CaseSensitivity,
+    ) -> QStringList {
         ffi::qstring_split(self, sep, behavior, cs)
     }
 
-    /// Returns a Latin-1 representation of the string as a QByteArray.
-    pub fn to_latin1(&self) -> ffi::QByteArray {
+    /// Returns a Latin-1 representation of the string as a `QByteArray`.
+    ///
+    /// The returned byte array is undefined if the string contains non-Latin1 characters. Those characters may be suppressed or replaced with a question mark.
+    pub fn to_latin1(&self) -> QByteArray {
         ffi::qstring_to_latin1(self)
     }
 
-    /// Returns the local 8-bit representation of the string as a QByteArray.
-    /// The returned byte array is undefined if the string contains characters not supported by the local 8-bit encoding.
-    pub fn to_local8bit(&self) -> ffi::QByteArray {
+    /// Returns the local 8-bit representation of the string as a `QByteArray`.
+    ///
+    /// If this string contains any characters that cannot be encoded in the local 8-bit encoding, the returned byte array is undefined. Those characters may be suppressed or replaced by another.
+    pub fn to_local8bit(&self) -> QByteArray {
         ffi::qstring_to_local8bit(self)
     }
 
@@ -401,12 +431,14 @@ impl QString {
         ffi::qstring_to_upper(self)
     }
 
-    /// Returns a UTF-8 representation of the string as a QByteArray.
-    pub fn to_utf8(&self) -> ffi::QByteArray {
+    /// Returns a UTF-8 representation of the string as a `QByteArray`.
+    pub fn to_utf8(&self) -> QByteArray {
         ffi::qstring_to_utf8(self)
     }
 
     /// Returns a string that has whitespace removed from the start and the end.
+    ///
+    /// Whitespace characters are the ASCII characters tabulation `'\t'`, line feed `'\n'`, carriage return `'\r'`, vertical tabulation `'\x08'` (`'\v'` in C), form feed `'\x0C'` (`'\f'` in C), and space `' '`.
     pub fn trimmed(&self) -> Self {
         ffi::qstring_trimmed(self)
     }

--- a/crates/cxx-qt-lib/src/core/qstringlist.rs
+++ b/crates/cxx-qt-lib/src/core/qstringlist.rs
@@ -27,21 +27,30 @@ mod ffi {
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = super::QStringList;
 
-        /// Returns true if the list contains the string str; otherwise returns false.
+        /// Returns `true` if the list contains the string `str`; otherwise returns `false`.
+        ///
+        /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the comparison is case-insensitive.
         fn contains(self: &QStringList, str: &QString, cs: CaseSensitivity) -> bool;
 
-        /// Returns a list of all the strings containing the substring str.
+        /// Returns a list of all the strings containing the substring `str`.
+        ///
+        /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the comparison is case-insensitive.
         fn filter(self: &QStringList, str: &QString, cs: CaseSensitivity) -> QStringList;
 
         /// Joins all the string list's strings into a single string with each element
-        /// separated by the given separator (which can be an empty string).
+        /// separated by the given `separator` (which can be an empty string).
         fn join(self: &QStringList, separator: &QString) -> QString;
 
         /// Sorts the list of strings in ascending order.
+        ///
+        /// If `cs` is [`CaseSensitivity::CaseSensitive`], the string comparison is case-sensitive; otherwise the comparison is case-insensitive.
         fn sort(self: &mut QStringList, cs: CaseSensitivity);
 
-        /// Returns a string list where every string has had the before text replaced with the after text wherever the before text is found.
-        /// The before text is matched case-sensitively or not depending on the cs flag.
+        /// Returns a string list where every string has had the `before` text replaced with the `after` text wherever the `before` text is found.
+        ///
+        /// **Note:** If you use an empty `before` argument, the `after` argument will be inserted *before and after* each character of the string.
+    ///
+    /// If `cs` is [`CaseSensitivity::CaseSensitive`], the string comparison is case-sensitive; otherwise the comparison is case-insensitive.
         #[rust_name = "replace_in_strings"]
         fn replaceInStrings(
             self: &mut QStringList,
@@ -107,7 +116,9 @@ mod ffi {
     }
 }
 
-/// The QStringList class provides a list of strings.
+/// The `QStringList` class provides a list of strings.
+///
+/// Qt Documentation: [QStringList](https://doc.qt.io/qt/qstringlist.html#details)
 #[repr(C)]
 pub struct QStringList {
     /// The layout has changed between Qt 5 and Qt 6
@@ -123,6 +134,8 @@ pub struct QStringList {
 impl QStringList {
     /// This function removes duplicate entries from a list.
     /// The entries do not have to be sorted. They will retain their original order.
+    ///
+    /// Returns the number of removed entries.
     pub fn remove_duplicates(&mut self) -> isize {
         ffi::qstringlist_remove_duplicates(self)
     }
@@ -170,21 +183,21 @@ impl Drop for QStringList {
 }
 
 impl From<&QString> for QStringList {
-    /// Constructs a string list that contains the given string
+    /// Constructs a string list that contains the given string.
     fn from(string: &QString) -> Self {
         ffi::qstringlist_from_qstring(string)
     }
 }
 
 impl From<&QList<QString>> for QStringList {
-    /// Converts a `QList<QString>` into QStringList.
+    /// Converts a `QList<QString>` into `QStringList`.
     fn from(list: &QList<QString>) -> Self {
         ffi::qstringlist_from_qlist_qstring(list)
     }
 }
 
 impl From<&QStringList> for QList<QString> {
-    /// Converts a QStringList into a `QList<QString>`
+    /// Converts a `QStringList` into a `QList<QString>`.
     fn from(list: &QStringList) -> Self {
         ffi::qstringlist_as_qlist_qstring(list)
     }

--- a/crates/cxx-qt-lib/src/core/qt.rs
+++ b/crates/cxx-qt-lib/src/core/qt.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::unsafe_impl_qflag;
+use crate::{unsafe_impl_qflag, QFlags};
 
 #[cxx::bridge(namespace = "Qt")]
 mod ffi {
@@ -26,15 +26,22 @@ mod ffi {
 
     #[repr(i32)]
     enum DateFormat {
+        /// The default Qt format, which includes the day and month name, the day number in the month, and the year in full. The day and month names will be short names in English (C locale). This effectively uses, for a date, format `ddd MMM d yyyy`, for a time `HH:mm:ss` and combines these as `ddd MMM d HH:mm:ss yyyy` for a date-time, with an optional zone-offset suffix, where relevant. When reading from a string, a fractional part is also recognized on the seconds of a time part, as `HH:mm:ss.zzz`, and some minor variants on the format may be recognized, for compatibility with earlier versions of Qt and with changes to the format planned for the future. In particular, the zone-offset suffix presently uses GMT\[±`tzoff`\] with a `tzoff` in `HH[[:]mm]` format (two-digit hour and optional two-digit minutes, with optional colon separator); this shall change to use UTC in place of GMT in a future release of Qt, so the planned UTC format is recognized.
         TextDate = 0,
+        /// ISO 8601 extended format: uses `yyyy-MM-dd` for dates, `HH:mm:ss.zzz` for times or `yyyy-MM-ddTHH:mm:ss.zzz` (e.g. `2017-07-24T15:46:29.739`) for combined dates and times, optionally with a time-zone suffix (`Z` for UTC otherwise an offset as `±HH:mm`) where appropriate. When parsed, a single space, `' '`, may be used in place of the `'T'` separator between date and time; no other spacing characters are permitted. This format also accepts `HH:mm` and plain `HH` formats for the time part, either of which may include a fractional part, `HH:mm.zzz` or `HH.zzz`, applied to the last field present (hour or minute).
         ISODateWithMs = 9,
+        /// ISO 8601 extended format, as for `ISODateWithMs`, but omitting the milliseconds (`.zzz`) part when converting to a string. There is no difference when reading from a string: if a fractional part is present on the last time field, either format will accept it.
         ISODate = 1,
+        /// RFC 2822, RFC 850 and RFC 1036 format: when converting dates to string form, format `dd MMM yyyy` is used, for times the format is `HH:mm:ss`. For combined date and time, these are combined as `dd MMM yyyy HH:mm:ss ±tzoff` (omitting the optional leading day of the week from the first format recognized). When reading from a string either `[ddd,] dd MMM yyyy [HH:mm[:ss]][ ±tzoff]` or `ddd MMM dd[ HH:mm:ss] yyyy[ ±tzoff]` will be recognized for combined dates and times, where `tzoff` is a timezone offset in `HHmm` format. Arbitrary spacing may appear before or after the text and any non-empty spacing may replace the spaces in this format. For dates and times separately, the same formats are matched and the unwanted parts are ignored. In particular, note that a time is not recognized without an accompanying date.
         RFC2822Date = 8,
     }
 
+    /// This enum specifies how [`QString::split`](crate::QString::split) functions should behave with respect to empty strings.
     #[repr(i32)]
     enum SplitBehaviorFlags {
+        /// If a field is empty, keep it in the result.
         KeepEmptyParts,
+        /// If a field is empty, don't include it in the result.
         SkipEmptyParts,
     }
 
@@ -59,10 +66,10 @@ mod ffi {
         SmoothTransformation,
     }
 
-    /// This enum type defines the pen styles that can be drawn using QPainter.
+    /// This enum type defines the pen styles that can be drawn using [`QPainter`](crate::QPainter).
     #[repr(i32)]
     enum PenStyle {
-        /// no line at all. For example, QPainter::drawRect() fills but does not draw any boundary line.
+        /// No line at all. For example, [`QPainter::draw_rect_f`](crate::QPainter::draw_rect_f) fills but does not draw any boundary line.
         NoPen,
         /// A plain line.
         SolidLine,
@@ -74,29 +81,39 @@ mod ffi {
         DashDotLine,
         /// One dash, two dots, one dash, two dots.
         DashDotDotLine,
-        /// A custom pattern defined using QPainterPathStroker::setDashPattern().
+        /// A custom pattern defined using [QPainterPathStroker::setDashPattern](https://doc.qt.io/qt/qpainterpathstroker.html#setDashPattern)().
         CustomDashLine,
     }
 
-    /// This enum type defines the line endcap style
+    /// This enum type defines the pen cap styles supported by Qt, i.e. the line end caps that can be drawn using [`QPainter`](crate::QPainter).
     #[repr(i32)]
     enum PenCapStyle {
+        /// A square line end that does not cover the end point of the line.
         FlatCap = 0x00,
+        /// A square line end that covers the end point and extends beyond it by half the line width.
         SquareCap = 0x10,
+        /// A rounded line end.
         RoundCap = 0x20,
+        #[doc(hidden)]
         MPenCapStyle = 0x30,
     }
 
-    /// This enum type defines the line join style.
+    /// This enum type defines the pen join styles supported by Qt, i.e. which joins between two connected lines can be drawn using [`QPainter`](crate::QPainter).
     #[repr(i32)]
     enum PenJoinStyle {
+        /// The outer edges of the lines are extended to meet at an angle, and this area is filled.
         MiterJoin = 0x00,
+        /// The triangular notch between the two lines is filled.
         BevelJoin = 0x40,
+        /// A circular arc between the two lines is filled.
         RoundJoin = 0x80,
+        /// A miter join corresponding to the definition of a miter join in the SVG 1.2 Tiny specification.
         SvgMiterJoin = 0x100,
+        #[doc(hidden)]
         MPenJoinStyle = 0x1c0,
     }
 
+    /// Specifies which method should be used to fill the paths and polygons.
     #[repr(i32)]
     enum FillRule {
         /// Specifies that the region is filled using the odd even fill rule.
@@ -117,12 +134,15 @@ mod ffi {
     /// This enum type specifies the direction of Qt's layouts and text handling.
     #[repr(i32)]
     enum LayoutDirection {
+        /// Left-to-right layout.
         LeftToRight,
+        /// Right-to-left layout.
         RightToLeft,
+        /// Automatic layout. Text directionality is determined from the content of the string to be layouted.
         LayoutDirectionAuto,
     }
 
-    /// This enum type specifies the background mode
+    /// This enum type specifies the background mode.
     #[repr(i32)]
     enum BGMode {
         TransparentMode,
@@ -131,12 +151,15 @@ mod ffi {
 
     #[repr(i32)]
     enum ClipOperation {
+        /// This operation turns clipping off.
         NoClip,
+        /// Replaces the current clip path/rect/region with the one supplied in the function call.
         ReplaceClip,
+        /// Intersects the current clip path/rect/region with the one supplied in the function call.
         IntersectClip,
     }
 
-    /// This enum is used by QPainter::drawRoundedRect() and QPainterPath::addRoundedRect()
+    /// This enum is used by [`QPainter::draw_rounded_rect`](crate::QPainter::draw_rounded_rect) and [`QPainterPath::add_rounded_rect`](crate::QPainterPath::add_rounded_rect)
     /// functions to specify the radii of rectangle corners with respect to the dimensions
     /// of the bounding rectangles specified.
     #[repr(i32)]
@@ -147,6 +170,7 @@ mod ffi {
         RelativeSize,
     }
 
+    /// This enum describes the modifier keys.
     #[derive(Debug)]
     #[repr(u32)]
     enum KeyboardModifier {
@@ -167,13 +191,14 @@ mod ffi {
         GroupSwitchModifier = 0x40000000,
     }
 
+    /// This enum type describes the different mouse buttons.
     #[derive(Debug)]
     #[repr(u32)]
     enum MouseButton {
         /// The button state does not refer to any button.
         NoButton = 0x00000000,
         /// This value corresponds to a mask of all possible mouse buttons. Use to set the
-        /// 'acceptedButtons' property of a MouseArea to accept ALL mouse buttons.
+        /// ['acceptedButtons'](https://doc.qt.io/qt/qml-qtquick-mousearea.html#acceptedButtons-prop) property of a [MouseArea](https://doc.qt.io/qt/qml-qtquick-mousearea.html) to accept ALL mouse buttons.
         AllButtons = 0x07ffffff,
         /// The left button is pressed, or an event refers to the left button. (The left button may
         /// be the right button on left-handed mice.)
@@ -243,8 +268,10 @@ pub use ffi::{
 // Reexport ConnectionType from cxx-qt
 pub use cxx_qt::ConnectionType;
 
-pub type MouseButtons = crate::QFlags<MouseButton>;
-pub type KeyboardModifiers = crate::QFlags<KeyboardModifier>;
+/// [`QFlags`] of [`MouseButton`].
+pub type MouseButtons = QFlags<MouseButton>;
+/// [`QFlags`] of [`KeyboardModifier`].
+pub type KeyboardModifiers = QFlags<KeyboardModifier>;
 
 unsafe_impl_qflag!(MouseButton, "Qt::MouseButtons", u32);
 unsafe_impl_qflag!(KeyboardModifier, "Qt::KeyboardModifiers", u32);

--- a/crates/cxx-qt-lib/src/core/qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qtime.rs
@@ -21,33 +21,47 @@ mod ffi {
         type QTime = super::QTime;
         type QString = crate::QString;
 
-        /// Returns a QTime object containing a time ms milliseconds later
-        /// than the time of this object (or earlier if ms is negative).
+        /// Returns a `QTime` object containing a time `ms` milliseconds later
+        /// than the time of this object (or earlier if `ms` is negative).
+        ///
+        /// Note that the time will wrap if it passes midnight.
+        ///
+        /// Returns a null time if this time is invalid.
         #[rust_name = "add_msecs"]
         fn addMSecs(self: &QTime, ms: i32) -> QTime;
 
-        /// Returns a QTime object containing a time s seconds later than the
-        /// time of this object (or earlier if s is negative).
+        /// Returns a `QTime` object containing a time `s` seconds later than the
+        /// time of this object (or earlier if `s` is negative).
+        ///
+        /// Note that the time will wrap if it passes midnight.
+        ///
+        /// Returns a null time if this time is invalid.
         #[rust_name = "add_secs"]
         fn addSecs(self: &QTime, s: i32) -> QTime;
 
         /// Returns the hour part (0 to 23) of the time.
+        ///
+        /// Returns -1 if the time is invalid.
         fn hour(self: &QTime) -> i32;
 
-        /// Returns true if the time is null (i.e., the QTime object was
-        /// constructed using the default constructor); otherwise returns false.
+        /// Returns `true` if the time is null (i.e., the `QTime` object was
+        /// constructed using the default constructor); otherwise returns `false`.
         /// A null time is also an invalid time.
         #[rust_name = "is_null"]
         fn isNull(self: &QTime) -> bool;
 
-        /// Returns true if the time is valid; otherwise returns false.
+        /// Returns `true` if the time is valid; otherwise returns `false`. For example, the time 23:30:55.746 is valid, but 24:12:30 is invalid.
         #[rust_name = "is_valid"]
         fn isValid(self: &QTime) -> bool;
 
         /// Returns the minute part (0 to 59) of the time.
+        ///
+        /// Returns -1 if the time is invalid.
         fn minute(self: &QTime) -> i32;
 
         /// Returns the millisecond part (0 to 999) of the time.
+        ///
+        /// Returns -1 if the time is invalid.
         fn msec(self: &QTime) -> i32;
 
         /// Returns the number of msecs since the start of the day, i.e. since 00:00:00.
@@ -55,17 +69,19 @@ mod ffi {
         fn msecsSinceStartOfDay(self: &QTime) -> i32;
 
         /// Returns the second part (0 to 59) of the time.
+        ///
+        /// Returns -1 if the time is invalid.
         fn second(self: &QTime) -> i32;
 
-        /// Sets the time to hour h, minute m, seconds s and milliseconds ms.
+        /// Sets the time to hour `h`, minute `m`, seconds `s` and milliseconds `ms`.
         #[rust_name = "set_hms"]
         fn setHMS(self: &mut QTime, h: i32, m: i32, s: i32, ms: i32) -> bool;
 
-        /// Returns the time as a string. The format parameter determines the format of the result string.
+        /// Returns the time as a string. The `format` parameter determines the format of the string.
         #[rust_name = "format"]
         fn toString(self: &QTime, format: &QString) -> QString;
 
-        /// Returns the time as a string. The format parameter determines the format of the string.
+        /// Returns the time as a string. The `format` parameter determines the format of the string.
         #[rust_name = "format_enum"]
         fn toString(self: &QTime, format: DateFormat) -> QString;
     }
@@ -116,7 +132,9 @@ mod ffi {
     }
 }
 
-/// The QTime class provides clock time functions.
+/// The `QTime` class provides clock time functions.
+///
+/// Qt Documentation: [QTime](https://doc.qt.io/qt/qtime.html#details)
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(C)]
 pub struct QTime {
@@ -125,45 +143,61 @@ pub struct QTime {
 
 impl QTime {
     /// Returns the current time as reported by the system clock.
+    ///
+    /// Note that the accuracy depends on the accuracy of the underlying operating system; not all systems provide 1-millisecond accuracy.
+    ///
+    /// Furthermore, the value only increases within each day; it shall drop by 24 hours each time midnight passes; and, beside this, changes in it may not correspond to elapsed time, if a daylight-saving transition intervenes.
     pub fn current_time() -> Self {
         ffi::qtime_current_time()
     }
 
-    /// Returns a new QTime instance with the time set to the number of msecs
+    /// Returns a new `QTime` instance with the time set to the number of `msecs`
     /// since the start of the day, i.e. since 00:00:00.
+    ///
+    /// If `msecs` falls outside the valid range an invalid `QTime` will be returned.
     pub fn from_msecs_since_start_of_day(msecs: i32) -> Self {
         ffi::qtime_from_msecs_since_start_of_day(msecs)
     }
 
-    /// Returns the QTime represented by the string, using the format given, or an invalid time if the string cannot be parsed.
-    pub fn from_string(string: &ffi::QString, format: &ffi::QString) -> Self {
+    /// Returns the time represented in the `string` as a `QTime` using the `format` given, or an invalid time if the string cannot be parsed.
+    pub fn from_string(string: &QString, format: &QString) -> Self {
         ffi::qtime_from_string(string, format)
     }
 
-    /// Returns the time represented in the string as a QTime using the format given, or an invalid time if this is not possible.
-    pub fn from_string_enum(string: &ffi::QString, format: ffi::DateFormat) -> Self {
+    /// Returns the time represented in the `string` as a `QTime` using the `format` given, or an invalid time if this is not possible.
+    pub fn from_string_enum(string: &QString, format: DateFormat) -> Self {
         ffi::qtime_from_string_enum(string, format)
     }
 
-    /// Returns the number of milliseconds from this time to t.
-    /// If t is earlier than this time, the number of milliseconds returned is negative.
+    /// Returns the number of milliseconds from this time to `t`.
+    /// If `t` is earlier than this time, the number of milliseconds returned is negative.
+    ///
+    /// Because `QTime` measures time within a day and there are 86400 seconds in a day, the result is always between -86400000 and 86400000 ms.
+    ///
+    /// Returns 0 if either time is invalid.
     pub fn msecs_to(&self, t: Self) -> i32 {
         ffi::qtime_msecs_to(self, t)
     }
 
-    /// Constructs a time with hour h, minute m, seconds s and milliseconds ms.
+    /// Constructs a time with hour `h`, minute `m`, seconds `s` and milliseconds `ms`.
     pub fn new(h: i32, m: i32, s: i32, ms: i32) -> Self {
         ffi::qtime_init(h, m, s, ms)
     }
 
-    /// Returns the number of seconds from this time to t.
-    /// If t is earlier than this time, the number of seconds returned is negative.
+    /// Returns the number of seconds from this time to `t`.
+    /// If `t` is earlier than this time, the number of seconds returned is negative.
+    ///
+    /// Because `QTime` measures time within a day and there are 86400 seconds in a day, the result is always between -86400 and 86400.
+    ///
+    /// This function does not take into account any milliseconds.
+    ///
+    /// Returns 0 if either time is invalid.
     pub fn secs_to(&self, t: Self) -> i32 {
         ffi::qtime_secs_to(self, t)
     }
 
-    /// Returns true if the specified time is valid; otherwise returns false.
-    /// The time is valid if h is in the range 0 to 23, m and s are in the range 0 to 59, and ms is in the range 0 to 999.
+    /// Returns `true` if the specified time is valid; otherwise returns `false`.
+    /// The time is valid if `h` is in the range 0 to 23, `m` and `s` are in the range 0 to 59, and `ms` is in the range 0 to 999.
     pub fn is_valid_time(h: i32, m: i32, s: i32, ms: i32) -> bool {
         ffi::qtime_is_valid(h, m, s, ms)
     }
@@ -178,7 +212,7 @@ impl Default for QTime {
 
 impl fmt::Display for QTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.format_enum(ffi::DateFormat::TextDate).fmt(f)
+        self.format_enum(DateFormat::TextDate).fmt(f)
     }
 }
 
@@ -191,12 +225,14 @@ impl fmt::Debug for QTime {
 #[cfg(feature = "chrono")]
 use chrono::Timelike;
 
+use crate::{DateFormat, QString};
+
 #[cfg(feature = "chrono")]
 impl TryFrom<chrono::NaiveTime> for QTime {
     type Error = &'static str;
 
-    /// Errors if [chrono::NaiveTime] has milliseconds larger than 999,
-    /// as Qt does not support representing a leap second in this way
+    /// Errors if [`NaiveTime`](chrono::NaiveTime) has milliseconds larger than 999,
+    /// as Qt does not support representing a leap second in this way.
     fn try_from(value: chrono::NaiveTime) -> Result<Self, Self::Error> {
         let ms = (value.nanosecond() / 1_000_000) as i32;
         // NaiveTime can have a nanosecond larger than 1 second

--- a/crates/cxx-qt-lib/src/core/qtimezone.rs
+++ b/crates/cxx-qt-lib/src/core/qtimezone.rs
@@ -4,8 +4,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use std::fmt;
 
+use crate::{QByteArray, QList, QString};
+
 #[cxx::bridge]
 mod ffi {
+    /// The type of time zone name.
     #[repr(i32)]
     #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     enum QTimeZoneNameType {
@@ -20,6 +23,7 @@ mod ffi {
         OffsetName,
     }
 
+    /// The type of time zone time, for example when requesting the name. In time zones that do not apply DST, all three values may return the same result.
     #[repr(i32)]
     #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     enum QTimeZoneTimeType {
@@ -47,7 +51,9 @@ mod ffi {
         type QString = crate::QString;
 
         include!("cxx-qt-lib/qtimezone.h");
-        /// The QTimeZone class converts between UTC and local time in a specific time zone.
+        /// The `QTimeZone` class converts between UTC and local time in a specific time zone.
+        ///
+        /// Qt Documentation: [QTimeZone](https://doc.qt.io/qt/qtimezone.html#details)
         //
         // QTimeZone only has a copy-constructor and not a move-constructor, which means that the following is true
         // "When the move constructor is not implicitly declared or explicitly supplied, expressions
@@ -58,45 +64,55 @@ mod ffi {
         type QTimeZoneNameType;
         type QTimeZoneTimeType;
 
-        /// Returns the time zone abbreviation at the given atDateTime. The abbreviation may change depending on DST or even historical events.
-        fn abbreviation(self: &QTimeZone, atDateTime: &QDateTime) -> QString;
+        /// Returns the time zone abbreviation at the given `at_date_time`. The abbreviation may change depending on DST or even historical events.
+        ///
+        /// **Note:** The abbreviation is not guaranteed to be unique to this time zone and should not be used in place of the ID or display name.
+        fn abbreviation(self: &QTimeZone, at_date_time: &QDateTime) -> QString;
 
         /// Returns any comment for the time zone.
+        ///
+        /// A comment may be provided by the host platform to assist users in choosing the correct time zone. Depending on the platform this may not be localized.
         fn comment(self: &QTimeZone) -> QString;
 
-        /// Returns the daylight-saving time offset at the given atDateTime,
+        /// Returns the daylight-saving time offset at the given `at_date_time`,
         /// i.e. the number of seconds to add to the standard time offset to obtain the local daylight-saving time.
+        ///
+        /// For example, for the time zone "Europe/Berlin" the DST offset is +3600 seconds. During standard time this function will return 0, and when daylight-saving is in effect it will return 3600.
         #[rust_name = "daylight_time_offset"]
-        fn daylightTimeOffset(self: &QTimeZone, atDateTime: &QDateTime) -> i32;
+        fn daylightTimeOffset(self: &QTimeZone, at_date_time: &QDateTime) -> i32;
 
-        /// Returns true if the time zone has practiced daylight-saving at any time.
+        /// Returns `true` if the time zone has practiced daylight-saving at any time.
         #[rust_name = "has_daylight_time"]
         fn hasDaylightTime(self: &QTimeZone) -> bool;
 
-        /// Returns true if the system backend supports obtaining transitions.
+        /// Returns `true` if the system backend supports obtaining transitions.
         #[rust_name = "has_transitions"]
         fn hasTransitions(self: &QTimeZone) -> bool;
 
         /// Returns the IANA ID for the time zone.
         fn id(self: &QTimeZone) -> QByteArray;
 
-        /// Returns true if daylight-saving was in effect at the given atDateTime.
+        /// Returns `true` if daylight-saving was in effect at the given `at_date_time`.
         #[rust_name = "is_daylight_time"]
-        fn isDaylightTime(self: &QTimeZone, atDateTime: &QDateTime) -> bool;
+        fn isDaylightTime(self: &QTimeZone, at_date_time: &QDateTime) -> bool;
 
-        /// Returns true if this time zone is valid.
+        /// Returns `true` if this time zone is valid.
         #[rust_name = "is_valid"]
         fn isValid(self: &QTimeZone) -> bool;
 
-        /// Returns the total effective offset at the given atDateTime, i.e. the number of seconds to add to UTC to obtain the local time.
-        /// This includes any DST offset that may be in effect, i.e. it is the sum of standardTimeOffset() and daylightTimeOffset() for the given datetime.
+        /// Returns the total effective offset at the given `at_date_time`, i.e. the number of seconds to add to UTC to obtain the local time.
+        /// This includes any DST offset that may be in effect, i.e. it is the sum of [`standard_time_offset`](QTimeZone::standard_time_offset) and [`daylight_time_offset`](QTimeZone::daylight_time_offset) for the given datetime.
+        ///
+        /// For example, for the time zone "Europe/Berlin" the standard time offset is +3600 seconds and the DST offset is +3600 seconds. During standard time this function will return 3600 (UTC+01:00), and during DST it will return 7200 (UTC+02:00).
         #[rust_name = "offset_from_utc"]
-        fn offsetFromUtc(self: &QTimeZone, atDateTime: &QDateTime) -> i32;
+        fn offsetFromUtc(self: &QTimeZone, at_date_time: &QDateTime) -> i32;
 
-        /// Returns the standard time offset at the given atDateTime, i.e. the number of seconds to add to UTC to obtain the local Standard Time.
+        /// Returns the standard time offset at the given `at_date_time`, i.e. the number of seconds to add to UTC to obtain the local Standard Time.
         /// This excludes any DST offset that may be in effect.
+        ///
+        /// For example, for the time zone "Europe/Berlin" the standard time offset is +3600 seconds. During both standard and DST this function will return 3600 (UTC+01:00).
         #[rust_name = "standard_time_offset"]
-        fn standardTimeOffset(self: &QTimeZone, atDateTime: &QDateTime) -> i32;
+        fn standardTimeOffset(self: &QTimeZone, at_date_time: &QDateTime) -> i32;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -164,12 +180,13 @@ impl Default for QTimeZoneNameType {
 
 impl QTimeZone {
     /// Returns a list of all available IANA time zone IDs on this system.
-    pub fn available_time_zone_ids() -> ffi::QList_QByteArray {
+    pub fn available_time_zone_ids() -> QList<QByteArray> {
         ffi::qtimezone_available_time_zone_ids()
     }
 
     /// Returns the localized time zone display name.
     ///
+    /// The name returned is the one for the application default locale, applicable when the given `time_type` is in effect and of the form indicated by `name_type`.
     /// Where the time zone display names have changed over time, the current names will be used.
     /// If no suitably localized name of the given type is available, another name type may be
     /// used, or an empty string may be returned.
@@ -178,21 +195,21 @@ impl QTimeZone {
     /// used, as no localization data will be available for it. If this timezone is invalid, an
     /// empty string is returned. This may also arise for the representation of local time if
     /// determining the system time zone fails.
-    fn display_name(
-        &self,
-        time_type: QTimeZoneTimeType,
-        name_type: QTimeZoneNameType,
-    ) -> ffi::QString {
+    fn display_name(&self, time_type: QTimeZoneTimeType, name_type: QTimeZoneNameType) -> QString {
         ffi::qtimezone_display_name(self, time_type, name_type)
     }
 
-    /// Creates an instance of a time zone with the requested Offset from UTC of offsetSeconds.
+    /// Creates a time zone instance with the given offset, `offset_seconds`, from UTC.
+    ///
+    /// The `offset_seconds` from UTC must be in the range -16 hours to +16 hours otherwise an invalid time zone will be returned.
     pub fn from_offset_seconds(offset_seconds: i32) -> cxx::UniquePtr<Self> {
         ffi::qtimezone_from_offset_seconds(offset_seconds)
     }
 
-    /// Creates an instance of the requested time zone ianaId.
-    pub fn from_iana(iana_id: &ffi::QByteArray) -> cxx::UniquePtr<Self> {
+    /// Creates a time zone instance with the requested IANA ID `iana_id`.
+    ///
+    /// The ID must be one of the available system IDs or a valid UTC-with-offset ID, otherwise an invalid time zone will be returned. For UTC-with-offset IDs, when they are not in fact IANA IDs, the ID of the resulting instance may differ from the ID passed to the constructor.
+    pub fn from_iana(iana_id: &QByteArray) -> cxx::UniquePtr<Self> {
         ffi::qtimezone_from_iana(iana_id)
     }
 
@@ -201,22 +218,22 @@ impl QTimeZone {
         ffi::qtimezone_default()
     }
 
-    /// Returns a QTimeZone object that refers to the local system time, as specified by systemTimeZoneId().
+    /// Returns a `QTimeZone` object that refers to the local system time, as specified by [`system_time_zone_id`](Self::system_time_zone_id).
     pub fn system_time_zone() -> cxx::UniquePtr<Self> {
         ffi::qtimezone_system_time_zone()
     }
 
     /// Returns the current system time zone IANA ID.
-    pub fn system_time_zone_id() -> ffi::QByteArray {
+    pub fn system_time_zone_id() -> QByteArray {
         ffi::qtimezone_system_time_zone_id()
     }
 
-    /// Copy constructor, create a copy of the QTimeZone.
+    /// Copy constructor, create a copy of the `QTimeZone`.
     pub fn to_owned(&self) -> cxx::UniquePtr<Self> {
         ffi::qtimezone_clone(self)
     }
 
-    /// Returns a QTimeZone object that refers to UTC (Universal Time Coordinated).
+    /// Returns a `QTimeZone` object that refers to UTC (Universal Time Coordinated).
     pub fn utc() -> cxx::UniquePtr<Self> {
         ffi::qtimezone_utc()
     }

--- a/crates/cxx-qt-lib/src/core/qtlogging.rs
+++ b/crates/cxx-qt-lib/src/core/qtlogging.rs
@@ -34,20 +34,28 @@ mod ffi {
         type QtMsgType;
 
         /// Outputs a message in the Qt message handler.
-        fn qt_message_output(msgType: QtMsgType, context: &QMessageLogContext, string: &QString);
+        ///
+        /// **Warning:** This function is an undocumented internal utility in the Qt library.
+        fn qt_message_output(msg_type: QtMsgType, context: &QMessageLogContext, string: &QString);
 
-        /// Generates a formatted string out of the type, context, str arguments.
+        /// Generates a formatted string out of the `msg_type`, `context`, `str` arguments.
+        ///
+        /// This function returns a `QString` that is formatted according to the current message pattern. It can be used by custom message handlers to format output similar to Qt's default message handler.
+        ///
+        /// The function is thread-safe.
         #[cxx_name = "qFormatLogMessage"]
         fn q_format_log_message(
-            msgType: QtMsgType,
+            msg_type: QtMsgType,
             context: &QMessageLogContext,
-            string: &QString,
+            str: &QString,
         ) -> QString;
 
         /// Changes the output of the default message handler.
+        /// See the [Qt documentation](https://doc.qt.io/qt/qtlogging.html#qSetMessagePattern) for full details.
         ///
         /// # Safety
         /// This function is marked as unsafe because it is not guaranteed to be thread-safe.
+        #[allow(clippy::missing_safety_doc)]
         #[cxx_name = "qSetMessagePattern"]
         unsafe fn q_set_message_pattern(pattern: &QString);
 
@@ -83,7 +91,9 @@ mod ffi {
     }
 }
 
-/// The QMessageLogContext struct defines the context passed to the Qt message handler.
+/// The `QMessageLogContext` class defines the context passed to the Qt message handler.
+///
+/// Qt Documentation: [QMessageLogContext](https://doc.qt.io/qt/qmessagelogcontext.html#details)
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct QMessageLogContext<'a> {

--- a/crates/cxx-qt-lib/src/core/quuid.rs
+++ b/crates/cxx-qt-lib/src/core/quuid.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 #[cxx::bridge]
 mod ffi {
+    /// This enum defines the values used in the variant field of the UUID. The value in the variant field determines the layout of the 128-bit value.
     #[repr(i32)]
     #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     enum QUuidVariant {
@@ -17,7 +18,7 @@ mod ffi {
         VarUnknown = -1,
         /// Reserved for NCS (Network Computing System) backward compatibility
         NCS = 0,
-        /// Distributed Computing Environment, the scheme used by QUuid
+        /// Distributed Computing Environment, the scheme used by [`QUuid`](super::QUuid)
         DCE = 2,
         /// Reserved for Microsoft backward compatibility (GUID)
         Microsoft = 6,
@@ -25,6 +26,7 @@ mod ffi {
         Reserved = 7,
     }
 
+    /// This enum defines the values used in the version field of the UUID. The version field is meaningful only if the value in the variant field is [`QUuidVariant::DCE`].
     #[repr(i32)]
     #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     enum QUuidVersion {
@@ -103,6 +105,9 @@ mod ffi {
 
 pub use ffi::{QUuidVariant, QUuidVersion};
 
+/// The `QUuid` class stores a Universally Unique Identifier (UUID).
+///
+/// Qt Documentation: [QUuid](https://doc.qt.io/qt/quuid.html#details)
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct QUuid {
@@ -150,22 +155,22 @@ impl QUuid {
         (unsafe { std::mem::transmute::<QUuid, u128>(*self) }) == 0
     }
 
-    /// This function returns a new UUID with variant `QUuidVariant::DCE` and version
-    /// `QUuidVersion::Md5`. `namespace` is the namespace and `data` is the basic data as described
+    /// This function returns a new UUID with variant [`QUuidVariant::DCE`] and version
+    /// [`QUuidVersion::Md5`]. `namespace` is the namespace and `data` is the basic data as described
     /// by RFC 4122.
     pub fn create_uuid_v3(namespace: &Self, data: &[u8]) -> Self {
         ffi::quuid_create_uuid_v3(namespace, data)
     }
 
     /// On any platform other than Windows, this function returns a new UUID with variant
-    /// `QUuidVariant::DCE` and version `QUuidVersion::Random`. On Windows, a GUID is generated using
+    /// [`QUuidVariant::DCE`] and version [`QUuidVersion::Random`]. On Windows, a GUID is generated using
     /// the Windows API and will be of the type that the API decides to create.
     pub fn create_uuid() -> Self {
         ffi::quuid_create_uuid()
     }
 
-    /// This function returns a new UUID with variant `QUuidVariant::DCE` and version
-    /// `QUuidVersion::Sha1`. `namespace` is the namespace and `data` is the basic data as described
+    /// This function returns a new UUID with variant [`QUuidVariant::DCE`] and version
+    /// [`QUuidVersion::Sha1`]. `namespace` is the namespace and `data` is the basic data as described
     /// by RFC 4122.
     pub fn create_uuid_v5(namespace: &Self, data: &[u8]) -> Self {
         ffi::quuid_create_uuid_v5(namespace, data)
@@ -245,14 +250,14 @@ impl QUuid {
     }
 
     /// Returns the value in the variant field of the UUID. If the return value is
-    /// `QUuidVariant::DCE`, call `version()` to see which layout it uses. The null UUID is
+    /// [`QUuidVariant::DCE`], call [`version`](Self::version) to see which layout it uses. The null UUID is
     /// considered to be of an unknown variant.
     pub fn variant(&self) -> QUuidVariant {
         ffi::quuid_variant(self)
     }
 
-    /// Returns the version field of the UUID, if the UUID's variant field is `QUuidVariant::DCE`.
-    /// Otherwise it returns `QUuidVariant::VerUnknown`.
+    /// Returns the version field of the UUID, if the UUID's variant field is [`QUuidVariant::DCE`].
+    /// Otherwise it returns [`QUuidVersion::VerUnknown`].
     pub fn version(&self) -> QUuidVersion {
         ffi::quuid_version(self)
     }
@@ -282,7 +287,7 @@ impl From<QUuid> for u128 {
 }
 
 impl From<&QString> for QUuid {
-    /// Creates a QUuid object from the string text, which must be formatted as five hex fields
+    /// Creates a `QUuid` object from the string text, which must be formatted as five hex fields
     /// separated by '-', e.g., "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}" where each 'x' is a hex
     /// digit. The curly braces shown here are optional, but it is normal to include them.
     ///
@@ -293,7 +298,7 @@ impl From<&QString> for QUuid {
 }
 
 impl From<&str> for QUuid {
-    /// Creates a QUuid object from the string text, which must be formatted as five hex fields
+    /// Creates a `QUuid` object from the string text, which must be formatted as five hex fields
     /// separated by '-', e.g., "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}" where each 'x' is a hex
     /// digit. The curly braces shown here are optional, but it is normal to include them.
     ///
@@ -304,7 +309,7 @@ impl From<&str> for QUuid {
 }
 
 impl From<&String> for QUuid {
-    /// Creates a QUuid object from the string text, which must be formatted as five hex fields
+    /// Creates a `QUuid` object from the string text, which must be formatted as five hex fields
     /// separated by '-', e.g., "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}" where each 'x' is a hex
     /// digit. The curly braces shown here are optional, but it is normal to include them.
     ///

--- a/crates/cxx-qt-lib/src/core/qvariant/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qvariant/mod.rs
@@ -160,6 +160,7 @@ impl fmt::Debug for QVariant {
     }
 }
 
+/// Trait implementation for a value in a [`QVariant`].
 pub trait QVariantValue {
     fn can_convert(variant: &QVariant) -> bool;
     fn construct(value: &Self) -> QVariant;

--- a/crates/cxx-qt-lib/src/core/qvector/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qvector/mod.rs
@@ -18,6 +18,8 @@ use std::fmt;
 /// The QVector class is a template class that provides a dynamic array.
 ///
 /// To use QVector with a custom type, implement the [`QVectorElement`] trait for T.
+///
+/// Qt Documentation: [QVector]("https://doc.qt.io/qt/qvector.html#details")
 #[repr(C)]
 pub struct QVector<T>
 where
@@ -25,8 +27,8 @@ where
 {
     /// The layout has changed between Qt 5 and Qt 6
     ///
-    /// Qt5 QVector has one pointer as a member
-    /// Qt6 QVector/QList has one member, which contains two pointers and a size_t
+    /// Qt5 `QVector` has one pointer as a member
+    /// Qt6 `QVector`/`QList` has one member, which contains two pointers and a `size_t`
     #[cfg(cxxqt_qt_version_major = "5")]
     _space: MaybeUninit<usize>,
     #[cfg(cxxqt_qt_version_major = "6")]
@@ -38,7 +40,7 @@ impl<T> Clone for QVector<T>
 where
     T: QVectorElement,
 {
-    /// Constructs a copy of the QVector.
+    /// Constructs a copy of the `QVector`.
     fn clone(&self) -> Self {
         T::clone(self)
     }
@@ -58,7 +60,7 @@ impl<T> Drop for QVector<T>
 where
     T: QVectorElement,
 {
-    /// Destroys the QVector.
+    /// Destroys the `QVector`.
     fn drop(&mut self) {
         T::drop(self);
     }
@@ -68,7 +70,7 @@ impl<T> PartialEq for QVector<T>
 where
     T: QVectorElement + PartialEq,
 {
-    /// Returns true if both vectors contain the same elements in the same order
+    /// Returns `true` if both vectors contain the same elements in the same order, otherwise returns `false`.
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().zip(other.iter()).all(|(a, b)| a == b)
     }
@@ -89,7 +91,7 @@ impl<T> QVector<T>
 where
     T: QVectorElement,
 {
-    /// Inserts value at the end of the vector.
+    /// Inserts `value` at the end of the vector.
     ///
     /// The value is a reference here so it can be opaque or trivial but
     /// note that the value is copied when being appended into the vector.
@@ -98,18 +100,18 @@ where
     }
 
     /// Removes all elements from the vector.
+    ///
+    /// In versions of Qt starting from 5.7, the capacity is preserved. In versions before 5.6, this also releases the memory used by the vector.
     pub fn clear(&mut self) {
         T::clear(self);
     }
 
-    /// Returns true if the vector contains item value; otherwise returns false.
+    /// Returns `true` if the vector contains item `value`; otherwise returns `false`.
     pub fn contains(&self, value: &T) -> bool {
         T::contains(self, value)
     }
 
-    /// Returns the item at index position in the vector.
-    ///
-    /// index must be a valid position in the vector (i.e., 0 <= index < len()).
+    /// Returns the item at index position `index` in the list, or `None` if `index` is out of bounds (i.e. `index < 0 || index >= self.len()`).
     pub fn get(&self, index: isize) -> Option<&T> {
         if index >= 0 && index < self.len() {
             Some(unsafe { T::get_unchecked(self, index) })
@@ -118,13 +120,12 @@ where
         }
     }
 
-    /// Returns the index position of the first occurrence of value in the vector,
-    /// searching forward from index position from. Returns -1 if no item matched.
+    /// Returns the index position of the first occurrence of `value` in the vector. Returns -1 if no item matched.
     pub fn index_of(&self, value: &T) -> isize {
         T::index_of(self, value)
     }
 
-    /// Inserts item value into the vector at the given position.
+    /// Inserts item value into the vector at index position `pos`.
     ///
     /// The value is a reference here so it can be opaque or trivial but
     /// note that the value is copied when being inserted into the vector.
@@ -132,13 +133,13 @@ where
         T::insert_clone(self, pos, value);
     }
 
-    /// Returns true if the vector contains no elements; otherwise returns false.
+    /// Returns `true` if the vector contains no elements; otherwise returns `false`.
     pub fn is_empty(&self) -> bool {
         T::len(self) == 0
     }
 
     /// An iterator visiting all elements in arbitrary order.
-    /// The iterator element type is &'a T.
+    /// The iterator element type is `&'a T`.
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             vector: self,
@@ -151,13 +152,16 @@ where
         T::len(self)
     }
 
-    /// Removes the element at index position.
+    /// Removes the element at index position `pos`.
     pub fn remove(&mut self, pos: isize) {
         T::remove(self, pos);
     }
 
-    /// Reserve the specified capacity to prevent repeated allocations
-    /// when the maximum size is known.
+    /// Attempts to allocate memory for at least `size` elements.
+    ///
+    /// If you know in advance how large the vector will be, you should call this function to prevent reallocations and memory fragmentation. If you resize the vector often, you are also likely to get better performance.
+    ///
+    /// If in doubt about how much space shall be needed, it is usually better to use an upper bound as `size`, or a high estimate of the most likely size, if a strict upper bound would be much bigger than this. If `size` is an underestimate, the vector will grow as needed once the reserved size is exceeded, which may lead to a larger allocation than your best overestimate would have and will slow the operation that triggers it.
     pub fn reserve(&mut self, size: isize) {
         T::reserve(self, size);
     }
@@ -174,12 +178,12 @@ impl<T> QVector<T>
 where
     T: QVectorElement + ExternType<Kind = cxx::kind::Trivial>,
 {
-    /// Inserts value at the end of the vector.
+    /// Inserts `value` at the end of the vector.
     pub fn append(&mut self, value: T) {
         T::append(self, value);
     }
 
-    /// Inserts item value into the vector at the given position.
+    /// Inserts item `value` into the vector at index position `pos`.
     pub fn insert(&mut self, pos: isize, value: T) {
         T::insert(self, pos, value);
     }
@@ -189,8 +193,8 @@ impl<T> From<&QVector<T>> for Vec<T>
 where
     T: QVectorElement + Clone,
 {
-    /// Convert a reference to a [QVector] into a [Vec] by making a deep copy of the data.
-    /// The original QVector can still be used after constructing the Vec.
+    /// Convert a reference to a [`QVector`] into a [`Vec`] by making a deep copy of the data.
+    /// The original `QVector` can still be used after constructing the `Vec`.
     fn from(qvec: &QVector<T>) -> Self {
         let mut vec = Vec::with_capacity(qvec.len().try_into().unwrap());
         for element in qvec.iter() {
@@ -205,9 +209,9 @@ where
     T: QVectorElement + Clone,
     S: AsRef<[T]>,
 {
-    /// Convert anything that can be cheaply converted to a slice, such as an [array] or [Vec], into a [QVector]
+    /// Convert anything that can be cheaply converted to a slice, such as an [array] or [`Vec`], into a [`QVector`]
     /// by making a deep copy of the data.
-    /// The original slice can still be used after constructing the QVector.
+    /// The original slice can still be used after constructing the `QVector`.
     fn from(vec: S) -> Self {
         let mut qvec = Self::default();
         qvec.reserve_usize(vec.as_ref().len());

--- a/crates/cxx-qt-lib/src/gui/qcolor.rs
+++ b/crates/cxx-qt-lib/src/gui/qcolor.rs
@@ -7,9 +7,11 @@ use cxx::{type_id, ExternType};
 use std::fmt;
 use std::mem::MaybeUninit;
 
+use crate::{QString, QStringList};
+
 #[cxx::bridge]
 mod ffi {
-    /// How to format the output of the name() function
+    /// How to format the output of [`QColor::name`].
     #[repr(i32)]
     #[namespace = "rust::cxxqtlib1"]
     enum QColorNameFormat {
@@ -45,12 +47,16 @@ mod ffi {
         fn black(self: &QColor) -> i32;
         /// Returns the blue color component of this color.
         fn blue(self: &QColor) -> i32;
-        /// Creates a copy of this color in the format specified by colorSpec.
+        /// Creates a copy of this color in the format specified by `color_spec`.
         #[rust_name = "convert_to"]
-        fn convertTo(self: &QColor, spec: QColorSpec) -> QColor;
+        fn convertTo(self: &QColor, color_spec: QColorSpec) -> QColor;
         /// Returns the cyan color component of this color.
         fn cyan(self: &QColor) -> i32;
         /// Returns a darker (or lighter) color, but does not change this object.
+        ///
+        /// If the `factor` is greater than 100, this functions returns a darker color. Setting `factor` to 300 returns a color that has one-third the brightness. If the `factor` is less than 100, the return color is lighter, but we recommend using [`lighter`](Self::lighter) for this purpose. If the `factor` is 0 or negative, the return value is unspecified.
+        ///
+        /// The function converts the current color to HSV, divides the value (V) component by factor and converts the color back to it's original color spec.
         fn darker(self: &QColor, factor: i32) -> QColor;
         /// Returns the green color component of this color.
         fn green(self: &QColor) -> i32;
@@ -70,16 +76,20 @@ mod ffi {
         ///
         /// The color is implicitly converted to HSV.
         fn hue(self: &QColor) -> i32;
-        /// Returns true if the color is valid; otherwise returns false.
+        /// Returns `true` if the color is valid; otherwise returns `false`.
         #[rust_name = "is_valid"]
         fn isValid(self: &QColor) -> bool;
         /// Returns a lighter (or darker) color, but does not change this object.
+        ///
+        /// If the `factor` is greater than 100, this functions returns a lighter color. Setting `factor` to 150 returns a color that is 50% brighter. If the `factor` is less than 100, the return color is darker, but we recommend using [`darker`](Self::darker) for this purpose. If the `factor` is 0 or negative, the return value is unspecified.
+        ///
+        /// The function converts the current color to HSV, multiplies the value (V) component by factor and converts the color back to it's original color spec.
         fn lighter(self: &QColor, factor: i32) -> QColor;
         /// Returns the lightness color component of this color.
         fn lightness(self: &QColor) -> i32;
         /// Returns the magenta color component of this color.
         fn magenta(self: &QColor) -> i32;
-        /// Returns the name of the color in the specified format.
+        /// Returns the name of the color in the specified `format`.
         fn name(self: &QColor, format: QColorNameFormat) -> QString;
         /// Returns the red color component of this color.
         fn red(self: &QColor) -> i32;
@@ -87,53 +97,53 @@ mod ffi {
         ///
         /// The color is implicitly converted to HSV.
         fn saturation(self: &QColor) -> i32;
-        /// Sets the alpha of this color to alpha. Integer alpha is specified in the range 0-255.
+        /// Sets the alpha of this color to `alpha`. Integer alpha is specified in the range 0-255.
         #[rust_name = "set_alpha"]
         fn setAlpha(self: &mut QColor, alpha: i32);
-        /// Sets the blue color component of this color to blue. Integer components are specified in the range 0-255.
+        /// Sets the blue color component of this color to 1. Integer components are specified in the range 0-255.
         #[rust_name = "set_blue"]
         fn setBlue(self: &mut QColor, blue: i32);
-        /// Sets the color to CMYK values, c (cyan), m (magenta), y (yellow), k (black), and a (alpha-channel, i.e. transparency).
+        /// Sets the color to CMYK values, `c` (cyan), `m` (magenta), `y` (yellow), `k` (black), and `a` (alpha-channel, i.e. transparency).
         ///
         /// All the values must be in the range 0-255.
         #[rust_name = "set_cmyk"]
         fn setCmyk(self: &mut QColor, c: i32, m: i32, y: i32, k: i32, a: i32);
-        /// Sets the green color component of this color to green. Integer components are specified in the range 0-255.
+        /// Sets the green color component of this color to `green`. Integer components are specified in the range 0-255.
         #[rust_name = "set_green"]
         fn setGreen(self: &mut QColor, green: i32);
-        /// Sets a HSL color value; h is the hue, s is the saturation, l is the lightness and a is the alpha component of the HSL color.
+        /// Sets a HSL color value; `h` is the hue, `s` is the saturation, `l` is the lightness and `a` is the alpha component of the HSL color.
         ///
         /// The saturation, value and alpha-channel values must be in the range 0-255, and the hue value must be greater than -1.
         #[rust_name = "set_hsl"]
         fn setHsl(self: &mut QColor, h: i32, s: i32, l: i32, a: i32);
-        /// Sets a HSV color value; h is the hue, s is the saturation, v is the value and a is the alpha component of the HSV color.
+        /// Sets a HSV color value; `h` is the hue, `s` is the saturation, `v` is the value and `a` is the alpha component of the HSV color.
         ///
         /// The saturation, value and alpha-channel values must be in the range 0-255, and the hue value must be greater than -1.
         #[rust_name = "set_hsv"]
         fn setHsv(self: &mut QColor, h: i32, s: i32, v: i32, a: i32);
-        /// Sets the red color component of this color to red. Integer components are specified in the range 0-255.
+        /// Sets the red color component of this color to `red`. Integer components are specified in the range 0-255.
         #[rust_name = "set_red"]
         fn setRed(self: &mut QColor, red: i32);
-        /// Sets the RGB value to r, g, b and the alpha value to a.
+        /// Sets the RGB value to `r`, `g`, `b` and the alpha value to `a`.
         ///
         /// All the values must be in the range 0-255.
         #[rust_name = "set_rgb"]
         fn setRgb(self: &mut QColor, r: i32, g: i32, b: i32, a: i32);
         /// Returns how the color was specified.
         fn spec(self: &QColor) -> QColorSpec;
-        /// Creates and returns a CMYK QColor based on this color.
+        /// Creates and returns a CMYK `QColor` based on this color.
         #[rust_name = "to_cmyk"]
         fn toCmyk(self: &QColor) -> QColor;
-        /// Create and returns an extended RGB QColor based on this color.
+        /// Create and returns an extended RGB `QColor` based on this color.
         #[rust_name = "to_extended_rgb"]
         fn toExtendedRgb(self: &QColor) -> QColor;
-        /// Creates and returns an HSL QColor based on this color.
+        /// Creates and returns an HSL `QColor` based on this color.
         #[rust_name = "to_hsl"]
         fn toHsl(self: &QColor) -> QColor;
-        /// Creates and returns an HSV QColor based on this color.
+        /// Creates and returns an HSV `QColor` based on this color.
         #[rust_name = "to_hsv"]
         fn toHsv(self: &QColor) -> QColor;
-        /// Create and returns an RGB QColor based on this color.
+        /// Create and returns an RGB `QColor` based on this color.
         #[rust_name = "to_rgb"]
         fn toRgb(self: &QColor) -> QColor;
         /// Returns the value color component of this color.
@@ -267,7 +277,9 @@ mod ffi {
 
 pub use ffi::{QColorNameFormat, QColorSpec};
 
-/// The QColor class provides colors based on RGB, HSL, HSV or CMYK values.
+/// The `QColor` class provides colors based on RGB, HSL, HSV or CMYK values.
+///
+/// Qt Documentation: [QColor](https://doc.qt.io/qt/qcolor.html#details)
 #[derive(Clone)]
 #[repr(C)]
 pub struct QColor {
@@ -291,8 +303,8 @@ impl QColor {
         ffi::qcolor_blue_f(self)
     }
 
-    /// Returns a QStringList containing the color names Qt knows about.
-    pub fn color_names() -> ffi::QStringList {
+    /// Returns a `QStringList` containing the color names Qt knows about.
+    pub fn color_names() -> QStringList {
         ffi::qcolor_color_names()
     }
 
@@ -301,86 +313,86 @@ impl QColor {
         ffi::qcolor_cyan_f(self)
     }
 
-    /// Constructs a QColor from the CMYK value c, m, y, and k.
+    /// Constructs a QColor from the CMYK value `c`, `m`, `y`, and `k`.
     pub fn from_cmyk(c: i32, m: i32, y: i32, k: i32) -> Self {
         ffi::qcolor_init_from_cmyk(c, m, y, k, 255)
     }
 
-    /// Constructs a QColor from the CMYK value c, m, y, k, and the alpha-channel (transparency) value of a.
+    /// Constructs a `QColor` from the CMYK value `c`, `m`, `y`, `k`, and the alpha-channel (transparency) value of `a`.
     pub fn from_cmyka(c: i32, m: i32, y: i32, k: i32, a: i32) -> Self {
         ffi::qcolor_init_from_cmyk(c, m, y, k, a)
     }
 
-    /// Constructs a QColor from the CMYK value c, m, y, and k.
+    /// Constructs a `QColor` from the CMYK value `c`, `m`, `y`, and `k`.
     pub fn from_cmyk_f(c: f32, m: f32, y: f32, k: f32) -> Self {
         ffi::qcolor_init_from_cmyk_f(c, m, y, k, 1.0)
     }
 
-    /// Constructs a QColor from the CMYK value c, m, y, k, and the alpha-channel (transparency) value of a.
+    /// Constructs a `QColor` from the CMYK value `c`, `m`, `y`, `k`, and the alpha-channel (transparency) value of `a`.
     pub fn from_cmyka_f(c: f32, m: f32, y: f32, k: f32, a: f32) -> Self {
         ffi::qcolor_init_from_cmyk_f(c, m, y, k, a)
     }
 
-    /// Constructs a QColor from the HSL value h, s, and l.
+    /// Constructs a `QColor` from the HSL value `h`, `s`, and `l`.
     pub fn from_hsl(h: i32, s: i32, l: i32) -> Self {
         ffi::qcolor_init_from_hsl(h, s, l, 255)
     }
 
-    /// Constructs a QColor from the HSL value h, s, l, and the alpha-channel (transparency) value of a.
+    /// Constructs a `QColor` from the HSL value `h`, `s`, `l`, and the alpha-channel (transparency) value of `a`.
     pub fn from_hsla(h: i32, s: i32, l: i32, a: i32) -> Self {
         ffi::qcolor_init_from_hsl(h, s, l, a)
     }
 
-    /// Constructs a QColor from the HSL value h, s, and l.
+    /// Constructs a `QColor` from the HSL value `h`, `s`, and `l`.
     pub fn from_hsl_f(h: f32, s: f32, l: f32) -> Self {
         ffi::qcolor_init_from_hsl_f(h, s, l, 1.0)
     }
 
-    /// Constructs a QColor from the HSL value h, s, l, and the alpha-channel (transparency) value of a.
+    /// Constructs a `QColor` from the HSL value `h`, `s`, `l`, and the alpha-channel (transparency) value of `a`.
     pub fn from_hsla_f(h: f32, s: f32, l: f32, a: f32) -> Self {
         ffi::qcolor_init_from_hsl_f(h, s, l, a)
     }
 
-    /// Constructs a QColor from the HSV value h, s, and v.
+    /// Constructs a `QColor` from the HSV value `h`, `s`, and `v`.
     pub fn from_hsv(h: i32, s: i32, v: i32) -> Self {
         ffi::qcolor_init_from_hsv(h, s, v, 255)
     }
 
-    /// Constructs a QColor from the HSV value h, s, v, and the alpha-channel (transparency) value of a.
+    /// Constructs a `QColor` from the HSV value `h`, `s`, `v`, and the alpha-channel (transparency) value of `a`.
     pub fn from_hsva(h: i32, s: i32, v: i32, a: i32) -> Self {
         ffi::qcolor_init_from_hsv(h, s, v, a)
     }
 
-    /// Constructs a QColor from the HSV value h, s, and v.
+    /// Constructs a `QColor` from the HSV value `h`, `s`, and `v`.
     pub fn from_hsv_f(h: f32, s: f32, v: f32) -> Self {
         ffi::qcolor_init_from_hsv_f(h, s, v, 1.0)
     }
 
-    /// Constructs a QColor from the HSV value h, s, v, and the alpha-channel (transparency) value of a.
+    /// Constructs a `QColor` from the HSV value `h`, `s`, `v`, and the alpha-channel (transparency) value of `a`.
     pub fn from_hsva_f(h: f32, s: f32, v: f32, a: f32) -> Self {
         ffi::qcolor_init_from_hsv_f(h, s, v, a)
     }
 
-    /// Constructs a QColor with the RGB value r, g, and b.
+    /// Constructs a `QColor` with the RGB value `r`, `g`, and `b`.
     ///
     /// The color is left invalid if any of the arguments are invalid.
     pub fn from_rgb(red: i32, green: i32, blue: i32) -> Self {
         ffi::qcolor_init_from_rgb(red, green, blue, 255)
     }
 
-    /// Constructs a QColor with the RGB value r, g, b, and the alpha-channel (transparency) value of a.
+    /// Constructs a `QColor` with the RGB value `r`, `g`, `b`, and the alpha-channel (transparency) value of `a`.
     ///
     /// The color is left invalid if any of the arguments are invalid.
     pub fn from_rgba(red: i32, green: i32, blue: i32, alpha: i32) -> Self {
         ffi::qcolor_init_from_rgb(red, green, blue, alpha)
     }
 
-    /// Constructs a QColor with the RGB value r, g, and b.
+    /// Constructs a `QColor` with the RGB value `r`, `g`, and `b`.
     pub fn from_rgb_f(red: f32, green: f32, blue: f32) -> Self {
         ffi::qcolor_init_from_rgb_f(red, green, blue, 1.0)
     }
 
-    /// Constructs a QColor with the RGB value r, g, b, and the alpha-channel (transparency) value of a.
+    /// Constructs a `QColor` with the RGB value `r`, `g`, `b`, and the alpha-channel (transparency) value of `a`.
     pub fn from_rgba_f(red: f32, green: f32, blue: f32, alpha: f32) -> Self {
         ffi::qcolor_init_from_rgb_f(red, green, blue, alpha)
     }
@@ -439,19 +451,19 @@ impl QColor {
         ffi::qcolor_saturation_f(self)
     }
 
-    /// Sets the alpha of this color to alpha. float alpha is specified in the range 0.0-1.0.
+    /// Sets the alpha of this color to `alpha`. float alpha is specified in the range 0.0-1.0.
     pub fn set_alpha_f(&mut self, alpha: f32) {
         ffi::qcolor_set_alpha_f(self, alpha);
     }
 
-    /// Sets the blue color component of this color to blue.
+    /// Sets the blue color component of this color to `blue`.
     ///
-    /// If blue lies outside the 0.0-1.0 range, the color model will be changed to ExtendedRgb.
+    /// If `blue` lies outside the 0.0-1.0 range, the color model will be changed to [`QColorSpec::ExtendedRgb`].
     pub fn set_blue_f(&mut self, blue: f32) {
         ffi::qcolor_set_blue_f(self, blue);
     }
 
-    /// Sets the color to CMYK values, c (cyan), m (magenta), y (yellow), k (black), and a (alpha-channel, i.e. transparency).
+    /// Sets the color to CMYK values, `c` (cyan), `m` (magenta), `y` (yellow), `k` (black), and `a` (alpha-channel, i.e. transparency).
     ///
     /// All the values must be in the range 0.0-1.0.
     pub fn set_cmyk_f(&mut self, c: f32, m: f32, y: f32, k: f32, a: f32) {
@@ -460,35 +472,35 @@ impl QColor {
 
     /// Sets the green color component of this color to green.
     ///
-    /// If green lies outside the 0.0-1.0 range, the color model will be changed to ExtendedRgb.
+    /// If `green` lies outside the 0.0-1.0 range, the color model will be changed to [`QColorSpec::ExtendedRgb`].
     pub fn set_green_f(&mut self, green: f32) {
         ffi::qcolor_set_green_f(self, green);
     }
 
-    /// Sets a HSL color lightness; h is the hue, s is the saturation, l is the lightness and a is the alpha component of the HSL color.
+    /// Sets a HSL color lightness; `h` is the hue, `s` is the saturation, `l` is the lightness and `a` is the alpha component of the HSL color.
     ///
     /// All the values must be in the range 0.0-1.0.
     pub fn set_hsl_f(&mut self, h: f32, s: f32, l: f32, a: f32) {
         ffi::qcolor_set_hsl_f(self, h, s, l, a);
     }
 
-    /// Sets a HSV color value; h is the hue, s is the saturation, v is the value and a is the alpha component of the HSV color.
+    /// Sets a HSV color value; `h` is the hue, `s` is the saturation, `v` is the value and `a` is the alpha component of the HSV color.
     ///
     /// All the values must be in the range 0.0-1.0.
     pub fn set_hsv_f(&mut self, h: f32, s: f32, v: f32, a: f32) {
         ffi::qcolor_set_hsv_f(self, h, s, v, a);
     }
 
-    /// Sets the red color component of this color to red.
+    /// Sets the red color component of this color to `red`.
     ///
-    /// If red lies outside the 0.0-1.0 range, the color model will be changed to ExtendedRgb.
+    /// If `red` lies outside the 0.0-1.0 range, the color model will be changed to [`QColorSpec::ExtendedRgb`].
     pub fn set_red_f(&mut self, red: f32) {
         ffi::qcolor_set_red_f(self, red);
     }
 
-    /// Sets the color channels of this color to r (red), g (green), b (blue) and a (alpha, transparency).
+    /// Sets the color channels of this color to `r` (red), `g` (green), `b` (blue) and `a` (alpha, transparency).
     ///
-    /// The alpha value must be in the range 0.0-1.0. If any of the other values are outside the range of 0.0-1.0 the color model will be set as ExtendedRgb.
+    /// The alpha value must be in the range 0.0-1.0. If any of the other values are outside the range of 0.0-1.0 the color model will be set as [`QColorSpec::ExtendedRgb`].
     pub fn set_rgb_f(&mut self, r: f32, g: f32, b: f32, a: f32) {
         ffi::qcolor_set_rgb_f(self, r, g, b, a);
     }
@@ -517,7 +529,7 @@ impl TryFrom<&str> for QColor {
     type Error = &'static str;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::try_from(&ffi::QString::from(value))
+        Self::try_from(&QString::from(value))
     }
 }
 
@@ -529,10 +541,10 @@ impl TryFrom<&String> for QColor {
     }
 }
 
-impl TryFrom<&ffi::QString> for QColor {
+impl TryFrom<&QString> for QColor {
     type Error = &'static str;
 
-    fn try_from(value: &ffi::QString) -> Result<Self, Self::Error> {
+    fn try_from(value: &QString) -> Result<Self, Self::Error> {
         let color = ffi::qcolor_init_from_qstring(value);
         if color.is_valid() {
             Ok(color)

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -6,6 +6,8 @@ use cxx::{type_id, ExternType};
 use std::fmt;
 use std::mem::MaybeUninit;
 
+use crate::QString;
+
 #[cxx::bridge]
 mod ffi {
     /// This enum describes the different styles of glyphs that are used to display text.
@@ -74,70 +76,70 @@ mod ffi {
         AbsoluteSpacing,
     }
 
-    /// The style strategy tells the font matching algorithm what type of fonts should
+    /// The style strategy tells the [font matching](https://doc.qt.io/qt/qfont.html#fontmatching) algorithm what type of fonts should
     /// be used to find an appropriate default family.
     #[repr(i32)]
     #[namespace = "rust::cxxqtlib1"]
     #[derive(Debug)]
     enum QFontStyleStrategy {
-        /// the default style strategy. It does not prefer any type of font
+        /// The default style strategy. It does not prefer any type of font.
         PreferDefault = 0x0001,
-        /// prefers bitmap fonts (as opposed to outline fonts).
+        /// Prefers bitmap fonts (as opposed to outline fonts).
         PreferBitmap = 0x0002,
-        /// prefers device fonts.
+        /// Prefers device fonts.
         PreferDevice = 0x0004,
-        /// prefers outline fonts (as opposed to bitmap fonts).
+        /// Prefers outline fonts (as opposed to bitmap fonts).
         PreferOutline = 0x0008,
-        /// forces the use of outline fonts.
+        /// Forces the use of outline fonts.
         ForceOutline = 0x0010,
-        // don't antialias the fonts.
+        // Don't antialias the fonts.
         // PreferMatch = 0x0020,
-        // avoid subpixel antialiasing on the fonts if possible
+        // Avoid subpixel antialiasing on the fonts if possible
         // PreferQuality = 0x0040,
-        /// antialias if possible.
+        /// Antialias if possible.
         PreferAntialias = 0x0080,
-        /// don't antialias the fonts.
+        /// Don't antialias the fonts.
         NoAntialias = 0x0100,
-        /// avoid subpixel antialiasing on the fonts if possible.
+        /// Avoid subpixel antialiasing on the fonts if possible.
         NoSubpixelAntialias = 0x0800,
         /// Sometimes, a font will apply complex rules to a set of characters
         /// in order to display them correctly. In some writing systems, such
         /// as Brahmic scripts, this is required in order for the text to be legible,
         /// but in e.g. Latin script, it is merely a cosmetic feature.
-        /// The PreferNoShaping flag will disable all such features when they are not
+        /// The `PreferNoShaping` flag will disable all such features when they are not
         /// required, which will improve performance in most cases (since Qt 5.10).
         PreferNoShaping = 0x1000,
         /// If the font selected for a certain writing system does not contain a character
         /// requested to draw, then Qt automatically chooses a similar looking font that
-        /// contains the character. The NoFontMerging flag disables this feature. Please note
+        /// contains the character. This flag disables this feature. Please note
         /// that enabling this flag will not prevent Qt from automatically picking a
         /// suitable font when the selected font does not support the writing system of the text.
         NoFontMerging = 0x8000,
     }
 
-    /// Style hints are used by the font matching algorithm to find an appropriate default
+    /// Style hints are used by the [font matching](https://doc.qt.io/qt/qfont.html#fontmatching) algorithm to find an appropriate default
     /// family if a selected font family is not available.
     #[repr(i32)]
     #[namespace = "rust::cxxqtlib1"]
     #[derive(Debug)]
     enum QFontStyleHint {
-        /// is a synonym for SansSerif.
+        /// The font matcher prefer sans serif fonts.
         Helvetica,
-        /// is a synonym for Serif.
+        /// The font matcher prefers serif fonts.
         Times,
-        /// a synonym for TypeWriter.
+        /// The font matcher prefers fixed pitch fonts.
         Courier,
-        /// the font matcher prefers decorative fonts.
+        /// The font matcher prefers decorative fonts.
         OldEnglish,
-        /// the font matcher prefers system fonts.
+        /// The font matcher prefers system fonts.
         System,
-        /// leaves the font matching algorithm to choose the family. This is the default.
+        /// Leaves the font matching algorithm to choose the family. This is the default.
         AnyStyle,
-        /// the font matcher prefers fonts that map to the CSS generic font-family 'cursive'.
+        /// The font matcher prefers fonts that map to the CSS generic font-family 'cursive'.
         Cursive,
-        /// the font matcher prefers fonts that map to the CSS generic font-family 'monospace'.
+        /// The font matcher prefers fonts that map to the CSS generic font-family 'monospace'.
         Monospace,
-        /// the font matcher prefers fonts that map to the CSS generic font-family 'fantasy'.
+        /// The font matcher prefers fonts that map to the CSS generic font-family 'fantasy'.
         Fantasy,
     }
 
@@ -149,7 +151,7 @@ mod ffi {
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = crate::QStringList;
 
-        /// Returns true if weight() is a value greater than QFont::Medium; otherwise returns false.
+        /// Returns `true` if [weight](https://doc.qt.io/qt/qfont.html#weight)() is a value greater than 400; otherwise returns `false`.
         fn bold(self: &QFont) -> bool;
 
         /// Returns the current capitalization type of the font.
@@ -159,26 +161,25 @@ mod ffi {
         #[rust_name = "default_family"]
         fn defaultFamily(self: &QFont) -> QString;
 
-        /// Returns true if a window system font exactly matching
+        /// Returns `true` if a window system font exactly matching
         /// the settings of this font is available.
         #[rust_name = "exact_match"]
         fn exactMatch(self: &QFont) -> bool;
 
-        /// Returns the requested font family name, i.e. the name
-        /// set in the constructor or the last setFont() call.
+        /// Returns the requested font family name. This will always be the same as the first entry in [`families`](Self::families).
         #[rust_name = "family_or_default"]
         fn family(self: &QFont) -> QString;
 
-        /// Returns the requested font family names, i.e. the names set in the last setFamilies()
+        /// Returns the requested font family names, i.e. the names set in the last [`set_families`](Self::set_families)
         /// call or via the constructor. Otherwise it returns an empty list.
         fn families(self: &QFont) -> QStringList;
 
-        /// Returns true if fixed pitch has been set; otherwise returns false.
+        /// Returns `true` if fixed pitch has been set; otherwise returns `false`.
         #[rust_name = "fixed_pitch"]
         fn fixedPitch(self: &QFont) -> bool;
 
-        /// Sets this font to match the description descrip. The description is a comma-separated
-        /// list of the font attributes, as returned by toString().
+        /// Sets this font to match the description `descrip`. The description is a comma-separated
+        /// list of the font attributes, as returned by [`to_qstring`](Self::to_qstring).
         #[rust_name = "from_string"]
         fn fromString(self: &mut QFont, descrip: &QString) -> bool;
 
@@ -186,15 +187,15 @@ mod ffi {
         #[rust_name = "hinting_preference"]
         fn hintingPreference(self: &QFont) -> QFontHintingPreference;
 
-        /// Returns true if this font and f are copies of each other, i.e. one of them was created
+        /// Returns `true` if this font and `f` are copies of each other, i.e. one of them was created
         /// as a copy of the other and neither has been modified since. This is much stricter than equality.
         #[rust_name = "is_copy_of"]
         fn isCopyOf(self: &QFont, font: &QFont) -> bool;
 
-        /// Returns true if the style() of the font is not QFont::StyleNormal
+        /// Returns `true` if the [style](https://doc.qt.io/qt/qfont.html#style)() of the font is not [`QFontStyle::StyleNormal`].
         fn italic(self: &QFont) -> bool;
 
-        /// Returns true if kerning should be used when drawing text with this font.
+        /// Returns `true` if kerning should be used when drawing text with this font.
         fn kerning(self: &QFont) -> bool;
 
         /// Returns the font's key, a textual representation of a font.
@@ -209,10 +210,10 @@ mod ffi {
         #[rust_name = "letter_spacing_type"]
         fn letterSpacingType(self: &QFont) -> QFontSpacingType;
 
-        /// Returns true if overline has been set; otherwise returns false.
+        /// Returns `true` if overline has been set; otherwise returns `false`.
         fn overline(self: &QFont) -> bool;
 
-        /// Returns the pixel size of the font if it was set with setPixelSize(). Returns -1 if the size was set with setPointSize() or setPointSizeF().
+        /// Returns the pixel size of the font if it was set with [`set_pixel_size`](Self::set_pixel_size). Returns -1 if the size was not specified in pixels.
         #[rust_name = "pixel_size"]
         fn pixelSize(self: &QFont) -> i32;
 
@@ -220,95 +221,110 @@ mod ffi {
         #[rust_name = "point_size"]
         fn pointSize(self: &QFont) -> i32;
 
-        /// Returns a new QFont that has attributes copied from other that have not been previously set on this font.
+        /// Returns a new `QFont` that has attributes copied from other that have not been previously set on this font.
         fn resolve(self: &QFont, other: &QFont) -> QFont;
 
-        /// If enable is true sets the font's weight to QFont::Bold; otherwise sets the weight to QFont::Normal.
+        /// If `enable` is `true` sets the font's weight to 700; otherwise sets the weight to 400.
+        ///
+        /// For finer boldness control use [setWeight](https://doc.qt.io/qt/qfont.html#setWeight)().
         #[rust_name = "set_bold"]
         fn setBold(self: &mut QFont, enable: bool);
 
-        /// Sets the capitalization of the text in this font to caps.
+        /// Sets the capitalization of the text in this font to `caps`.
+        ///
+        /// A font's capitalization makes the text appear in the selected capitalization mode.
         #[rust_name = "set_capitalization"]
         fn setCapitalization(self: &mut QFont, caps: QFontCapitalization);
 
         /// Sets the family name of the font. The name is case insensitive and may include a foundry name.
+        ///
+        /// The family name may optionally also include a foundry name, e.g. "Helvetica [Cronyx]". If the family is available from more than one foundry and the foundry isn't specified, an arbitrary foundry is chosen. If the family isn't available a family will be set using the [font matching](https://doc.qt.io/qt/qfont.html#fontmatching) algorithm.
         #[rust_name = "set_family"]
         fn setFamily(self: &mut QFont, family: &QString);
 
         /// Sets the list of family names for the font. The names are case insensitive and may include
-        /// a foundry name. The first family in families will be set as the main family for the font.
+        /// a foundry name. The first family in `families` will be set as the main family for the font.
+        ///
+        /// Each family name entry in families may optionally also include a foundry name, e.g. "Helvetica [Cronyx]". If the family is available from more than one foundry and the foundry isn't specified, an arbitrary foundry is chosen. If the family isn't available a family will be set using the [font matching](https://doc.qt.io/qt/qfont.html#fontmatching) algorithm.
         #[rust_name = "set_families"]
         fn setFamilies(self: &mut QFont, families: &QStringList);
 
-        /// If enable is true, sets fixed pitch on; otherwise sets fixed pitch off.
+        /// If `enable` is `true`, sets fixed pitch on; otherwise sets fixed pitch off.
         #[rust_name = "set_fixed_pitch"]
         fn setFixedPitch(self: &mut QFont, enable: bool);
 
-        /// Sets the style strategy for the font to s.
+        /// Sets the style strategy for the font to `strategy`.
         #[rust_name = "set_style_strategy"]
         fn setStyleStrategy(self: &mut QFont, strategy: QFontStyleStrategy);
 
-        /// Set the preference for the hinting level of the glyphs to hintingPreference.
+        /// Set the preference for the hinting level of the glyphs to `hinting_preference`.
+        ///  This is a hint to the underlying font rendering system to use a certain level of hinting, and has varying support across platforms.
         #[rust_name = "set_hinting_preference"]
-        fn setHintingPreference(self: &mut QFont, hintingPreference: QFontHintingPreference);
+        fn setHintingPreference(self: &mut QFont, hinting_preference: QFontHintingPreference);
 
-        /// Sets the style() of the font to QFont::StyleItalic if enable is true; otherwise the style is set to QFont::StyleNormal.
+        /// Sets the [style](https://doc.qt.io/qt/qfont.html#style)() of the font to [`QFontStyle::StyleItalic`] if `enable` is `true`; otherwise the style is set to [`QFontStyle::StyleNormal`].
+        ///
+        /// Note: If [`style_name`](Self::style_name) is set, this value may be ignored, or if supported on the platform, the font may be rendered tilted instead of picking a designed italic font-variant.
         #[rust_name = "set_italic"]
         fn setItalic(self: &mut QFont, enable: bool);
 
-        /// Enables kerning for this font if enable is true; otherwise disables it. By default, kerning is enabled.
+        /// Enables kerning for this font if `enable` is `true`; otherwise disables it. By default, kerning is enabled.
+        ///
+        /// When kerning is enabled, glyph metrics do not add up anymore, even for Latin text. In other words, the assumption that `width("a") + width("b") = width("ab")` is not necessarily true.
         #[rust_name = "set_kerning"]
         fn setKerning(self: &mut QFont, enable: bool);
 
-        /// Sets the letter spacing for the font to spacing and the type of spacing to type.
+        /// Sets the letter spacing for the font to `spacing` and the type of spacing to `spacing_type`.
+        ///
+        /// Letter spacing changes the default spacing between individual letters in the font. The spacing between the letters can be made smaller as well as larger either in percentage of the character width or in pixels, depending on the selected spacing type.
         #[rust_name = "set_letter_spacing"]
-        fn setLetterSpacing(self: &mut QFont, spacingType: QFontSpacingType, spacing: f64);
+        fn setLetterSpacing(self: &mut QFont, spacing_type: QFontSpacingType, spacing: f64);
 
-        /// If enable is true, sets overline on; otherwise sets overline off.
+        /// If `enable` is `true`, sets overline on; otherwise sets overline off.
         #[rust_name = "set_overline"]
         fn setOverline(self: &mut QFont, enable: bool);
 
-        /// Sets the font size to pixelSize pixels.
+        /// Sets the font size to `pixel_size` pixels.
         #[rust_name = "set_pixel_size"]
-        fn setPixelSize(self: &mut QFont, pixelSize: i32);
+        fn setPixelSize(self: &mut QFont, pixel_size: i32);
 
-        /// Sets the stretch factor for the font.
+        /// Sets the stretch `factor` for the font.
         #[rust_name = "set_stretch"]
         fn setStretch(self: &mut QFont, factor: i32);
 
-        /// If enable is true, sets strikeout on; otherwise sets strikeout off.
+        /// If `enable` is `true`, sets strikeout on; otherwise sets strikeout off.
         #[rust_name = "set_strikeout"]
         fn setStrikeOut(self: &mut QFont, enable: bool);
 
-        /// Sets the style of the font to style.
+        /// Sets the style of the font to `style`.
         #[rust_name = "set_style"]
         fn setStyle(self: &mut QFont, style: QFontStyle);
 
-        /// Sets the style hint and strategy to hint and strategy, respectively.
+        /// Sets the style hint and strategy to `hint` and `strategy`, respectively.
         /// Qt does not support style hints on X11 since this information is not provided by the window system.
         #[rust_name = "set_style_hint"]
         fn setStyleHint(self: &mut QFont, hint: QFontStyleHint, strategy: QFontStyleStrategy);
 
-        /// Sets the style name of the font to styleName.
+        /// Sets the style name of the font to `style_name`.
         #[rust_name = "set_style_name"]
-        fn setStyleName(self: &mut QFont, styleName: &QString);
+        fn setStyleName(self: &mut QFont, style_name: &QString);
 
-        /// If enable is true, sets underline on; otherwise sets underline off.
+        /// If `enable` is `true`, sets underline on; otherwise sets underline off.
         #[rust_name = "set_underline"]
         fn setUnderline(self: &mut QFont, enable: bool);
 
-        /// Sets the word spacing for the font to spacing.
+        /// Sets the word spacing for the font to `spacing`.
         #[rust_name = "set_word_spacing"]
         fn setWordSpacing(self: &mut QFont, spacing: f64);
 
         /// Returns the stretch factor for the font.
         fn stretch(self: &QFont) -> i32;
 
-        /// Returns true if strikeout has been set; otherwise returns false.
+        /// Returns `true` if strikeout has been set; otherwise returns `false`.
         #[rust_name = "strike_out"]
         fn strikeOut(self: &QFont) -> bool;
 
-        /// Returns the StyleHint.
+        /// Returns the style hint.
         #[rust_name = "style_hint"]
         fn styleHint(self: &QFont) -> QFontStyleHint;
 
@@ -317,7 +333,7 @@ mod ffi {
         #[rust_name = "style_name"]
         fn styleName(self: &QFont) -> QString;
 
-        /// Returns the StyleStrategy.
+        /// Returns the style strategy.
         #[rust_name = "style_strategy"]
         fn styleStrategy(self: &QFont) -> QFontStyleStrategy;
 
@@ -325,7 +341,7 @@ mod ffi {
         #[rust_name = "to_qstring"]
         fn toString(self: &QFont) -> QString;
 
-        /// Returns true if underline has been set; otherwise returns false.
+        /// Returns `true` if underline has been set; otherwise returns `false`.
         fn underline(self: &QFont) -> bool;
 
         /// Returns the word spacing for the font.
@@ -366,6 +382,9 @@ pub use ffi::{
     QFontStyleStrategy,
 };
 
+/// The `QFont` class specifies a query for a font used for drawing text.
+///
+/// Qt Documentation: [QFont](https://doc.qt.io/qt/qfont.html#details)
 #[repr(C)]
 pub struct QFont {
     _cspec: MaybeUninit<usize>,
@@ -413,7 +432,7 @@ impl Eq for QFont {}
 impl QFont {
     /// Returns the bounding rectangle of the current clip if there is a clip;
     /// otherwise returns `None`. Note that the clip region is given in logical coordinates.
-    pub fn family(&self) -> Option<ffi::QString> {
+    pub fn family(&self) -> Option<QString> {
         let result = self.family_or_default();
         if result.is_empty() {
             None

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.rs
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.rs
@@ -33,6 +33,10 @@ mod ffi {
 
     unsafe extern "C++Qt" {
         include!("cxx-qt-lib/qguiapplication.h");
+
+        /// The `QGuiApplication` class manages the GUI application's control flow and main settings.
+        ///
+        /// Qt Documentation: [QGuiApplication](https://doc.qt.io/qt/qguiapplication.html#details)
         #[qobject]
         #[base = QCoreApplication]
         type QGuiApplication;
@@ -123,25 +127,28 @@ mod ffi {
 pub use ffi::QGuiApplication;
 
 impl QGuiApplication {
-    /// Prepends path to the beginning of the library path list,
+    /// Prepends `path` to the beginning of the library path list,
     /// ensuring that it is searched for libraries first.
-    /// If path is empty or already in the path list, the path list is not changed.
+    /// If `path` is empty or already in the path list, the path list is not changed.
     pub fn add_library_path(self: Pin<&mut Self>, path: &QString) {
         ffi::qguiapplication_add_library_path(self, path);
     }
 
-    /// The name of this application
+    /// Returns the name of this application.
     pub fn application_name(&self) -> QString {
         ffi::qguiapplication_application_name(self)
     }
 
-    /// The version of this application
+    /// Returns the version of this application.
     pub fn application_version(&self) -> QString {
         ffi::qguiapplication_application_version(self)
     }
 
-    /// Enters the main event loop and waits until exit() is called,
-    /// and then returns the value that was set to exit() (which is 0 if exit() is called via quit()).
+    /// Enters the main event loop and waits until [exit]\() is called,
+    /// and then returns the value that was set to [exit]\() (which is 0 if [exit]\() is called via [quit]\()).
+    ///
+    /// [exit]: https://doc.qt.io/qt/qcoreapplication.html#exit
+    /// [quit]: https://doc.qt.io/qt/qcoreapplication.html#quit
     pub fn exec(self: Pin<&mut Self>) -> i32 {
         ffi::qguiapplication_exec(self)
     }
@@ -157,7 +164,7 @@ impl QGuiApplication {
     }
 
     /// Initializes the window system and constructs an application object.
-    /// Standard [Qt command line arguments](https://doc.qt.io/qt-6/qguiapplication.html#supported-command-line-options) are handled automatically.
+    /// Standard [Qt command line arguments](https://doc.qt.io/qt/qguiapplication.html#supported-command-line-options) are handled automatically.
     pub fn new() -> cxx::UniquePtr<Self> {
         let mut vector = QVector::<QByteArray>::default();
 
@@ -181,53 +188,53 @@ impl QGuiApplication {
         ffi::qguiapplication_new(&vector)
     }
 
-    /// The Internet domain of the organization that wrote this application
+    /// Returns the Internet domain of the organization that wrote this application.
     pub fn organization_domain(&self) -> QString {
         ffi::qguiapplication_organization_domain(self)
     }
 
-    /// The name of the organization that wrote this application
+    /// Returns the name of the organization that wrote this application.
     pub fn organization_name(&self) -> QString {
         ffi::qguiapplication_organization_name(self)
     }
 
-    /// Set the name of this application
+    /// Set the `name` of this application.
     pub fn set_application_name(self: Pin<&mut Self>, name: &QString) {
         ffi::qguiapplication_set_application_name(self, name);
     }
 
-    /// Removes path from the library path list. If path is empty or not in the path list, the list is not changed.
+    /// Removes `path` from the library path list. If `path` is empty or not in the path list, the list is not changed.
     pub fn remove_library_path(&self, path: &QString) {
         ffi::qguiapplication_remove_library_path(self, path)
     }
 
-    /// Set the version of this application
+    /// Set the `version` of this application.
     pub fn set_application_version(self: Pin<&mut Self>, version: &QString) {
         ffi::qguiapplication_set_application_version(self, version);
     }
 
-    /// Changes the default application font to font.
+    /// Changes the default application font to `font`.
     pub fn set_application_font(self: Pin<&mut Self>, font: &QFont) {
         ffi::qguiapplication_set_font(font);
     }
 
-    /// Sets the list of directories to search when loading plugins with QLibrary to paths.
-    /// All existing paths will be deleted and the path list will consist of the paths given in paths and the path to the application.
+    /// Sets the list of directories to search when loading plugins with [QLibrary](https://doc.qt.io/qt/qlibrary.html) to `paths`.
+    /// All existing paths will be deleted and the path list will consist of the paths given in `paths` and the path to the application.
     pub fn set_library_paths(self: Pin<&mut Self>, paths: &QStringList) {
         ffi::qguiapplication_set_library_paths(self, paths);
     }
 
-    /// Sets the Internet domain of the organization that wrote this application
+    /// Sets the Internet `domain` of the organization that wrote this application.
     pub fn set_organization_domain(self: Pin<&mut Self>, domain: &QString) {
         ffi::qguiapplication_set_organization_domain(self, domain);
     }
 
-    /// Sets the name of the organization that wrote this application
+    /// Sets the `name` of the organization that wrote this application.
     pub fn set_organization_name(self: Pin<&mut Self>, name: &QString) {
         ffi::qguiapplication_set_organization_name(self, name);
     }
 
-    /// Changes the desktop file name to name.
+    /// Changes the desktop file name to `name`.
     pub fn set_desktop_file_name(name: &QString) {
         ffi::qguiapplication_set_desktop_file_name(name);
     }
@@ -239,33 +246,33 @@ impl QGuiApplication {
 
     /// Returns the current state of the modifier keys on the keyboard. The current state is updated
     /// synchronously as the event queue is emptied of events that will spontaneously change the
-    /// keyboard state (QEvent::KeyPress and QEvent::KeyRelease events).
+    /// keyboard state ([QEvent::KeyPress](https://doc.qt.io/qt/qevent.html#Type-enum) and [QEvent::KeyRelease](https://doc.qt.io/qt/qevent.html#Type-enum)).
     ///
     /// It should be noted this may not reflect the actual keys held on the input device at the time
     /// of calling but rather the modifiers as last reported in an event.
-    /// If no keys are being held Qt::NoModifier is returned.
+    /// If no keys are being held [`KeyboardModifier::NoModifier`](crate::KeyboardModifier::NoModifier) is returned.
     pub fn keyboard_modifiers(&self) -> KeyboardModifiers {
         ffi::qguiapplication_keyboard_modifiers()
     }
 
     /// Returns the current state of the buttons on the mouse. The current state is updated
     /// synchronously as the event queue is emptied of events that will spontaneously change the
-    /// mouse state (QEvent::MouseButtonPress and QEvent::MouseButtonRelease events).
+    /// mouse state ([QEvent::MouseButtonPress](https://doc.qt.io/qt/qevent.html#Type-enum) and [QEvent::MouseButtonRelease](https://doc.qt.io/qt/qevent.html#Type-enum) events).
     ///
     /// It should be noted this may not reflect the actual buttons held on the input device at the
     /// time of calling but rather the mouse buttons as last reported in one of the above events.
-    /// If no mouse buttons are being held Qt::NoButton is returned.
+    /// If no mouse buttons are being held [`MouseButton::NoButton`](crate::MouseButton::NoButton) is returned.
     pub fn mouse_buttons(&self) -> MouseButtons {
         ffi::qguiapplication_mouse_buttons()
     }
 
     /// Queries and returns the state of the modifier keys on the keyboard. Unlike
-    /// keyboardModifiers, this method returns the actual keys held on the input device at the time
+    /// [`keyboard_modifiers`](Self::keyboard_modifiers), this method returns the actual keys held on the input device at the time
     /// of calling the method.
     ///
     /// It does not rely on the keypress events having been received by this process, which makes it
     /// possible to check the modifiers while moving a window, for instance. Note that in most
-    /// cases, you should use keyboardModifiers(), which is faster and more accurate since it
+    /// cases, you should use [`keyboard_modifiers`](Self::keyboard_modifiers), which is faster and more accurate since it
     /// contains the state of the modifiers as they were when the currently processed event was
     /// received.
     pub fn query_keyboard_modifiers(&self) -> KeyboardModifiers {

--- a/crates/cxx-qt-lib/src/gui/qimage.rs
+++ b/crates/cxx-qt-lib/src/gui/qimage.rs
@@ -16,12 +16,14 @@ mod ffi {
         type AspectRatioMode = crate::AspectRatioMode;
     }
 
-    /// The type of image format available in Qt.
+    /// This enum type is used to describe how pixel values should be inverted in the [`QImage::invert_pixels`] function.
     #[repr(i32)]
     #[namespace = "rust::cxxqtlib1"]
     #[derive(Debug)]
     enum QImageInvertMode {
+        /// Invert only the RGB values and leave the alpha channel unchanged.
         InvertRgb,
+        /// Invert all channels, including the alpha channel.
         InvertRgba,
     }
 
@@ -30,35 +32,65 @@ mod ffi {
     #[namespace = "rust::cxxqtlib1"]
     #[derive(Debug)]
     enum QImageFormat {
+        /// The image is invalid.
         Format_Invalid,
+        /// The image is stored using 1-bit per pixel. Bytes are packed with the most significant bit (MSB) first.
         Format_Mono,
+        /// The image is stored using 1-bit per pixel. Bytes are packed with the less significant bit (LSB) first.
         Format_MonoLSB,
+        /// The image is stored using 8-bit indexes into a colormap.
         Format_Indexed8,
+        /// The image is stored using a 32-bit RGB format (0xffRRGGBB).
         Format_RGB32,
+        /// The image is stored using a 32-bit ARGB format (0xAARRGGBB).
         Format_ARGB32,
+        /// The image is stored using a premultiplied 32-bit ARGB format (0xAARRGGBB), i.e. the red, green, and blue channels are multiplied by the alpha component divided by 255. (If RR, GG, or BB has a higher value than the alpha channel, the results are undefined.) Certain operations (such as image composition using alpha blending) are faster using premultiplied ARGB32 than with plain ARGB32.
         Format_ARGB32_Premultiplied,
+        /// The image is stored using a 16-bit RGB format (5-6-5).
         Format_RGB16,
+        /// The image is stored using a premultiplied 24-bit ARGB format (8-5-6-5).
         Format_ARGB8565_Premultiplied,
+        /// The image is stored using a 24-bit RGB format (6-6-6). The unused most significant bits is always zero.
         Format_RGB666,
+        /// The image is stored using a premultiplied 24-bit ARGB format (6-6-6-6).
         Format_ARGB6666_Premultiplied,
+        /// The image is stored using a 16-bit RGB format (5-5-5). The unused most significant bit is always zero.
         Format_RGB555,
+        /// The image is stored using a premultiplied 24-bit ARGB format (8-5-5-5).
         Format_ARGB8555_Premultiplied,
+        /// The image is stored using a 24-bit RGB format (8-8-8).
         Format_RGB888,
+        /// The image is stored using a 16-bit RGB format (4-4-4). The unused bits are always zero.
         Format_RGB444,
+        /// The image is stored using a premultiplied 16-bit ARGB format (4-4-4-4).
         Format_ARGB4444_Premultiplied,
+        /// The image is stored using a 32-bit byte-ordered RGB(x) format (8-8-8-8). This is the same as the Format_RGBA8888 except alpha must always be 255.
         Format_RGBX8888,
+        /// The image is stored using a 32-bit byte-ordered RGBA format (8-8-8-8). Unlike ARGB32 this is a byte-ordered format, which means the 32bit encoding differs between big endian and little endian architectures, being respectively (0xRRGGBBAA) and (0xAABBGGRR). The order of the colors is the same on any architecture if read as bytes 0xRR,0xGG,0xBB,0xAA.
         Format_RGBA8888,
+        /// The image is stored using a premultiplied 32-bit byte-ordered RGBA format (8-8-8-8).
         Format_RGBA8888_Premultiplied,
+        /// The image is stored using a 32-bit BGR format (x-10-10-10).
         Format_BGR30,
+        /// The image is stored using a 32-bit premultiplied ABGR format (2-10-10-10).
         Format_A2BGR30_Premultiplied,
+        /// The image is stored using a 32-bit RGB format (x-10-10-10).
         Format_RGB30,
+        /// The image is stored using a 32-bit premultiplied ARGB format (2-10-10-10).
         Format_A2RGB30_Premultiplied,
+        /// The image is stored using an 8-bit alpha only format.
         Format_Alpha8,
+        /// The image is stored using an 8-bit grayscale format.
         Format_Grayscale8,
+        /// The image is stored using a 64-bit halfword-ordered RGB(x) format (16-16-16-16). This is the same as the Format_RGBA64 except alpha must always be 65535.
         Format_RGBX64,
+        /// The image is stored using a 64-bit halfword-ordered RGBA format (16-16-16-16).
         Format_RGBA64,
+        /// The image is stored using a premultiplied 64-bit halfword-ordered RGBA format (16-16-16-16).
         Format_RGBA64_Premultiplied,
+        /// The image is stored using an 16-bit grayscale format.
         Format_Grayscale16,
+        /// The image is stored using a 24-bit BGR format.
         Format_BGR888,
         /* Qt 6.2
         Format_RGBX16FPx4,
@@ -89,147 +121,217 @@ mod ffi {
         type QImageCleanupFunction = super::QImageCleanupFunction;
         type uchar;
 
-        /// Returns true if all the colors in the image are shades of gray
+        /// Returns `true` if all the colors in the image are shades of gray (i.e. their red, green and blue components are equal); otherwise `false`.
+        ///
+        /// Note that this function is slow for images without color table.
         #[rust_name = "all_gray"]
         fn allGray(self: &QImage) -> bool;
 
         /// Returns the number of bit planes in the image.
+        ///
+        /// The number of bit planes is the number of bits of color and transparency information for each pixel. This is different from (i.e. smaller than) the depth when the image format contains unused bits.
         #[rust_name = "bit_plane_count"]
         fn bitPlaneCount(self: &QImage) -> i32;
 
         /// Returns a sub-area of the image as a new image.
-        fn copy(self: &QImage, rect: &QRect) -> QImage;
+        ///
+        /// The returned image is copied from the position (`rectangle.x()`, `rectangle.y()`) in this image, and will always have the size of the given `rectangle`.
+        ///
+        /// In areas beyond this image, pixels are set to 0. For 32-bit RGB images, this means black; for 32-bit ARGB images, this means transparent black; for 8-bit images, this means the color with index 0 in the color table which can be anything; for 1-bit images, this means Qt::color0.
+        ///
+        /// If the given `rectangle` is a null rectangle the entire image is copied.
+        fn copy(self: &QImage, rectangle: &QRect) -> QImage;
 
         /// Creates and returns a 1-bpp heuristic mask for this image.
+        ///
+        /// The function works by selecting a color from one of the corners, then chipping away pixels of that color starting at all the edges. The four corners vote for which color is to be masked away. In case of a draw (this generally means that this function is not applicable to the image), the result is arbitrary.
+        ///
+        /// The returned image has little-endian bit order (i.e. the image's format is [`QImageFormat::Format_MonoLSB`]), which you can convert to big-endian ([`QImageFormat::Format_Mono`]) using the [convertToFormat](https://doc.qt.io/qt/qimage.html#convertToFormat)() function.
+        ///
+        /// If `clip_tight` is `true` the mask is just large enough to cover the pixels; otherwise, the mask is larger than the data pixels.
+        ///
+        /// Note that this function disregards the alpha buffer.
         #[rust_name = "create_heuristic_mask"]
-        fn createHeuristicMask(self: &QImage, clipTight: bool) -> QImage;
+        fn createHeuristicMask(self: &QImage, clip_tight: bool) -> QImage;
 
         /// Returns the size of the color table for the image.
+        ///
+        /// Notice that this function returns 0 for 32-bpp images because these images do not use color tables, but instead encode pixel values as ARGB quadruplets.
         #[rust_name = "color_count"]
         fn colorCount(self: &QImage) -> i32;
 
         /// Returns the depth of the image.
+        ///
+        /// The image depth is the number of bits used to store a single pixel, also called bits per pixel (bpp).
+        ///
+        /// The supported depths are 1, 8, 16, 24, 32 and 64.
         fn depth(self: &QImage) -> i32;
 
         /// Returns the size of the image in device independent pixels.
         /// This value should be used when using the image size in user interface size calculations.
-        /// The return value is equivalent to image.size() / image.devicePixelRatio().
+        /// The return value is equivalent to [`size`](Self::size) / [devicePixelRatio](https://doc.qt.io/qt/qimage.html#devicePixelRatio)().
+        ///
+        /// This function was introduced in Qt 6.2.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_2))]
         #[rust_name = "device_independent_size"]
         fn deviceIndependentSize(self: &QImage) -> QSizeF;
 
-        /// Returns the number of pixels that fit horizontally in a physical meter.
+        /// Returns the number of pixels that fit horizontally in a physical meter. Together with [`dots_per_meter_y`](Self::dots_per_meter_y), this number defines the intended scale and aspect ratio of the image.
         #[rust_name = "dots_per_meter_x"]
         fn dotsPerMeterX(self: &QImage) -> i32;
 
-        /// Returns the number of pixels that fit vertically in a physical meter.
+        /// Returns the number of pixels that fit vertically in a physical meter. Together with [`dots_per_meter_x`](Self::dots_per_meter_x), this number defines the intended scale and aspect ratio of the image.
         #[rust_name = "dots_per_meter_y"]
         fn dotsPerMeterY(self: &QImage) -> i32;
 
-        /// Fills the entire image with the given color.
+        /// Fills the entire image with the given `color`.
+        ///
+        /// If the depth of this image is 1, only the lowest bit is used. If you say fill(0), fill(2), etc., the image is filled with 0s. If you say fill(1), fill(3), etc., the image is filled with 1s. If the depth is 8, the lowest 8 bits are used and if the depth is 16 the lowest 16 bits are used.
+        ///
+        /// If the image depth is higher than 32bit the result is undefined.
         fn fill(self: &mut QImage, color: &QColor);
 
         /// Returns the format of the image.
         fn format(self: &QImage) -> QImageFormat;
 
         /// Inverts all pixel values in the image.
+        ///
+        /// The given invert mode only have a meaning when the image's depth is 32. If the mode is [`QImageInvertMode::InvertRgb`], the alpha channel is left unchanged. If the mode is [`QImageInvertMode::InvertRgba`], the alpha bits are also inverted.
+        ///
+        /// Inverting an 8-bit image means to replace all pixels using color index `i` with a pixel using color index 255 minus `i`. The same is the case for a 1-bit image. Note that the color table is `not` changed.
+        ///
+        /// If the image has a premultiplied alpha channel, the image is first converted to an unpremultiplied image format to be inverted and then converted back.
         #[rust_name = "invert_pixels"]
         fn invertPixels(self: &mut QImage, mode: QImageInvertMode);
 
-        /// Whether the QImage is null.
+        /// Returns `true` if it is a null image, otherwise returns `false`.
         ///
-        /// This means that the QImage has all parameters set to zero and no allocated data.
+        /// A null image has all parameters set to zero and no allocated data.
         #[rust_name = "is_null"]
         fn isNull(self: &QImage) -> bool;
 
-        /// For 32-bit images, this function is equivalent to allGray().
-        /// For color indexed images, this function returns true if color(i) is QRgb(i, i, i)
-        /// for all indexes of the color table; otherwise returns false.
+        /// For 32-bit images, this function is equivalent to [`all_gray`](Self::all_gray).
+        /// For color indexed images, this function returns `true` if color(i) is QRgb(i, i, i)
+        /// for all indexes of the color table; otherwise returns `false`.
         #[rust_name = "is_gray_scale"]
         fn isGrayscale(self: &QImage) -> bool;
 
-        /// Returns true if the image has a format that respects the alpha channel, otherwise returns false.
+        /// Returns `true` if the image has a format that respects the alpha channel, otherwise returns `false`.
         #[rust_name = "has_alpha_channel"]
         fn hasAlphaChannel(self: &QImage) -> bool;
 
         /// Returns the height of the image.
         fn height(self: &QImage) -> i32;
 
-        /// Mirrors of the image in the horizontal and/or the vertical direction depending on whether horizontal and vertical are set to true or false.
+        /// Mirrors of the image in the horizontal and/or the vertical direction depending on whether `horizontal` and `vertical` are set to `true` or `false`.
+        ///
+        /// This function was introduced in Qt 6.0.
         #[cfg(cxxqt_qt_version_at_least_6)]
         fn mirror(self: &mut QImage, horizontal: bool, vertical: bool);
 
         /// Swaps the values of the red and blue components of all pixels, effectively converting an RGB image to an BGR image.
+        ///
+        /// This function was introduced in Qt 6.0.
         #[cfg(cxxqt_qt_version_at_least_6)]
         #[rust_name = "rgb_swap"]
         fn rgbSwap(self: &mut QImage);
 
-        /// Returns the enclosing rectangle (0, 0, width(), height()) of the image.
+        /// Returns the enclosing rectangle (`0`, `0`, `width()`, `height()`) of the image.
         fn rect(self: &QImage) -> QRect;
 
-        /// Returns a copy of the image scaled to a rectangle with the given width and height according to the given aspectRatioMode and transformMode.
+        /// Returns a copy of the image scaled to a rectangle with the given `width` and `height` according to the given `aspect_ratio_mode` and `transform_mode`.
         fn scaled(
             self: &QImage,
             width: i32,
             height: i32,
-            aspectRatioMode: AspectRatioMode,
-            transformMode: TransformationMode,
+            aspect_ratio_mode: AspectRatioMode,
+            transform_mode: TransformationMode,
         ) -> QImage;
 
-        /// Returns a scaled copy of the image. The returned image is scaled to the given height using the specified transformation mode.
+        /// Returns a scaled copy of the image. The returned image is scaled to the given `height` using the specified transformation `mode`.
+        ///
+        /// This function automatically calculates the width of the image so that the ratio of the image is preserved.
+        ///
+        /// If the given `height` is 0 or negative, a null image is returned.
         #[rust_name = "scaled_to_height"]
-        fn scaledToHeight(self: &QImage, width: i32, mode: TransformationMode) -> QImage;
+        fn scaledToHeight(self: &QImage, height: i32, mode: TransformationMode) -> QImage;
 
-        /// Returns a scaled copy of the image. The returned image is scaled to the given width using the specified transformation mode.
+        /// Returns a scaled copy of the image. The returned image is scaled to the given `width` using the specified transformation `mode`.
+        ///
+        /// This function automatically calculates the height of the image so that the ratio of the image is preserved.
+        ///
+        /// If the given `width` is 0 or negative, a null image is returned.
         #[rust_name = "scaled_to_width"]
         fn scaledToWidth(self: &QImage, width: i32, mode: TransformationMode) -> QImage;
 
-        /// Resizes the color table to contain colorCount entries.
+        /// Resizes the color table to contain `color_count` entries.
+        ///
+        /// If the color table is expanded, all the extra colors will be set to transparent.
+        ///
+        /// When the image is used, the color table must be large enough to have entries for all the pixel/index values present in the image, otherwise the results are undefined.
         #[rust_name = "set_color_count"]
-        fn setColorCount(self: &mut QImage, colorCount: i32);
+        fn setColorCount(self: &mut QImage, color_count: i32);
 
-        /// Sets the alpha channel of this image to the given alphaChannel.
+        /// Sets the alpha channel of this image to the given `alpha_channel`.
+        ///
+        /// If `alpha_channel` is an 8 bit alpha image, the alpha values are used directly. Otherwise, `alpha_channel` is converted to 8 bit grayscale and the intensity of the pixel values is used.
+        ///
+        /// If the image already has an alpha channel, the existing alpha channel is multiplied with the new one. If the image doesn't have an alpha channel it will be converted to a format that does.
         #[rust_name = "set_alpha_channel"]
-        fn setAlphaChannel(self: &mut QImage, alphaChannel: &QImage);
+        fn setAlphaChannel(self: &mut QImage, alpha_channel: &QImage);
 
-        /// Sets the number of pixels that fit horizontally in a physical meter, to x.
+        /// Sets the number of pixels that fit horizontally in a physical meter, to `x`.
         #[rust_name = "set_dots_per_meter_x"]
         fn setDotsPerMeterX(self: &mut QImage, x: i32);
 
-        /// Sets the number of pixels that fit vertically in a physical meter, to y.
+        /// Sets the number of pixels that fit vertically in a physical meter, to `y`.
         #[rust_name = "set_dots_per_meter_y"]
         fn setDotsPerMeterY(self: &mut QImage, y: i32);
 
-        /// Sets the number of pixels by which the image is intended to be offset by when positioning relative to other images, to offset.
+        /// Sets the number of pixels by which the image is intended to be offset by when positioning relative to other images, to `offset`.
         #[rust_name = "set_offset"]
-        fn setOffset(self: &mut QImage, point: &QPoint);
+        fn setOffset(self: &mut QImage, offset: &QPoint);
 
-        /// Sets the pixel color at (x, y) to color.
+        /// Sets the pixel color at (`x`, `y`) to `color`.
+        ///
+        /// If (`x`, `y`) is not a valid coordinate pair in the image, or the image's format is either monochrome or paletted, the result is undefined.
         #[rust_name = "set_pixel_color"]
         fn setPixelColor(self: &mut QImage, x: i32, y: i32, color: &QColor);
 
         /// Returns the size of the image.
         fn size(self: &QImage) -> QSize;
 
-        /// Swaps image other with this image. This operation is very fast and never fails.
+        /// Swaps image `other` with this image. This operation is very fast and never fails.
         fn swap(self: &mut QImage, other: &mut QImage);
 
-        /// Changes the format of the image to format without changing the data. Only works between formats of the same depth.
+        /// Changes the format of the image to `format` without changing the data. Only works between formats of the same depth.
+        ///
+        /// Returns `true` if successful.
+        ///
+        /// This function can be used to change images with alpha-channels to their corresponding opaque formats if the data is known to be opaque-only, or to change the format of a given image buffer before overwriting it with new data.
+        ///
+        /// **Warning:** The function does not check if the image data is valid in the new format and will still return true if the depths are compatible. Operations on an image with invalid data are undefined.
+        ///
+        /// **Warning:** If the image is not detached, this will cause the data to be copied.
         #[rust_name = "reinterpret_as_format"]
         fn reinterpretAsFormat(self: &mut QImage, format: QImageFormat) -> bool;
 
         /// Returns the number of pixels by which the image is intended to be offset by when positioning relative to other images.
         fn offset(self: &QImage) -> QPoint;
 
-        /// Returns the color of the pixel at coordinates (x, y) as a QColor.
+        /// Returns the color of the pixel at coordinates (`x`, `y`) as a `QColor`.
+        ///
+        /// If the position (`x`, `y`) is not valid, an invalid `QColor` is returned.
         #[rust_name = "pixel_color"]
         fn pixelColor(self: &QImage, x: i32, y: i32) -> QColor;
 
-        /// Returns the pixel index at (x, y).
+        /// Returns the pixel index at (`x`, `y`).
+        ///
+        /// If the position (`x`, `y`) is not valid, or if the image is not a paletted image ([`depth`](Self::depth) > 8), the results are undefined.
         #[rust_name = "pixel_index"]
         fn pixelIndex(self: &QImage, x: i32, y: i32) -> i32;
 
-        /// Returns true if pos is a valid coordinate pair within the image.
+        /// Returns `true` if (`x`, `y`) is a valid coordinate pair within the image; otherwise returns `false`.
         fn valid(self: &QImage, x: i32, y: i32) -> bool;
 
         /// Returns the width of the image.
@@ -300,10 +402,9 @@ mod ffi {
 
 pub use ffi::{QImageFormat, QImageInvertMode};
 
-/// This struct is the Rust representation of the [`QImage`](https://doc.qt.io/qt-6/qimage.html)
-/// class.
+/// The `QImage` class provides a hardware-independent image representation that allows direct access to the pixel data, and can be used as a paint device.
 ///
-/// It provides a way to store and manipulate images in a hardware-independent manner.
+/// Qt Documentation: [QImage](https://doc.qt.io/qt/qimage.html#details)
 #[repr(C)]
 pub struct QImage {
     // Static checks on the C++ side ensure this is true.
@@ -369,12 +470,12 @@ unsafe impl ExternType for QImageCleanupFunction {
 }
 
 impl QImage {
-    /// Convert raw image data to a [`QImage`].
+    /// Convert raw image data to a `QImage`.
     ///
     /// The data must be in the given `format`.
-    /// See [`QImageReader::supportedImageFormats()`](https://doc.qt.io/qt-6/qimagereader.html#supportedImageFormats) for the list of supported formats.
+    /// See [QImageReader::supportedImageFormats](https://doc.qt.io/qt/qimagereader.html#supportedImageFormats)() for the list of supported formats.
     ///
-    /// If no `format` is provided, the format will be quessed from the image header.
+    /// If `format` is `None`, the format will be quessed from the image header.
     pub fn from_data(data: &[u8], format: Option<&str>) -> Option<Self> {
         let image = ffi::qimage_init_from_data(data, format.unwrap_or(""));
 
@@ -385,10 +486,10 @@ impl QImage {
         }
     }
 
-    /// Constructs a QImage from an existing memory buffer.
+    /// Constructs a `QImage` from an existing memory buffer.
     ///
     /// # Safety
-    /// For details on safety see the [Qt documentation](https://doc.qt.io/qt-6/qimage.html#QImage-7)
+    /// For details on safety see the [Qt documentation](https://doc.qt.io/qt/qimage.html#QImage-7)
     pub unsafe fn from_raw_parts(
         data: *const ffi::uchar,
         width: i32,
@@ -407,10 +508,10 @@ impl QImage {
         )
     }
 
-    /// Constructs a QImage from an existing mutable memory buffer.
+    /// Constructs a `QImage` from an existing mutable memory buffer.
     ///
     /// # Safety
-    /// For details on safety see the [Qt documentation](https://doc.qt.io/qt-6/qimage.html#QImage-8)
+    /// For details on safety see the [Qt documentation](https://doc.qt.io/qt/qimage.html#QImage-8)
     pub unsafe fn from_raw_parts_mut(
         data: *mut ffi::uchar,
         width: i32,
@@ -429,13 +530,13 @@ impl QImage {
         )
     }
 
-    /// Constructs a QImage from the raw data inside a `Vec<u8>`.
+    /// Constructs a `QImage` from the raw data inside a `Vec<u8>`.
     ///
     /// # Safety
-    /// This function is unsafe because it requires that the data matches the given QImageFormat,
-    /// width and height.
+    /// This function is unsafe because it requires that the data matches the given `QImageFormat`,
+    /// `width` and `height`.
     ///
-    /// It is a convenience function around [Self::from_raw_parts_mut].
+    /// It is a convenience function around [`from_raw_parts_mut`](Self::from_raw_parts_mut).
     pub unsafe fn from_raw_bytes(
         data: Vec<u8>,
         width: i32,
@@ -457,17 +558,15 @@ impl QImage {
         QImage::from_raw_parts_mut(bytes, width, height, format, delete_boxed_vec, raw_box)
     }
 
-    /// Returns a number that identifies the contents of this QImage object.
+    /// Returns a number that identifies the contents of this `QImage` object. Distinct `QImage` objects can only have the same key if they refer to the same contents.
+    ///
+    /// The key will change when the image is altered.
     pub fn cache_key(&self) -> i64 {
         ffi::qimage_cache_key(self)
     }
 
-    /// Construct a Rust QImage from a given width, height, and QImage Format
-    pub fn from_width_height_and_format(
-        width: i32,
-        height: i32,
-        format: ffi::QImageFormat,
-    ) -> Self {
+    /// Construct a `QImage` from a given `width`, `height`, and image `format`.
+    pub fn from_width_height_and_format(width: i32, height: i32, format: QImageFormat) -> Self {
         ffi::qimage_init_from_width_and_height_and_image_format(width, height, format)
     }
 }
@@ -519,16 +618,16 @@ mod tests {
 
     #[test]
     fn test_create_qimage_from_format() {
-        let qimage = QImage::from_width_height_and_format(50, 70, ffi::QImageFormat::Format_Mono);
+        let qimage = QImage::from_width_height_and_format(50, 70, QImageFormat::Format_Mono);
         assert_eq!(qimage.width(), 50);
         assert_eq!(qimage.height(), 70);
         assert!(!qimage.is_null());
-        assert_eq!(qimage.format(), ffi::QImageFormat::Format_Mono);
+        assert_eq!(qimage.format(), QImageFormat::Format_Mono);
     }
 
     #[test]
     fn test_copy() {
-        let qimage = QImage::from_width_height_and_format(50, 70, ffi::QImageFormat::Format_Mono);
+        let qimage = QImage::from_width_height_and_format(50, 70, QImageFormat::Format_Mono);
         let qimage2 = qimage.copy(&qimage.rect());
         assert_eq!(qimage.width(), qimage2.width());
         assert_eq!(qimage.height(), qimage2.height());

--- a/crates/cxx-qt-lib/src/gui/qpainter.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainter.rs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::QRectF;
+
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
@@ -15,22 +17,22 @@ mod ffi {
         type SizeMode = crate::SizeMode;
     }
 
-    /// Warning: Only a [QPainter](https://doc.qt.io/qt-6/qpainter.html) operating on a [QImage](https://doc.qt.io/qt-6/qimage.html)
+    /// Warning: Only a [`QPainter`] operating on a [`QImage`]
     /// fully supports all composition modes. The RasterOp modes are supported for X11 as described
-    /// in [compositionMode](https://doc.qt.io/qt-6/qpainter.html#compositionMode)().
+    /// in [`QPainter::composition_mode`].
     ///
     /// Defines the modes supported for digital image compositing. Composition modes are used to specify
     /// how the pixels in one image, the source, are merged with the pixel in another image, the destination.
     /// Please note that the bitwise raster operation modes, denoted with a RasterOp prefix,
     /// are only natively supported in the X11 and raster paint engines. This means that the only way to utilize
-    /// these modes on the Mac is via a QImage. The RasterOp denoted blend modes are not supported for pens
-    /// and brushes with alpha components. Also, turning on the QPainter::Antialiasing render hint will
+    /// these modes on the Mac is via a [`QImage`]. The RasterOp denoted blend modes are not supported for pens
+    /// and brushes with alpha components. Also, turning on the [`QPainterRenderHint::Antialiasing`] render hint will
     /// effectively disable the RasterOp modes.
-    /// The most common type is SourceOver (often referred to as just alpha blending) where the source pixel
+    /// The most common type is [`CompositionMode_SourceOver`](Self::CompositionMode_SourceOver) (often referred to as just alpha blending) where the source pixel
     /// is blended on top of the destination pixel in such a way that the alpha component of the source
     /// defines the translucency of the pixel.
     /// Several composition modes require an alpha channel in the source or target images to have an effect.
-    /// For optimal performance the image format Format_ARGB32_Premultiplied is preferred.
+    /// For optimal performance the image format [`QImageFormat::Format_ARGB32_Premultiplied`](crate::QImageFormat::Format_ARGB32_Premultiplied) is preferred.
     /// When a composition mode is set it applies to all painting operator, pens, brushes, gradients and pixmap/image drawing.
     #[repr(i32)]
     #[namespace = "rust::cxxqtlib1"]
@@ -38,29 +40,29 @@ mod ffi {
     enum QPainterCompositionMode {
         /// This is the default mode. The alpha of the source is used to blend the pixel on top of the destination.
         CompositionMode_SourceOver,
-        /// The alpha of the destination is used to blend it on top of the source pixels. This mode is the inverse of CompositionMode_SourceOver.
+        /// The alpha of the destination is used to blend it on top of the source pixels. This mode is the inverse of [`CompositionMode_SourceOver`](Self::CompositionMode_SourceOver).
         CompositionMode_DestinationOver,
         /// The pixels in the destination are cleared (set to fully transparent) independent of the source.
         CompositionMode_Clear,
         /// The output is the source pixel. (This means a basic copy operation and is identical to SourceOver when the source pixel is opaque).
         CompositionMode_Source,
-        /// The output is the destination pixel. This means that the blending has no effect. This mode is the inverse of CompositionMode_Source.
+        /// The output is the destination pixel. This means that the blending has no effect. This mode is the inverse of [`CompositionMode_Source`](Self::CompositionMode_Source).
         CompositionMode_Destination,
         /// The output is the source, where the alpha is reduced by that of the destination.
         CompositionMode_SourceIn,
-        /// The output is the destination, where the alpha is reduced by that of the source. This mode is the inverse of CompositionMode_SourceIn.
+        /// The output is the destination, where the alpha is reduced by that of the source. This mode is the inverse of [`CompositionMode_SourceIn`](Self::CompositionMode_SourceIn).
         CompositionMode_DestinationIn,
         /// The output is the source, where the alpha is reduced by the inverse of destination.
         CompositionMode_SourceOut,
-        /// The output is the destination, where the alpha is reduced by the inverse of the source. This mode is the inverse of CompositionMode_SourceOut.
+        /// The output is the destination, where the alpha is reduced by the inverse of the source. This mode is the inverse of [`CompositionMode_SourceOut`](Self::CompositionMode_SourceOut).
         CompositionMode_DestinationOut,
         /// The source pixel is blended on top of the destination, with the alpha of the source pixel reduced by the alpha of the destination pixel.
         CompositionMode_SourceAtop,
         /// The destination pixel is blended on top of the source, with the alpha of the destination pixel is reduced by the alpha of the destination pixel.
-        /// This mode is the inverse of CompositionMode_SourceAtop.
+        /// This mode is the inverse of [`CompositionMode_SourceAtop`](Self::CompositionMode_SourceAtop).
         CompositionMode_DestinationAtop,
         /// The source, whose alpha is reduced with the inverse of the destination alpha, is merged with the destination, whose alpha is reduced by the
-        /// inverse of the source alpha. CompositionMode_Xor is not the same as the bitwise Xor.
+        /// inverse of the source alpha. `CompositionMode_Xor` is not the same as the bitwise Xor.
         CompositionMode_Xor,
 
         //svg 1.2 blend modes
@@ -92,7 +94,7 @@ mod ffi {
         /// Subtracts the darker of the colors from the lighter. Painting with white inverts the destination
         /// color, whereas painting with black leaves the destination color unchanged.
         CompositionMode_Difference,
-        /// Similar to CompositionMode_Difference, but with a lower contrast. Painting with white inverts
+        /// Similar to [`CompositionMode_Difference`](Self::CompositionMode_Difference), but with a lower contrast. Painting with white inverts
         /// the destination color, whereas painting with black leaves the destination color unchanged.
         CompositionMode_Exclusion,
 
@@ -127,7 +129,7 @@ mod ffi {
         RasterOp_NotDestination,
     }
 
-    /// Renderhints are used to specify flags to QPainter that may or may not be respected by any given engine.
+    /// Renderhints are used to specify flags to [`QPainter`] that may or may not be respected by any given engine.
     #[repr(i32)]
     #[namespace = "rust::cxxqtlib1"]
     #[derive(Debug)]
@@ -136,20 +138,23 @@ mod ffi {
         Antialiasing = 0x01,
         /// Indicates that the engine should antialias text if possible.
         /// To forcibly disable antialiasing for text, do not use this hint.
-        /// Instead, set QFont::NoAntialias on your font's style strategy.
+        /// Instead, set [`QFontStyleStrategy::NoAntialias`](crate::QFontStyleStrategy::NoAntialias) on your font's style strategy.
         TextAntialiasing = 0x02,
         /// Indicates that the engine should use a smooth pixmap transformation algorithm
         /// (such as bilinear) rather than nearest neighbor.
         SmoothPixmapTransform = 0x04,
         /// Use a lossless image rendering, whenever possible. Currently, this hint is only
-        /// used when QPainter is employed to output a PDF file through QPrinter or QPdfWriter,
-        /// where drawImage()/drawPixmap() calls will encode images using a lossless compression
+        /// used when [`QPainter`] is employed to output a PDF file through [QPrinter](https://doc.qt.io/qt/qprinter.html) or [QPdfWriter](https://doc.qt.io/qt/qpdfwriter.html),
+        /// where [QPainter::draw_image`]/[drawPixmap](https://doc.qt.io/qt/qpainter.html#drawPixmap)() calls will encode images using a lossless compression
         /// algorithm instead of lossy JPEG compression. This value was added in Qt 5.13.
         LosslessImageRendering = 0x40,
     }
 
     unsafe extern "C++" {
         include!("cxx-qt-lib/qpainter.h");
+        /// The `QPainter` class performs low-level painting on widgets and other paint devices.
+        ///
+        /// Qt Documentation: [QPainter](https://doc.qt.io/qt/qpainter.html#details)
         type QPainter;
         include!("cxx-qt-lib/qrect.h");
         type QRect = crate::QRect;
@@ -192,14 +197,20 @@ mod ffi {
 
         /// Returns the bounding rectangle of the current clip if there is a clip;
         /// otherwise returns an empty rectangle. Note that the clip region is given in logical coordinates.
+        ///
+        /// The bounding rectangle is not guaranteed to be tight.
         #[rust_name = "clip_bounding_rect_or_empty"]
         fn clipBoundingRect(self: &QPainter) -> QRectF;
 
         /// Returns the current clip path in logical coordinates.
+        ///
+        /// **Warning:** `QPainter` does not store the combined clip explicitly as this is handled by the underlying [QPaintEngine](https://doc.qt.io/qt/qpaintengine.html), so the path is recreated on demand and transformed to the current logical coordinate system. This is potentially an expensive operation.
         #[rust_name = "clip_path"]
         fn clipPath(self: &QPainter) -> QPainterPath;
 
         /// Returns the currently set clip region. Note that the clip region is given in logical coordinates.
+        ///
+        /// **Warning:** `QPainter` does not store the combined clip explicitly as this is handled by the underlying [QPaintEngine](https://doc.qt.io/qt/qpaintengine.html), so the path is recreated on demand and transformed to the current logical coordinate system. This is potentially an expensive operation.
         #[rust_name = "clip_region"]
         fn clipRegion(self: &QPainter) -> QRegion;
 
@@ -207,8 +218,10 @@ mod ffi {
         #[rust_name = "composition_mode"]
         fn compositionMode(self: &QPainter) -> QPainterCompositionMode;
 
-        /// Draws the arc defined by the rectangle beginning at (x, y) with the specified width and height,
-        /// and the given startAngle and spanAngle.
+        /// Draws the arc defined by the rectangle beginning at (`x`, `y`) with the specified `width` and `height`,
+        /// and the given `start_angle` and `span_angle`.
+        ///
+        /// The `start_angle` and `span_angle` must be specified in 1/16th of a degree, i.e. a full circle equals 5760 (16 * 360). Positive values for the angles mean counter-clockwise while negative values mean the clockwise direction. Zero degrees is at the 3 o'clock position.
         #[rust_name = "draw_arc"]
         fn drawArc(
             self: Pin<&mut QPainter>,
@@ -216,105 +229,125 @@ mod ffi {
             y: i32,
             width: i32,
             height: i32,
-            startAngle: i32,
-            spanAngle: i32,
+            start_angle: i32,
+            span_angle: i32,
         );
 
-        /// Draws the chord defined by the given rectangle, startAngle and spanAngle.
+        /// Draws the chord defined by the given rectangle, `start_angle` and `span_angle`.
+        ///
+        /// The `start_angle` and `span_angle` must be specified in 1/16th of a degree, i.e. a full circle equals 5760 (16 * 360). Positive values for the angles mean counter-clockwise while negative values mean the clockwise direction. Zero degrees is at the 3 o'clock position.
         #[rust_name = "draw_chord"]
         fn drawChord(
             self: Pin<Pin<&mut QPainter>>,
             rectangle: &QRect,
-            startAngle: i32,
-            spanAngle: i32,
+            start_angle: i32,
+            span_angle: i32,
         );
 
-        /// Draws the convex polygon defined by polygon using the current pen and brush.
+        /// Draws the convex polygon defined by `polygon` using the current pen and brush.
+        ///
+        /// If the supplied polygon is not convex, i.e. it contains at least one angle larger than 180 degrees, the results are undefined.
         #[rust_name = "draw_convex_polygon"]
         fn drawConvexPolygon(self: Pin<&mut QPainter>, polygon: &QPolygon);
 
-        /// Draws the ellipse defined by the given rectangle.
+        /// Draws the ellipse defined by the given `rectangle`.
         #[rust_name = "draw_ellipse"]
-        fn drawEllipse(self: Pin<&mut QPainter>, rect: &QRect);
+        fn drawEllipse(self: Pin<&mut QPainter>, rectangle: &QRect);
 
-        /// Draws the given image into the given rectangle.
+        /// Draws the given `image` into the given `rectangle`.
+        ///
+        /// **Note:** The image is scaled to fit the rectangle, if both the image and rectangle size disagree.
+        ///
+        /// **Note:** See [Drawing High Resolution Versions of Pixmaps and Images](https://doc.qt.io/qt/qpainter.html#drawing-high-resolution-versions-of-pixmaps-and-images) on how this is affected by [QImage::devicePixelRatio](https://doc.qt.io/qt/qimage.html#devicePixelRatio)().
         #[rust_name = "draw_image"]
         fn drawImage(self: Pin<&mut QPainter>, rectangle: &QRect, image: &QImage);
 
-        /// Draws a line defined by line.
+        /// Draws a line defined by `line`.
         #[rust_name = "draw_line"]
         fn drawLine(self: Pin<&mut QPainter>, line: &QLine);
 
-        /// Draws a line defined by line.
+        /// Draws a line defined by `line`.
         #[rust_name = "draw_linef"]
         fn drawLine(self: Pin<&mut QPainter>, line: &QLineF);
 
-        /// Draws the set of lines defined by the list lines using the current pen and brush.
+        /// Draws the set of lines defined by the list `lines` using the current pen and brush.
         #[rust_name = "draw_lines"]
         fn drawLines(self: Pin<&mut QPainter>, lines: &QVector_QLine);
 
-        /// Draws the set of lines defined by the list lines using the current pen and brush.
+        /// Draws the set of lines defined by the list `lines` using the current pen and brush.
         #[rust_name = "draw_linefs"]
         fn drawLines(self: Pin<&mut QPainter>, lines: &QVector_QLineF);
 
-        /// Draws the given painter path using the current pen for outline and the current brush for filling.
+        /// Draws the given painter `path` using the current pen for outline and the current brush for filling.
         #[rust_name = "draw_path"]
         fn drawPath(self: Pin<&mut QPainter>, path: &QPainterPath);
 
-        /// Draws a pie defined by the given rectangle, startAngle and spanAngle.
+        /// Draws a pie defined by the given `rectangle`, `start_angle` and `span_angle`.
+        ///
+        /// The `start_angle` and `span_angle` must be specified in 1/16th of a degree, i.e. a full circle equals 5760 (16 * 360). Positive values for the angles mean counter-clockwise while negative values mean the clockwise direction. Zero degrees is at the 3 o'clock position.
         #[rust_name = "draw_pie"]
-        fn drawPie(self: Pin<&mut QPainter>, rectangle: &QRectF, startAngle: i32, spanAngle: i32);
+        fn drawPie(self: Pin<&mut QPainter>, rectangle: &QRectF, start_angle: i32, span_angle: i32);
 
-        /// Draws a single point at the given position using the current pen's color.
+        /// Draws a single point at the given `position` using the current pen's color.
         #[rust_name = "draw_point"]
         fn drawPoint(self: Pin<&mut QPainter>, point: &QPoint);
 
-        /// Draws the points in the vector points.
+        /// Draws the points in the vector `points`.
         #[rust_name = "draw_points"]
         fn drawPoints(self: Pin<&mut QPainter>, points: &QPolygon);
 
-        /// Draws the polygon defined by the given points using the fill rule fillRule.
+        /// Draws the polygon defined by the given `points` using the fill rule `fill_rule`.
         #[rust_name = "draw_polygon"]
-        fn drawPolygon(self: Pin<&mut QPainter>, points: &QPolygon, fillRule: FillRule);
+        fn drawPolygon(self: Pin<&mut QPainter>, points: &QPolygon, fill_rule: FillRule);
 
-        /// Draws the polyline defined by the given points using the current pen.
+        /// Draws the polyline defined by the given `points` using the current pen.
         #[rust_name = "draw_polyline"]
         fn drawPolyline(self: Pin<&mut QPainter>, points: &QPolygon);
 
-        /// Draws the current rectangle with the current pen and brush.
+        /// Draws the current `rectangle` with the current pen and brush.
         #[rust_name = "draw_rect_f"]
         fn drawRect(self: Pin<&mut QPainter>, rectangle: &QRectF);
 
-        /// Draws the given rectangle rect with rounded corners.
+        /// Draws the given rectangle `rect` with rounded corners.
+        ///
+        /// The `x_radius` and `y_radius` arguments specify the radii of the ellipses defining the corners of the rounded rectangle. When `mode` is [`SizeMode::RelativeSize`], `x_radius` and `y_radius` are specified in percentage of half the rectangle's width and height respectively, and should be in the range 0.0 to 100.0.
+        ///
+        /// A filled rectangle has a size of `rect.size()`. A stroked rectangle has a size of `rect.size()` plus the pen width.
         #[rust_name = "draw_rounded_rect"]
         fn drawRoundedRect(
             self: Pin<&mut QPainter>,
             rect: &QRectF,
-            xRadius: f64,
-            yRadius: f64,
+            x_radiu: f64,
+            y_radius: f64,
             mode: SizeMode,
         );
 
-        /// Draws the given text with the currently defined text direction, beginning at the given position.
+        /// Draws the given `text` with the currently defined text direction, beginning at the given `position`.
+        ///
+        /// This function does not handle the newline character (\n), as it cannot break text into multiple lines, and it cannot display the newline character. Use the [QPainter::drawText() overload](https://doc.qt.io/qt/qpainter.html#drawText-5) that takes a rectangle instead if you want to draw multiple lines of text with the newline character, or if you want the text to be wrapped.
+        ///
+        /// By default, `QPainter` draws text anti-aliased.
+        ///
+        /// Note: The y-position is used as the baseline of the font.
         #[rust_name = "draw_text"]
-        fn drawText(self: Pin<&mut QPainter>, point: &QPoint, text: &QString);
+        fn drawText(self: Pin<&mut QPainter>, position: &QPoint, text: &QString);
 
-        /// Erases the area inside the given rectangle.
+        /// Erases the area inside the given `rectangle`.
         #[rust_name = "erase_rect"]
         fn eraseRect(self: Pin<&mut QPainter>, rectangle: &QRectF);
 
-        /// Fills the given rectangle with the color specified.
+        /// Fills the given `rectangle` with the `color` specified.
         #[rust_name = "fill_rect"]
         fn fillRect(self: Pin<&mut QPainter>, rectangle: &QRectF, color: &QColor);
 
         /// Returns the currently set font used for drawing text.
         fn font(self: &QPainter) -> &QFont;
 
-        /// Returns true if clipping has been set; otherwise returns false.
+        /// Returns `true` if clipping has been set; otherwise returns `false`.
         #[rust_name = "has_clipping"]
         fn hasClipping(self: &QPainter) -> bool;
 
-        /// Returns true if begin() has been called and end() has not yet been called; otherwise returns false.
+        /// Returns `true` if [begin](https://doc.qt.io/qt/qpainter.html#begin)() has been called and [end](https://doc.qt.io/qt/qpainter.html#end)() has not yet been called; otherwise returns `false`.
         #[rust_name = "is_active"]
         fn isActive(self: &QPainter) -> bool;
 
@@ -329,86 +362,112 @@ mod ffi {
         fn pen(self: &QPainter) -> &QPen;
 
         /// Saves the current painter state (pushes the state onto a stack).
-        /// A save() must be followed by a corresponding restore(); the end() function unwinds the stack.
+        /// A save() must be followed by a corresponding [restore](Self::restore)(); the [end](https://doc.qt.io/qt/qpainter.html#end)() function unwinds the stack.
         fn save(self: Pin<&mut QPainter>);
 
-        /// Sets the background mode of the painter to the given mode
+        /// Sets the background mode of the painter to the given `mode`.
+        ///
+        /// [`BGMode::TransparentMode`] draws stippled lines and text without setting the background pixels. [`BGMode::OpaqueMode`] fills these space with the current background color.
+        ///
+        /// Note that in order to draw a bitmap or pixmap transparently, you must use [QPixmap::setMask](https://doc.qt.io/qt/qpixmap.html#setMask)().
         #[rust_name = "set_background_mode"]
         fn setBackgroundMode(self: Pin<&mut QPainter>, mode: BGMode);
 
-        /// Enables clipping if enable is true, or disables clipping if enable is false.
+        /// Enables clipping if `enable` is `true`, or disables clipping if `enable` is `false`.
         #[rust_name = "set_clipping"]
         fn setClipping(self: Pin<&mut QPainter>, enable: bool);
 
-        /// Enables clipping, and sets the clip path for the painter to the given path, with the clip operation.
+        /// Enables clipping, and sets the clip path for the painter to the given `path`, with the clip `operation`.
+        ///
+        /// Note that the clip path is specified in logical (painter) coordinates.
         #[rust_name = "set_clip_path"]
         fn setClipPath(self: Pin<&mut QPainter>, path: &QPainterPath, operation: ClipOperation);
 
-        /// Enables clipping, and sets the clip region to the given rectangle using the given clip operation.
+        /// Enables clipping, and sets the clip region to the given `rectangle` using the given clip `operation`.
         ///
         /// Note that the clip rectangle is specified in logical (painter) coordinates.
         #[rust_name = "set_clip_rect"]
         fn setClipRect(self: Pin<&mut QPainter>, rectangle: &QRect, operation: ClipOperation);
 
-        /// Sets the clip region to the given region using the specified clip operation. The default
-        /// clip operation is to replace the current clip region.
+        /// Sets the clip region to the given `region` using the specified clip `operation`.
+        ///
         /// Note that the clip region is given in logical coordinates.
         #[rust_name = "set_clip_region"]
         fn setClipRegion(self: Pin<&mut QPainter>, region: &QRegion, operation: ClipOperation);
 
-        /// Sets the composition mode to the given mode.
+        /// Sets the composition mode to the given `mode`.
+        ///
+        /// Warning: Only a `QPainter` operating on a [`QImage`](crate::QImage) fully supports all composition modes. The RasterOp modes are supported for X11 as described in [`composition_mode`](Self::composition_mode).
         #[rust_name = "set_composition_mode"]
         fn setCompositionMode(self: Pin<&mut QPainter>, mode: QPainterCompositionMode);
 
         /// Sets the painter's font to the given font.
+        /// This font is used by subsequent [`draw_text`](Self::draw_text) functions. The text color is the same as the pen color.
+        ///
+        /// If you set a font that isn't available, Qt finds a close match. [`font`](Self::font) will return what you set using this function and [fontInfo](https://doc.qt.io/qt/qpainter.html#fontInfo)() returns the font actually being used (which may be the same).
         #[rust_name = "set_font"]
         fn setFont(self: Pin<&mut QPainter>, font: &QFont);
 
-        /// Sets the layout direction used by the painter when drawing text, to the specified direction.
+        /// Sets the layout direction used by the painter when drawing text, to the specified `direction`.
         #[rust_name = "set_layout_direction"]
         fn setLayoutDirection(self: Pin<&mut QPainter>, direction: LayoutDirection);
 
-        /// Sets the opacity of the painter to opacity. The value should be in the range 0.0 to 1.0,
+        /// Sets the opacity of the painter to `opacity`. The value should be in the range 0.0 to 1.0,
         /// where 0.0 is fully transparent and 1.0 is fully opaque.
+        ///
+        /// Opacity set on the painter will apply to all drawing operations individually.
         #[rust_name = "set_opacity"]
         fn setOpacity(self: Pin<&mut QPainter>, opacity: f64);
 
-        /// Sets the painter's pen to be the given pen.
+        /// Sets the painter's pen to be the given `pen`.
+        ///
+        /// The `pen` defines how to draw lines and outlines, and it also defines the text color.
         #[rust_name = "set_pen"]
         fn setPen(self: Pin<&mut QPainter>, pen: &QPen);
 
-        /// Sets the given render hint on the painter if on is true; otherwise clears the render hint.
+        /// Sets the given render `hint` on the painter if `on` is `true`; otherwise clears the render hint.
         #[rust_name = "set_render_hint"]
         fn setRenderHint(self: Pin<&mut QPainter>, hint: QPainterRenderHint, on: bool);
 
-        /// Sets the painter's viewport rectangle to the given rectangle, and enables view transformations.
+        /// Sets the painter's viewport rectangle to the given `rectangle`, and enables view transformations.
+        ///
+        /// The [`viewport`](Self::viewport) rectangle is part of the view transformation. The viewport specifies the device coordinate system. Its sister, the [`window`](Self::window), specifies the logical coordinate system.
+        ///
+        /// The default viewport rectangle is the same as the device's rectangle.
         #[rust_name = "set_viewport"]
         fn setViewport(self: Pin<&mut QPainter>, rectangle: &QRect);
 
-        /// Sets the painter's window to the given rectangle, and enables view transformations.
+        /// Sets the painter's window to the given `rectangle`, and enables view transformations.
+        ///
+        /// The [`window`](Self::window) rectangle is part of the view transformation. The window specifies the logical coordinate system. Its sister, the [`viewport`](Self::viewport), specifies the device coordinate system.
+        ///
+        /// The default window rectangle is the same as the device's rectangle.
         #[rust_name = "set_window"]
         fn setWindow(self: Pin<&mut QPainter>, rectangle: &QRect);
 
-        /// Draws the outline (strokes) the path path with the pen specified by pen
+        /// Draws the outline (strokes) the path `path` with the pen specified by `pen`.
         #[rust_name = "stroke_path"]
         fn strokePath(self: Pin<&mut QPainter>, path: &QPainterPath, pen: &QPen);
 
-        /// Returns true if hint is set; otherwise returns false.
+        /// Returns `true` if `hint` is set; otherwise returns `false`.
         #[rust_name = "test_render_hint"]
         fn testRenderHint(self: &QPainter, hint: QPainterRenderHint) -> bool;
 
         /// Restores the current painter state (pops a saved state off the stack).
         fn restore(self: Pin<&mut QPainter>);
 
-        /// Rotates the coordinate system clockwise. The given angle parameter is in degrees.
+        /// Rotates the coordinate system clockwise. The given `angle` parameter is in degrees.
         fn rotate(self: Pin<&mut QPainter>, angle: f64);
 
-        /// Translates the coordinate system by the given offset.
+        /// Translates the coordinate system by the given `offset`; i.e. the given `offset` is added to points.
         fn translate(self: Pin<&mut QPainter>, offset: &QPoint);
 
-        /// Returns true if view transformation is enabled; otherwise returns false.
+        /// Returns `true` if view transformation is enabled; otherwise returns `false`.
         #[rust_name = "view_transform_enabled"]
         fn viewTransformEnabled(self: &QPainter) -> bool;
+
+        /// Returns the viewport rectangle.
+        fn viewport(self: &QPainter) -> QRect;
 
         /// Returns the window rectangle.
         fn window(self: &QPainter) -> QRect;
@@ -430,14 +489,16 @@ mod ffi {
 pub use ffi::{QPainter, QPainterCompositionMode, QPainterRenderHint};
 
 impl QPainter {
-    /// Create a QPainter
+    /// Create a `QPainter`.
     pub fn new() -> cxx::UniquePtr<Self> {
         ffi::qpainter_init_default()
     }
 
     /// Returns the bounding rectangle of the current clip if there is a clip;
     /// otherwise returns `None`. Note that the clip region is given in logical coordinates.
-    pub fn clip_bounding_rect(&self) -> Option<ffi::QRectF> {
+    ///
+    /// The bounding rectangle is not guaranteed to be tight.
+    pub fn clip_bounding_rect(&self) -> Option<QRectF> {
         let result = self.clip_bounding_rect_or_empty();
         if result.is_valid() {
             Some(result)

--- a/crates/cxx-qt-lib/src/gui/qpainterpath.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainterpath.rs
@@ -32,82 +32,105 @@ mod ffi {
         include!("cxx-qt-lib/qregion.h");
         type QRegion = crate::QRegion;
 
-        /// Creates an ellipse within the specified boundingRectangle and adds it to the painter
+        /// Creates an ellipse within the specified `bounding_rectangle` and adds it to the painter
         /// path as a closed subpath.
+        ///
+        /// The ellipse is composed of a clockwise curve, starting and finishing at zero degrees (the 3 o'clock position).
         #[rust_name = "add_ellipse"]
-        fn addEllipse(self: &mut QPainterPath, boundingRectangle: &QRectF);
+        fn addEllipse(self: &mut QPainterPath, bounding_rectangle: &QRectF);
 
-        /// Adds the given path to this path as a closed subpath.
+        /// Adds the given `path` to this path as a closed subpath.
         #[rust_name = "add_path"]
         fn addPath(self: &mut QPainterPath, path: &QPainterPath);
 
-        /// Adds the given polygon to the path as an (unclosed) subpath.
+        /// Adds the given `polygon` to the path as an (unclosed) subpath.
+        ///
+        /// Note that the current position after the polygon has been added, is the last point in `polygon`. To draw a line back to the first point, use [`close_subpath`](Self::close_subpath).
         #[rust_name = "add_polygon"]
         fn addPolygon(self: &mut QPainterPath, polygon: &QPolygonF);
 
-        /// Adds the given rectangle to this path as a closed subpath.
+        /// Adds the given `rectangle` to this path as a closed subpath.
+        ///
+        /// The `rectangle` is added as a clockwise set of lines. The painter path's current position after the `rectangle` has been added is at the top-left corner of the rectangle.
         #[rust_name = "add_rect"]
         fn addRect(self: &mut QPainterPath, rectangle: &QRectF);
 
+        /// Adds the given `region` to the path by adding each rectangle in the region as a separate closed subpath.
         #[rust_name = "add_region"]
         fn addRegion(self: &mut QPainterPath, region: &QRegion);
 
-        /// Adds the given rectangle rect with rounded corners to the path.
+        /// Adds the given rectangle `rect` with rounded corners to the path.
+        ///
+        /// The `x_radius` and `y_radius` arguments specify the radii of the ellipses defining the corners of the rounded rectangle. When `mode` is [`SizeMode::RelativeSize`], `x_radius` and `y_radius` are specified in percentage of half the rectangle's width and height respectively, and should be in the range 0.0 to 100.0.
         #[rust_name = "add_rounded_rect"]
         fn addRoundedRect(
             self: &mut QPainterPath,
             rect: &QRectF,
-            xRadius: f64,
-            yRadius: f64,
+            x_radius: f64,
+            y_radius: f64,
             mode: SizeMode,
         );
 
-        /// Creates a move to that lies on the arc that occupies the given rectangle at angle.
+        /// Creates a move to that lies on the arc that occupies the given `rectangle` at `angle`.
+        ///
+        /// Angles are specified in degrees. Clockwise arcs can be specified using negative angles.
         #[rust_name = "arc_move_to"]
         fn arcMoveTo(self: &mut QPainterPath, rectangle: &QRectF, angle: f64);
 
-        /// Adds the given text to this path as a set of closed subpaths created from the font supplied.
-        /// The subpaths are positioned so that the left end of the text's baseline lies at the specified point.
+        /// Adds the given `text` to this path as a set of closed subpaths created from the `font` supplied.
+        /// The subpaths are positioned so that the left end of the text's baseline lies at the specified `point`.
+        ///
+        /// Some fonts may yield overlapping subpaths and will require the [`FillRule::WindingFill`] fill rule for correct rendering.
         #[rust_name = "add_text"]
         fn addText(self: &mut QPainterPath, point: &QPointF, font: &QFont, text: &QString);
 
-        /// Creates an arc that occupies the given rectangle, beginning at the specified
-        /// startAngle and extending sweepLength degrees counter-clockwise.
+        /// Creates an arc that occupies the given `rectangle`, beginning at the specified
+        /// `start_angle` and extending `sweep_length` degrees counter-clockwise.
+        ///
+        /// Angles are specified in degrees. Clockwise arcs can be specified using negative angles.
+        ///
+        /// Note that this function connects the starting point of the arc to the current position if they are not already connected. After the arc has been added, the current position is the last point in arc. To draw a line back to the first point, use [`close_subpath`](Self::close_subpath).
         #[rust_name = "arc_to"]
-        fn arcTo(self: &mut QPainterPath, rectangle: &QRectF, startAngle: f64, sweepLength: f64);
+        fn arcTo(self: &mut QPainterPath, rectangle: &QRectF, start_angle: f64, sweep_length: f64);
 
         /// Returns the bounding rectangle of this painter path as a rectangle with floating point precision.
         #[rust_name = "bounding_rect"]
         fn boundingRect(self: &QPainterPath) -> QRectF;
 
-        /// Returns the number of elements allocated by the QPainterPath.
+        /// Returns the number of elements allocated by the `QPainterPath`.
         fn capacity(self: &QPainterPath) -> i32;
 
         /// Clears the path elements stored.
+        ///
+        /// This allows the path to reuse previous memory allocations.
         fn clear(self: &mut QPainterPath);
 
         /// Closes the current subpath by drawing a line to the beginning of the subpath,
         /// automatically starting a new path. The current point of the new path is (0, 0).
+        ///
+        /// If the subpath does not contain any elements, this function does nothing.
         #[rust_name = "close_subpath"]
         fn closeSubpath(self: &mut QPainterPath);
 
-        /// Connects the given path to this path by adding a line from the last element of
+        /// Connects the given `path` to this path by adding a line from the last element of
         /// this path to the first element of the given path.
         #[rust_name = "connect_path"]
         fn connectPath(self: &mut QPainterPath, path: &QPainterPath);
 
-        /// Returns true if the given point is inside the path, otherwise returns false.
+        /// Returns `true` if the given `point` is inside the path, otherwise returns `false`.
         fn contains(self: &QPainterPath, point: &QPointF) -> bool;
 
         /// Returns the rectangle containing all the points and control points in this path.
+        ///
+        /// This function is significantly faster to compute than the exact [`bounding_rect`](Self::bounding_rect), and the returned rectangle is always a superset of the rectangle returned by [`bounding_rect`](Self::bounding_rect).
         #[rust_name = "control_point_rect"]
         fn controlPointRect(self: &QPainterPath) -> QRectF;
 
-        /// Adds a cubic Bezier curve between the current position and the given endPoint using the control
-        /// points specified by c1, and c2.
+        /// Adds a cubic Bezier curve between the current position and the given `end_point` using the control
+        /// points specified by `c1`, and `c2`.
         /// After the curve is added, the current position is updated to be at the end point of the curve.
         #[rust_name = "cubic_to"]
-        fn cubicTo(self: &mut QPainterPath, c1: &QPointF, c2: &QPointF, endPoint: &QPointF);
+        fn cubicTo(self: &mut QPainterPath, c1: &QPointF, c2: &QPointF, end_point: &QPointF);
 
         /// Returns the current position of the path.
         #[rust_name = "current_position"]
@@ -121,58 +144,65 @@ mod ffi {
         #[rust_name = "fill_rule"]
         fn fillRule(self: &QPainterPath) -> FillRule;
 
-        /// Returns a path which is the intersection of this path's fill area and p's fill area.
+        /// Returns a path which is the intersection of this path's fill area and `p`'s fill area.
         /// Bezier curves may be flattened to line segments due to numerical instability of doing bezier curve intersections.
         fn intersected(self: &QPainterPath, p: &QPainterPath) -> QPainterPath;
 
-        /// Returns true if the current path intersects at any point the given path p.
-        /// Also returns true if the current path contains or is contained by any part of p.
+        /// Returns `true` if the current path intersects at any point the given path `p`.
+        /// Also returns `true` if the current path contains or is contained by any part of `p`.
         fn intersects(self: &QPainterPath, p: &QPainterPath) -> bool;
 
-        /// Returns true if either there are no elements in this path,
-        /// or if the only element is a MoveToElement; otherwise returns false.
+        /// Returns `true` if either there are no elements in this path,
+        /// or if the only element is a [MoveToElement](https://doc.qt.io/qt/qpainterpath.html#ElementType-enum); otherwise returns `false`.
         #[rust_name = "is_empty"]
         fn isEmpty(self: &QPainterPath) -> bool;
 
         /// Returns the length of the current path.
         fn length(self: &QPainterPath) -> f64;
 
-        /// Adds a straight line from the current position to the given endPoint.
+        /// Adds a straight line from the current position to the given `end_point`.
         /// After the line is drawn, the current position is updated to be at the end point of the line.
         #[rust_name = "line_to"]
-        fn lineTo(self: &mut QPainterPath, endPoint: &QPointF);
+        fn lineTo(self: &mut QPainterPath, end_point: &QPointF);
 
-        /// Adds a quadratic Bezier curve between the current position and the given endPoint
-        /// with the control point specified by c.
+        /// Adds a quadratic Bezier curve between the current position and the given `end_point`
+        /// with the control point specified by `c`.
         /// After the curve is added, the current point is updated to be at the end point of the curve.
         #[rust_name = "quad_to"]
         fn quadTo(self: &mut QPainterPath, c: &QPointF, endPoint: &QPointF);
 
-        /// Reserves a given amount of elements in QPainterPath's internal memory.
+        /// Reserves a given amount of elements in `QPainterPath`'s internal memory.
+        ///
+        /// Attempts to allocate memory for at least `size` elements.
         fn reserve(self: &mut QPainterPath, size: i32);
 
-        /// Sets the fill rule of the painter path to the given fillRule. Qt provides two methods for filling paths:
+        /// Sets the fill rule of the painter path to the given `fill_rule`.
         #[rust_name = "set_fill_rule"]
-        fn setFillRule(self: &mut QPainterPath, fillRule: FillRule);
+        fn setFillRule(self: &mut QPainterPath, fill_rule: FillRule);
 
         /// Returns a simplified version of this path.
+        /// This implies merging all subpaths that intersect, and returning a path containing no intersecting edges. Consecutive parallel lines will also be merged. The simplified path will always use the default fill rule, [`FillRule::OddEvenFill`]. Bezier curves may be flattened to line segments due to numerical instability of doing bezier curve intersections.
         fn simplified(self: &QPainterPath) -> QPainterPath;
 
-        /// Returns a path which is p's fill area subtracted from this path's fill area.
+        /// Returns a path which is `p`'s fill area subtracted from this path's fill area.
+        ///
+        /// Set operations on paths will treat the paths as areas. Non-closed paths will be treated as implicitly closed. Bezier curves may be flattened to line segments due to numerical instability of doing bezier curve intersections.
         fn subtracted(self: &QPainterPath, painterpath: &QPainterPath) -> QPainterPath;
 
-        /// Translates all elements in the path by (dx, dy).
+        /// Translates all elements in the path by (`dx`, `dy`).
         fn translate(self: &mut QPainterPath, dx: f64, dy: f64);
 
-        /// Returns a copy of the path that is translated by the given offset.
+        /// Returns a copy of the path that is translated by the given `offset`.
         fn translated(self: &QPainterPath, offset: &QPointF) -> QPainterPath;
 
         /// Creates and returns a reversed copy of the path.
+        ///
+        /// It is the order of the elements that is reversed: If a `QPainterPath` is composed by calling the moveTo(), lineTo() and cubicTo() functions in the specified order, the reversed copy is composed by calling cubicTo(), lineTo() and moveTo().
         #[rust_name = "to_reversed"]
         fn toReversed(self: &QPainterPath) -> QPainterPath;
 
-        /// Returns a path which is the union of this path's fill area and p's fill area.
-        fn united(self: &QPainterPath, painterpath: &QPainterPath) -> QPainterPath;
+        /// Returns a path which is the union of this path's fill area and `p`'s fill area.
+        fn united(self: &QPainterPath, p: &QPainterPath) -> QPainterPath;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -205,6 +235,9 @@ mod ffi {
     }
 }
 
+/// The `QPainterPath` class provides a container for painting operations, enabling graphical shapes to be constructed and reused.
+///
+/// Qt Documentation: [QPainterPath](https://doc.qt.io/qt/qpainterpath.html#details)
 #[repr(C)]
 pub struct QPainterPath {
     _cspec: MaybeUninit<usize>,
@@ -223,16 +256,16 @@ impl Drop for QPainterPath {
 }
 
 impl Clone for QPainterPath {
-    /// Constructs a copy of other.
+    /// Constructs a copy of this `QPainterPath`.
     fn clone(&self) -> Self {
         ffi::qpainterpath_clone(self)
     }
 }
 
 impl From<&QPointF> for QPainterPath {
-    /// Creates a QPainterPath object with the given startPoint as its current position.
-    fn from(p: &QPointF) -> Self {
-        ffi::qpainterpath_from_qpointf(p)
+    /// Creates a `QPainterPath` object with the given `start_point` as its current position.
+    fn from(start_point: &QPointF) -> Self {
+        ffi::qpainterpath_from_qpointf(start_point)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpen.rs
+++ b/crates/cxx-qt-lib/src/gui/qpen.rs
@@ -6,6 +6,8 @@ use cxx::{type_id, ExternType};
 use std::fmt;
 use std::mem::MaybeUninit;
 
+use crate::{PenStyle, QColor};
+
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
@@ -35,11 +37,15 @@ mod ffi {
         #[rust_name = "dash_offset"]
         fn dashOffset(self: &QPen) -> f64;
 
-        /// Returns true if the pen is cosmetic; otherwise returns false.
+        /// Returns `true` if the pen is cosmetic; otherwise returns `false`.
+        ///
+        /// Cosmetic pens are used to draw strokes that have a constant width regardless of any transformations applied to the [`QPainter`](crate::QPainter) they are used with. Drawing a shape with a cosmetic pen ensures that its outline will have the same thickness at different scale factors.
+        ///
+        /// A zero width pen is cosmetic by default.
         #[rust_name = "is_comestic"]
         fn isCosmetic(self: &QPen) -> bool;
 
-        /// Returns true if the pen has a solid fill, otherwise false.
+        /// Returns `true` if the pen has a solid fill, otherwise `false`.
         #[rust_name = "is_solid"]
         fn isSolid(self: &QPen) -> bool;
 
@@ -48,41 +54,49 @@ mod ffi {
         fn joinStyle(self: &QPen) -> PenJoinStyle;
 
         /// Returns the miter limit of the pen. The miter limit is only
-        /// relevant when the join style is set to Qt::MiterJoin.
+        /// relevant when the join style is set to [`PenJoinStyle::MiterJoin`].
         #[rust_name = "miter_limit"]
         fn miterLimit(self: &QPen) -> f64;
 
-        /// Sets the pen's cap style to the given style. The default value is Qt::SquareCap.
+        /// Sets the pen's cap style to the given `style`. The default value is [`PenCapStyle::SquareCap`].
         #[rust_name = "set_cap_style"]
         fn setCapStyle(self: &mut QPen, style: PenCapStyle);
 
-        /// Sets the color of this pen's brush to the given color.
+        /// Sets the color of this pen's brush to the given `color`.
         #[rust_name = "set_color"]
         fn setColor(self: &mut QPen, color: &QColor);
 
-        /// Sets this pen to cosmetic or non-cosmetic, depending on the value of cosmetic.
+        /// Sets this pen to cosmetic or non-cosmetic, depending on the value of `cosmetic`.
         #[rust_name = "set_cosmetic"]
         fn setCosmetic(self: &mut QPen, cosmetic: bool);
 
         /// Sets the dash offset (the starting point on the dash pattern) for this pen to
-        /// the offset specified. The offset is measured in terms of the units used to
+        /// the `offset` specified. The offset is measured in terms of the units used to
         /// specify the dash pattern.
         #[rust_name = "set_dash_offset"]
         fn setDashOffset(self: &mut QPen, offset: f64);
 
-        /// Sets the pen's join style to the given style. The default value is Qt::BevelJoin.
+        /// Sets the pen's join style to the given style. The default value is [`PenJoinStyle::BevelJoin`].
         #[rust_name = "set_join_style"]
         fn setJoinStyle(self: &mut QPen, style: PenJoinStyle);
 
-        /// Sets the pen style to the given style.
+        /// Sets the pen style to the given `style`.
         #[rust_name = "set_style"]
         fn setStyle(self: &mut QPen, style: PenStyle);
 
-        /// Sets the miter limit of this pen to the given limit.
+        /// Sets the miter limit of this pen to the given `limit`.
+        ///
+        /// The miter limit describes how far a miter join can extend from the join point. This is used to reduce artifacts between line joins where the lines are close to parallel.
+        ///
+        /// This value does only have effect when the pen style is set to [`PenJoinStyle::MiterJoin`]. The value is specified in units of the pen's width, e.g. a miter limit of 5 in width 10 is 50 pixels long. The default miter limit is 2, i.e. twice the pen width in pixels.
         #[rust_name = "set_miter_limit"]
         fn setMiterLimit(self: &mut QPen, limit: f64);
 
-        /// Sets the pen width to the given width in pixels with integer precision.
+        /// Sets the pen width to the given `width` in pixels with integer precision.
+        ///
+        /// A line width of zero indicates a cosmetic pen. This means that the pen width is always drawn one pixel wide, independent of the transformation set on the painter.
+        ///
+        /// Setting a pen width with a negative value is not supported.
         #[rust_name = "set_width"]
         fn setWidth(self: &mut QPen, width: i32);
 
@@ -127,6 +141,9 @@ mod ffi {
     }
 }
 
+/// The `QPen` class defines how a [`QPainter`](crate::QPainter) should draw lines and outlines of shapes.
+///
+/// Qt Documentation: [QPen](https://doc.qt.io/qt/qpen.html#details)
 #[repr(C)]
 pub struct QPen {
     _cspec: MaybeUninit<usize>,
@@ -159,15 +176,17 @@ impl PartialEq for QPen {
 
 impl Eq for QPen {}
 
-impl From<&ffi::QColor> for QPen {
-    fn from(color: &ffi::QColor) -> Self {
+impl From<&QColor> for QPen {
+    /// Constructs a solid line pen with 1 width and the given `color`.
+    fn from(color: &QColor) -> Self {
         ffi::qpen_init_from_qcolor(color)
     }
 }
 
-impl From<&ffi::PenStyle> for QPen {
-    fn from(penstyle: &ffi::PenStyle) -> Self {
-        ffi::qpen_init_from_penstyle(penstyle)
+impl From<&PenStyle> for QPen {
+    /// Constructs a black pen with 1 width and the given `style`.
+    fn from(style: &PenStyle) -> Self {
+        ffi::qpen_init_from_penstyle(style)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpolygon.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.rs
@@ -34,44 +34,53 @@ mod ffi {
         include!("cxx-qt-lib/qpolygon.h");
         type QPolygon = super::QPolygon;
 
-        /// Returns the bounding rectangle of the polygon, or QRect(0, 0, 0, 0) if the polygon is empty.
+        /// Returns the bounding rectangle of the polygon, or `QRect::new(0, 0, 0, 0)` if the polygon is empty.
         #[rust_name = "bounding_rect"]
         fn boundingRect(self: &QPolygon) -> QRect;
 
-        /// Returns true if the given point is inside the polygon according to the specified fillRule; otherwise returns false.
+        /// Returns `true` if the given `point` is inside the polygon according to the specified `fill_rule`; otherwise returns `false`.
         #[rust_name = "contains_point"]
-        fn containsPoint(self: &QPolygon, point: &QPoint, fillRule: FillRule) -> bool;
+        fn containsPoint(self: &QPolygon, point: &QPoint, fill_rule: FillRule) -> bool;
 
-        /// Returns a polygon which is the intersection of this polygon and r.
+        /// Returns a polygon which is the intersection of this polygon and `r`.
+        ///
+        /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
         fn intersected(self: &QPolygon, r: &QPolygon) -> QPolygon;
 
-        /// Returns true if the current polygon intersects at any point the given polygon p.
-        /// Also returns true if the current polygon contains or is contained by any part of p.
+        /// Returns `true` if the current polygon intersects at any point the given polygon `p`.
+        /// Also returns `true` if the current polygon contains or is contained by any part of `p`.
+        ///
+        /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
         fn intersects(self: &QPolygon, p: &QPolygon) -> bool;
 
-        /// Returns the point at the given index.
+        /// Returns the point at the given `index`.
         fn point(self: &QPolygon, index: i32) -> QPoint;
 
-        /// Sets the point at the given index to the given point.
+        /// Sets the point at the given `index` to the given `point`.
         #[rust_name = "set_point"]
         fn setPoint(self: &mut QPolygon, index: i32, point: &QPoint);
 
-        /// Returns a polygon which is r subtracted from this polygon.
+        /// Returns a polygon which is `r` subtracted from this polygon.
+        ///
+        /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
         fn subtracted(self: &QPolygon, r: &QPolygon) -> QPolygon;
 
         /// Returns this polygon as a polygon with floating point accuracy.
-        /// since Qt 6.4.
+        ///
+        /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_polygonf"]
         fn toPolygonF(self: &QPolygon) -> QPolygonF;
 
-        /// Translates all points in the polygon by (dx, dy).
+        /// Translates all points in the polygon by (`dx`, `dy`).
         fn translate(self: &mut QPolygon, dx: i32, dy: i32);
 
-        /// Returns a copy of the polygon that is translated by (dx, dy).
+        /// Returns a copy of the polygon that is translated by (`dx`, `dy`).
         fn translated(self: &QPolygon, dx: i32, dy: i32) -> QPolygon;
 
-        /// Returns a polygon which is the union of this polygon and r.
+        /// Returns a polygon which is the union of this polygon and `r`.
+        ///
+        /// Set operations on polygons, will treat the polygons as areas, and implicitly close the polygon.
         fn united(self: &QPolygon, r: &QPolygon) -> QPolygon;
     }
 
@@ -118,7 +127,9 @@ mod ffi {
     }
 }
 
-/// The QPolygon class provides a list of QPoint.
+/// The `QPolygon` class provides a list of points using integer precision.
+///
+/// Qt Documentation: [QPolygon](https://doc.qt.io/qt/qpolygon.html#details)
 #[repr(C)]
 pub struct QPolygon {
     /// The layout has changed between Qt 5 and Qt 6
@@ -132,7 +143,7 @@ pub struct QPolygon {
 }
 
 impl Default for QPolygon {
-    /// Constructs a copy of the given polygon.
+    /// Constructs a polygon with no points.
     fn default() -> Self {
         ffi::qpolygon_init_default()
     }
@@ -151,11 +162,13 @@ impl Clone for QPolygon {
 }
 
 impl QPolygon {
-    /// Constructs a polygon from the given rectangle. If closed is false, the polygon
+    /// Constructs a polygon from the given `rectangle`. If `closed` is `false`, the polygon
     /// just contains the four points of the rectangle ordered clockwise, otherwise the
-    /// polygon's fifth point is set to rectangle.topLeft().
-    pub fn new(rect: &QRect, closed: bool) -> Self {
-        ffi::qpolygon_init_qrect(rect, closed)
+    /// polygon's fifth point is set to `rectangle.top_left()`.
+    ///
+    /// Note that the bottom-right corner of the rectangle is located at (`rectangle.x() + rectangle.width()`, `rectangle.y() + rectangle.height()`).
+    pub fn new(rectangle: &QRect, closed: bool) -> Self {
+        ffi::qpolygon_init_qrect(rectangle, closed)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.rs
@@ -38,35 +38,45 @@ mod ffi {
         #[rust_name = "bounding_rect"]
         fn boundingRect(self: &QPolygonF) -> QRectF;
 
-        /// Returns true if the given point is inside the polygon according to the specified fillRule; otherwise returns false.
+        /// Returns `true` if the given point is inside the polygon according to the specified `fill_rule`; otherwise returns `false`.
         #[rust_name = "contains_point"]
-        fn containsPoint(self: &QPolygonF, point: &QPointF, fillRule: FillRule) -> bool;
+        fn containsPoint(self: &QPolygonF, point: &QPointF, fill_rule: FillRule) -> bool;
 
-        /// Returns a polygon which is the intersection of this polygon and r.
+        /// Returns a polygon which is the intersection of this polygon and `r`.
+        ///
+        /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
         fn intersected(self: &QPolygonF, r: &QPolygonF) -> QPolygonF;
 
-        /// Returns true if the current polygon intersects at any point the given polygon p.
-        /// Also returns true if the current polygon contains or is contained by any part of p.
+        /// Returns `true` if the current polygon intersects at any point the given polygon `p`.
+        /// Also returns `true` if the current polygon contains or is contained by any part of `p`.
+        ///
+        /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
         fn intersects(self: &QPolygonF, p: &QPolygonF) -> bool;
 
-        /// Returns true if the polygon is closed; otherwise returns false.
+        /// Returns `true` if the polygon is closed; otherwise returns `false`.
+        ///
+        /// A polygon is said to be closed if its start point and end point are equal.
         #[rust_name = "is_closed"]
         fn isClosed(self: &QPolygonF) -> bool;
 
-        /// Returns a polygon which is r subtracted from this polygon.
+        /// Returns a polygon which is `r` subtracted from this polygon.
+        ///
+        /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
         fn subtracted(self: &QPolygonF, r: &QPolygonF) -> QPolygonF;
 
-        /// Creates and returns a QPolygon by converting each QPointF to a QPoint.
+        /// Creates and returns a `QPolygon` by converting each [`QPointF`](crate::QPointF) to a [`QPoint`](crate::QPoint).
         #[rust_name = "to_polygon"]
         fn toPolygon(self: &QPolygonF) -> QPolygon;
 
-        /// Translates all points in the polygon by (dx, dy).
+        /// Translates all points in the polygon by (`dx`, `dy`).
         fn translate(self: &mut QPolygonF, dx: f64, dy: f64);
 
-        /// Returns a copy of the polygon that is translated by (dx, dy).
+        /// Returns a copy of the polygon that is translated by (`dx`, `dy`).
         fn translated(self: &QPolygonF, dx: f64, dy: f64) -> QPolygonF;
 
-        /// Returns a polygon which is the union of this polygon and r.
+        /// Returns a polygon which is the union of this polygon and `r`.
+        ///
+        /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
         fn united(self: &QPolygonF, r: &QPolygonF) -> QPolygonF;
     }
 

--- a/crates/cxx-qt-lib/src/gui/qregion.rs
+++ b/crates/cxx-qt-lib/src/gui/qregion.rs
@@ -17,22 +17,22 @@ mod ffi {
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = crate::QPoint;
 
-        /// Returns the bounding rectangle of this region. An empty region gives a rectangle that is QRect::isNul
+        /// Returns the bounding rectangle of this region. An empty region gives a rectangle that is [`QRect::is_null`].
         #[rust_name = "bounding_rect"]
         fn boundingRect(self: &QRegion) -> QRect;
 
-        /// Returns true if the region overlaps the rectangle r; otherwise returns false.
+        /// Returns `true` if the region overlaps the rectangle `r`; otherwise returns `false`.
         fn contains(self: &QRegion, r: &QRect) -> bool;
 
-        /// Returns a region which is the intersection of this region and r.
+        /// Returns a region which is the intersection of this region and `r`.
         fn intersected(self: &QRegion, r: &QRegion) -> QRegion;
 
-        /// Returns true if the region is empty; otherwise returns false. An empty region is a region that contains no points.
+        /// Returns `true` if the region is empty; otherwise returns `false`. An empty region is a region that contains no points.
         #[rust_name = "is_empty"]
         fn isEmpty(self: &QRegion) -> bool;
 
-        /// Returns true if the region is empty; otherwise returns false. An empty region is a region that contains no points.
-        /// This function is the same as isEmpty
+        /// Returns `true` if the region is empty; otherwise returns `false`. An empty region is a region that contains no points.
+        /// This function is the same as [`is_empty`](Self::is_empty).
         #[rust_name = "is_null"]
         fn isNull(self: &QRegion) -> bool;
 
@@ -40,22 +40,23 @@ mod ffi {
         #[rust_name = "rect_count"]
         fn rectCount(self: &QRegion) -> i32;
 
-        /// Returns a region which is r subtracted from this region.
+        /// Returns a region which is `r` subtracted from this region.
         fn subtracted(self: &QRegion, r: &QRegion) -> QRegion;
 
-        /// Translates the region point.x() along the x axis and point.y() along the y axis, relative to the current position.
+        /// Translates the region `point.x()` along the x axis and `point.y()` along the y axis, relative to the current position.
         /// Positive values move the region to the right and down.
-        /// Translates to the given point.
+        ///
+        /// Translates to the given `point`.
         fn translate(self: &mut QRegion, point: &QPoint);
 
-        /// Returns a copy of the region that is translated p.x() along the x axis and p.y() along the y axis,
+        /// Returns a copy of the region that is translated `p.x()` along the x axis and `p.y()` along the y axis,
         /// relative to the current position. Positive values move the rectangle to the right and down.
         fn translated(self: &QRegion, p: &QPoint) -> QRegion;
 
-        /// Returns a region which is the union of this region and r.
+        /// Returns a region which is the union of this region and `r`.
         fn united(self: &QRegion, r: &QRegion) -> QRegion;
 
-        /// Returns a region which is the exclusive or (XOR) of this region and r.
+        /// Returns a region which is the exclusive or (XOR) of this region and `r`.
         fn xored(self: &QRegion, r: &QRegion) -> QRegion;
     }
 
@@ -77,6 +78,9 @@ mod ffi {
     }
 }
 
+/// The `QRegion` class specifies a clip region for a painter.
+///
+/// Qt Documentation: [QRegion](https://doc.qt.io/qt/qregion.html#details)
 #[repr(C)]
 pub struct QRegion {
     _cspec: MaybeUninit<usize>,

--- a/crates/cxx-qt-lib/src/gui/qvector2d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.rs
@@ -7,6 +7,8 @@ use std::fmt;
 
 use cxx::{type_id, ExternType};
 
+use crate::{QPoint, QPointF, QVector3D, QVector4D};
+
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
@@ -24,7 +26,7 @@ mod ffi {
         include!("cxx-qt-lib/qvector4d.h");
         type QVector4D = crate::QVector4D;
 
-        /// Returns true if the x and y coordinates are set to 0.0, otherwise returns false.
+        /// Returns `true` if the x and y coordinates are set to 0.0, otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QVector2D) -> bool;
 
@@ -47,10 +49,10 @@ mod ffi {
         /// Otherwise the normalized form of the vector of length 1 will be returned.
         fn normalized(self: &QVector2D) -> QVector2D;
 
-        /// Sets the x coordinate of this point to the given finite x coordinate.
+        /// Sets the x coordinate of this point to the given finite `x` coordinate.
         #[rust_name = "set_x"]
         fn setX(self: &mut QVector2D, x: f32);
-        /// Sets the y coordinate of this point to the given finite y coordinate.
+        /// Sets the y coordinate of this point to the given finite `y` coordinate.
         #[rust_name = "set_y"]
         fn setY(self: &mut QVector2D, y: f32);
 
@@ -127,6 +129,8 @@ mod ffi {
 }
 
 /// The QVector2D class represents a vector or vertex in 2D space.
+///
+/// Qt Documentation: [QVector2D](https://doc.qt.io/qt/qvector2d.html#details)
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QVector2D {
@@ -134,20 +138,20 @@ pub struct QVector2D {
 }
 
 impl QVector2D {
-    /// Constructs a vector with coordinates (xpos, ypos). Both coordinates must be finite.
+    /// Constructs a vector with coordinates (`xpos`, `ypos`). Both coordinates must be finite.
     pub fn new(xpos: f32, ypos: f32) -> Self {
         ffi::qvector2d_init(xpos, ypos)
     }
 
-    /// Returns the distance that this vertex is from a line defined by point and the unit vector direction.
+    /// Returns the distance that this vertex is from a line defined by `point` and the unit vector `direction`.
     ///
-    /// If direction is a null vector, then it does not define a line.
-    /// In that case, the distance from point to this vertex is returned.
+    /// If `direction` is a null vector, then it does not define a line.
+    /// In that case, the distance from `point` to this vertex is returned.
     pub fn distance_to_line(&self, point: QVector2D, direction: QVector2D) -> f32 {
         ffi::qvector2d_distance_to_line(self, point, direction)
     }
 
-    /// Returns the distance from this vertex to a point defined by the vertex point.
+    /// Returns the distance from this vertex to a point defined by the vertex `point`.
     pub fn distance_to_point(&self, point: QVector2D) -> f32 {
         ffi::qvector2d_distance_to_point(self, point)
     }
@@ -194,46 +198,46 @@ impl std::ops::Div<f32> for QVector2D {
     }
 }
 
-impl From<crate::QVector4D> for QVector2D {
+impl From<QVector4D> for QVector2D {
     /// Constructs a vector with x and y coordinates from a 3D vector.
     /// The z and w coordinates of vector are dropped.
-    fn from(value: crate::QVector4D) -> Self {
+    fn from(value: QVector4D) -> Self {
         ffi::qvector2d_init_qvector4d(value)
     }
 }
 
-impl From<crate::QVector3D> for QVector2D {
+impl From<QVector3D> for QVector2D {
     /// Constructs a vector with x and y coordinates from a 3D vector.
     /// The z coordinate of vector is dropped.
-    fn from(value: crate::QVector3D) -> Self {
+    fn from(value: QVector3D) -> Self {
         ffi::qvector2d_init_qvector3d(value)
     }
 }
 
-impl From<crate::QPointF> for QVector2D {
+impl From<QPointF> for QVector2D {
     /// Constructs a vector with x and y coordinates from a 2D point.
-    fn from(value: crate::QPointF) -> Self {
+    fn from(value: QPointF) -> Self {
         ffi::qvector2d_init_qpointf(value)
     }
 }
 
-impl From<QVector2D> for crate::QPointF {
-    /// Returns the QPoint form of this 2D vector.
+impl From<QVector2D> for QPointF {
+    /// Returns the `QPointF` form of this 2D vector.
     /// Each coordinate is rounded to the nearest integer.
     fn from(value: QVector2D) -> Self {
         value.to_pointf()
     }
 }
 
-impl From<crate::QPoint> for QVector2D {
+impl From<QPoint> for QVector2D {
     /// Constructs a vector with x and y coordinates from a 2D point.
-    fn from(value: crate::QPoint) -> Self {
+    fn from(value: QPoint) -> Self {
         ffi::qvector2d_init_qpoint(value)
     }
 }
 
-impl From<QVector2D> for crate::QPoint {
-    /// Returns the QPointF form of this 2D vector.
+impl From<QVector2D> for QPoint {
+    /// Returns the `QPoint` form of this 2D vector.
     fn from(value: QVector2D) -> Self {
         value.to_point()
     }

--- a/crates/cxx-qt-lib/src/gui/qvector3d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.rs
@@ -7,6 +7,8 @@ use std::fmt;
 
 use cxx::{type_id, ExternType};
 
+use crate::{QPoint, QPointF, QVector2D, QVector4D};
+
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
@@ -24,7 +26,7 @@ mod ffi {
         include!("cxx-qt-lib/qvector4d.h");
         type QVector4D = crate::QVector4D;
 
-        /// Returns true if the x, y, and z coordinates are set to 0.0, otherwise returns false.
+        /// Returns `true` if the x, y, and z coordinates are set to 0.0, otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QVector3D) -> bool;
 
@@ -47,13 +49,13 @@ mod ffi {
         /// Otherwise the normalized form of the vector of length 1 will be returned.
         fn normalized(self: &QVector3D) -> QVector3D;
 
-        /// Sets the x coordinate of this point to the given finite x coordinate.
+        /// Sets the x coordinate of this point to the given finite `x` coordinate.
         #[rust_name = "set_x"]
         fn setX(self: &mut QVector3D, x: f32);
-        /// Sets the y coordinate of this point to the given finite y coordinate.
+        /// Sets the y coordinate of this point to the given finite `y` coordinate.
         #[rust_name = "set_y"]
         fn setY(self: &mut QVector3D, y: f32);
-        /// Sets the z coordinate of this point to the given finite z coordinate.
+        /// Sets the z coordinate of this point to the given finite `z` coordinate.
         #[rust_name = "set_z"]
         fn setZ(self: &mut QVector3D, z: f32);
 
@@ -143,6 +145,8 @@ mod ffi {
 }
 
 /// The QVector3D class represents a vector or vertex in 3D space.
+///
+/// Qt Documentation: [QVector3D](https://doc.qt.io/qt/qvector3d.html#details)
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QVector3D {
@@ -150,27 +154,27 @@ pub struct QVector3D {
 }
 
 impl QVector3D {
-    /// Constructs a vector with coordinates (xpos, ypos, zpos). All parameters must be finite.
+    /// Constructs a vector with coordinates (`xpos`, `ypos`, `zpos`). All parameters must be finite.
     pub fn new(xpos: f32, ypos: f32, zpos: f32) -> Self {
         ffi::qvector3d_init(xpos, ypos, zpos)
     }
 
-    /// Returns the distance that this vertex is from a line defined by point and the unit vector direction.
+    /// Returns the distance that this vertex is from a line defined by `point` and the unit vector `direction`.
     ///
-    /// If direction is a null vector, then it does not define a line.
-    /// In that case, the distance from point to this vertex is returned.
+    /// If `direction` is a null vector, then it does not define a line.
+    /// In that case, the distance from `point` to this vertex is returned.
     pub fn distance_to_line(&self, point: QVector3D, direction: QVector3D) -> f32 {
         ffi::qvector3d_distance_to_line(self, point, direction)
     }
 
-    /// Returns the distance from this vertex to a plane defined by the vertex plane and a normal unit vector. The normal parameter is assumed to have been normalized to a unit vector.
+    /// Returns the distance from this vertex to a plane defined by the vertex `plane` and a `normal` unit vector. The `normal` parameter is assumed to have been normalized to a unit vector.
     ///
     /// The return value will be negative if the vertex is below the plane, or zero if it is on the plane.
-    pub fn distance_to_plane(&self, point: QVector3D, normal: QVector3D) -> f32 {
-        ffi::qvector3d_distance_to_plane(self, point, normal)
+    pub fn distance_to_plane(&self, plane: QVector3D, normal: QVector3D) -> f32 {
+        ffi::qvector3d_distance_to_plane(self, plane, normal)
     }
 
-    /// Returns the distance from this vertex to a point defined by the vertex point.
+    /// Returns the distance from this vertex to a point defined by the vertex `point`.
     pub fn distance_to_point(&self, point: QVector3D) -> f32 {
         ffi::qvector3d_distance_to_point(self, point)
     }
@@ -217,45 +221,45 @@ impl std::ops::Div<f32> for QVector3D {
     }
 }
 
-impl From<crate::QVector4D> for QVector3D {
+impl From<QVector4D> for QVector3D {
     /// Constructs a 3D vector from the specified 4D vector.
     /// The w coordinate is dropped.
-    fn from(value: crate::QVector4D) -> Self {
+    fn from(value: QVector4D) -> Self {
         ffi::qvector3d_init_qvector4d(value)
     }
 }
 
-impl From<crate::QVector2D> for QVector3D {
+impl From<QVector2D> for QVector3D {
     /// Constructs a 3D vector from the specified 2D vector.
     /// The z coordinate is set to zero.
-    fn from(value: crate::QVector2D) -> Self {
+    fn from(value: QVector2D) -> Self {
         ffi::qvector3d_init_qvector2d(value)
     }
 }
 
-impl From<crate::QPointF> for QVector3D {
+impl From<QPointF> for QVector3D {
     /// Constructs a vector with x and y coordinates from a 2D point, and a z coordinate of 0.
-    fn from(value: crate::QPointF) -> Self {
+    fn from(value: QPointF) -> Self {
         ffi::qvector3d_init_qpointf(value)
     }
 }
 
-impl From<QVector3D> for crate::QPointF {
-    /// Returns the QPointF form of this 3D vector. The z coordinate is dropped.
+impl From<QVector3D> for QPointF {
+    /// Returns the `QPointF` form of this 3D vector. The z coordinate is dropped.
     fn from(value: QVector3D) -> Self {
         value.to_pointf()
     }
 }
 
-impl From<crate::QPoint> for QVector3D {
+impl From<QPoint> for QVector3D {
     /// Constructs a vector with x and y coordinates from a 2D point, and a z coordinate of 0.
-    fn from(value: crate::QPoint) -> Self {
+    fn from(value: QPoint) -> Self {
         ffi::qvector3d_init_qpoint(value)
     }
 }
 
-impl From<QVector3D> for crate::QPoint {
-    /// Returns the QPoint form of this 3D vector. The z coordinate is dropped.
+impl From<QVector3D> for QPoint {
+    /// Returns the `QPoint` form of this 3D vector. The z coordinate is dropped.
     fn from(value: QVector3D) -> Self {
         value.to_point()
     }

--- a/crates/cxx-qt-lib/src/gui/qvector4d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.rs
@@ -7,6 +7,8 @@ use std::fmt;
 
 use cxx::{type_id, ExternType};
 
+use crate::{QPoint, QPointF, QVector2D, QVector3D};
+
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
@@ -24,7 +26,7 @@ mod ffi {
         include!("cxx-qt-lib/qvector4d.h");
         type QVector4D = super::QVector4D;
 
-        /// Returns true if the x, y, z, and w coordinates are set to 0.0, otherwise returns false.
+        /// Returns `true` if the x, y, z, and w coordinates are set to 0.0, otherwise returns `false`.
         #[rust_name = "is_null"]
         fn isNull(self: &QVector4D) -> bool;
 
@@ -47,16 +49,16 @@ mod ffi {
         /// Otherwise the normalized form of the vector of length 1 will be returned.
         fn normalized(self: &QVector4D) -> QVector4D;
 
-        /// Sets the w coordinate of this point to the given finite w coordinate.
+        /// Sets the w coordinate of this point to the given finite `w` coordinate.
         #[rust_name = "set_w"]
         fn setW(self: &mut QVector4D, w: f32);
-        /// Sets the x coordinate of this point to the given finite x coordinate.
+        /// Sets the x coordinate of this point to the given finite `x` coordinate.
         #[rust_name = "set_x"]
         fn setX(self: &mut QVector4D, x: f32);
-        /// Sets the y coordinate of this point to the given finite y coordinate.
+        /// Sets the y coordinate of this point to the given finite `y` coordinate.
         #[rust_name = "set_y"]
         fn setY(self: &mut QVector4D, y: f32);
-        /// Sets the z coordinate of this point to the given finite z coordinate.
+        /// Sets the z coordinate of this point to the given finite `z` coordinate.
         #[rust_name = "set_z"]
         fn setZ(self: &mut QVector4D, z: f32);
 
@@ -134,6 +136,8 @@ mod ffi {
 }
 
 /// The QVector4D class represents a vector or vertex in 4D space.
+///
+/// Qt Documentation: [QVector4D](https://doc.qt.io/qt/qvector4d.html#details)
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct QVector4D {
@@ -141,7 +145,7 @@ pub struct QVector4D {
 }
 
 impl QVector4D {
-    /// Constructs a vector with coordinates (xpos, ypos, zpos, wpos).
+    /// Constructs a vector with coordinates (`xpos`, `ypos`, `zpos`, `wpos`).
     /// All parameters must be finite.
     pub fn new(xpos: f32, ypos: f32, zpos: f32, wpos: f32) -> Self {
         ffi::qvector4d_init(xpos, ypos, zpos, wpos)
@@ -189,45 +193,45 @@ impl std::ops::Div<f32> for QVector4D {
     }
 }
 
-impl From<crate::QVector3D> for QVector4D {
+impl From<QVector3D> for QVector4D {
     /// Constructs a 4D vector from the specified 3D vector.
     /// The w coordinate is set to zero.
-    fn from(value: crate::QVector3D) -> Self {
+    fn from(value: QVector3D) -> Self {
         ffi::qvector4d_init_qvector3d(value)
     }
 }
 
-impl From<crate::QVector2D> for QVector4D {
+impl From<QVector2D> for QVector4D {
     /// Constructs a 4D vector from the specified 2D vector.
     /// The z and w coordinates are set to zero.
-    fn from(value: crate::QVector2D) -> Self {
+    fn from(value: QVector2D) -> Self {
         ffi::qvector4d_init_qvector2d(value)
     }
 }
 
-impl From<crate::QPointF> for QVector4D {
+impl From<QPointF> for QVector4D {
     /// Constructs a vector with x and y coordinates from a 2D point, and z and w coordinates of 0.
-    fn from(value: crate::QPointF) -> Self {
+    fn from(value: QPointF) -> Self {
         ffi::qvector4d_init_qpointf(value)
     }
 }
 
-impl From<QVector4D> for crate::QPointF {
-    /// Returns the QPointF form of this 4D vector. The z and w coordinates are dropped.
+impl From<QVector4D> for QPointF {
+    /// Returns the `QPointF` form of this 4D vector. The z and w coordinates are dropped.
     fn from(value: QVector4D) -> Self {
         value.to_pointf()
     }
 }
 
-impl From<crate::QPoint> for QVector4D {
+impl From<QPoint> for QVector4D {
     /// Constructs a vector with x and y coordinates from a 2D point, and z and w coordinates of 0.
-    fn from(value: crate::QPoint) -> Self {
+    fn from(value: QPoint) -> Self {
         ffi::qvector4d_init_qpoint(value)
     }
 }
 
-impl From<QVector4D> for crate::QPoint {
-    /// Returns the QPoint form of this 4D vector. The z and w coordinates are dropped.
+impl From<QVector4D> for QPoint {
+    /// Returns the `QPoint` form of this 4D vector. The z and w coordinates are dropped.
     /// The x and y coordinates are rounded to nearest integers.
     fn from(value: QVector4D) -> Self {
         value.to_point()

--- a/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.rs
+++ b/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.rs
@@ -13,16 +13,16 @@ mod ffi {
         include!("cxx-qt-lib/qurl.h");
         type QUrl = crate::QUrl;
 
-        /// Adds path as a directory where the engine searches for installed modules in a URL-based directory structure.
+        /// Adds `path` as a directory where the engine searches for installed modules in a URL-based directory structure.
         #[rust_name = "add_import_path"]
         fn addImportPath(self: Pin<&mut QQmlApplicationEngine>, path: &QString);
 
-        /// Adds path as a directory where the engine searches for native plugins for imported modules (referenced in the qmldir file).
+        /// Adds `path` as a directory where the engine searches for native plugins for imported modules (referenced in the `qmldir` file).
         #[rust_name = "add_plugin_path"]
         fn addPluginPath(self: Pin<&mut QQmlApplicationEngine>, path: &QString);
 
         /// Return the base URL for this engine.
-        /// The base URL is only used to resolve components when a relative URL is passed to the QQmlComponent constructor.
+        /// The base URL is only used to resolve components when a relative URL is passed to the [QQmlComponent](https://doc.qt.io/qt/qqmlcomponent.html) constructor.
         #[rust_name = "base_url"]
         fn baseUrl(self: &QQmlApplicationEngine) -> QUrl;
 
@@ -30,42 +30,50 @@ mod ffi {
         #[rust_name = "import_path_list"]
         fn importPathList(self: &QQmlApplicationEngine) -> QStringList;
 
-        /// Loads the root QML file located at url.
+        /// Loads the root QML file located at `url`.
         fn load(self: Pin<&mut QQmlApplicationEngine>, url: &QUrl);
 
-        /// This property holds the directory for storing offline user data
+        /// Returns the directory for storing offline user data.
         #[rust_name = "offline_storage_path"]
         fn offlineStoragePath(self: &QQmlApplicationEngine) -> QString;
 
-        /// Returns the list of directories where the engine searches for native plugins for imported modules (referenced in the qmldir file).
+        /// Returns the list of directories where the engine searches for native plugins for imported modules (referenced in the `qmldir` file).
         #[rust_name = "plugin_path_list"]
         fn pluginPathList(self: &QQmlApplicationEngine) -> QStringList;
 
-        /// Set the base URL for this engine to url.
+        /// Set the base URL for this engine to `url`.
         #[rust_name = "set_base_url"]
         fn setBaseUrl(self: Pin<&mut QQmlApplicationEngine>, url: &QUrl);
 
-        /// Sets paths as the list of directories where the engine searches for installed modules in a URL-based directory structure.
+        /// Sets `paths` as the list of directories where the engine searches for installed modules in a URL-based directory structure.
         #[rust_name = "set_import_path_list"]
         fn setImportPathList(self: Pin<&mut QQmlApplicationEngine>, paths: &QStringList);
 
-        /// Sets the list of directories where the engine searches for native plugins for imported modules (referenced in the qmldir file) to paths.
+        /// Sets the list of directories where the engine searches for native plugins for imported modules (referenced in the `qmldir` file) to `paths`.
         #[rust_name = "set_plugin_path_list"]
         fn setPluginPathList(self: Pin<&mut QQmlApplicationEngine>, paths: &QStringList);
 
-        /// Sets path as string for storing offline user data.
+        /// Sets `path` as string for storing offline user data.
         #[rust_name = "set_offline_storage_path"]
         fn setOfflineStoragePath(self: Pin<&mut QQmlApplicationEngine>, dir: &QString);
     }
 
     unsafe extern "C++Qt" {
         include!("cxx-qt-lib/qqmlapplicationengine.h");
+        /// `QQmlApplicationEngine` provides a convenient way to load an application from a single QML file.
+        ///
+        /// Qt Documentation: [QQmlApplicationEngine](https://doc.qt.io/qt/qqmlapplicationengine.html#details)
         #[qobject]
         #[base = QQmlEngine]
         type QQmlApplicationEngine;
     }
 
     unsafe extern "C++Qt" {
+        /// This signal is emitted when an object finishes loading. If loading was successful, `object` contains a pointer to the loaded object, otherwise the pointer is null.
+        ///
+        /// The `url` to the component the `object` came from is also provided.
+        ///
+        /// Note: If the path to the component was provided as a [`QString`](crate::QString) containing a relative path, the `url` will contain a fully resolved path to the file.
         #[qsignal]
         #[rust_name = "object_created"]
         unsafe fn objectCreated(
@@ -74,6 +82,13 @@ mod ffi {
             url: &QUrl,
         );
 
+        /// This signal is emitted when loading finishes because an error occurred.
+        ///
+        /// The `url` to the component that failed to load is provided as an argument.
+        ///
+        /// **Note:** If the path to the component was provided as a [`QString`](crate::QString) containing a relative path, the `url` will contain a fully resolved path to the file.
+        ///
+        /// This function was introduced in Qt 6.4.
         #[qsignal]
         #[rust_name = "object_creation_failed"]
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
@@ -102,7 +117,9 @@ mod ffi {
 pub use ffi::QQmlApplicationEngine;
 
 impl QQmlApplicationEngine {
-    /// Create a new QQmlApplicationEngine
+    /// Create a new `QQmlApplicationEngine`.
+    ///
+    /// You will have to call [load](https://doc.qt.io/qt/qqmlapplicationengine.html#load)() later in order to load a QML file.
     pub fn new() -> cxx::UniquePtr<Self> {
         ffi::qqmlapplicationengine_new()
     }

--- a/crates/cxx-qt-lib/src/qml/qqmlengine.rs
+++ b/crates/cxx-qt-lib/src/qml/qqmlengine.rs
@@ -7,10 +7,13 @@
 mod ffi {
     unsafe extern "C++Qt" {
         include!("cxx-qt-lib/qqmlengine.h");
+        /// The `QQmlEngine` class provides an environment for instantiating QML components.
+        ///
+        /// Qt Documentation: [QQmlEngine](https://doc.qt.io/qt/qqmlengine.html#details)
         #[qobject]
         type QQmlEngine;
 
-        /// This signal is emitted when the QML loaded by the engine would like to exit from the event loop with the specified return code ret_code.
+        /// This signal is emitted when the QML loaded by the engine would like to exit from the event loop with the specified return code `ret_code`.
         #[qsignal]
         fn exit(self: Pin<&mut QQmlEngine>, ret_code: i32);
 
@@ -27,16 +30,24 @@ mod ffi {
         include!("cxx-qt-lib/qurl.h");
         type QUrl = crate::QUrl;
 
-        /// Adds path as a directory where the engine searches for installed modules in a URL-based directory structure.
+        /// Adds `path` as a directory where the engine searches for installed modules in a URL-based directory structure.
+        ///
+        /// The path may be a local filesystem directory, a Qt Resource path (`:/imports`), a Qt Resource url (`qrc:/imports`) or a URL.
+        ///
+        /// The path will be converted into canonical form before it is added to the import path list.
+        ///
+        /// The newly added `path` will be first in the [`import_path_list`](Self::import_path_list).
         #[rust_name = "add_import_path"]
         fn addImportPath(self: Pin<&mut QQmlEngine>, path: &QString);
 
-        /// Adds path as a directory where the engine searches for native plugins for imported modules (referenced in the qmldir file).
+        /// Adds `path` as a directory where the engine searches for native plugins for imported modules (referenced in the `qmldir` file).
+        ///
+        /// The newly added `path` will be first in the [`plugin_path_list`](Self::plugin_path_list).
         #[rust_name = "add_plugin_path"]
         fn addPluginPath(self: Pin<&mut QQmlEngine>, path: &QString);
 
         /// Return the base URL for this engine.
-        /// The base URL is only used to resolve components when a relative URL is passed to the QQmlComponent constructor.
+        /// The base URL is only used to resolve components when a relative URL is passed to the [QQmlComponent](https://doc.qt.io/qt/qqmlcomponent.html) constructor.
         #[rust_name = "base_url"]
         fn baseUrl(self: &QQmlEngine) -> QUrl;
 
@@ -44,35 +55,47 @@ mod ffi {
         #[rust_name = "import_path_list"]
         fn importPathList(self: &QQmlEngine) -> QStringList;
 
-        /// This property holds the directory for storing offline user data. Returns the directory where SQL and other offline storage is placed.
+        /// Returns the directory for storing offline user data. Returns the directory where SQL and other offline storage is placed.
+        ///
+        /// The SQL databases created with [openDatabaseSync](https://doc.qt.io/qt/qtquick-localstorage-qmlmodule.html#opendatabasesync)() are stored here.
+        ///
+        /// The default is QML/OfflineStorage in the platform-standard user application data directory.
+        ///
+        /// Note that the path may not currently exist on the filesystem, so callers wanting to create new files at this location should create it first.
         #[rust_name = "offline_storage_path"]
         fn offlineStoragePath(self: &QQmlEngine) -> QString;
 
-        /// Returns true if warning messages will be output to stderr in addition to being emitted by the warnings() signal, otherwise false.
+        /// Returns `true` if warning messages will be output to stderr in addition to being emitted by the [warnings](https://doc.qt.io/qt/qqmlengine.html#warnings)() signal, otherwise `false`.
         #[rust_name = "output_warnings_to_standard_error"]
         fn outputWarningsToStandardError(self: &QQmlEngine) -> bool;
 
-        /// Returns the list of directories where the engine searches for native plugins for imported modules (referenced in the qmldir file).
+        /// Returns the list of directories where the engine searches for native plugins for imported modules (referenced in the `qmldir` file).
+        ///
+        /// By default, the list contains only `.`, i.e. the engine searches in the directory of the `qmldir` file itself.
         #[rust_name = "plugin_path_list"]
         fn pluginPathList(self: &QQmlEngine) -> QStringList;
 
-        /// Set the base URL for this engine to url.
+        /// Set the base URL for this engine to `url`.
         #[rust_name = "set_base_url"]
         fn setBaseUrl(self: Pin<&mut QQmlEngine>, url: &QUrl);
 
-        /// Sets paths as the list of directories where the engine searches for installed modules in a URL-based directory structure.
+        /// Sets `paths` as the list of directories where the engine searches for installed modules in a URL-based directory structure.
+        ///
+        /// By default, this list contains the paths mentioned in [QML Import Path](https://doc.qt.io/qt/qtqml-syntax-imports.html#qml-import-path).
+        ///
+        /// **Warning:** Calling this function does not preserve the default import paths.
         #[rust_name = "set_import_path_list"]
         fn setImportPathList(self: Pin<&mut QQmlEngine>, paths: &QStringList);
 
-        /// This property holds the directory for storing offline user data
+        /// Returns the directory for storing offline user data.
         #[rust_name = "set_offline_storage_path"]
         fn setOfflineStoragePath(self: Pin<&mut QQmlEngine>, dir: &QString);
 
-        /// Set whether warning messages will be output to stderr to enabled.
+        /// Set whether warning messages will be output to stderr to `enabled`.
         #[rust_name = "set_output_warnings_to_standard_error"]
         fn setOutputWarningsToStandardError(self: Pin<&mut QQmlEngine>, enabled: bool);
 
-        /// Sets the list of directories where the engine searches for native plugins for imported modules (referenced in the qmldir file) to paths.
+        /// Sets the list of directories where the engine searches for native plugins for imported modules (referenced in the `qmldir` file) to `paths`.
         #[rust_name = "set_plugin_path_list"]
         fn setPluginPathList(self: Pin<&mut QQmlEngine>, paths: &QStringList);
     }
@@ -94,7 +117,7 @@ mod ffi {
 pub use ffi::QQmlEngine;
 
 impl QQmlEngine {
-    /// Create a new QQmlEngine
+    /// Create a new `QQmlEngine`.
     pub fn new() -> cxx::UniquePtr<Self> {
         ffi::qqmlengine_new()
     }

--- a/crates/cxx-qt-lib/src/quickcontrols/qquickstyle.rs
+++ b/crates/cxx-qt-lib/src/quickcontrols/qquickstyle.rs
@@ -7,6 +7,9 @@
 mod ffi {
     unsafe extern "C++" {
         include!("cxx-qt-lib/qquickstyle.h");
+        /// The `QQuickStyle` class allows configuring the application style.
+        ///
+        /// Qt Documentation: [QQuickStyle](https://doc.qt.io/qt/qquickstyle.html#details)
         type QQuickStyle;
 
         include!("cxx-qt-lib/qstring.h");
@@ -33,14 +36,27 @@ use crate::QString;
 pub use ffi::QQuickStyle;
 
 impl QQuickStyle {
+    /// Returns the name of the application style.
+    ///
+    /// **Note:** The application style can be specified by passing a `-style` command line argument. Therefore this function may not return a fully resolved value if called before constructing a [`QGuiApplication`](crate::QGuiApplication).
     pub fn name() -> QString {
         ffi::qquickstyle_name()
     }
 
+    /// Sets the application fallback style to `style`.
+    ///
+    /// **Note:** The fallback style must be the name of one of the built-in Qt Quick Controls styles, e.g. "Material".
+    ///
+    /// **Note:** The style must be configured before loading QML that imports Qt Quick Controls. It is not possible to change the style after the QML types have been registered.
+    ///
+    /// The fallback style can be also specified by setting the `QT_QUICK_CONTROLS_FALLBACK_STYLE` [environment variable](https://doc.qt.io/qt/qtquickcontrols-environment.html).
     pub fn set_fallback_style(style: &QString) {
         ffi::qquickstyle_set_fallback_style(style)
     }
 
+    /// Sets the application style to `style`.
+    ///
+    /// Note: The style must be configured before loading QML that imports Qt Quick Controls. It is not possible to change the style after the QML types have been registered.
     pub fn set_style(style: &QString) {
         ffi::qquickstyle_set_style(style)
     }

--- a/crates/cxx-qt-lib/src/util.rs
+++ b/crates/cxx-qt-lib/src/util.rs
@@ -11,6 +11,7 @@
 /// const_assert!(5 == 4);
 /// ```
 #[macro_export]
+#[doc(hidden)]
 macro_rules! const_assert {
     ($x:expr $(,)?) => {
         const _: () = ::core::assert!($x);

--- a/crates/cxx-qt/src/connection.rs
+++ b/crates/cxx-qt/src/connection.rs
@@ -30,12 +30,12 @@ mod ffi {
 
     /// This enum describes the types of connection that can be used with signals.
     ///
-    /// Note that UniqueConnection is not supported.
+    /// Note that [UniqueConnection](https://doc.qt.io/qt/qt.html#ConnectionType-enum) is not supported.
     #[namespace = "Qt"]
     #[repr(i32)]
     enum ConnectionType {
-        /// If the receiver lives in the thread that emits the signal, Qt::DirectConnection is used.
-        /// Otherwise, Qt::QueuedConnection is used. The connection type is determined when the signal is emitted.
+        /// If the receiver lives in the thread that emits the signal, [`DirectConnection`](Self::DirectConnection) is used.
+        /// Otherwise, [`QueuedConnection`](Self::QueuedConnection) is used. The connection type is determined when the signal is emitted.
         AutoConnection,
         /// The slot is invoked immediately when the signal is emitted.
         /// The slot is executed in the signalling thread.
@@ -43,7 +43,7 @@ mod ffi {
         /// The slot is invoked when control returns to the event loop of the receiver's thread.
         /// The slot is executed in the receiver's thread.
         QueuedConnection,
-        /// Same as Qt::QueuedConnection, except that the signalling thread blocks until the slot returns.
+        /// Same as [`QueuedConnection`](Self::QueuedConnection), except that the signalling thread blocks until the slot returns.
         /// This connection must not be used if the receiver lives in the signalling thread, or else the application will deadlock.
         BlockingQueuedConnection,
     }
@@ -62,13 +62,16 @@ mod ffi {
 ///
 /// Note that when this struct is dropped the connection is disconnected.
 /// So so keep a connection active either hold onto the struct for the duration
-/// that the connection should be active or call `release`.
+/// that the connection should be active or call [`QMetaObjectConnectionGuard::release`](crate::QMetaObjectConnectionGuard::release).
+///
+/// Qt Documentation: [QMetaObject::Connection](https://doc.qt.io/qt/qmetaobject-connection.html#details)
 #[repr(C)]
 pub struct QMetaObjectConnection {
     _space: MaybeUninit<*const c_void>,
 }
 
 impl Default for QMetaObjectConnection {
+    /// Creates a Connection instance.
     fn default() -> Self {
         ffi::qmetaobjectconnection_default()
     }
@@ -81,7 +84,9 @@ impl Drop for QMetaObjectConnection {
 }
 
 impl QMetaObjectConnection {
-    /// Disconnect the signal
+    /// Disconnect a connection.
+    ///
+    /// If the connection is invalid or has already been disconnected, do nothing and return `false`.
     pub fn disconnect(&self) -> bool {
         ffi::qmetaobjectconnection_disconnect(self)
     }

--- a/crates/cxx-qt/src/connectionguard.rs
+++ b/crates/cxx-qt/src/connectionguard.rs
@@ -9,7 +9,7 @@ use crate::QMetaObjectConnection;
 
 /// Represents a scoped guard to a signal-slot (or signal-functor) connection.
 ///
-/// This struct can be created from a [QMetaObjectConnection].
+/// This struct can be created from a [`QMetaObjectConnection`].
 ///
 /// Note that when this struct is dropped the connection is disconnected.
 /// So to keep a connection active hold onto the struct for the duration
@@ -22,11 +22,11 @@ pub struct QScopedMetaObjectConnectionGuard<'a> {
 
 /// Represents a static guard to a signal-slot (or signal-functor) connection.
 ///
-/// This struct can be created from a [QMetaObjectConnection].
+/// This struct can be created from a [`QMetaObjectConnection`].
 ///
 /// Note that when this struct is dropped the connection is disconnected.
 /// So to keep a connection active either hold onto the struct for the duration
-/// that the connection should be active or call `release`, hence the `#[must_use]`.
+/// that the connection should be active or call [`release`](Self::release), hence the `#[must_use]`.
 pub type QMetaObjectConnectionGuard = QScopedMetaObjectConnectionGuard<'static>;
 
 impl From<QMetaObjectConnection> for QScopedMetaObjectConnectionGuard<'static> {
@@ -39,14 +39,14 @@ impl From<QMetaObjectConnection> for QScopedMetaObjectConnectionGuard<'static> {
 }
 
 impl Drop for QScopedMetaObjectConnectionGuard<'_> {
-    /// Disconnect and deconstruct the connection
+    /// Disconnect and deconstruct the connection.
     fn drop(&mut self) {
         self.connection.disconnect();
     }
 }
 
 impl QScopedMetaObjectConnectionGuard<'static> {
-    /// Release the connection without disconnecting
+    /// Release the connection without disconnecting.
     pub fn release(mut self) -> QMetaObjectConnection {
         // Take the connection as our Drop implementation disconnects automatically
         // whereas we just want to release

--- a/crates/cxx-qt/src/qobject.rs
+++ b/crates/cxx-qt/src/qobject.rs
@@ -9,14 +9,16 @@
 mod ffi {
     unsafe extern "C++" {
         include!(<QtCore/QObject>);
-        /// QObject type.
+        /// The `QObject` class is the base class of all Qt objects.
         ///
-        /// Most methods available on this type are within the [cxx_qt_lib::core::QObjectExt] trait,
+        /// Most methods available on this type are within the [`cxx_qt_lib::QObjectExt`] trait,
         /// which needs to be imported in order to access these.
+        ///
+        /// Qt Documentation: [QObject](https://doc.qt.io/qt/qobject.html#details)
         type QObject;
 
         #[cxx_name = "dumpObjectInfo"]
-        /// Dump information about this QObjects name and signals
+        /// Dumps information about signal connections, etc. for this object to the debug output.
         fn dump_object_info(&self);
     }
 }


### PR DESCRIPTION
Currently, cxx-qt-lib has many errors in its documentation. Most of them are minor. Rather than writing documentation by hand, I think it is probably simpler and lower-maintenance to simply copy in the documentation provided by Qt.