### PR TITLE
CXX-Qt 0.7.3 backports

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -251,7 +251,7 @@ jobs:
           - name: Ubuntu 24.04 (gcc) Qt6
             os: ubuntu-24.04
             qt_version: 6
-            aqt_version: '6.9.0'
+            aqt_version: '6.9.3'
             aqt_arch: 'linux_gcc_64'
             aqt_host: 'linux'
             cores: 4
@@ -294,10 +294,10 @@ jobs:
           - name: macOS 14 (clang) Qt6
             os: macos-14
             qt_version: 6
-            aqt_version: '6.9.0'
+            aqt_version: '6.9.3'
             aqt_arch: 'clang_64'
             aqt_host: 'mac'
-            dyld_framework_path: /Users/runner/work/cxx-qt/Qt/6.9.0/macos/lib
+            dyld_framework_path: /Users/runner/work/cxx-qt/Qt/6.9.3/macos/lib
             # https://doc.qt.io/qt-6.7/macos.html#target-platforms
             macosx_deployment_target: '13.0'
             cores: 3
@@ -352,7 +352,7 @@ jobs:
           - name: Windows 2022 (MSVC2022) Qt6 Debug
             os: windows-2022
             qt_version: 6
-            aqt_version: '6.9.0'
+            aqt_version: '6.9.3'
             aqt_arch: 'win64_msvc2022_64'
             aqt_host: 'windows'
             cores: 4

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -116,13 +116,15 @@ jobs:
             ~/.cargo/bin/sccache
             ~/.cargo/bin/mdbook
             ~/.cargo/bin/mdbook-linkcheck
-          key: ubuntu-24.04_sccache-0.7.6_mdbook-0.4.36_mdbook-linkcheck-0.7.7
+          key: ubuntu-24.04_sccache-0.9.1-patched_mdbook-0.4.36_mdbook-linkcheck-0.7.7
       - name: "Build Rust tools"
         if: steps.rust-tools-cache.outputs.cache-hit != 'true'
         # Do not build with storage backends enabled, we only need local
+        # cargo install --locked --no-default-features --version 0.9.1 sccache
         run: |
-          cargo install --no-default-features sccache
-          cargo install mdbook mdbook-linkcheck
+          cargo install --locked --no-default-features --git=https://github.com/ahayzen-kdab/sccache --branch=2092-ignore-notfound-errors sccache
+          cargo install --version 0.4.36 mdbook 
+          cargo install --version 0.7.7 mdbook-linkcheck
       # We want our compiler cache to always update to the newest state.
       # The best way for us to achieve this is to **always** update the cache after every landed commit.
       # That way it will closely follow our development.
@@ -395,13 +397,15 @@ jobs:
           ${{ matrix.cargo_dir }}/bin/sccache${{ matrix.exe_suffix }}
           ${{ matrix.cargo_dir }}/bin/mdbook${{ matrix.exe_suffix }}
           ${{ matrix.cargo_dir }}/bin/mdbook-linkcheck${{ matrix.exe_suffix }}
-        key: ${{ matrix.os }}_sccache-0.7.6_mdbook-0.4.36_mdbook-linkcheck-0.7.7
+        key: ${{ matrix.os }}_sccache-0.9.1-patched_mdbook-0.4.36_mdbook-linkcheck-0.7.7
     - name: "Build Rust tools"
       if: steps.rust-tools-cache.outputs.cache-hit != 'true'
       # Do not build with storage backends enabled, we only need local
+      # cargo install --locked --no-default-features --version 0.9.1 sccache
       run: |
-        cargo install --no-default-features sccache
-        cargo install mdbook mdbook-linkcheck
+        cargo install --locked --no-default-features --git=https://github.com/ahayzen-kdab/sccache --branch=2092-ignore-notfound-errors sccache
+        cargo install --version 0.4.36 mdbook 
+        cargo install --version 0.7.7 mdbook-linkcheck
 
     # We want our compiler cache to always update to the newest state.
     # The best way for us to achieve this is to **always** update the cache after every landed commit.

--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup toolchain
         run: |
-          cargo install grcov
+          cargo install --locked --version 0.8.20 grcov
           rustup component add llvm-tools
       - name: build
         env:
@@ -123,8 +123,8 @@ jobs:
         # cargo install --locked --no-default-features --version 0.9.1 sccache
         run: |
           cargo install --locked --no-default-features --git=https://github.com/ahayzen-kdab/sccache --branch=2092-ignore-notfound-errors sccache
-          cargo install --version 0.4.36 mdbook 
-          cargo install --version 0.7.7 mdbook-linkcheck
+          cargo install --locked --version 0.4.36 mdbook 
+          cargo install --locked --version 0.7.7 mdbook-linkcheck
       # We want our compiler cache to always update to the newest state.
       # The best way for us to achieve this is to **always** update the cache after every landed commit.
       # That way it will closely follow our development.
@@ -404,8 +404,8 @@ jobs:
       # cargo install --locked --no-default-features --version 0.9.1 sccache
       run: |
         cargo install --locked --no-default-features --git=https://github.com/ahayzen-kdab/sccache --branch=2092-ignore-notfound-errors sccache
-        cargo install --version 0.4.36 mdbook 
-        cargo install --version 0.7.7 mdbook-linkcheck
+        cargo install --locked --version 0.4.36 mdbook 
+        cargo install --locked --version 0.7.7 mdbook-linkcheck
 
     # We want our compiler cache to always update to the newest state.
     # The best way for us to achieve this is to **always** update the cache after every landed commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.7.2...HEAD)
+## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.7.3...HEAD)
+
+## [0.7.3](https://github.com/KDAB/cxx-qt/compare/v0.7.2...v0.7.3) - 2025-10-01
+
+- Fix QEnum generation for Qt 6.9.2+
 
 ## [0.7.2](https://github.com/KDAB/cxx-qt/compare/v0.7.1...v0.7.2) - 2025-04-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,18 +27,18 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/KDAB/cxx-qt/"
-version = "0.7.2"
+version = "0.7.3"
 
 # Note a version needs to be specified on dependencies of packages
 # we publish, otherwise crates.io complains as it doesn't know the version.
 [workspace.dependencies]
-cxx-qt = { path = "crates/cxx-qt", version = "0.7.2" }
-cxx-qt-macro = { path = "crates/cxx-qt-macro", version = "0.7.2" }
-cxx-qt-build = { path = "crates/cxx-qt-build", version = "0.7.2" }
-cxx-qt-gen = { path = "crates/cxx-qt-gen", version = "0.7.2" }
-cxx-qt-lib = { path = "crates/cxx-qt-lib", version = "0.7.2" }
-qt-build-utils = { path = "crates/qt-build-utils", version = "0.7.2" }
-cxx-qt-lib-extras = { path = "crates/cxx-qt-lib-extras", version = "0.7.2" }
+cxx-qt = { path = "crates/cxx-qt", version = "0.7.3" }
+cxx-qt-macro = { path = "crates/cxx-qt-macro", version = "0.7.3" }
+cxx-qt-build = { path = "crates/cxx-qt-build", version = "0.7.3" }
+cxx-qt-gen = { path = "crates/cxx-qt-gen", version = "0.7.3" }
+cxx-qt-lib = { path = "crates/cxx-qt-lib", version = "0.7.3" }
+qt-build-utils = { path = "crates/qt-build-utils", version = "0.7.3" }
+cxx-qt-lib-extras = { path = "crates/cxx-qt-lib-extras", version = "0.7.3" }
 
 cc = { version = "1.0.100", features = ["parallel"] }
 # Ensure that the example comments are kept in sync

