### PR TITLE
cxx-qt-gen: use full declarative macros and fix moc to include dir

### DIFF
--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -732,6 +732,10 @@ impl CxxQtBuilder {
         {
 
             let mut moc_arguments = moc_arguments.clone();
+            // Ensure that header root is in the include path of moc
+            // otherwise it cannot read the .cxx.h paths
+            moc_arguments = moc_arguments.include_path(dir::header_root());
+
             if let Some(qml_module) = &self.qml_module {
                 // Ensure that the generated QObject header is in the include path
                 // so that qmltyperegistar can include them later

--- a/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/cpp/qobject.rs
@@ -62,11 +62,9 @@ impl GeneratedCppQObjectBlocks {
 
     pub fn from(qobject: &ParsedQObject) -> GeneratedCppQObjectBlocks {
         let mut qml_specifiers = Vec::new();
-        let mut includes = BTreeSet::new();
         if let Some(qml_metadata) = &qobject.qml_metadata {
-            // When specifying the QML declarative macros moc needs the header to be
-            // included, otherwise it does not understand what these expand to.
-            includes.insert("#include <QtQml/QQmlEngine>".to_string());
+            // Note ensure that the header moc processes has QtQml/QQmlEngine
+            // this is done via generator/rust/qobject
 
             qml_specifiers.push(format!("QML_NAMED_ELEMENT({})", qml_metadata.name));
 
@@ -79,7 +77,6 @@ impl GeneratedCppQObjectBlocks {
             }
         }
         GeneratedCppQObjectBlocks {
-            includes,
             metaobjects: qml_specifiers,
             ..Default::default()
         }

--- a/crates/cxx-qt-gen/src/generator/rust/qobject.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/qobject.rs
@@ -40,15 +40,13 @@ impl GeneratedRustFragment {
             generate_rust_signals(&structured_qobject.signals, &qobject_names, type_names)?,
         ];
 
-        // If this type is a singleton then we need to add an include
-        if let Some(qml_metadata) = &qobject.qml_metadata {
-            if qml_metadata.singleton {
-                generated.push(GeneratedRustFragment::from_cxx_item(parse_quote! {
-                    unsafe extern "C++" {
-                        include!(<QtQml/QQmlEngine>);
-                    }
-                }))
-            }
+        // If this type is using QML declarative macros then ensure we have the right include
+        if qobject.qml_metadata.is_some() {
+            generated.push(GeneratedRustFragment::from_cxx_item(parse_quote! {
+                unsafe extern "C++" {
+                    include!(<QtQml/QQmlEngine>);
+                }
+            }))
         }
 
         // If this type has threading enabled then add generation


### PR DESCRIPTION
Before we couldn't get things like QML_ELEMENT to work, this was due to two reasons
- we needed to include QtQml/QQmlEngine
- we needed moc to have it's include path setup to allow for the header.cxx.h to be found (where the include!(..)'s end up)