### PR TITLE
Allow passing additional args to rcc via QtBuild

### DIFF
--- a/crates/cxx-qt-build/src/lib.rs
+++ b/crates/cxx-qt-build/src/lib.rs
@@ -1167,6 +1167,13 @@ extern "C" bool {init_fun}() {{
 
         let mut qtbuild = qt_build_utils::QtBuild::new(qt_modules.iter().cloned().collect())
             .expect("Could not find Qt installation");
+        if let Some(autorcc) = env::var_os("CXX_QT_AUTORCC_OPTIONS") {
+            let autorcc = autorcc
+                .to_str()
+                .expect("CXX_QT_AUTORCC_OPTIONS are not UTF-8!");
+            let autorcc: Vec<_> = autorcc.split(':').collect();
+            qtbuild = qtbuild.autorcc_options(autorcc);
+        }
         qtbuild.cargo_link_libraries(&mut self.cc_builder);
 
         // Define the Qt cfg to cargo


### PR DESCRIPTION
Together with the corresponding CMake PR, this closes #1251.
