### PR TITLE
Remove deprecated config attr

### DIFF
--- a/crates/cxx-qt-lib/src/lib.rs
+++ b/crates/cxx-qt-lib/src/lib.rs
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(not(any(cxxqt_qt_version_major = "5", cxxqt_qt_version_major = "6")))]
 compile_error!("cxxqt_qt_version_major must be either \"5\" or \"6\"");


### PR DESCRIPTION
Attribute for rustdoc has been deprecated in 1.92.0, fixes #1387.