--- a/book/src/getting-started/5-cmake-integration.md
+++ b/book/src/getting-started/5-cmake-integration.md
@@ -134,7 +134,7 @@ Download CXX-Qts CMake code with FetchContent:
 
 ```cmake,ignore
 {{#include ../../../examples/qml_minimal/CMakeLists.txt:book_cmake_find_cxx_qt_start}}
-        GIT_TAG 0.7.2
+        GIT_TAG 0.7.3
 {{#include ../../../examples/qml_minimal/CMakeLists.txt:book_cmake_find_cxx_qt_end}}
 ```
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,7 @@ coverage:
   status:
     project:
       default:
-        target: 100%
+        target: 95%
     patch: true
 
 

--- a/crates/cxx-qt-build/src/diagnostics.rs
+++ b/crates/cxx-qt-build/src/diagnostics.rs
@@ -22,8 +22,8 @@ pub(crate) enum GeneratedError {
 impl Display for GeneratedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            GeneratedError::Cxx(err) => write!(f, "{}", err),
-            GeneratedError::CxxQt(err) => write!(f, "{}", err),
+            GeneratedError::Cxx(err) => write!(f, "{err}"),
+            GeneratedError::CxxQt(err) => write!(f, "{err}"),
         }
     }
 }

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -129,7 +129,7 @@ impl GeneratedCpp {
                     }
                     found_bridge = true;
 
-                    let parser = Parser::from(m.clone())
+                    let parser = Parser::from(*m.clone())
                         .map_err(GeneratedError::from)
                         .map_err(to_diagnostic)?;
                     let generated_cpp = GeneratedCppBlocks::from(&parser)

--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -559,7 +559,7 @@ impl CxxQtBuilder {
         } else {
             println!("cargo::rustc-cfg={key}");
         }
-        let variable_cargo = format!("CARGO_CFG_{}", key);
+        let variable_cargo = format!("CARGO_CFG_{key}");
         env::set_var(variable_cargo, value.unwrap_or("true"));
     }
 
@@ -613,7 +613,7 @@ impl CxxQtBuilder {
 
         // We don't support Qt < 5
         for major in 5..=version.major {
-            let at_least_qt_major_version = format!("cxxqt_qt_version_at_least_{}", major);
+            let at_least_qt_major_version = format!("cxxqt_qt_version_at_least_{major}");
             CxxQtBuilder::define_cfg_variable(at_least_qt_major_version, None);
         }
     }

--- a/crates/cxx-qt-gen/src/generator/cpp/method.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/method.rs
@@ -46,10 +46,11 @@ pub fn generate_cpp_methods(
                 ParsedQInvokableSpecifiers::Virtual => is_virtual = "virtual ",
             });
 
