### PR TITLE
CI: Bump macOS runners

### DIFF
--- a/.github/workflows/github-cxx-qt-tests.yml
+++ b/.github/workflows/github-cxx-qt-tests.yml
@@ -309,8 +309,8 @@ jobs:
                 libvulkan-dev
                 libxkbcommon-dev
 
-          - name: macOS 14 (clang) Qt5
-            os: macos-14
+          - name: macOS 15 (clang) Qt5
+            os: macos-15-intel
             qt_version: 5
             aqt_version: '5.15.2'
             aqt_arch: 'clang_64'


### PR DESCRIPTION
macOS 13 runners are being deprecated by GH actions.
Update to macOS-14/15 respectively.

Closes #1359
