### PR TITLE
Add QByteArray:from_base64_encoding and QByteArray::to_base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `QScopedMetaObjectConnectionGuard`, which is `QMetaObjectConnectionGuard` with a scoped lifetime. `QMetaObjectConnectionGuard` is now a type alias for `QScopedMetaObjectConnectionGuard<'static>`.
 - Support for setting Qt log message patterns with `q_set_message_pattern` and formatting log messages ith `q_format_log_message`.
 - Implement `IntoIterator` for `&QHash`, `&QList`, `&QMap`, `&QSet`, and `&QVector`.
+- Add `QByteArray:from_base64_encoding` and `QByteArray::to_base64`.
 
 ### Removed
 

--- a/crates/cxx-qt-lib/include/core/qbytearray.h
+++ b/crates/cxx-qt-lib/include/core/qbytearray.h
@@ -20,10 +20,19 @@ template<>
 struct IsRelocatable<QByteArray> : ::std::true_type
 {};
 
+template<>
+struct IsRelocatable<QByteArray::FromBase64Result> : ::std::true_type
+{};
+
 } // namespace rust
 
 namespace rust {
 namespace cxxqtlib1 {
+
+using QByteArrayBase64Option = QByteArray::Base64Option;
+using QByteArrayBase64Options = QByteArray::Base64Options;
+using QByteArrayBase64DecodingStatus = QByteArray::Base64DecodingStatus;
+using QByteArrayFromBase64Result = QByteArray::FromBase64Result;
 
 QByteArray
 qbytearrayFromSliceU8(::rust::Slice<const ::std::uint8_t> slice);
@@ -41,6 +50,9 @@ void
 qbytearrayAppend(QByteArray& byteArray, ::std::uint8_t ch);
 void
 qbytearrayFill(QByteArray& byteArray, ::std::uint8_t ch, ::rust::isize size);
+QByteArray::FromBase64Result
+qbytearrayFromBase64Encoding(const QByteArray& base64,
+                             QByteArray::Base64Options options);
 void
 qbytearrayInsert(QByteArray& byteArray, ::rust::isize pos, ::std::uint8_t ch);
 ::rust::isize

--- a/crates/cxx-qt-lib/src/core/mod.rs
+++ b/crates/cxx-qt-lib/src/core/mod.rs
@@ -4,7 +4,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod qbytearray;
-pub use qbytearray::QByteArray;
+pub use qbytearray::{
+    QByteArray, QByteArrayBase64Option, QByteArrayBase64Options, QByteArrayFromBase64Error,
+};
 
 mod qcoreapplication;
 pub use qcoreapplication::QCoreApplication;

--- a/crates/cxx-qt-lib/src/core/qbytearray.cpp
+++ b/crates/cxx-qt-lib/src/core/qbytearray.cpp
@@ -34,6 +34,22 @@ static_assert(!::std::is_trivially_destructible<QByteArray>::value);
 
 static_assert(QTypeInfo<QByteArray>::isRelocatable);
 
+using QByteArrayFromBase64Result = QByteArray::FromBase64Result;
+assert_alignment_and_size(QByteArrayFromBase64Result, {
+  QByteArray decoded;
+  QByteArray::Base64DecodingStatus decodingStatus;
+});
+
+static_assert(
+  !::std::is_trivially_copy_assignable<QByteArray::FromBase64Result>::value);
+static_assert(
+  !::std::is_trivially_copy_constructible<QByteArray::FromBase64Result>::value);
+
+static_assert(
+  !::std::is_trivially_destructible<QByteArray::FromBase64Result>::value);
+
+static_assert(QTypeInfo<QByteArray::FromBase64Result>::isRelocatable);
+
 namespace rust {
 namespace cxxqtlib1 {
 
@@ -102,6 +118,13 @@ qbytearrayFill(QByteArray& byteArray, ::std::uint8_t ch, ::rust::isize size)
 #else
   byteArray.fill(static_cast<char>(ch), static_cast<int>(size));
 #endif
+}
+
+QByteArray::FromBase64Result
+qbytearrayFromBase64Encoding(const QByteArray& base64,
+                             QByteArray::Base64Options options)
+{
+  return QByteArray::fromBase64Encoding(base64, options);
 }
 
 void


### PR DESCRIPTION
Qt documentation:
- [QByteArray::fromBase64Encoding](https://doc.qt.io/qt-6/qbytearray.html#fromBase64Encoding)
- [QByteArray:toBase64](https://doc.qt.io/qt-6/qbytearray.html#toBase64)