### PR TITLE
Generic attributes parsing

### DIFF
--- a/crates/cxx-qt-gen/src/parser/attribute.rs
+++ b/crates/cxx-qt-gen/src/parser/attribute.rs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Ben Ford <ben.ford@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{parser, syntax::path::path_compare_str};
+use std::collections::BTreeMap;
+use syn::{spanned::Spanned, Attribute, Error, Result};
+
+pub struct ParsedAttribute<'a> {
+    pub cxx_qt_attrs: BTreeMap<&'a str, &'a Attribute>,
+    pub passthrough_attrs: BTreeMap<&'a str, &'a Attribute>,
+}
+
+/// Iterate the attributes of the method to extract cfg attributes
+pub fn extract_cfgs(attrs: &[Attribute]) -> Vec<Attribute> {
+    attrs
+        .iter()
+        .filter(|attr| path_compare_str(attr.meta.path(), &["cfg"]))
+        .cloned()
+        .collect()
+}
+
+/// Iterate the attributes of the method to extract Doc attributes (doc comments are parsed as this)
+pub fn extract_docs(attrs: &[Attribute]) -> Vec<Attribute> {
+    attrs
+        .iter()
+        .filter(|attr| path_compare_str(attr.meta.path(), &["doc"]))
+        .cloned()
+        .collect()
+}
+
+impl<'a> ParsedAttribute<'a> {
+    /// Collects a Map of all attributes found from the allowed list
+    /// Will error if an attribute which is not in the allowed list is found
+    pub fn require_attributes(
+        attrs: &'a [Attribute],
+        allowed: &'a [&str],
+    ) -> Result<ParsedAttribute<'a>> {
+        let mut output = BTreeMap::default();
+        for attr in attrs {
+            let index = allowed
+                .iter()
+                .position(|string| path_compare_str(attr.meta.path(), &parser::split_path(string)));
+            if let Some(index) = index {
+                output.insert(allowed[index], attr); // TODO: Doesn't error on duplicates
+            } else {
+                return Err(Error::new(
+                    attr.span(),
+                    format!(
+                        "Unsupported attribute! The only attributes allowed on this item are\n{}",
+                        allowed.join(", ")
+                    ),
+                ));
+            }
+        }
+        Ok(Self {
+            cxx_qt_attrs: output,
+            passthrough_attrs: Default::default(),
+        })
+    }
+
+    // Wrapper methods for the internal BTreeMaps
+    // TODO: Refactor usage to use more specialised methods / rename
+
+    /// Search in first the CXX-Qt, and then passthrough attributes by key
+    pub fn get(&self, key: &str) -> Option<&Attribute> {
+        self.cxx_qt_attrs
+            .get(key)
+            .or(self.passthrough_attrs.get(key))
+            .map(|attr| &**attr)
+    }
+
+    /// Check if CXX-Qt or passthrough attributes contains a particular key
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.cxx_qt_attrs.contains_key(key) || self.passthrough_attrs.contains_key(key)
+    }
+}

