### PR TITLE
qt-build-utils: ensure that all tools function before using them

### DIFF
--- a/crates/qt-build-utils/src/tool/moc.rs
+++ b/crates/qt-build-utils/src/tool/moc.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{QmlUri, QtInstallation, QtTool};
+use crate::{utils, QmlUri, QtInstallation, QtTool};
 
 use std::{
     path::{Path, PathBuf},
@@ -71,6 +71,10 @@ impl QtToolMoc {
         let executable = qt_installation
             .try_find_tool(QtTool::Moc)
             .expect("Could not find moc");
+
+        // Ensure that the executable works
+        utils::check_executable_help(&executable).unwrap();
+
         let qt_include_paths = qt_installation.include_paths(qt_modules);
         let qt_framework_paths = qt_installation.framework_paths(qt_modules);
 

--- a/crates/qt-build-utils/src/tool/qmlcachegen.rs
+++ b/crates/qt-build-utils/src/tool/qmlcachegen.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{QmlUri, QtInstallation, QtTool};
+use crate::{utils, QmlUri, QtInstallation, QtTool};
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -39,6 +39,9 @@ impl QtToolQmlCacheGen {
         let executable = qt_installation
             .try_find_tool(QtTool::QmlCacheGen)
             .expect("Could not find qmlcachegen");
+
+        // Ensure that the executable works
+        utils::check_executable_help(&executable).unwrap();
 
         Self { executable }
     }

--- a/crates/qt-build-utils/src/tool/qmltyperegistrar.rs
+++ b/crates/qt-build-utils/src/tool/qmltyperegistrar.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{QmlUri, QtInstallation, QtTool};
+use crate::{utils, QmlUri, QtInstallation, QtTool};
 use semver::Version;
 use std::{
     path::{Path, PathBuf},
@@ -21,6 +21,9 @@ impl QtToolQmlTypeRegistrar {
         let executable = qt_installation
             .try_find_tool(QtTool::QmlTypeRegistrar)
             .expect("Could not find qmltyperegistrar");
+
+        // Ensure that the executable works
+        utils::check_executable_help(&executable).unwrap();
 
         Self { executable }
     }

--- a/crates/qt-build-utils/src/tool/qtpaths.rs
+++ b/crates/qt-build-utils/src/tool/qtpaths.rs
@@ -5,7 +5,7 @@
 
 use std::{path::PathBuf, process::Command};
 
-use crate::{QtInstallation, QtTool};
+use crate::{utils, QtInstallation, QtTool};
 
 /// Arguments for [QtToolQtPaths::query]
 #[derive(Default)]
@@ -46,6 +46,9 @@ impl QtToolQtPaths {
         let executable = qt_installation
             .try_find_tool(QtTool::QtPaths)
             .expect("Could not find qtpaths");
+
+        // Ensure that the executable works
+        utils::check_executable_help(&executable).unwrap();
 
         Self { executable }
     }
@@ -89,31 +92,9 @@ impl QtToolQtPaths {
 impl QtToolQtPaths {
     /// Construct from an executable path this is used interally to allow for querying for the Qt version
     pub(crate) fn from_path_buf(executable: PathBuf) -> Self {
+        // Ensure that the executable works
+        utils::check_executable_help(&executable).unwrap();
+
         Self { executable }
-            // Ensure that the command works as this is used to query the Qt version
-            // so if there are missing libraries the errors are not obvious
-            .check_command()
-    }
-
-    /// Ensure that the qtpaths command works
-    ///
-    /// As this can fail to run due to missing libraries and then cause errors
-    /// which choosing Qt versions that are non obvious.
-    fn check_command(self) -> Self {
-        let output = Command::new(&self.executable)
-            .arg("--help")
-            // Binaries should work without environment and this prevents
-            // LD_LIBRARY_PATH from causing different Qt version clashes
-            .env_clear()
-            .output()
-            .expect("Could not run qtpaths");
-        if !output.status.success() {
-            panic!(
-                "qtpaths unexpectedly exited a non-zero status code: '{:#?}'",
-                output
-            );
-        }
-
-        self
     }
 }

--- a/crates/qt-build-utils/src/tool/rcc.rs
+++ b/crates/qt-build-utils/src/tool/rcc.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{Initializer, QtInstallation, QtTool};
+use crate::{utils, Initializer, QtInstallation, QtTool};
 
 use semver::Version;
 use std::{
@@ -25,6 +25,10 @@ impl QtToolRcc {
         let executable = qt_installation
             .try_find_tool(QtTool::Rcc)
             .expect("Could not find rcc");
+
+        // Ensure that the executable works
+        utils::check_executable_help(&executable).unwrap();
+
         let qt_version = qt_installation.version();
 
         Self {

--- a/crates/qt-build-utils/src/utils.rs
+++ b/crates/qt-build-utils/src/utils.rs
@@ -3,6 +3,37 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::{path::Path, process::Command};
+
+/// Ensure that the given executable runs
+///
+/// This allows for raising errors that point to linker failures
+/// as --help should always work
+pub(crate) fn check_executable_help(executable: &Path) -> anyhow::Result<()> {
+    let output = Command::new(executable)
+        .arg("--help")
+        // Binaries should work without environment and this prevents
+        // LD_LIBRARY_PATH from causing different Qt version clashes
+        .env_clear()
+        .output()
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "{} process failed to complete: '{}'",
+                executable.display(),
+                err
+            )
+        })?;
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "{} unexpectedly exited a non-zero status code: '{:#?}'",
+            executable.display(),
+            output
+        ));
+    }
+
+    Ok(())
+}
+
 /// Whether apple is the current target
 pub(crate) fn is_apple_target() -> bool {
     // TODO: should CARGO_CFG_* be used here instead?


### PR DESCRIPTION
This catches issues such as linker failures due to missing libraries and improves the error message.

Closes #1439