### PR TITLE
Use QString::as_slice for String conversions

### DIFF
--- a/crates/cxx-qt-lib/include/core/qstring.h
+++ b/crates/cxx-qt-lib/include/core/qstring.h
@@ -27,8 +27,9 @@ namespace cxxqtlib1 {
 
 QString
 qstringInitFromRustString(::rust::Str string);
-::rust::String
-qstringToRustString(const QString& string);
+
+::rust::Slice<const ::std::uint16_t>
+qstringAsSlice(const QString& string);
 
 QString
 qstringArg(const QString& string, const QString& a);

--- a/crates/cxx-qt-lib/src/core/qstring.cpp
+++ b/crates/cxx-qt-lib/src/core/qstring.cpp
@@ -46,12 +46,12 @@ qstringInitFromRustString(::rust::Str string)
   return QString::fromUtf8(string.data(), string.size());
 }
 
-::rust::String
-qstringToRustString(const QString& string)
+::rust::Slice<const ::std::uint16_t>
+qstringAsSlice(const QString& string)
 {
-  // Note that this changes UTF-16 to UTF-8
-  const auto byteArray = string.toUtf8();
-  return ::rust::String(byteArray.constData(), byteArray.size());
+  return ::rust::Slice<const ::std::uint16_t>(
+    reinterpret_cast<const std::uint16_t*>(string.data()),
+    static_cast<::std::size_t>(string.size()));
 }
 
 QString

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use cxx::{type_id, ExternType};
 use std::cmp::Ordering;
-use std::fmt;
+use std::fmt::{self, Write};
 use std::mem::MaybeUninit;
 
 use crate::{CaseSensitivity, QByteArray, QStringList, SplitBehaviorFlags};
@@ -141,8 +141,8 @@ mod ffi {
         fn operatorCmp(a: &QString, b: &QString) -> i8;
 
         #[doc(hidden)]
-        #[rust_name = "qstring_to_rust_string"]
-        fn qstringToRustString(string: &QString) -> String;
+        #[rust_name = "qstring_as_slice"]
+        fn qstringAsSlice(string: &QString) -> &[u16];
 
         #[doc(hidden)]
         #[rust_name = "qstring_arg"]
@@ -262,14 +262,20 @@ impl fmt::Display for QString {
     /// Format the `QString` as a Rust string.
     ///
     /// Note that this converts from UTF-16 to UTF-8.
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.pad(&String::from(self))
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if f.width().is_some() || f.precision().is_some() {
+            return f.pad(&String::from(self));
+        }
+        for c in char::decode_utf16(self.as_slice().iter().copied()) {
+            f.write_char(c.unwrap_or(char::REPLACEMENT_CHARACTER))?;
+        }
+        Ok(())
     }
 }
 
 impl fmt::Debug for QString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.pad(&String::from(self))
+        String::from(self).fmt(f)
     }
 }
 
@@ -321,7 +327,7 @@ impl From<&QString> for String {
     ///
     /// Note that this converts from UTF-16 to UTF-8.
     fn from(qstring: &QString) -> Self {
-        ffi::qstring_to_rust_string(qstring)
+        String::from_utf16_lossy(&qstring.as_slice())
     }
 }
 
@@ -330,7 +336,7 @@ impl From<QString> for String {
     ///
     /// Note that this converts from UTF-16 to UTF-8.
     fn from(qstring: QString) -> Self {
-        ffi::qstring_to_rust_string(&qstring)
+        String::from_utf16_lossy(&qstring.as_slice())
     }
 }
 
@@ -340,6 +346,11 @@ impl QString {
     /// If there is no unreplaced place-marker remaining, a warning message is printed and the result is undefined. Place-marker numbers must be in the range 1 to 99.
     pub fn arg(&self, a: &QString) -> Self {
         ffi::qstring_arg(self, a)
+    }
+
+    /// Extracts a slice containing the entire UTF-16 array.
+    pub fn as_slice(&self) -> &[u16] {
+        ffi::qstring_as_slice(self)
     }
 
     /// Lexically compares this string with the `other` string.


### PR DESCRIPTION
Currently, if you have a `qstring: QString` and call `qstring.to_string()`, here is what happens:

1. We allocate a `QByteArray`.
2. Qt fills the byte array with `qstring`'s UTF-8 data.
3. We allocate a `String` and copy the data into it.
4. Rust allocates a `String` of its own.
5. Rust copies the data from our string into its own string.

That's a lot of work and it's unnecessary. All we have to do is get the UTF-16 data of `qstring`, which is a constant-time operation, and write that into the formatter. `String::from(&qstring)` is still a bit more efficient than `qstring.to_string()`, but the gap is smaller.