### PR TITLE
Improve CI log readability by removing sccache debug statements

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -420,7 +420,6 @@ jobs:
         # Allow a larger cache size so that code in branches can be cached
         # but still leave room for the tools cache
         SCCACHE_CACHE_SIZE: 600M
-        SCCACHE_LOG: debug
         SCCACHE_ERROR_LOG: ${{ matrix.sccache_log_path }}
 
     steps:


### PR DESCRIPTION
This gets rid of all those messages like

```
warning: qml_features@0.1.0: [2025-07-19T16:17:37Z DEBUG sccache::config] Attempting to read config file at "/home/runner/.config/sccache/config"
```

that make it incredibly difficult to spot why tests fail.