### PR TITLE
github: update the python version for the macOS Qt 6 runner

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -347,7 +347,7 @@ jobs:
             qt_qpa_platform: cocoa
             compiler_cache_path: /Users/runner/Library/Caches/Mozilla.sccache
             sccache_log_path: /Users/runner/Library/Caches/Mozilla.sccache.log.txt
-            clang_format_path: /Users/runner/Library/Python/3.13/bin/clang-format
+            clang_format_path: /Users/runner/Library/Python/3.14/bin/clang-format
             cargo_dir: ~/.cargo
             cc: clang
             cxx: clang++


### PR DESCRIPTION
Note that as github collapses the script it runs so there is no indication that the error was coming from our second command test -x rather than pip.