### PR TITLE
Add allow(dead_code) to signal generation

### DIFF
--- a/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/property/mod.rs
@@ -310,6 +310,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "trivialPropertyChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+                    #[allow(dead_code)]
                     pub fn connect_trivial_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_trivial_property_changed(
@@ -330,6 +331,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
+                    #[allow(dead_code)]
                     pub fn on_trivial_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_trivial_property_changed(
@@ -435,6 +437,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "opaquePropertyChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+                    #[allow(dead_code)]
                     pub fn connect_opaque_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_opaque_property_changed(
@@ -455,6 +458,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
+                    #[allow(dead_code)]
                     pub fn on_opaque_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_opaque_property_changed(
@@ -560,6 +564,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "unsafePropertyChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+                    #[allow(dead_code)]
                     pub fn connect_unsafe_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_property_changed(
@@ -580,6 +585,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
+                    #[allow(dead_code)]
                     pub fn on_unsafe_property_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_property_changed(

--- a/crates/cxx-qt-gen/src/generator/rust/signals.rs
+++ b/crates/cxx-qt-gen/src/generator/rust/signals.rs
@@ -173,6 +173,7 @@ pub fn generate_rust_signal(
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = #signal_name_cpp]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+                    #[allow(dead_code)]
                     pub fn #connect_ident_rust<F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'static + Send>(self: #self_type_qualified, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(#module_ident::#free_connect_ident_rust(
@@ -192,6 +193,7 @@ pub fn generate_rust_signal(
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
+                    #[allow(dead_code)]
                     pub fn #on_ident_rust<F: FnMut(#self_type_qualified, #(#parameters_qualified_type),*) + 'static + Send>(self: #self_type_qualified, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(#module_ident::#free_connect_ident_rust(
@@ -322,6 +324,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "ready"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+                    #[allow(dead_code)]
                     pub fn connect_ready<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_ready(
@@ -342,6 +345,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
+                    #[allow(dead_code)]
                     pub fn on_ready<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_ready(
@@ -500,6 +504,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "dataChanged"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+                    #[allow(dead_code)]
                     pub fn connect_data_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_data_changed(
@@ -520,6 +525,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
+                    #[allow(dead_code)]
                     pub fn on_data_changed<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, i32, cxx::UniquePtr<QColor>) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_data_changed(
@@ -641,6 +647,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "unsafeSignal"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+                    #[allow(dead_code)]
                     pub fn connect_unsafe_signal<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'static +Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_signal(
@@ -661,6 +668,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
+                    #[allow(dead_code)]
                     pub fn on_unsafe_signal<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, *mut T) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_unsafe_signal(
@@ -784,6 +792,7 @@ mod tests {
                     #[doc = "Connect the given function pointer to the signal "]
                     #[doc = "baseName"]
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+                    #[allow(dead_code)]
                     pub fn connect_existing_signal<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F, conn_type: cxx_qt::ConnectionType) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_existing_signal(
@@ -804,6 +813,7 @@ mod tests {
                     #[doc = ", so that when the signal is emitted the function pointer is executed."]
                     #[doc = "\n"]
                     #[doc = "Note that this method uses a AutoConnection connection type."]
+                    #[allow(dead_code)]
                     pub fn on_existing_signal<F: FnMut(core::pin::Pin<&mut qobject::MyObject>, ) + 'static + Send>(self: core::pin::Pin<&mut qobject::MyObject>, closure: F) -> cxx_qt::QMetaObjectConnectionGuard
                     {
                         cxx_qt::QMetaObjectConnectionGuard::from(qobject::MyObject_connect_existing_signal(

--- a/crates/cxx-qt-gen/test_outputs/cfgs.rs
+++ b/crates/cxx-qt-gen/test_outputs/cfgs.rs
@@ -509,6 +509,7 @@ impl ffi::QObjectEnabled {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "signal_disabled"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_signal_disabled<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'static + Send,
     >(
@@ -532,6 +533,7 @@ impl ffi::QObjectEnabled {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_signal_disabled<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'static + Send,
     >(
@@ -583,6 +585,7 @@ impl ffi::QObjectEnabled {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "signal_enabled"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_signal_enabled<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'static + Send,
     >(
@@ -606,6 +609,7 @@ impl ffi::QObjectEnabled {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_signal_enabled<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectEnabled>) + 'static + Send,
     >(
@@ -688,6 +692,7 @@ impl ffi::QObjectDisabled {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "signal_disabled"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_signal_disabled<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'static + Send,
     >(
@@ -711,6 +716,7 @@ impl ffi::QObjectDisabled {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_signal_disabled<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'static + Send,
     >(
@@ -762,6 +768,7 @@ impl ffi::QObjectDisabled {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "signal_enabled"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_signal_enabled<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'static + Send,
     >(
@@ -785,6 +792,7 @@ impl ffi::QObjectDisabled {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_signal_enabled<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectDisabled>) + 'static + Send,
     >(
@@ -875,6 +883,7 @@ impl ffi::QObjectExternEnabled {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "signal_disabled1"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_signal_disabled1<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'static + Send,
     >(
@@ -900,6 +909,7 @@ impl ffi::QObjectExternEnabled {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_signal_disabled1<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'static + Send,
     >(
@@ -958,6 +968,7 @@ impl ffi::QObjectExternEnabled {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "signal_enabled1"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_signal_enabled1<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'static + Send,
     >(
@@ -981,6 +992,7 @@ impl ffi::QObjectExternEnabled {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_signal_enabled1<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectExternEnabled>) + 'static + Send,
     >(
@@ -1045,6 +1057,7 @@ impl ffi::QObjectExternDisabled {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "signal_disabled2"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_signal_disabled2<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'static + Send,
     >(
@@ -1070,6 +1083,7 @@ impl ffi::QObjectExternDisabled {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_signal_disabled2<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'static + Send,
     >(
@@ -1128,6 +1142,7 @@ impl ffi::QObjectExternDisabled {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "signal_enabled2"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_signal_enabled2<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'static + Send,
     >(
@@ -1153,6 +1168,7 @@ impl ffi::QObjectExternDisabled {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_signal_enabled2<
         F: FnMut(core::pin::Pin<&mut ffi::QObjectExternDisabled>) + 'static + Send,
     >(

--- a/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
+++ b/crates/cxx-qt-gen/test_outputs/passthrough_and_naming.rs
@@ -525,6 +525,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "propertyNameChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_property_name_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -547,6 +548,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_property_name_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -593,6 +595,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "ready"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_ready<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
@@ -613,6 +616,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_ready<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
@@ -699,6 +703,7 @@ impl ffi::SecondObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "propertyNameChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_property_name_changed<
         F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'static + Send,
     >(
@@ -721,6 +726,7 @@ impl ffi::SecondObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_property_name_changed<
         F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'static + Send,
     >(
@@ -779,6 +785,7 @@ impl ffi::SecondObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "ready"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_ready<F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
@@ -799,6 +806,7 @@ impl ffi::SecondObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_ready<F: FnMut(core::pin::Pin<&mut ffi::SecondObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::SecondObject>,
         closure: F,
@@ -910,6 +918,7 @@ impl ffi::QPushButton {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "clicked"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_clicked<
         F: FnMut(core::pin::Pin<&mut ffi::QPushButton>, bool) + 'static + Send,
     >(
@@ -932,6 +941,7 @@ impl ffi::QPushButton {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_clicked<F: FnMut(core::pin::Pin<&mut ffi::QPushButton>, bool) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::QPushButton>,
         closure: F,
@@ -973,6 +983,7 @@ impl ffi::ExternObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "dataReady"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_data_ready<F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,
@@ -987,6 +998,7 @@ impl ffi::ExternObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_data_ready<F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,
@@ -1022,6 +1034,7 @@ impl ffi::ExternObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "errorOccurred"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_error_occurred<
         F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'static + Send,
     >(
@@ -1046,6 +1059,7 @@ impl ffi::ExternObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_error_occurred<F: FnMut(core::pin::Pin<&mut ffi::ExternObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::ExternObject>,
         closure: F,

--- a/crates/cxx-qt-gen/test_outputs/properties.rs
+++ b/crates/cxx-qt-gen/test_outputs/properties.rs
@@ -637,6 +637,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "primitiveChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_primitive_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -661,6 +662,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_primitive_changed<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
@@ -707,6 +709,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "trivialChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_trivial_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -723,6 +726,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_trivial_changed<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
@@ -759,6 +763,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "propAutoCxxNameChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_prop_auto_cxx_name_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -781,6 +786,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_prop_auto_cxx_name_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -827,6 +833,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "customFunctionPropChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_custom_function_prop_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -851,6 +858,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_custom_function_prop_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -899,6 +907,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "renamedPropertyChanged"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_renamed_property_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -921,6 +930,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_renamed_property_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -967,6 +977,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "named_prop_2Changed"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_renamed_property_2_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -989,6 +1000,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_renamed_property_2_changed<
         F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send,
     >(
@@ -1035,6 +1047,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "my_on_changed"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_my_on_changed<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
@@ -1049,6 +1062,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_my_on_changed<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,

--- a/crates/cxx-qt-gen/test_outputs/signals.rs
+++ b/crates/cxx-qt-gen/test_outputs/signals.rs
@@ -263,6 +263,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "ready"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_ready<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
@@ -283,6 +284,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_ready<F: FnMut(core::pin::Pin<&mut ffi::MyObject>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::MyObject>,
         closure: F,
@@ -322,6 +324,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "data_changed"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_data_changed<
         F: FnMut(
                 core::pin::Pin<&mut ffi::MyObject>,
@@ -346,6 +349,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_data_changed<
         F: FnMut(
                 core::pin::Pin<&mut ffi::MyObject>,
@@ -400,6 +404,7 @@ impl ffi::MyObject {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "newData"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_base_class_new_data<
         F: FnMut(
                 core::pin::Pin<&mut ffi::MyObject>,
@@ -430,6 +435,7 @@ impl ffi::MyObject {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_base_class_new_data<
         F: FnMut(
                 core::pin::Pin<&mut ffi::MyObject>,
@@ -525,6 +531,7 @@ impl ffi::QTimer {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "timeout"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_timeout<F: FnMut(core::pin::Pin<&mut ffi::QTimer>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::QTimer>,
         closure: F,
@@ -545,6 +552,7 @@ impl ffi::QTimer {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_timeout<F: FnMut(core::pin::Pin<&mut ffi::QTimer>) + 'static + Send>(
         self: core::pin::Pin<&mut ffi::QTimer>,
         closure: F,
@@ -584,6 +592,7 @@ impl ffi::QTimer {
     #[doc = "Connect the given function pointer to the signal "]
     #[doc = "const_ready"]
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
+    #[allow(dead_code)]
     pub fn connect_const_ready<F: FnMut(&ffi::QTimer) + 'static + Send>(
         self: &ffi::QTimer,
         closure: F,
@@ -604,6 +613,7 @@ impl ffi::QTimer {
     #[doc = ", so that when the signal is emitted the function pointer is executed."]
     #[doc = "\n"]
     #[doc = "Note that this method uses a AutoConnection connection type."]
+    #[allow(dead_code)]
     pub fn on_const_ready<F: FnMut(&ffi::QTimer) + 'static + Send>(
         self: &ffi::QTimer,
         closure: F,

--- a/examples/qml_features/rust/src/properties.rs
+++ b/examples/qml_features/rust/src/properties.rs
@@ -117,10 +117,7 @@ impl qobject::RustProperties {
         let previous_url = self.as_ref().connected_url.clone();
         self.as_mut().rust_mut().previous_connected_url = previous_url;
 
-        std::mem::swap(
-            &mut self.as_mut().rust_mut().connected_url,
-            &mut QUrl::default(),
-        );
+        self.as_mut().rust_mut().connected_url = QUrl::default();
         self.as_mut().connected_state_changed();
     }
 }


### PR DESCRIPTION
Fix #1381, and a lint found in qml_properties