### PR TITLE
Implement From<T> for types that implements From<&T> and Into<T>, and vice versa

### DIFF
--- a/crates/cxx-qt-lib/src/core/qline.rs
+++ b/crates/cxx-qt-lib/src/core/qline.rs
@@ -91,7 +91,7 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "qline_new"]
-        fn construct(pt1: QPoint, pt2: QPoint) -> QLine;
+        fn construct(pt1: &QPoint, pt2: &QPoint) -> QLine;
 
         #[doc(hidden)]
         #[rust_name = "qline_to_debug_qstring"]
@@ -112,7 +112,7 @@ pub struct QLine {
 impl QLine {
     /// Constructs a line object that represents the line between `p1` and `p2`.
     pub fn new(pt1: QPoint, pt2: QPoint) -> Self {
-        ffi::qline_new(pt1, pt2)
+        ffi::qline_new(&pt1, &pt2)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qlinef.rs
+++ b/crates/cxx-qt-lib/src/core/qlinef.rs
@@ -126,7 +126,7 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "qlinef_new"]
-        fn construct(pt1: QPointF, pt2: QPointF) -> QLineF;
+        fn construct(pt1: &QPointF, pt2: &QPointF) -> QLineF;
         #[doc(hidden)]
         #[rust_name = "qlinef_from_qline"]
         fn construct(line: &QLine) -> QLineF;
@@ -150,7 +150,7 @@ pub struct QLineF {
 impl QLineF {
     /// Constructs a line object that represents the line between `pt1` and `pt2`.
     pub fn new(pt1: QPointF, pt2: QPointF) -> Self {
-        ffi::qlinef_new(pt1, pt2)
+        ffi::qlinef_new(&pt1, &pt2)
     }
 }
 
@@ -167,12 +167,25 @@ impl From<&QLine> for QLineF {
         ffi::qlinef_from_qline(line)
     }
 }
+impl From<QLine> for QLineF {
+    /// Construct a `QLineF` object from the given integer-based line.
+    fn from(line: QLine) -> Self {
+        Self::from(&line)
+    }
+}
 
+impl From<&QLineF> for QLine {
+    /// Returns an integer-based copy of this line.
+    /// Note that the returned line's start and end points are rounded to the nearest integer.
+    fn from(line: &QLineF) -> Self {
+        line.to_line()
+    }
+}
 impl From<QLineF> for QLine {
     /// Returns an integer-based copy of this line.
     /// Note that the returned line's start and end points are rounded to the nearest integer.
-    fn from(value: QLineF) -> Self {
-        value.to_line()
+    fn from(line: QLineF) -> Self {
+        Self::from(&line)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qmarginsf.rs
+++ b/crates/cxx-qt-lib/src/core/qmarginsf.rs
@@ -174,6 +174,12 @@ impl From<&QMargins> for QMarginsF {
         ffi::qmarginsf_from_qmargin(margins)
     }
 }
+impl From<QMargins> for QMarginsF {
+    /// Constructs margins copied from the given `margins`.
+    fn from(margins: QMargins) -> Self {
+        Self::from(&margins)
+    }
+}
 
 impl From<&QMarginsF> for QMargins {
     /// Returns an integer-based copy of `margins`.
@@ -181,6 +187,14 @@ impl From<&QMarginsF> for QMargins {
     /// Note that the components in the returned margins will be rounded to the nearest integer.
     fn from(margins: &QMarginsF) -> Self {
         margins.to_margins()
+    }
+}
+impl From<QMarginsF> for QMargins {
+    /// Returns an integer-based copy of `margins`.
+    ///
+    /// Note that the components in the returned margins will be rounded to the nearest integer.
+    fn from(margins: QMarginsF) -> Self {
+        Self::from(&margins)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qpointf.rs
+++ b/crates/cxx-qt-lib/src/core/qpointf.rs
@@ -130,12 +130,25 @@ impl From<&QPoint> for QPointF {
         ffi::qpointf_from_qpoint(point)
     }
 }
+impl From<QPoint> for QPointF {
+    /// Constructs a copy of the given `point`.
+    fn from(point: QPoint) -> Self {
+        Self::from(&point)
+    }
+}
 
+impl From<&QPointF> for QPoint {
+    /// Rounds the coordinates of `point` to the nearest integer,
+    /// and returns a `QPoint` object with the rounded coordinates.
+    fn from(point: &QPointF) -> Self {
+        point.to_point()
+    }
+}
 impl From<QPointF> for QPoint {
     /// Rounds the coordinates of `point` to the nearest integer,
     /// and returns a `QPoint` object with the rounded coordinates.
     fn from(point: QPointF) -> Self {
-        point.to_point()
+        Self::from(&point)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qrectf.rs
+++ b/crates/cxx-qt-lib/src/core/qrectf.rs
@@ -310,12 +310,25 @@ impl From<&QRect> for QRectF {
         ffi::qrectf_from_qrect(rectangle)
     }
 }
+impl From<QRect> for QRectF {
+    /// Constructs a `QRectF` rectangle from the given `QRect` rectangle.
+    fn from(rectangle: QRect) -> Self {
+        Self::from(&rectangle)
+    }
+}
 
 impl From<&QRectF> for QRect {
     /// Returns a `QRect` based on the values of this rectangle.
     /// Note that the coordinates in the returned rectangle are rounded to the nearest integer.
-    fn from(value: &QRectF) -> Self {
-        value.to_rect()
+    fn from(rectangle: &QRectF) -> Self {
+        rectangle.to_rect()
+    }
+}
+impl From<QRectF> for QRect {
+    /// Returns a `QRect` based on the values of this rectangle.
+    /// Note that the coordinates in the returned rectangle are rounded to the nearest integer.
+    fn from(rectangle: QRectF) -> Self {
+        Self::from(&rectangle)
     }
 }
 

--- a/crates/cxx-qt-lib/src/core/qsizef.rs
+++ b/crates/cxx-qt-lib/src/core/qsizef.rs
@@ -155,13 +155,27 @@ impl From<&QSize> for QSizeF {
         ffi::qsizef_from_qsize(size)
     }
 }
+impl From<QSize> for QSizeF {
+    /// Constructs a size with floating point accuracy from the given `size`.
+    fn from(size: QSize) -> Self {
+        Self::from(&size)
+    }
+}
 
+impl From<&QSizeF> for QSize {
+    /// Returns an integer based copy of this size.
+    ///
+    /// Note that the coordinates in the returned size will be rounded to the nearest integer.
+    fn from(size: &QSizeF) -> Self {
+        size.to_size()
+    }
+}
 impl From<QSizeF> for QSize {
     /// Returns an integer based copy of this size.
     ///
     /// Note that the coordinates in the returned size will be rounded to the nearest integer.
     fn from(size: QSizeF) -> Self {
-        size.to_size()
+        Self::from(&size)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpainterpath.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainterpath.rs
@@ -268,6 +268,12 @@ impl From<&QPointF> for QPainterPath {
         ffi::qpainterpath_from_qpointf(start_point)
     }
 }
+impl From<QPointF> for QPainterPath {
+    /// Creates a `QPainterPath` object with the given `start_point` as its current position.
+    fn from(start_point: QPointF) -> Self {
+        Self::from(&start_point)
+    }
+}
 
 impl PartialEq for QPainterPath {
     fn eq(&self, other: &Self) -> bool {

--- a/crates/cxx-qt-lib/src/gui/qpen.rs
+++ b/crates/cxx-qt-lib/src/gui/qpen.rs
@@ -121,7 +121,7 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "qpen_init_from_penstyle"]
-        fn construct(penstyle: &PenStyle) -> QPen;
+        fn construct(penstyle: PenStyle) -> QPen;
 
         #[doc(hidden)]
         #[rust_name = "qpen_drop"]
@@ -182,11 +182,23 @@ impl From<&QColor> for QPen {
         ffi::qpen_init_from_qcolor(color)
     }
 }
+impl From<QColor> for QPen {
+    /// Constructs a solid line pen with 1 width and the given `color`.
+    fn from(color: QColor) -> Self {
+        Self::from(&color)
+    }
+}
 
+impl From<PenStyle> for QPen {
+    /// Constructs a black pen with 1 width and the given `style`.
+    fn from(style: PenStyle) -> Self {
+        ffi::qpen_init_from_penstyle(style)
+    }
+}
 impl From<&PenStyle> for QPen {
     /// Constructs a black pen with 1 width and the given `style`.
     fn from(style: &PenStyle) -> Self {
-        ffi::qpen_init_from_penstyle(style)
+        ffi::qpen_init_from_penstyle(*style)
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.rs
@@ -8,7 +8,7 @@ use cxx_qt::casting::Upcast;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
-use crate::{QPointF, QRectF, QVector};
+use crate::{QPointF, QPolygon, QRectF, QVector};
 
 #[cxx::bridge]
 mod ffi {
@@ -110,6 +110,10 @@ mod ffi {
         fn construct(points: &QVector_QPointF) -> QPolygonF;
 
         #[doc(hidden)]
+        #[rust_name = "qpolygonf_from_qpolygon"]
+        fn construct(polygon: &QPolygon) -> QPolygonF;
+
+        #[doc(hidden)]
         #[rust_name = "qpolygonf_drop"]
         fn drop(pen: &mut QPolygonF);
 
@@ -193,8 +197,33 @@ impl DerefMut for QPolygonF {
     }
 }
 
+impl From<&QPolygon> for QPolygonF {
+    /// Constructs a float based polygon from the specified integer based polygon.
+    fn from(polygon: &QPolygon) -> Self {
+        ffi::qpolygonf_from_qpolygon(polygon)
+    }
+}
+impl From<QPolygon> for QPolygonF {
+    /// Constructs a float based polygon from the specified integer based polygon.
+    fn from(polygon: QPolygon) -> Self {
+        Self::from(&polygon)
+    }
+}
+
+impl From<&QPolygonF> for QPolygon {
+    /// Creates and returns a `QPolygon` by converting each `QPointF` to a `QPoint`.
+    fn from(polygon: &QPolygonF) -> Self {
+        polygon.to_polygon()
+    }
+}
+impl From<QPolygonF> for QPolygon {
+    /// Creates and returns a `QPolygon` by converting each `QPointF` to a `QPoint`.
+    fn from(value: QPolygonF) -> Self {
+        Self::from(&value)
+    }
+}
+
 impl From<&QVector<QPointF>> for QPolygonF {
-    /// Constructs a polygon containing the specified `points`.
     fn from(points: &QVector<QPointF>) -> Self {
         ffi::qpolygonf_from_qvector_qpointf(points)
     }

--- a/crates/cxx-qt-lib/src/gui/qquaternion.rs
+++ b/crates/cxx-qt-lib/src/gui/qquaternion.rs
@@ -375,6 +375,12 @@ impl From<&QVector4D> for QQuaternion {
         ffi::qquaternion_init_qvector4d(value)
     }
 }
+impl From<QVector4D> for QQuaternion {
+    /// Constructs a quaternion from the components of vector.
+    fn from(value: QVector4D) -> Self {
+        Self::from(&value)
+    }
+}
 
 // Safety:
 //


### PR DESCRIPTION
There's an odd pattern across many files that looks like this:

```rs

impl From<&QLine> for QLineF {
    fn from(line: &QLine) -> Self {
        ffi::qlinef_from_qline(line)
    }
}

impl From<QLineF> for QLine {
    fn from(value: QLineF) -> Self {
        value.to_line()
    }
}
```

One of the implementations uses a borrow, and the other one does not, even though both are calling functions that take references. Theoretically, in order to be consistent with Qt, both implementations should use borrowing (`From<&QLine>` and `From<&QLineF>`). But I don't think it would make sense to remove the by-value implementations, because A) that would be a breaking change, and B) it is useful to be able to do e.g. `let pointf = QPoint::new(1, 2).into()` rather than `let pointf = (&QPoint::new(1, 2)).into()`. So instead, I just added complementary implementations so now `From<QLine> for QLineF` and `From<&QLineF> for QLine` are implemented as well.

That said, I'm not sure why `QPen` implements `From<&PenStyle>`. I added an implementation for `From<PenStyle>`, so that part is handled, but at some point it might be worth removing the `From<&PenStyle>` implementation, because `PenStyle` is just an `i32` enum. There's no point in passing it by reference rather than value.