--- a/crates/cxx-qt-gen/src/parser/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externcxxqt.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::attribute::ParsedAttribute;
+use crate::parser::attribute::ParsedAttributes;
 use crate::{
     parser::{externqobject::ParsedExternQObject, signals::ParsedSignal, CaseConversion},
     syntax::{attribute::attribute_get_path, expr::expr_to_string},
@@ -34,15 +34,15 @@ impl ParsedExternCxxQt {
         parent_namespace: Option<&str>,
     ) -> Result<Self> {
         // TODO: support cfg on foreign mod blocks
-        let attrs = ParsedAttribute::require_attributes(
-            &foreign_mod.attrs,
+        let attrs = ParsedAttributes::require_attributes(
+            foreign_mod.attrs,
             &["namespace", "auto_cxx_name", "auto_rust_name"],
         )?;
 
-        let auto_case = CaseConversion::from_attrs(&attrs.cxx_qt_attrs)?;
+        let auto_case = CaseConversion::from_attrs(&attrs)?;
 
         let namespace = attrs
-            .get("namespace")
+            .get_one("namespace")
             .map(|attr| -> Result<String> {
                 expr_to_string(&attr.meta.require_name_value()?.value)
             })

--- a/crates/cxx-qt-gen/src/parser/externcxxqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externcxxqt.rs
@@ -3,11 +3,9 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::parser::attribute::ParsedAttribute;
 use crate::{
-    parser::{
-        externqobject::ParsedExternQObject, require_attributes, signals::ParsedSignal,
-        CaseConversion,
-    },
+    parser::{externqobject::ParsedExternQObject, signals::ParsedSignal, CaseConversion},
     syntax::{attribute::attribute_get_path, expr::expr_to_string},
 };
 use syn::{
@@ -36,12 +34,12 @@ impl ParsedExternCxxQt {
         parent_namespace: Option<&str>,
     ) -> Result<Self> {
         // TODO: support cfg on foreign mod blocks
-        let attrs = require_attributes(
+        let attrs = ParsedAttribute::require_attributes(
             &foreign_mod.attrs,
             &["namespace", "auto_cxx_name", "auto_rust_name"],
         )?;
 
-        let auto_case = CaseConversion::from_attrs(&attrs)?;
+        let auto_case = CaseConversion::from_attrs(&attrs.cxx_qt_attrs)?;
 
         let namespace = attrs
             .get("namespace")

--- a/crates/cxx-qt-gen/src/parser/externqobject.rs
+++ b/crates/cxx-qt-gen/src/parser/externqobject.rs
@@ -3,7 +3,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::naming::Name;
-use crate::parser::{parse_base_type, require_attributes, CaseConversion};
+use crate::parser::attribute::ParsedAttribute;
+use crate::parser::{parse_base_type, CaseConversion};
 use syn::{ForeignItemType, Ident, Result};
 
 /// A representation of a QObject to be generated in an extern C++ block
@@ -32,9 +33,9 @@ impl ParsedExternQObject {
         module_ident: &Ident,
         parent_namespace: Option<&str>,
     ) -> Result<ParsedExternQObject> {
-        let attributes = require_attributes(&ty.attrs, &Self::ALLOWED_ATTRS)?;
+        let attrs = ParsedAttribute::require_attributes(&ty.attrs, &Self::ALLOWED_ATTRS)?;
 
-        let base_class = parse_base_type(&attributes)?;
+        let base_class = parse_base_type(&attrs.cxx_qt_attrs)?;
 
         Ok(Self {
             name: Name::from_ident_and_attrs(

--- a/crates/cxx-qt-gen/src/parser/externqobject.rs
+++ b/crates/cxx-qt-gen/src/parser/externqobject.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::naming::Name;
-use crate::parser::attribute::ParsedAttribute;
+use crate::parser::attribute::ParsedAttributes;
 use crate::parser::{parse_base_type, CaseConversion};
 use syn::{ForeignItemType, Ident, Result};
 
@@ -33,14 +33,15 @@ impl ParsedExternQObject {
         module_ident: &Ident,
         parent_namespace: Option<&str>,
     ) -> Result<ParsedExternQObject> {
-        let attrs = ParsedAttribute::require_attributes(&ty.attrs, &Self::ALLOWED_ATTRS)?;
+        // TODO: ATTR Can this be done without clone
+        let attrs = ParsedAttributes::require_attributes(ty.attrs.clone(), &Self::ALLOWED_ATTRS)?;
 
-        let base_class = parse_base_type(&attrs.cxx_qt_attrs)?;
+        let base_class = parse_base_type(&attrs)?;
 
         Ok(Self {
             name: Name::from_ident_and_attrs(
                 &ty.ident,
-                &ty.attrs,
+                &attrs.clone_attrs(),
                 parent_namespace,
                 Some(module_ident),
                 CaseConversion::none(),

--- a/crates/cxx-qt-gen/src/parser/externqobject.rs
+++ b/crates/cxx-qt-gen/src/parser/externqobject.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::naming::Name;
-use crate::parser::attribute::ParsedAttributes;
+use crate::parser::attribute::{AttributeConstraint, ParsedAttributes};
 use crate::parser::{parse_base_type, CaseConversion};
 use syn::{ForeignItemType, Ident, Result};
 
@@ -18,14 +18,14 @@ pub struct ParsedExternQObject {
 }
 
 impl ParsedExternQObject {
-    const ALLOWED_ATTRS: [&'static str; 7] = [
-        "cxx_name",
-        "rust_name",
-        "namespace",
-        "cfg",
-        "doc",
-        "qobject",
-        "base",
+    const ALLOWED_ATTRS: [(AttributeConstraint, &'static str); 7] = [
+        (AttributeConstraint::Unique, "cxx_name"),
+        (AttributeConstraint::Unique, "rust_name"),
+        (AttributeConstraint::Unique, "namespace"),
+        (AttributeConstraint::Duplicate, "cfg"),
+        (AttributeConstraint::Duplicate, "doc"),
+        (AttributeConstraint::Unique, "qobject"),
+        (AttributeConstraint::Unique, "base"),
     ];
 
     pub fn parse(

--- a/crates/cxx-qt-gen/src/parser/externrustqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externrustqt.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::naming::cpp::err_unsupported_item;
-use crate::parser::attribute::ParsedAttribute;
+use crate::parser::attribute::ParsedAttributes;
 use crate::parser::inherit::ParsedInheritedMethod;
 use crate::parser::method::ParsedMethod;
 use crate::parser::qobject::ParsedQObject;
@@ -39,12 +39,12 @@ impl ParsedExternRustQt {
         parent_namespace: Option<&str>,
     ) -> Result<Self> {
         // TODO: support cfg on foreign mod blocks
-        let attrs = ParsedAttribute::require_attributes(
-            &foreign_mod.attrs,
+        let attrs = ParsedAttributes::require_attributes(
+            foreign_mod.attrs,
             &["namespace", "auto_cxx_name", "auto_rust_name"],
         )?;
 
-        let auto_case = CaseConversion::from_attrs(&attrs.cxx_qt_attrs)?;
+        let auto_case = CaseConversion::from_attrs(&attrs)?;
 
         let mut extern_rustqt_block = Self {
             unsafety: foreign_mod.unsafety,
@@ -52,7 +52,7 @@ impl ParsedExternRustQt {
         };
 
         let namespace = attrs
-            .get("namespace")
+            .get_one("namespace")
             .map(|attr| expr_to_string(&attr.meta.require_name_value()?.value))
             .transpose()?
             .or_else(|| parent_namespace.map(String::from));

--- a/crates/cxx-qt-gen/src/parser/externrustqt.rs
+++ b/crates/cxx-qt-gen/src/parser/externrustqt.rs
@@ -4,11 +4,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::naming::cpp::err_unsupported_item;
+use crate::parser::attribute::ParsedAttribute;
 use crate::parser::inherit::ParsedInheritedMethod;
 use crate::parser::method::ParsedMethod;
 use crate::parser::qobject::ParsedQObject;
 use crate::parser::signals::ParsedSignal;
-use crate::parser::{require_attributes, CaseConversion};
+use crate::parser::CaseConversion;
 use crate::syntax::attribute::attribute_get_path;
 use crate::syntax::expr::expr_to_string;
 use crate::syntax::foreignmod::ForeignTypeIdentAlias;
@@ -38,12 +39,12 @@ impl ParsedExternRustQt {
         parent_namespace: Option<&str>,
     ) -> Result<Self> {
         // TODO: support cfg on foreign mod blocks
-        let attrs = require_attributes(
+        let attrs = ParsedAttribute::require_attributes(
             &foreign_mod.attrs,
             &["namespace", "auto_cxx_name", "auto_rust_name"],
         )?;
 
-        let auto_case = CaseConversion::from_attrs(&attrs)?;
+        let auto_case = CaseConversion::from_attrs(&attrs.cxx_qt_attrs)?;
 
         let mut extern_rustqt_block = Self {
             unsafety: foreign_mod.unsafety,

--- a/crates/cxx-qt-gen/src/parser/inherit.rs
+++ b/crates/cxx-qt-gen/src/parser/inherit.rs
@@ -3,9 +3,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::{
-    extract_cfgs, extract_docs, method::MethodFields, require_attributes, CaseConversion,
-};
+use crate::parser::attribute::{extract_cfgs, extract_docs, ParsedAttribute};
+use crate::parser::{method::MethodFields, CaseConversion};
 use core::ops::Deref;
 use quote::format_ident;
 use std::ops::DerefMut;
@@ -32,7 +31,7 @@ impl ParsedInheritedMethod {
     ];
 
     pub fn parse(method: ForeignItemFn, auto_case: CaseConversion) -> Result<Self> {
-        require_attributes(&method.attrs, &Self::ALLOWED_ATTRS)?;
+        ParsedAttribute::require_attributes(&method.attrs, &Self::ALLOWED_ATTRS)?;
         let docs = extract_docs(&method.attrs);
         let cfgs = extract_cfgs(&method.attrs);
 

--- a/crates/cxx-qt-gen/src/parser/inherit.rs
+++ b/crates/cxx-qt-gen/src/parser/inherit.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::parser::attribute::AttributeConstraint;
 use crate::parser::{method::MethodFields, CaseConversion};
 use core::ops::Deref;
 use quote::format_ident;
@@ -20,13 +21,13 @@ pub struct ParsedInheritedMethod {
 }
 
 impl ParsedInheritedMethod {
-    const ALLOWED_ATTRS: [&'static str; 6] = [
-        "cxx_name",
-        "rust_name",
-        "qinvokable",
-        "doc",
-        "inherit",
-        "cfg",
+    const ALLOWED_ATTRS: [(AttributeConstraint, &'static str); 6] = [
+        (AttributeConstraint::Unique, "cxx_name"),
+        (AttributeConstraint::Unique, "rust_name"),
+        (AttributeConstraint::Unique, "qinvokable"),
+        (AttributeConstraint::Duplicate, "doc"),
+        (AttributeConstraint::Unique, "inherit"),
+        (AttributeConstraint::Duplicate, "cfg"),
     ];
 
     pub fn parse(method: ForeignItemFn, auto_case: CaseConversion) -> Result<Self> {

--- a/crates/cxx-qt-gen/src/parser/inherit.rs
+++ b/crates/cxx-qt-gen/src/parser/inherit.rs
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::attribute::{extract_cfgs, extract_docs, ParsedAttribute};
 use crate::parser::{method::MethodFields, CaseConversion};
 use core::ops::Deref;
 use quote::format_ident;
@@ -31,12 +30,12 @@ impl ParsedInheritedMethod {
     ];
 
     pub fn parse(method: ForeignItemFn, auto_case: CaseConversion) -> Result<Self> {
-        ParsedAttribute::require_attributes(&method.attrs, &Self::ALLOWED_ATTRS)?;
-        let docs = extract_docs(&method.attrs);
-        let cfgs = extract_cfgs(&method.attrs);
+        let method_fields = MethodFields::parse(method, auto_case, &Self::ALLOWED_ATTRS)?;
 
+        let docs = method_fields.attrs.extract_docs();
+        let cfgs = method_fields.attrs.extract_cfgs();
         Ok(Self {
-            method_fields: MethodFields::parse(method, auto_case)?,
+            method_fields,
             docs,
             cfgs,
         })

--- a/crates/cxx-qt-gen/src/parser/method.rs
+++ b/crates/cxx-qt-gen/src/parser/method.rs
@@ -2,10 +2,11 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::parser::attribute::{extract_cfgs, ParsedAttribute};
 use crate::parser::CaseConversion;
 use crate::{
     naming::Name,
-    parser::{extract_cfgs, parameter::ParsedFunctionParameter, require_attributes},
+    parser::parameter::ParsedFunctionParameter,
     syntax::{foreignmod, types},
 };
 use core::ops::Deref;
@@ -121,13 +122,14 @@ impl ParsedMethod {
         unsafe_block: bool,
     ) -> Result<Self> {
         let fields = MethodFields::parse(method, auto_case)?;
-        let attrs = require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
+        let attrs =
+            ParsedAttribute::require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
         let cfgs = extract_cfgs(&fields.method.attrs);
 
         // Determine if the method is invokable
         let is_qinvokable = attrs.contains_key("qinvokable");
         let is_pure = attrs.contains_key("cxx_pure");
-        let specifiers = ParsedQInvokableSpecifiers::from_attrs(attrs);
+        let specifiers = ParsedQInvokableSpecifiers::from_attrs(attrs.cxx_qt_attrs);
 
         Ok(Self {
             method_fields: fields,

--- a/crates/cxx-qt-gen/src/parser/method.rs
+++ b/crates/cxx-qt-gen/src/parser/method.rs
@@ -2,7 +2,7 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use crate::parser::attribute::{extract_cfgs, ParsedAttributes};
+use crate::parser::attribute::{extract_cfgs, AttributeConstraint, ParsedAttributes};
 use crate::parser::CaseConversion;
 use crate::{
     naming::Name,
@@ -69,16 +69,16 @@ pub struct ParsedMethod {
 }
 
 impl ParsedMethod {
-    const ALLOWED_ATTRS: [&'static str; 9] = [
-        "cxx_name",
-        "rust_name",
-        "qinvokable",
-        "cxx_final",
-        "cxx_override",
-        "cxx_virtual",
-        "cxx_pure",
-        "doc",
-        "cfg",
+    const ALLOWED_ATTRS: [(AttributeConstraint, &'static str); 9] = [
+        (AttributeConstraint::Unique, "cxx_name"),
+        (AttributeConstraint::Unique, "rust_name"),
+        (AttributeConstraint::Unique, "qinvokable"),
+        (AttributeConstraint::Unique, "cxx_final"),
+        (AttributeConstraint::Unique, "cxx_override"),
+        (AttributeConstraint::Unique, "cxx_virtual"),
+        (AttributeConstraint::Unique, "cxx_pure"),
+        (AttributeConstraint::Duplicate, "doc"),
+        (AttributeConstraint::Duplicate, "cfg"),
     ];
 
     #[cfg(test)]
@@ -172,7 +172,7 @@ impl MethodFields {
     pub fn parse(
         method: ForeignItemFn,
         auto_case: CaseConversion,
-        allowed: &[&str],
+        allowed: &[(AttributeConstraint, &str)],
     ) -> Result<Self> {
         // TODO: Remove this clone?
         let attrs = ParsedAttributes::require_attributes(method.attrs.clone(), allowed)?;

--- a/crates/cxx-qt-gen/src/parser/mod.rs
+++ b/crates/cxx-qt-gen/src/parser/mod.rs
@@ -19,11 +19,10 @@ pub mod qobject;
 pub mod signals;
 pub mod trait_impl;
 
-use crate::parser::attribute::{ParsedAttribute, ParsedAttributes};
+use crate::parser::attribute::{AttributeConstraint, ParsedAttributes};
 use crate::{naming::TypeNames, syntax::expr::expr_to_string};
 use convert_case::Case;
 use cxxqtdata::ParsedCxxQtData;
-use proc_macro2::Span;
 use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
@@ -73,51 +72,14 @@ impl CaseConversion {
     /// Create a CaseConversion object from a Map of attributes, collected using `require_attributes`
     /// Parses both `auto_cxx_name` and `auto_cxx_name = Camel`
     pub fn from_attrs(attrs: &ParsedAttributes) -> Result<Self> {
-        // TODO: ATTR Won't error on duplicates, and needs error handling
-        // let rust = attrs
-        //     .get_one("auto_rust_name")
-        //     .map(|attr| meta_to_case(attr, Case::Snake))
-        //     .transpose()?;
-        // let cxx = attrs
-        //     .get_one("auto_cxx_name")
-        //     .map(|attr| meta_to_case(attr, Case::Camel))
-        //     .transpose()?;
-
-        let rust = match attrs.require_one("auto_rust_name") {
-            ParsedAttribute::Single(attr) => Some(meta_to_case(attr, Case::Snake)?),
-            ParsedAttribute::Absent => None,
-            ParsedAttribute::MultipleDisallowed(_) => {
-                Err(Error::new(
-                    Span::call_site(),
-                    "There must be at most one auto_rust_name attribute",
-                ))? // TODO: ATTR use real span
-            }
-            _ => {
-                // CODECOV_EXCLUDE_START
-                unreachable!(
-                    "Auto_rust_name is not an allowed duplicate, nor required so this block should be unreachable"
-                )
-                // CODECOV_EXCLUDE_STOP
-            }
-        };
-
-        let cxx = match attrs.require_one("auto_cxx_name") {
-            ParsedAttribute::Single(attr) => Some(meta_to_case(attr, Case::Camel)?),
-            ParsedAttribute::Absent => None,
-            ParsedAttribute::MultipleDisallowed(_) => {
-                Err(Error::new(
-                    Span::call_site(),
-                    "There must be at most one auto_cxx_name attribute",
-                ))? // TODO: ATTR use real span
-            }
-            _ => {
-                // CODECOV_EXCLUDE_START
-                unreachable!(
-                    "Auto_cxx_name is not an allowed duplicate, nor required so this block should be unreachable"
-                )
-                // CODECOV_EXCLUDE_STOP
-            }
-        };
+        let rust = attrs
+            .get_one("auto_rust_name")
+            .map(|attr| meta_to_case(attr, Case::Snake))
+            .transpose()?;
+        let cxx = attrs
+            .get_one("auto_cxx_name")
+            .map(|attr| meta_to_case(attr, Case::Camel))
+            .transpose()?;
 
         Ok(Self { rust, cxx })
     }
@@ -135,35 +97,20 @@ fn split_path(path_str: &str) -> Vec<&str> {
 
 // Extract base identifier from attribute
 pub fn parse_base_type(attributes: &ParsedAttributes) -> Result<Option<Ident>> {
-    match attributes.require_one("base") {
-        ParsedAttribute::Single(attr) => {
+    attributes
+        .get_one("base")
+        .map(|attr| -> Result<Ident> {
             let expr = &attr.meta.require_name_value()?.value;
             if let Expr::Path(path_expr) = expr {
-                Ok(Some(path_expr.path.require_ident()?.clone()))
+                Ok(path_expr.path.require_ident()?.clone())
             } else {
                 Err(Error::new_spanned(
                     expr,
                     "There must be a single base identifier, not string, and cannot be empty!",
                 ))
             }
-        }
-        ParsedAttribute::Absent => Ok(None),
-        ParsedAttribute::MultipleDisallowed(attrs) => {
-            let attr = attrs.first().expect("Expected at least one attribute");
-            let expr = &attr.meta.require_name_value()?.value;
-            Err(Error::new_spanned(
-                expr,
-                "There must be a single base identifier, not string, and cannot be empty!",
-            ))
-        }
-        _ => {
-            // CODECOV_EXCLUDE_START
-            unreachable!(
-                "base is not an allowed duplicate, nor required so this block should be unreachable"
-            )
-            // CODECOV_EXCLUDE_STOP
-        }
-    }
+        })
+        .transpose()
 }
 
 /// Struct representing the necessary components of a cxx mod to be passed through to generation
@@ -204,8 +151,13 @@ pub struct Parser {
 impl Parser {
     fn parse_mod_attributes(module: &mut ItemMod) -> Result<Option<String>> {
         // TODO: ATTR Can this be done without clone
-        let attrs =
-            ParsedAttributes::require_attributes(module.attrs.clone(), &["doc", "cxx_qt::bridge"])?;
+        let attrs = ParsedAttributes::require_attributes(
+            module.attrs.clone(),
+            &[
+                (AttributeConstraint::Duplicate, "doc"),
+                (AttributeConstraint::Unique, "cxx_qt::bridge"),
+            ],
+        )?;
         let mut namespace = None;
 
         // Check for the cxx_qt::bridge attribute

--- a/crates/cxx-qt-gen/src/parser/qenum.rs
+++ b/crates/cxx-qt-gen/src/parser/qenum.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::attribute::{extract_cfgs, extract_docs, ParsedAttribute};
+use crate::parser::attribute::ParsedAttributes;
 use crate::parser::CaseConversion;
 use crate::{naming::Name, syntax::path::path_compare_str};
 use quote::ToTokens;
@@ -61,9 +61,11 @@ impl ParsedQEnum {
         parent_namespace: Option<&str>,
         module: &Ident,
     ) -> Result<Self> {
-        ParsedAttribute::require_attributes(&qenum.attrs, &Self::ALLOWED_ATTRS)?;
-        let cfgs = extract_cfgs(&qenum.attrs);
-        let docs = extract_docs(&qenum.attrs);
+        // TODO: ATTR Can this be done without clone?
+        let attrs =
+            ParsedAttributes::require_attributes(qenum.attrs.clone(), &Self::ALLOWED_ATTRS)?;
+        let cfgs = attrs.extract_cfgs();
+        let docs = attrs.extract_docs();
 
         if qenum.variants.is_empty() {
             return Err(syn::Error::new_spanned(
@@ -74,7 +76,7 @@ impl ParsedQEnum {
 
         let name = Name::from_ident_and_attrs(
             &qenum.ident,
-            &qenum.attrs,
+            &attrs.clone_attrs(),
             parent_namespace,
             Some(module),
             CaseConversion::none(),

--- a/crates/cxx-qt-gen/src/parser/qenum.rs
+++ b/crates/cxx-qt-gen/src/parser/qenum.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::attribute::ParsedAttributes;
+use crate::parser::attribute::{AttributeConstraint, ParsedAttributes};
 use crate::parser::CaseConversion;
 use crate::{naming::Name, syntax::path::path_compare_str};
 use quote::ToTokens;
@@ -25,8 +25,14 @@ pub struct ParsedQEnum {
 }
 
 impl ParsedQEnum {
-    const ALLOWED_ATTRS: [&'static str; 6] =
-        ["cfg", "doc", "cxx_name", "rust_name", "namespace", "qenum"];
+    const ALLOWED_ATTRS: [(AttributeConstraint, &'static str); 6] = [
+        (AttributeConstraint::Duplicate, "cfg"),
+        (AttributeConstraint::Duplicate, "doc"),
+        (AttributeConstraint::Unique, "cxx_name"),
+        (AttributeConstraint::Unique, "rust_name"),
+        (AttributeConstraint::Unique, "namespace"),
+        (AttributeConstraint::Unique, "qenum"),
+    ];
     fn parse_variant(variant: &Variant) -> Result<Ident> {
         fn err(spanned: &impl ToTokens, message: &str) -> Result<Ident> {
             Err(syn::Error::new_spanned(spanned, message))

--- a/crates/cxx-qt-gen/src/parser/qenum.rs
+++ b/crates/cxx-qt-gen/src/parser/qenum.rs
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::{extract_cfgs, extract_docs, CaseConversion};
-use crate::{naming::Name, parser::require_attributes, syntax::path::path_compare_str};
+use crate::parser::attribute::{extract_cfgs, extract_docs, ParsedAttribute};
+use crate::parser::CaseConversion;
+use crate::{naming::Name, syntax::path::path_compare_str};
 use quote::ToTokens;
 use syn::{Attribute, Ident, ItemEnum, Result, Variant};
 
@@ -60,7 +61,7 @@ impl ParsedQEnum {
         parent_namespace: Option<&str>,
         module: &Ident,
     ) -> Result<Self> {
-        require_attributes(&qenum.attrs, &Self::ALLOWED_ATTRS)?;
+        ParsedAttribute::require_attributes(&qenum.attrs, &Self::ALLOWED_ATTRS)?;
         let cfgs = extract_cfgs(&qenum.attrs);
         let docs = extract_docs(&qenum.attrs);
 

--- a/crates/cxx-qt-gen/src/parser/qnamespace.rs
+++ b/crates/cxx-qt-gen/src/parser/qnamespace.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::attribute::ParsedAttributes;
+use crate::parser::attribute::{AttributeConstraint, ParsedAttributes};
 use syn::{ItemMacro, LitStr, Result};
 
 pub struct ParsedQNamespace {
@@ -15,7 +15,10 @@ pub struct ParsedQNamespace {
 
 impl ParsedQNamespace {
     pub fn parse(mac: ItemMacro) -> Result<Self> {
-        let attrs = ParsedAttributes::require_attributes(mac.attrs, &["qml_element"])?;
+        let attrs = ParsedAttributes::require_attributes(
+            mac.attrs,
+            &[(AttributeConstraint::Unique, "qml_element")],
+        )?;
         let namespace_literal: LitStr = syn::parse2(mac.mac.tokens)?;
         let namespace = namespace_literal.value();
         if namespace.contains(char::is_whitespace) {

--- a/crates/cxx-qt-gen/src/parser/qnamespace.rs
+++ b/crates/cxx-qt-gen/src/parser/qnamespace.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::require_attributes;
+use crate::parser::attribute::ParsedAttribute;
 use syn::{ItemMacro, LitStr, Result};
 
 pub struct ParsedQNamespace {
@@ -15,7 +15,7 @@ pub struct ParsedQNamespace {
 
 impl ParsedQNamespace {
     pub fn parse(mac: ItemMacro) -> Result<Self> {
-        let attrs = require_attributes(&mac.attrs, &["qml_element"])?;
+        let attrs = ParsedAttribute::require_attributes(&mac.attrs, &["qml_element"])?;
         let namespace_literal: LitStr = syn::parse2(mac.mac.tokens)?;
         let namespace = namespace_literal.value();
         if namespace.contains(char::is_whitespace) {

--- a/crates/cxx-qt-gen/src/parser/qnamespace.rs
+++ b/crates/cxx-qt-gen/src/parser/qnamespace.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::parser::attribute::ParsedAttribute;
+use crate::parser::attribute::ParsedAttributes;
 use syn::{ItemMacro, LitStr, Result};
 
 pub struct ParsedQNamespace {
@@ -15,7 +15,7 @@ pub struct ParsedQNamespace {
 
 impl ParsedQNamespace {
     pub fn parse(mac: ItemMacro) -> Result<Self> {
-        let attrs = ParsedAttribute::require_attributes(&mac.attrs, &["qml_element"])?;
+        let attrs = ParsedAttributes::require_attributes(mac.attrs, &["qml_element"])?;
         let namespace_literal: LitStr = syn::parse2(mac.mac.tokens)?;
         let namespace = namespace_literal.value();
         if namespace.contains(char::is_whitespace) {

--- a/crates/cxx-qt-gen/src/parser/qobject.rs
+++ b/crates/cxx-qt-gen/src/parser/qobject.rs
@@ -11,7 +11,7 @@ use crate::{
 #[cfg(test)]
 use quote::format_ident;
 
-use crate::parser::attribute::ParsedAttributes;
+use crate::parser::attribute::{AttributeConstraint, ParsedAttributes};
 use crate::parser::{parse_base_type, CaseConversion};
 use syn::{Attribute, Error, Ident, Meta, Result};
 
@@ -48,19 +48,20 @@ pub struct ParsedQObject {
 }
 
 impl ParsedQObject {
-    const ALLOWED_ATTRS: [&'static str; 11] = [
-        "cxx_name",
-        "rust_name",
-        "namespace",
-        "cfg",
-        "doc",
-        "qobject",
-        "base",
-        "qml_element",
-        "qml_uncreatable",
-        "qml_singleton",
-        "qproperty",
+    const ALLOWED_ATTRS: [(AttributeConstraint, &'static str); 11] = [
+        (AttributeConstraint::Unique, "cxx_name"),
+        (AttributeConstraint::Unique, "rust_name"),
+        (AttributeConstraint::Unique, "namespace"),
+        (AttributeConstraint::Duplicate, "cfg"),
+        (AttributeConstraint::Duplicate, "doc"),
+        (AttributeConstraint::Unique, "qobject"),
+        (AttributeConstraint::Unique, "base"),
+        (AttributeConstraint::Unique, "qml_element"),
+        (AttributeConstraint::Unique, "qml_uncreatable"),
+        (AttributeConstraint::Unique, "qml_singleton"),
+        (AttributeConstraint::Duplicate, "qproperty"),
     ];
+
     #[cfg(test)]
     pub fn mock() -> Self {
         ParsedQObject {
@@ -356,6 +357,13 @@ pub mod tests {
             |input |ParsedQObject::parse(input, None, &format_ident!("qobject"), CaseConversion::none()) =>
 
             {
+                #[qobject]
+                #[base = ""]
+                type MyObject = super::T;
+            }
+            // Duplicate attribute should fail
+            {
+                #[qobject]
                 #[qobject]
                 #[base = ""]
                 type MyObject = super::T;

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -2,6 +2,7 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::parser::attribute::AttributeConstraint;
 use crate::parser::CaseConversion;
 use crate::{parser::method::MethodFields, syntax::path::path_compare_str};
 use core::ops::Deref;
@@ -24,8 +25,14 @@ pub struct ParsedSignal {
 }
 
 impl ParsedSignal {
-    const ALLOWED_ATTRS: [&'static str; 6] =
-        ["cfg", "cxx_name", "rust_name", "inherit", "doc", "qsignal"];
+    const ALLOWED_ATTRS: [(AttributeConstraint, &'static str); 6] = [
+        (AttributeConstraint::Duplicate, "cfg"),
+        (AttributeConstraint::Unique, "cxx_name"),
+        (AttributeConstraint::Unique, "rust_name"),
+        (AttributeConstraint::Unique, "inherit"),
+        (AttributeConstraint::Duplicate, "doc"),
+        (AttributeConstraint::Unique, "qsignal"),
+    ];
 
     #[cfg(test)]
     /// Test fn for creating a mocked signal from a method body

--- a/crates/cxx-qt-gen/src/parser/signals.rs
+++ b/crates/cxx-qt-gen/src/parser/signals.rs
@@ -2,11 +2,9 @@
 // SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::parser::attribute::{extract_cfgs, extract_docs, ParsedAttribute};
 use crate::parser::CaseConversion;
-use crate::{
-    parser::{extract_cfgs, extract_docs, method::MethodFields, require_attributes},
-    syntax::path::path_compare_str,
-};
+use crate::{parser::method::MethodFields, syntax::path::path_compare_str};
 use core::ops::Deref;
 use std::ops::DerefMut;
 use syn::{spanned::Spanned, Attribute, Error, ForeignItemFn, Result, Visibility};
@@ -40,7 +38,8 @@ impl ParsedSignal {
         let docs = extract_docs(&method.attrs);
         let cfgs = extract_cfgs(&method.attrs);
         let fields = MethodFields::parse(method, auto_case)?;
-        let attrs = require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
+        let attrs =
+            ParsedAttribute::require_attributes(&fields.method.attrs, &Self::ALLOWED_ATTRS)?;
 
         if !fields.mutable {
             return Err(Error::new(


### PR DESCRIPTION
Generalise parsing of attributes, and make it more robust in terms of duplicate attributes, passthrough and reusability.
Fix #1132