-        let is_qinvokable = invokable
-            .is_qinvokable
-            .then_some("Q_INVOKABLE ")
-            .unwrap_or_default();
+        let is_qinvokable = if invokable.is_qinvokable {
+            "Q_INVOKABLE "
+        } else {
+            Default::default()
+        };
 
         // Matching return type or void
         let return_cxx_ty = if let Some(return_cxx_ty) = &return_cxx_ty {

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -33,6 +33,8 @@ pub struct GeneratedCppQObjectBlocks {
     pub forward_declares_namespaced: Vec<String>,
     /// List of fragments which are outside of the QObject namespace
     pub fragments: Vec<CppFragment>,
+    /// List of fragments which are outside of the QObject namespace and after the class
+    pub post_fragments: Vec<CppFragment>,
     /// Base class of the QObject
     pub base_classes: Vec<String>,
     /// List of Qt Meta Object items (eg Q_PROPERTY)
@@ -50,6 +52,7 @@ impl GeneratedCppQObjectBlocks {
         self.forward_declares_namespaced
             .append(&mut other.forward_declares_namespaced);
         self.fragments.append(&mut other.fragments);
+        self.post_fragments.append(&mut other.post_fragments);
         self.base_classes.append(&mut other.base_classes);
         self.metaobjects.append(&mut other.metaobjects);
         self.methods.append(&mut other.methods);
@@ -154,6 +157,7 @@ impl GeneratedCppQObject {
         )?);
         generated.blocks.append(&mut qenum::generate_on_qobject(
             structured_qobject.qenums.iter().cloned(),
+            &generated.name,
         )?);
 
         let mut class_initializers = vec![];

--- a/crates/cxx-qt-gen/src/generator/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/mod.rs
@@ -19,14 +19,12 @@ use crate::generator::{rust::fragment::GeneratedRustFragment, structuring};
 use crate::parser::{parameter::ParsedFunctionParameter, Parser};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
-use syn::{parse_quote, Item, ItemMod, Result};
+use syn::{parse_quote, ItemMod, Result};
 
 /// Representation of the generated Rust code for a QObject
 pub struct GeneratedRustBlocks {
     /// Module for the CXX bridge with passthrough items
     pub cxx_mod: ItemMod,
-    /// Any global extra items for the CXX bridge
-    pub cxx_mod_contents: Vec<Item>,
     /// Ident of the namespace of the QObject
     pub namespace: String,
     /// Rust fragments
@@ -86,9 +84,13 @@ impl GeneratedRustBlocks {
             #module
         };
 
+        let qenums = &parser.cxx_qt_data.qenums;
+        if !qenums.is_empty() {
+            fragments.extend(qenum::generate(qenums));
+        }
+
         Ok(GeneratedRustBlocks {
             cxx_mod,
-            cxx_mod_contents: qenum::generate_cxx_mod_contents(&parser.cxx_qt_data.qenums),
             namespace,
             fragments,
         })
@@ -141,7 +143,6 @@ mod tests {
 
         let rust = GeneratedRustBlocks::from(&parser).unwrap();
         assert!(rust.cxx_mod.content.is_none());
-        assert_eq!(rust.cxx_mod_contents.len(), 0);
         assert_eq!(rust.namespace, "");
         assert_eq!(rust.fragments.len(), 1);
     }
@@ -161,7 +162,6 @@ mod tests {
 
         let rust = GeneratedRustBlocks::from(&parser).unwrap();
         assert!(rust.cxx_mod.content.is_none());
-        assert_eq!(rust.cxx_mod_contents.len(), 0);
         assert_eq!(rust.namespace, "cxx_qt");
         assert_eq!(rust.fragments.len(), 1);
     }
@@ -181,7 +181,6 @@ mod tests {
 
         let rust = GeneratedRustBlocks::from(&parser).unwrap();
         assert!(rust.cxx_mod.content.is_none());
-        assert_eq!(rust.cxx_mod_contents.len(), 0);
         assert_eq!(rust.namespace, "");
         assert_eq!(rust.fragments.len(), 1);
     }

--- a/crates/cxx-qt-gen/src/generator/rust/qenum.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qenum.rs
@@ -5,28 +5,46 @@
 
 use crate::parser::qenum::ParsedQEnum;
 use quote::quote;
-use syn::{parse_quote_spanned, spanned::Spanned, Item};
+use syn::{parse_quote_spanned, spanned::Spanned};
 
-pub fn generate_cxx_mod_contents(qenums: &[ParsedQEnum]) -> Vec<Item> {
+use super::fragment::GeneratedRustFragment;
+
+pub fn generate(qenums: &[ParsedQEnum]) -> Vec<GeneratedRustFragment> {
     qenums
         .iter()
-        .flat_map(|qenum| {
-            let qenum_ident = &qenum.name.rust_unqualified();
-            let namespace = &qenum.name.namespace();
-            let item = &qenum.item;
-            let vis = &item.vis;
-            let variants = &item.variants;
-            let docs = &qenum.docs;
-            let cfgs = &qenum.cfgs;
-
-            let cxx_namespace = if namespace.is_none() {
-                quote! {}
+        .map(|qenum| {
+            if qenum.name.namespace().is_some() {
+                generate_namespaced_qenum(qenum)
             } else {
-                quote! { #[namespace = #namespace ] }
-            };
-            vec![
-                parse_quote_spanned! {
-                    item.span() =>
+                generate_member_qenum(qenum)
+            }
+        })
+        .collect()
+}
+
+fn generate_member_qenum(qenum: &ParsedQEnum) -> GeneratedRustFragment {
+    // TODO
+    generate_namespaced_qenum(qenum)
+}
+
+fn generate_namespaced_qenum(qenum: &ParsedQEnum) -> GeneratedRustFragment {
+    let qenum_ident = &qenum.name.rust_unqualified();
+    let namespace = &qenum.name.namespace();
+    let item = &qenum.item;
+    let vis = &item.vis;
+    let variants = &item.variants;
+    let docs = &qenum.docs;
+    let cfgs = &qenum.cfgs;
+
+    let cxx_namespace = if namespace.is_none() {
+        quote! {}
+    } else {
+        quote! { #[namespace = #namespace ] }
+    };
+    GeneratedRustFragment {
+        cxx_mod_contents: vec![
+            parse_quote_spanned! {
+                item.span() =>
                     #[repr(i32)]
                     #(#cfgs)*
                     #(#docs)*
@@ -34,35 +52,27 @@ pub fn generate_cxx_mod_contents(qenums: &[ParsedQEnum]) -> Vec<Item> {
                     #vis enum #qenum_ident {
                         #variants
                     }
-                },
-                parse_quote_spanned! {
-                    item.span() =>
+            },
+            parse_quote_spanned! {
+                item.span() =>
                     extern "C++" {
                         #(#cfgs)*
                         #cxx_namespace
                         type #qenum_ident;
                     }
-                },
-            ]
-            .into_iter()
-        })
-        .collect()
+            },
+        ],
+        cxx_qt_mod_contents: vec![],
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{generator::rust::fragment::GeneratedRustFragment, tests::assert_tokens_eq};
+    use crate::tests::assert_tokens_eq;
     use quote::{format_ident, quote};
     use syn::parse_quote;
 
     use super::*;
-
-    fn generate(qenums: &[ParsedQEnum]) -> GeneratedRustFragment {
-        GeneratedRustFragment {
-            cxx_mod_contents: generate_cxx_mod_contents(qenums),
-            ..Default::default()
-        }
-    }
 
     #[test]
     fn generates() {
@@ -84,6 +94,8 @@ mod tests {
         .unwrap()];
 
         let generated = generate(&qenums);
+        assert_eq!(generated.len(), 1);
+        let generated = &generated[0];
         assert_eq!(generated.cxx_mod_contents.len(), 2);
         assert_tokens_eq(
             &generated.cxx_mod_contents[0],

--- a/crates/cxx-qt-gen/src/generator/rust/qenum.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qenum.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::parser::qenum::ParsedQEnum;
-use quote::quote;
+use quote::{format_ident, quote_spanned};
 use syn::{parse_quote_spanned, spanned::Spanned};
 
 use super::fragment::GeneratedRustFragment;
@@ -13,8 +13,8 @@ pub fn generate(qenums: &[ParsedQEnum]) -> Vec<GeneratedRustFragment> {
     qenums
         .iter()
         .map(|qenum| {
-            if qenum.name.namespace().is_some() {
-                generate_namespaced_qenum(qenum)
+            if qenum.qobject.is_none() {
+                generate_standalone_qenum(qenum)
             } else {
                 generate_member_qenum(qenum)
             }
@@ -22,25 +22,94 @@ pub fn generate(qenums: &[ParsedQEnum]) -> Vec<GeneratedRustFragment> {
         .collect()
 }
 
+// Previously we used CXX to generate ourselves a C++ enum that we then imported into the QObject
+// class.
+//
+// However, this broke in Qt 6.9.2, see https://github.com/KDAB/cxx-qt/issues/1328
+//
+// We now have to emulate what CXX generates on the Rust side ourselves.
+// By then using just an import inside the CXX bridge, the include order works out on the C++ side.
+// The general problem is that the order in C++ usually is:
+//
+// 1. forward-declare everything for CXX
+// 2. Include the CXX generated header, which checks the types exist
+// 3. Define the QObject class
+//
+// The problem is that we cannot forward-declare a member enum inside the QObject class.
+// So then we have to basically let CXX think this is a custom trivial type, which it only checks inside
+// the generated cpp file, not the header file.
 fn generate_member_qenum(qenum: &ParsedQEnum) -> GeneratedRustFragment {
-    // TODO
-    generate_namespaced_qenum(qenum)
+    let item = &qenum.item;
+    let docs = &qenum.docs;
+    let cfgs = &qenum.cfgs;
+    let (qenum_ident, qenum_attrs, _qualified) = qenum.name.clone().into_cxx_parts();
+    let qenum_ident_str = qenum_ident.to_string();
+
+    let variants = qenum
+        .variants
+        .iter()
+        .enumerate()
+        .map(|(index, variant)| {
+            // Note: The types here must match with the `repr` inside the struct, as quote will
+            // emit the type that exactly matches the input type.
+            let index = index as i32;
+            quote_spanned! {
+                variant.span() =>
+                pub const #variant: #qenum_ident = #qenum_ident { repr: #index };
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let module_name = format_ident!("cxx_qt_private_qenum_{qenum_ident}");
+
+    // TODO: Support different repr types
+    GeneratedRustFragment {
+        cxx_mod_contents: vec![parse_quote_spanned! {
+            item.span() =>
+            #(#cfgs)*
+            extern "C++" {
+                #[allow(private_interfaces)]
+                #(#docs)*
+                #(#qenum_attrs)*
+                type #qenum_ident = super::#module_name::#qenum_ident;
+            }
+        }],
+        cxx_qt_mod_contents: vec![parse_quote_spanned! {
+            item.span() =>
+
+            #(#cfgs)*
+            mod #module_name {
+                #(#docs)*
+                #[derive(PartialEq, Eq, Clone, Copy)]
+                #[repr(transparent)]
+                pub(super) struct #qenum_ident {
+                    #[allow(missing_docs)]
+                    pub repr: i32
+                }
+
+                #[allow(non_upper_case_globals)]
+                impl #qenum_ident {
+                    #(#variants)*
+                }
+
+                #[automatically_derived]
+                unsafe impl ::cxx::ExternType for #qenum_ident {
+                    type Id = ::cxx::type_id!(#qenum_ident_str);
+                    type Kind = ::cxx::kind::Trivial;
+                }
+            }
+        }],
+    }
 }
 
-fn generate_namespaced_qenum(qenum: &ParsedQEnum) -> GeneratedRustFragment {
-    let qenum_ident = &qenum.name.rust_unqualified();
-    let namespace = &qenum.name.namespace();
+fn generate_standalone_qenum(qenum: &ParsedQEnum) -> GeneratedRustFragment {
+    let (qenum_ident, qenum_attrs, _qualified) = &qenum.name.clone().into_cxx_parts();
     let item = &qenum.item;
     let vis = &item.vis;
     let variants = &item.variants;
     let docs = &qenum.docs;
     let cfgs = &qenum.cfgs;
 
-    let cxx_namespace = if namespace.is_none() {
-        quote! {}
-    } else {
-        quote! { #[namespace = #namespace ] }
-    };
     GeneratedRustFragment {
         cxx_mod_contents: vec![
             parse_quote_spanned! {
@@ -48,7 +117,7 @@ fn generate_namespaced_qenum(qenum: &ParsedQEnum) -> GeneratedRustFragment {
                     #[repr(i32)]
                     #(#cfgs)*
                     #(#docs)*
-                    #cxx_namespace
+                    #(#qenum_attrs)*
                     #vis enum #qenum_ident {
                         #variants
                     }
@@ -57,7 +126,7 @@ fn generate_namespaced_qenum(qenum: &ParsedQEnum) -> GeneratedRustFragment {
                 item.span() =>
                     extern "C++" {
                         #(#cfgs)*
-                        #cxx_namespace
+                        #(#qenum_attrs)*
                         type #qenum_ident;
                     }
             },
@@ -75,10 +144,60 @@ mod tests {
     use super::*;
 
     #[test]
-    fn generates() {
+    fn generates_namespaced() {
         let qenums = vec![ParsedQEnum::parse(
             parse_quote! {
                 /// Doc comment
+                #[namespace="my_namespace"]
+                enum MyEnum {
+                    /// Document Variant1
+                    Variant1,
+                    /// Document Variant2
+                    Variant2,
+                }
+            },
+            None,
+            None,
+            &format_ident!("qobject"),
+        )
+        .unwrap()];
+
+        let generated = generate(&qenums);
+        assert_eq!(generated.len(), 1);
+        let generated = &generated[0];
+        assert!(generated.cxx_qt_mod_contents.is_empty());
+        assert_eq!(generated.cxx_mod_contents.len(), 2);
+        assert_tokens_eq(
+            &generated.cxx_mod_contents[0],
+            quote! {
+                #[repr(i32)]
+                #[doc = r" Doc comment"]
+                #[namespace = "my_namespace"]
+                enum MyEnum {
+                    #[doc = r" Document Variant1"]
+                    Variant1,
+                    #[doc = r" Document Variant2"]
+                    Variant2,
+                }
+            },
+        );
+        assert_tokens_eq(
+            &generated.cxx_mod_contents[1],
+            quote! {
+                extern "C++" {
+                    #[namespace = "my_namespace"]
+                    type MyEnum;
+                }
+            },
+        )
+    }
+
+    #[test]
+    fn generates_member() {
+        let qenums = vec![ParsedQEnum::parse(
+            parse_quote! {
+                /// Doc comment
+                #[namespace="my_namespace"]
                 enum MyEnum {
                     /// Document Variant1
                     Variant1,
@@ -92,31 +211,45 @@ mod tests {
             &format_ident!("qobject"),
         )
         .unwrap()];
-
         let generated = generate(&qenums);
         assert_eq!(generated.len(), 1);
         let generated = &generated[0];
-        assert_eq!(generated.cxx_mod_contents.len(), 2);
+        assert_eq!(generated.cxx_mod_contents.len(), 1);
         assert_tokens_eq(
             &generated.cxx_mod_contents[0],
             quote! {
-                #[repr(i32)]
-                #[doc = r" Doc comment"]
-                enum MyEnum {
-                    #[doc = r" Document Variant1"]
-                    Variant1,
-                    #[doc = r" Document Variant2"]
-                    Variant2,
+                extern "C++" {
+                    #[allow(private_interfaces)]
+                    #[doc = r" Doc comment"]
+                    #[namespace = "my_namespace"]
+                    type MyEnum = super::cxx_qt_private_qenum_MyEnum::MyEnum;
                 }
             },
         );
+        assert_eq!(generated.cxx_qt_mod_contents.len(), 1);
         assert_tokens_eq(
-            &generated.cxx_mod_contents[1],
+            &generated.cxx_qt_mod_contents[0],
             quote! {
-                extern "C++" {
-                    type MyEnum;
+                mod cxx_qt_private_qenum_MyEnum {
+                    #[doc = r" Doc comment"]
+                    #[derive(PartialEq, Eq, Clone, Copy)]
+                    #[repr(transparent)]
+                    pub(super) struct MyEnum {
+                        #[allow(missing_docs)]
+                        pub repr: i32
+                    }
+                    #[allow(non_upper_case_globals)]
+                    impl MyEnum {
+                        pub const Variant1: MyEnum = MyEnum { repr: 0i32 };
+                        pub const Variant2: MyEnum = MyEnum { repr: 1i32 };
+                    }
+                    #[automatically_derived]
+                    unsafe impl ::cxx::ExternType for MyEnum {
+                        type Id = ::cxx::type_id!("MyEnum");
+                        type Kind = ::cxx::kind::Trivial;
+                    }
                 }
             },
-        )
+        );
     }
 }

--- a/crates/cxx-qt-gen/src/generator/rust/threading.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/threading.rs
@@ -89,7 +89,7 @@ pub fn generate(
 
                     #[doc(hidden)]
                     #(#thread_drop_attrs)*
-                    fn #thread_drop_name(cxx_qt_thread: &mut #cxx_qt_thread_ident);
+                    fn #thread_drop_name(cxx_qt_thread: Pin<&mut #cxx_qt_thread_ident>);
 
                     #[doc(hidden)]
                     #(#thread_is_destroyed_attrs)*
@@ -151,7 +151,7 @@ pub fn generate(
                     }
 
                     #[doc(hidden)]
-                    fn threading_drop(cxx_qt_thread: &mut #module_ident::#cxx_qt_thread_ident)
+                    fn threading_drop(cxx_qt_thread: Pin<&mut #module_ident::#cxx_qt_thread_ident>)
                     {
                         #thread_drop_qualified(cxx_qt_thread);
                     }
@@ -234,7 +234,7 @@ mod tests {
                     #[doc(hidden)]
                     #[cxx_name = "cxxQtThreadDrop"]
                     #[namespace = "rust::cxxqt1"]
-                    fn cxx_qt_ffi_MyObject_cxxQtThreadDrop(cxx_qt_thread: &mut MyObjectCxxQtThread);
+                    fn cxx_qt_ffi_MyObject_cxxQtThreadDrop(cxx_qt_thread: Pin<&mut MyObjectCxxQtThread>);
 
                     #[doc(hidden)]
                     #[cxx_name = "cxxQtThreadIsDestroyed"]
@@ -302,7 +302,7 @@ mod tests {
                     }
 
                     #[doc(hidden)]
-                    fn threading_drop(cxx_qt_thread: &mut qobject::MyObjectCxxQtThread)
+                    fn threading_drop(cxx_qt_thread: Pin<&mut qobject::MyObjectCxxQtThread>)
                     {
                         qobject::cxx_qt_ffi_MyObject_cxxQtThreadDrop(cxx_qt_thread);
                     }

--- a/crates/cxx-qt-gen/src/lib.rs
+++ b/crates/cxx-qt-gen/src/lib.rs
@@ -107,7 +107,7 @@ mod tests {
 
     // CODECOV_EXCLUDE_START
     fn update_expected_file(path: PathBuf, source: &str) {
-        println!("Updating expected file: {:?}", path);
+        println!("Updating expected file: {path:?}");
 
         let mut file = OpenOptions::new()
             .write(true)

--- a/crates/cxx-qt-gen/src/parser/trait_impl.rs
+++ b/crates/cxx-qt-gen/src/parser/trait_impl.rs
@@ -11,7 +11,7 @@ use crate::{parser::constructor::Constructor, syntax::path::path_compare_str};
 #[derive(Debug, PartialEq, Eq)]
 pub enum TraitKind {
     Threading,
-    Constructor(Constructor),
+    Constructor(Box<Constructor>),
 }
 
 impl TraitKind {
@@ -33,7 +33,7 @@ impl TraitKind {
 
     fn parse_constructor(imp: &ItemImpl) -> Result<Self> {
         let constructor = Constructor::parse(imp.clone())?;
-        Ok(Self::Constructor(constructor))
+        Ok(Self::Constructor(Box::new(constructor)))
     }
 
     fn parse(imp: &ItemImpl) -> Result<Self> {

--- a/crates/cxx-qt-gen/src/syntax/qtitem.rs
+++ b/crates/cxx-qt-gen/src/syntax/qtitem.rs
@@ -13,11 +13,11 @@ use syn::{Attribute, Item, ItemMod, Result, Token, Visibility};
 /// Representation of either a Syn Item, a CXX module, or a CXX-Qt module
 pub enum CxxQtItem {
     /// A normal syntax item that we pass through
-    Item(Item),
+    Item(Box<Item>),
     /// A CXX module that we need to generate code for
-    Cxx(ItemMod),
+    Cxx(Box<ItemMod>),
     /// A CxxQt module block that we need to parse and later generate code for
-    CxxQt(ItemMod),
+    CxxQt(Box<ItemMod>),
 }
 
 impl std::fmt::Debug for CxxQtItem {

--- a/crates/cxx-qt-gen/src/syntax/qtitem.rs
+++ b/crates/cxx-qt-gen/src/syntax/qtitem.rs
@@ -93,7 +93,7 @@ mod tests {
           #[cxx::bridge]
           mod ffi {}
         };
-        let debug_formatted = format!("{:?}", cxx);
+        let debug_formatted = format!("{cxx:?}");
         assert!(debug_formatted.starts_with("Cxx(ItemMod"))
     }
 
@@ -103,7 +103,7 @@ mod tests {
           #[cxx_qt::bridge]
           mod ffi {}
         };
-        let debug_formatted = format!("{:?}", cxx_qt);
+        let debug_formatted = format!("{cxx_qt:?}");
         assert!(debug_formatted.starts_with("CxxQt(ItemMod"))
     }
 
@@ -113,7 +113,7 @@ mod tests {
             #[attr]
             mod ffi {}
         };
-        let debug_formatted = format!("{:?}", cxx);
+        let debug_formatted = format!("{cxx:?}");
         assert!(debug_formatted.starts_with("Item(Item::Mod"))
     }
 
@@ -124,7 +124,7 @@ mod tests {
                 name: &str
           }
         };
-        let debug_formatted = format!("{:?}", rust);
+        let debug_formatted = format!("{rust:?}");
         assert!(debug_formatted.starts_with("Item(Item::Struct"))
     }
 }

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -108,6 +108,13 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
             .filter_map(pair_as_header)
             .collect::<Vec<String>>()
             .join("\n");
+        let post_fragments = qobject
+            .blocks
+            .post_fragments
+            .iter()
+            .filter_map(pair_as_header)
+            .collect::<Vec<String>>()
+            .join("\n");
 
         let declare_metatype = if qobject.has_qobject_macro {
             let ty = qobject.name.cxx_qualified();
@@ -119,6 +126,7 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
         formatdoc! {r#"
             {fragments}
             {class_definition}
+            {post_fragments}
 
             {declare_metatype}
             "#

--- a/crates/cxx-qt-gen/src/writer/cpp/header.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/header.rs
@@ -95,7 +95,7 @@ fn qobjects_header(generated: &GeneratedCppBlocks) -> Vec<String> {
 
                 {qobject_assert}"#,
             // Note that there is always a base class as we always have CxxQtType
-            base_classes = qobject.blocks.base_classes.iter().map(|base| format!("public {}", base)).collect::<Vec<String>>().join(", "),
+            base_classes = qobject.blocks.base_classes.iter().map(|base| format!("public {base}")).collect::<Vec<String>>().join(", "),
             metaobjects = qobject.blocks.metaobjects.join("\n  "),
             public_methods = create_block("public", &qobject.blocks.methods.iter().filter_map(pair_as_header).collect::<Vec<String>>()),
             private_methods = create_block("private", &qobject.blocks.private_methods.iter().filter_map(pair_as_header).collect::<Vec<String>>()),

--- a/crates/cxx-qt-gen/src/writer/cpp/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/cpp/mod.rs
@@ -380,6 +380,7 @@ mod tests {
         } // namespace cxx_qt::my_object
 
 
+
         Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)
 
         "#}
@@ -433,6 +434,7 @@ mod tests {
         } // namespace cxx_qt
 
 
+
         Q_DECLARE_METATYPE(cxx_qt::FirstObject*)
 
 
@@ -457,6 +459,7 @@ mod tests {
 
         static_assert(::std::is_base_of<QObject, SecondObject>::value, "SecondObject must inherit from QObject");
         } // namespace cxx_qt
+
 
 
         Q_DECLARE_METATYPE(cxx_qt::SecondObject*)
@@ -506,6 +509,7 @@ mod tests {
         };
 
         static_assert(::std::is_base_of<QObject, MyObject>::value, "MyObject must inherit from QObject");
+
 
         Q_DECLARE_METATYPE(MyObject*)
 

--- a/crates/cxx-qt-gen/src/writer/rust/mod.rs
+++ b/crates/cxx-qt-gen/src/writer/rust/mod.rs
@@ -12,7 +12,7 @@ use syn::{parse_quote_spanned, spanned::Spanned};
 pub fn write_rust(generated: &GeneratedRustBlocks, include_path: Option<&str>) -> TokenStream {
     // Retrieve the module contents and namespace
     let mut cxx_mod = generated.cxx_mod.clone();
-    let mut cxx_mod_contents = generated.cxx_mod_contents.clone();
+    let mut cxx_mod_contents = vec![];
     let mut cxx_qt_mod_contents = vec![];
 
     // Add common includes for all objects
@@ -99,7 +99,6 @@ mod tests {
                 #[cxx::bridge(namespace = "cxx_qt::my_object")]
                 mod ffi {}
             },
-            cxx_mod_contents: vec![],
             namespace: "cxx_qt::my_object".to_owned(),
             fragments: vec![GeneratedRustFragment {
                 cxx_mod_contents: vec![
@@ -138,7 +137,6 @@ mod tests {
                 #[cxx::bridge(namespace = "cxx_qt")]
                 mod ffi {}
             },
-            cxx_mod_contents: vec![],
             namespace: "cxx_qt".to_owned(),
             fragments: vec![
                 GeneratedRustFragment {

--- a/crates/cxx-qt-gen/test_outputs/invokables.rs
+++ b/crates/cxx-qt-gen/test_outputs/invokables.rs
@@ -141,7 +141,7 @@ mod ffi {
         #[doc(hidden)]
         #[cxx_name = "cxxQtThreadDrop"]
         #[namespace = "rust::cxxqt1"]
-        fn cxx_qt_ffi_MyObject_cxxQtThreadDrop(cxx_qt_thread: &mut MyObjectCxxQtThread);
+        fn cxx_qt_ffi_MyObject_cxxQtThreadDrop(cxx_qt_thread: Pin<&mut MyObjectCxxQtThread>);
         #[doc(hidden)]
         #[cxx_name = "cxxQtThreadIsDestroyed"]
         #[namespace = "rust::cxxqt1"]
@@ -297,7 +297,7 @@ impl cxx_qt::Threading for ffi::MyObject {
         ffi::cxx_qt_ffi_MyObject_cxxQtThreadClone(cxx_qt_thread)
     }
     #[doc(hidden)]
-    fn threading_drop(cxx_qt_thread: &mut ffi::MyObjectCxxQtThread) {
+    fn threading_drop(cxx_qt_thread: Pin<&mut ffi::MyObjectCxxQtThread>) {
         ffi::cxx_qt_ffi_MyObject_cxxQtThreadDrop(cxx_qt_thread);
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/qenum.h
+++ b/crates/cxx-qt-gen/test_outputs/qenum.h
@@ -25,28 +25,12 @@ Q_NAMESPACE
 } // namespace other_namespace
 
 namespace cxx_qt::my_object {
-enum class MyEnum : ::std::int32_t
-{
-  A
-};
-} // namespace cxx_qt::my_object
-
-namespace my_namespace {
-enum class MyOtherEnum : ::std::int32_t
-{
-  X,
-  Y,
-  Z
-};
-} // namespace my_namespace
-
-namespace cxx_qt::my_object {
 Q_NAMESPACE
 enum class MyNamespacedEnum : ::std::int32_t
 {
-  A,
-  B,
-  C
+  A = 0,
+  B = 1,
+  C = 2
 };
 Q_ENUM_NS(MyNamespacedEnum)
 } // namespace cxx_qt::my_object
@@ -55,20 +39,11 @@ namespace other_namespace {
 Q_NAMESPACE
 enum class MyOtherNamespacedEnum : ::std::int32_t
 {
-  Variant1,
-  Variant2
+  Variant1 = 0,
+  Variant2 = 1
 };
 Q_ENUM_NS(MyOtherNamespacedEnum)
 } // namespace other_namespace
-
-namespace cxx_qt::my_object {
-enum class MyRenamedEnum : ::std::int32_t
-{
-  A,
-  B,
-  C
-};
-} // namespace cxx_qt::my_object
 
 #include "directory/file_ident.cxx.h"
 
@@ -79,21 +54,18 @@ class MyObject
 {
   Q_OBJECT
 public:
-#ifdef Q_MOC_RUN
-  enum class MyEnum : ::std::int32_t{ A };
+  enum class MyEnum : ::std::int32_t
+  {
+    A = 0
+  };
   Q_ENUM(MyEnum)
-#else
-  using MyEnum = ::cxx_qt::my_object::MyEnum;
-  Q_ENUM(MyEnum)
-#endif
-
-#ifdef Q_MOC_RUN
-  enum class MyOtherEnum : ::std::int32_t{ X, Y, Z };
+  enum class MyOtherEnum : ::std::int32_t
+  {
+    X = 0,
+    Y = 1,
+    Z = 2
+  };
   Q_ENUM(MyOtherEnum)
-#else
-  using MyOtherEnum = ::my_namespace::MyOtherEnum;
-  Q_ENUM(MyOtherEnum)
-#endif
 
   virtual ~MyObject() = default;
 
@@ -108,6 +80,14 @@ static_assert(::std::is_base_of<QObject, MyObject>::value,
               "MyObject must inherit from QObject");
 } // namespace cxx_qt::my_object
 
+namespace cxx_qt::my_object {
+using MyEnum = ::cxx_qt::my_object::MyObject::MyEnum;
+} // namespace cxx_qt::my_object
+
+namespace my_namespace {
+using MyOtherEnum = ::cxx_qt::my_object::MyObject::MyOtherEnum;
+} // namespace my_namespace
+
 Q_DECLARE_METATYPE(cxx_qt::my_object::MyObject*)
 
 namespace cxx_qt::my_object {
@@ -117,13 +97,13 @@ class CxxName
 {
   Q_OBJECT
 public:
-#ifdef Q_MOC_RUN
-  enum class MyRenamedEnum : ::std::int32_t{ A, B, C };
+  enum class MyRenamedEnum : ::std::int32_t
+  {
+    A = 0,
+    B = 1,
+    C = 2
+  };
   Q_ENUM(MyRenamedEnum)
-#else
-  using MyRenamedEnum = ::cxx_qt::my_object::MyRenamedEnum;
-  Q_ENUM(MyRenamedEnum)
-#endif
 
   virtual ~CxxName() = default;
 
@@ -133,6 +113,10 @@ public:
 
 static_assert(::std::is_base_of<QObject, CxxName>::value,
               "CxxName must inherit from QObject");
+} // namespace cxx_qt::my_object
+
+namespace cxx_qt::my_object {
+using MyRenamedEnum = ::cxx_qt::my_object::CxxName::MyRenamedEnum;
 } // namespace cxx_qt::my_object
 
 Q_DECLARE_METATYPE(cxx_qt::my_object::CxxName*)

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs
@@ -91,25 +91,15 @@ mod ffi {
             outer: Pin<&mut MyRenamedObject>,
         ) -> Pin<&mut InternalObject>;
     }
-    #[repr(i32)]
-    #[namespace = "cxx_qt::my_object"]
-    enum MyEnum {
-        A,
-    }
     extern "C++" {
+        #[allow(private_interfaces)]
         #[namespace = "cxx_qt::my_object"]
-        type MyEnum;
-    }
-    #[repr(i32)]
-    #[namespace = "my_namespace"]
-    enum MyOtherEnum {
-        X,
-        Y,
-        Z,
+        type MyEnum = super::cxx_qt_private_qenum_MyEnum::MyEnum;
     }
     extern "C++" {
+        #[allow(private_interfaces)]
         #[namespace = "my_namespace"]
-        type MyOtherEnum;
+        type MyOtherEnum = super::cxx_qt_private_qenum_MyOtherEnum::MyOtherEnum;
     }
     #[repr(i32)]
     #[namespace = "cxx_qt::my_object"]
@@ -132,16 +122,10 @@ mod ffi {
         #[namespace = "other_namespace"]
         type MyOtherNamespacedEnum;
     }
-    #[repr(i32)]
-    #[namespace = "cxx_qt::my_object"]
-    enum MyRenamedEnum {
-        A,
-        B,
-        C,
-    }
     extern "C++" {
+        #[allow(private_interfaces)]
         #[namespace = "cxx_qt::my_object"]
-        type MyRenamedEnum;
+        type MyRenamedEnum = super::cxx_qt_private_qenum_MyRenamedEnum::MyRenamedEnum;
     }
 }
 #[doc(hidden)]
@@ -182,5 +166,60 @@ impl ::cxx_qt::CxxQtType for ffi::MyRenamedObject {
     }
     fn rust_mut(self: core::pin::Pin<&mut Self>) -> core::pin::Pin<&mut Self::Rust> {
         ffi::cxx_qt_ffi_CxxName_unsafeRustMut(self)
+    }
+}
+mod cxx_qt_private_qenum_MyEnum {
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    #[repr(transparent)]
+    pub(super) struct MyEnum {
+        #[allow(missing_docs)]
+        pub repr: i32,
+    }
+    #[allow(non_upper_case_globals)]
+    impl MyEnum {
+        pub const A: MyEnum = MyEnum { repr: 0i32 };
+    }
+    #[automatically_derived]
+    unsafe impl ::cxx::ExternType for MyEnum {
+        type Id = ::cxx::type_id!("MyEnum");
+        type Kind = ::cxx::kind::Trivial;
+    }
+}
+mod cxx_qt_private_qenum_MyOtherEnum {
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    #[repr(transparent)]
+    pub(super) struct MyOtherEnum {
+        #[allow(missing_docs)]
+        pub repr: i32,
+    }
+    #[allow(non_upper_case_globals)]
+    impl MyOtherEnum {
+        pub const X: MyOtherEnum = MyOtherEnum { repr: 0i32 };
+        pub const Y: MyOtherEnum = MyOtherEnum { repr: 1i32 };
+        pub const Z: MyOtherEnum = MyOtherEnum { repr: 2i32 };
+    }
+    #[automatically_derived]
+    unsafe impl ::cxx::ExternType for MyOtherEnum {
+        type Id = ::cxx::type_id!("MyOtherEnum");
+        type Kind = ::cxx::kind::Trivial;
+    }
+}
+mod cxx_qt_private_qenum_MyRenamedEnum {
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    #[repr(transparent)]
+    pub(super) struct MyRenamedEnum {
+        #[allow(missing_docs)]
+        pub repr: i32,
+    }
+    #[allow(non_upper_case_globals)]
+    impl MyRenamedEnum {
+        pub const A: MyRenamedEnum = MyRenamedEnum { repr: 0i32 };
+        pub const B: MyRenamedEnum = MyRenamedEnum { repr: 1i32 };
+        pub const C: MyRenamedEnum = MyRenamedEnum { repr: 2i32 };
+    }
+    #[automatically_derived]
+    unsafe impl ::cxx::ExternType for MyRenamedEnum {
+        type Id = ::cxx::type_id!("MyRenamedEnum");
+        type Kind = ::cxx::kind::Trivial;
     }
 }

--- a/crates/cxx-qt-gen/test_outputs/qenum.rs
+++ b/crates/cxx-qt-gen/test_outputs/qenum.rs
@@ -18,58 +18,6 @@ mod ffi {
     unsafe extern "C++" {
         include!("directory/file_ident.cxxqt.h");
     }
-    #[repr(i32)]
-    #[namespace = "cxx_qt::my_object"]
-    enum MyEnum {
-        A,
-    }
-    extern "C++" {
-        #[namespace = "cxx_qt::my_object"]
-        type MyEnum;
-    }
-    #[repr(i32)]
-    #[namespace = "my_namespace"]
-    enum MyOtherEnum {
-        X,
-        Y,
-        Z,
-    }
-    extern "C++" {
-        #[namespace = "my_namespace"]
-        type MyOtherEnum;
-    }
-    #[repr(i32)]
-    #[namespace = "cxx_qt::my_object"]
-    enum MyNamespacedEnum {
-        A,
-        B,
-        C,
-    }
-    extern "C++" {
-        #[namespace = "cxx_qt::my_object"]
-        type MyNamespacedEnum;
-    }
-    #[repr(i32)]
-    #[namespace = "other_namespace"]
-    enum MyOtherNamespacedEnum {
-        Variant1,
-        Variant2,
-    }
-    extern "C++" {
-        #[namespace = "other_namespace"]
-        type MyOtherNamespacedEnum;
-    }
-    #[repr(i32)]
-    #[namespace = "cxx_qt::my_object"]
-    enum MyRenamedEnum {
-        A,
-        B,
-        C,
-    }
-    extern "C++" {
-        #[namespace = "cxx_qt::my_object"]
-        type MyRenamedEnum;
-    }
     unsafe extern "C++" {
         #[doc = "The C++ type for the QObject "]
         #[doc = "MyObjectRust"]
@@ -142,6 +90,58 @@ mod ffi {
         fn cxx_qt_ffi_CxxName_unsafeRustMut(
             outer: Pin<&mut MyRenamedObject>,
         ) -> Pin<&mut InternalObject>;
+    }
+    #[repr(i32)]
+    #[namespace = "cxx_qt::my_object"]
+    enum MyEnum {
+        A,
+    }
+    extern "C++" {
+        #[namespace = "cxx_qt::my_object"]
+        type MyEnum;
+    }
+    #[repr(i32)]
+    #[namespace = "my_namespace"]
+    enum MyOtherEnum {
+        X,
+        Y,
+        Z,
+    }
+    extern "C++" {
+        #[namespace = "my_namespace"]
+        type MyOtherEnum;
+    }
+    #[repr(i32)]
+    #[namespace = "cxx_qt::my_object"]
+    enum MyNamespacedEnum {
+        A,
+        B,
+        C,
+    }
+    extern "C++" {
+        #[namespace = "cxx_qt::my_object"]
+        type MyNamespacedEnum;
+    }
+    #[repr(i32)]
+    #[namespace = "other_namespace"]
+    enum MyOtherNamespacedEnum {
+        Variant1,
+        Variant2,
+    }
+    extern "C++" {
+        #[namespace = "other_namespace"]
+        type MyOtherNamespacedEnum;
+    }
+    #[repr(i32)]
+    #[namespace = "cxx_qt::my_object"]
+    enum MyRenamedEnum {
+        A,
+        B,
+        C,
+    }
+    extern "C++" {
+        #[namespace = "cxx_qt::my_object"]
+        type MyRenamedEnum;
     }
 }
 #[doc(hidden)]

--- a/crates/cxx-qt-macro/Cargo.toml
+++ b/crates/cxx-qt-macro/Cargo.toml
@@ -21,7 +21,3 @@ proc-macro = true
 cxx-qt-gen.workspace = true
 proc-macro2.workspace = true
 syn.workspace = true
-
-[dev-dependencies]
-cxx.workspace = true
-cxx-qt.workspace = true

--- a/crates/cxx-qt-macro/src/lib.rs
+++ b/crates/cxx-qt-macro/src/lib.rs
@@ -4,43 +4,19 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#![deny(missing_docs)]
+// We explicitly allow missing docs for the macros in this crate, as they should be documented in
+// cxx-qt itself.
+#![allow(missing_docs)]
 //! The cxx-qt-macro crate provides the procedural attribute macros which are used with cxx-qt.
+//!
+//! See the [cxx-qt crate docs](https://docs.rs/cxx-qt/latest/) for documentation of the macros
+//! inside this crate.
 
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, ItemMod};
 
 use cxx_qt_gen::{write_rust, GeneratedRustBlocks, Parser};
 
-/// A procedural macro which generates a QObject for a struct inside a module.
-///
-/// # Example
-///
-/// ```rust
-/// #[cxx_qt::bridge(namespace = "cxx_qt::my_object")]
-/// mod qobject {
-///     extern "RustQt" {
-///         #[qobject]
-///         # // Note that we can't use properties as this confuses the linker on Windows
-///         type MyObject = super::MyObjectRust;
-///
-///         #[qinvokable]
-///         fn invokable(self: &MyObject, a: i32, b: i32) -> i32;
-///     }
-/// }
-///
-/// #[derive(Default)]
-/// pub struct MyObjectRust;
-///
-/// impl qobject::MyObject {
-///     fn invokable(&self, a: i32, b: i32) -> i32 {
-///         a + b
-///     }
-/// }
-///
-/// # // Note that we need a fake main for doc tests to build
-/// # fn main() {}
-/// ```
 #[proc_macro_attribute]
 pub fn bridge(args: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the TokenStream of a macro
@@ -63,55 +39,6 @@ pub fn bridge(args: TokenStream, input: TokenStream) -> TokenStream {
     extract_and_generate(module)
 }
 
-/// A macro which describes that a struct should be made into a QObject.
-///
-/// It should not be used by itself and instead should be used inside a cxx_qt::bridge definition.
-///
-/// # Example
-///
-/// ```rust
-/// #[cxx_qt::bridge]
-/// mod my_object {
-///     extern "RustQt" {
-///         #[qobject]
-///         # // Note that we can't use properties as this confuses the linker on Windows
-///         type MyObject = super::MyObjectRust;
-///     }
-/// }
-///
-/// #[derive(Default)]
-/// pub struct MyObjectRust;
-///
-/// # // Note that we need a fake main for doc tests to build
-/// # fn main() {}
-/// ```
-///
-/// You can also specify a custom base class by using `#[base = QStringListModel]`, you must then use CXX to add any includes needed.
-///
-/// # Example
-///
-/// ```rust
-/// #[cxx_qt::bridge]
-/// mod my_object {
-///     extern "RustQt" {
-///         #[qobject]
-///         #[base = QStringListModel]
-///         # // Note that we can't use properties as this confuses the linker on Windows
-///         type MyModel = super::MyModelRust;
-///     }
-///
-///     unsafe extern "C++" {
-///         include!(<QtCore/QStringListModel>);
-///         type QStringListModel;
-///     }
-/// }
-///
-/// #[derive(Default)]
-/// pub struct MyModelRust;
-///
-/// # // Note that we need a fake main for doc tests to build
-/// # fn main() {}
-/// ```
 #[proc_macro_attribute]
 pub fn qobject(_args: TokenStream, _input: TokenStream) -> TokenStream {
     unreachable!("qobject should not be used as a macro by itself. Instead it should be used within a cxx_qt::bridge definition")

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -118,7 +118,7 @@ pub trait Threading: Sized {
     fn threading_clone(cxx_qt_thread: &CxxQtThread<Self>) -> CxxQtThread<Self>;
 
     #[doc(hidden)]
-    fn threading_drop(cxx_qt_thread: &mut CxxQtThread<Self>);
+    fn threading_drop(cxx_qt_thread: core::pin::Pin<&mut CxxQtThread<Self>>);
 }
 
 /// Placeholder for upcasting objects, suppresses dead code warning

--- a/crates/cxx-qt/src/lib.rs
+++ b/crates/cxx-qt/src/lib.rs
@@ -17,7 +17,89 @@ mod connectionguard;
 pub mod signalhandler;
 mod threading;
 
+/// A procedural macro which generates a QObject for a struct inside a module.
+///
+/// # Example
+///
+/// ```rust
+/// #[cxx_qt::bridge(namespace = "cxx_qt::my_object")]
+/// mod qobject {
+///     extern "RustQt" {
+///         #[qobject]
+///         # // Note that we can't use properties as this confuses the linker on Windows
+///         type MyObject = super::MyObjectRust;
+///
+///         #[qinvokable]
+///         fn invokable(self: &MyObject, a: i32, b: i32) -> i32;
+///     }
+/// }
+///
+/// #[derive(Default)]
+/// pub struct MyObjectRust;
+///
+/// impl qobject::MyObject {
+///     fn invokable(&self, a: i32, b: i32) -> i32 {
+///         a + b
+///     }
+/// }
+///
+/// # // Note that we need a fake main for doc tests to build
+/// # fn main() {
+/// # }
+/// ```
 pub use cxx_qt_macro::bridge;
+
+/// A macro which describes that a struct should be made into a QObject.
+///
+/// It should not be used by itself and instead should be used inside a cxx_qt::bridge definition.
+///
+/// # Example
+///
+/// ```rust
+/// #[cxx_qt::bridge]
+/// mod my_object {
+///     extern "RustQt" {
+///         #[qobject]
+///         # // Note that we can't use properties as this confuses the linker on Windows
+///         type MyObject = super::MyObjectRust;
+///     }
+/// }
+///
+/// #[derive(Default)]
+/// pub struct MyObjectRust;
+///
+/// # // Note that we need a fake main for doc tests to build
+/// # fn main() {
+/// # }
+/// ```
+///
+/// You can also specify a custom base class by using `#[base = QStringListModel]`, you must then use CXX to add any includes needed.
+///
+/// # Example
+///
+/// ```rust
+/// #[cxx_qt::bridge]
+/// mod my_object {
+///     extern "RustQt" {
+///         #[qobject]
+///         #[base = QStringListModel]
+///         # // Note that we can't use properties as this confuses the linker on Windows
+///         type MyModel = super::MyModelRust;
+///     }
+///
+///     unsafe extern "C++" {
+///         include!(<QtCore/QStringListModel>);
+///         type QStringListModel;
+///     }
+/// }
+///
+/// #[derive(Default)]
+/// pub struct MyModelRust;
+///
+/// # // Note that we need a fake main for doc tests to build
+/// # fn main() {
+/// # }
+/// ```
 pub use cxx_qt_macro::qobject;
 
 pub use connection::{ConnectionType, QMetaObjectConnection};

--- a/crates/cxx-qt/src/threading.rs
+++ b/crates/cxx-qt/src/threading.rs
@@ -79,7 +79,7 @@ where
     T: Threading,
 {
     fn drop(&mut self) {
-        T::threading_drop(self);
+        T::threading_drop(unsafe { core::pin::Pin::new_unchecked(self) });
     }
 }
 

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -419,10 +419,7 @@ impl QtBuild {
         qt_module: &str,
     ) -> String {
         for arch in ["", "_arm64-v8a", "_armeabi-v7a", "_x86", "_x86_64"] {
-            let prl_path = format!(
-                "{}/{}Qt{}{}{}.prl",
-                lib_path, prefix, version_major, qt_module, arch
-            );
+            let prl_path = format!("{lib_path}/{prefix}Qt{version_major}{qt_module}{arch}.prl");
             match Path::new(&prl_path).try_exists() {
                 Ok(exists) => {
                     if exists {
@@ -430,18 +427,12 @@ impl QtBuild {
                     }
                 }
                 Err(e) => {
-                    println!(
-                        "cargo::warning=failed checking for existence of {}: {}",
-                        prl_path, e
-                    );
+                    println!("cargo::warning=failed checking for existence of {prl_path}: {e}");
                 }
             }
         }
 
-        format!(
-            "{}/{}Qt{}{}.prl",
-            lib_path, prefix, version_major, qt_module
-        )
+        format!("{lib_path}/{prefix}Qt{version_major}{qt_module}.prl")
     }
 
     /// Tell Cargo to link each Qt module.
@@ -775,7 +766,7 @@ prefer :/qt/qml/{qml_uri_dirs}/
                     "    <file alias=\"{}\">{}</file>\n",
                     path_display,
                     std::fs::canonicalize(file_path)
-                        .unwrap_or_else(|_| panic!("Could not canonicalize path {}", path_display))
+                        .unwrap_or_else(|_| panic!("Could not canonicalize path {path_display}"))
                         .display()
                 )
             }

--- a/examples/qml_features/rust/src/properties.rs
+++ b/examples/qml_features/rust/src/properties.rs
@@ -117,10 +117,7 @@ impl qobject::RustProperties {
         let previous_url = self.as_ref().connected_url.clone();
         self.as_mut().rust_mut().previous_connected_url = previous_url;
 
-        std::mem::swap(
-            &mut self.as_mut().rust_mut().connected_url,
-            &mut QUrl::default(),
-        );
+        self.as_mut().rust_mut().connected_url = QUrl::default();
         self.as_mut().connected_state_changed();
     }
 }

--- a/examples/qml_features/rust/src/signals.rs
+++ b/examples/qml_features/rust/src/signals.rs
@@ -109,7 +109,7 @@ impl cxx_qt::Initialize for qobject::RustSignals {
                     // ANCHOR: book_signals_connect
                     let connections = [
                         qobject.as_mut().on_connected(|_, url| {
-                            println!("Connected: {}", url);
+                            println!("Connected: {url}");
                         }),
                         qobject.as_mut().on_disconnected(|_| {
                             println!("Disconnected");
@@ -117,7 +117,7 @@ impl cxx_qt::Initialize for qobject::RustSignals {
                         // Demonstration of connecting with a different connection type
                         qobject.as_mut().connect_error(
                             |_, message| {
-                                println!("Error: {}", message);
+                                println!("Error: {message}");
                             },
                             ConnectionType::QueuedConnection,
                         ),

--- a/tests/qt_types_standalone/rust/src/qanystringview.rs
+++ b/tests/qt_types_standalone/rust/src/qanystringview.rs
@@ -19,7 +19,7 @@ mod qanystringview_cxx {
     }
 
     extern "Rust" {
-        fn construct_qanystringview(str: &str) -> QAnyStringView;
+        fn construct_qanystringview(str: &str) -> QAnyStringView<'_>;
     }
 
     // This method must be unsafe otherwise we hit


### PR DESCRIPTION
- **threading: fix `mutable reference to C++ type requires a pin` in drop**
- **Remove cxx-qt dependency of cxx-qt-macro**
- **Refactor QEnum generation to return fragments**
- **Fix QEnum generation for Qt 6.9.2**
- **Bump version to 0.7.3**
