### PR TITLE
Use `&self`, `&mut self`, `Pin<&mut Self>` in `#[cxx::bridge]`

### DIFF
--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.rs
@@ -23,13 +23,13 @@ mod ffi {
 
         /// Returns the default values set for this option.
         #[rust_name = "default_values"]
-        fn defaultValues(self: &QCommandLineOption) -> QStringList;
+        fn defaultValues(&self) -> QStringList;
 
         /// Returns the description set for this option.
-        fn description(self: &QCommandLineOption) -> QString;
+        fn description(&self) -> QString;
 
         /// Returns the names set for this option.
-        fn names(self: &QCommandLineOption) -> QStringList;
+        fn names(&self) -> QStringList;
 
         /// Sets the default value used for this option to `default_value`.
         ///
@@ -37,20 +37,20 @@ mod ffi {
         ///
         /// If `default_value` is empty, the option has no default values.
         #[rust_name = "set_default_value"]
-        fn setDefaultValue(self: &mut QCommandLineOption, default_value: &QString);
+        fn setDefaultValue(&mut self, default_value: &QString);
 
         /// Sets the list of default values used for this option to `default_values`.
         ///
         /// The default values are used if the user of the application does not specify the option on the command line.
         #[rust_name = "set_default_values"]
-        fn setDefaultValues(self: &mut QCommandLineOption, default_values: &QStringList);
+        fn setDefaultValues(&mut self, default_values: &QStringList);
 
         /// Sets the description used for this option to `description`.
         /// It is customary to add a "." at the end of the description.
         ///
         /// The description is used by [QCommandLineParser::showHelp](https://doc.qt.io/qt/qcommandlineparser.html#showHelp)().
         #[rust_name = "set_description"]
-        fn setDescription(self: &mut QCommandLineOption, description: &QString);
+        fn setDescription(&mut self, description: &QString);
 
         /// Sets the name of the expected value, for the documentation, to `value_name`.
         ///
@@ -60,11 +60,11 @@ mod ffi {
         ///
         /// Call [`QCommandLineParser::value`](crate::QCommandLineParser::value) if you expect the option to be present only once, and [`QCommandLineParser::values`](crate::QCommandLineParser::values) if you expect that option to be present multiple times.
         #[rust_name = "set_value_name"]
-        fn setValueName(self: &mut QCommandLineOption, value_name: &QString);
+        fn setValueName(&mut self, value_name: &QString);
 
         /// Returns the name of the expected value.
         #[rust_name = "value_name"]
-        fn valueName(self: &QCommandLineOption) -> QString;
+        fn valueName(&self) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.rs
@@ -9,13 +9,17 @@ use std::mem::MaybeUninit;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
-        include!("cxx-qt-lib-extras/core/qcommandlineoption.h");
-        type QCommandLineOption = super::QCommandLineOption;
+    extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         type QString = cxx_qt_lib::QString;
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = cxx_qt_lib::QStringList;
+
+        include!("cxx-qt-lib-extras/core/qcommandlineoption.h");
+    }
+
+    unsafe extern "C++" {
+        type QCommandLineOption = super::QCommandLineOption;
 
         /// Returns the default values set for this option.
         #[rust_name = "default_values"]

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.rs
@@ -57,7 +57,7 @@ mod ffi {
         ///
         /// These options are handled automatically by `QCommandLineParser`.
         #[rust_name = "add_help_option"]
-        fn addHelpOption(self: &mut QCommandLineParser) -> QCommandLineOption;
+        fn addHelpOption(&mut self) -> QCommandLineOption;
 
         /// Adds the option `option` to look for while parsing.
         /// Returns `true` if adding the option was successful; otherwise returns `false`.
@@ -65,29 +65,29 @@ mod ffi {
         /// Adding the option fails if there is no name attached to the option,
         /// or the option has a name that clashes with an option name added before.
         #[rust_name = "add_option"]
-        fn addOption(self: &mut QCommandLineParser, option: &QCommandLineOption) -> bool;
+        fn addOption(&mut self, option: &QCommandLineOption) -> bool;
 
         /// Adds the `-v` / `--version` option, which displays the version string of the application.
         ///
         /// This option is handled automatically by `QCommandLineParser`.
         #[rust_name = "add_version_option"]
-        fn addVersionOption(self: &mut QCommandLineParser) -> QCommandLineOption;
+        fn addVersionOption(&mut self) -> QCommandLineOption;
 
         /// Returns the application description.
         #[rust_name = "application_description"]
-        fn applicationDescription(self: &QCommandLineParser) -> QString;
+        fn applicationDescription(&self) -> QString;
 
         /// Clears the definitions of additional arguments from the help text.
         #[rust_name = "clear_positional_arguments"]
-        fn clearPositionalArguments(self: &mut QCommandLineParser);
+        fn clearPositionalArguments(&mut self);
 
         /// Returns a translated error text for the user. This should only be called when [`parse`](Self::parse) returns `false`.
         #[rust_name = "error_text"]
-        fn errorText(self: &QCommandLineParser) -> QString;
+        fn errorText(&self) -> QString;
 
         /// Returns a string containing the complete help information.
         #[rust_name = "help_text"]
-        fn helpText(self: &QCommandLineParser) -> QString;
+        fn helpText(&self) -> QString;
 
         /// Returns a list of option names that were found.
         ///
@@ -97,7 +97,7 @@ mod ffi {
         ///
         /// Any entry in the list can be used with [`value`](Self::value) or with [`values`](Self::values) to get any relevant option values.
         #[rust_name = "option_names"]
-        fn optionNames(self: &QCommandLineParser) -> QStringList;
+        fn optionNames(&self) -> QStringList;
 
         /// Parses the command line arguments.
         ///
@@ -113,13 +113,13 @@ mod ffi {
         ///
         /// [`process`]: Self::process
         /// [`error_text`]: Self::error_text
-        fn parse(self: &mut QCommandLineParser, arguments: &QStringList) -> bool;
+        fn parse(&mut self, arguments: &QStringList) -> bool;
 
         /// Returns a list of positional arguments.
         ///
         /// These are all of the arguments that were not recognized as part of an option.
         #[rust_name = "positional_arguments"]
-        fn positionalArguments(self: &QCommandLineParser) -> QStringList;
+        fn positionalArguments(&self) -> QStringList;
 
         /// Processes the command line arguments.
         ///
@@ -128,23 +128,23 @@ mod ffi {
         /// The builtin options are `--version` if [`add_version_option`](Self::add_version_option) was called and `--help` / `--help-all` if [`add_help_option`](Self::add_help_option) was called.
         ///
         /// When invoking one of these options, or when an error happens (for instance an unknown option was passed), the current process will then stop, using the [exit](https://doc.qt.io/qt/qcoreapplication.html#exit)() function.
-        fn process(self: &mut QCommandLineParser, arguments: &QStringList);
+        fn process(&mut self, arguments: &QStringList);
 
         /// Sets the application description shown by [`help_text`](Self::help_text).
         #[rust_name = "set_application_description"]
-        fn setApplicationDescription(self: &mut QCommandLineParser, description: &QString);
+        fn setApplicationDescription(&mut self, description: &QString);
 
         /// Sets the parsing mode to `single_dash_word_option_mode`. This must be called before [`process`](Self::process) or [`parse`](Self::parse).
         #[rust_name = "set_single_dash_word_option_mode"]
         fn setSingleDashWordOptionMode(
-            self: &mut QCommandLineParser,
+            &mut self,
             single_dash_word_option_mode: QCommandLineParserSingleDashWordOptionMode,
         );
 
         /// Sets the parsing mode to `parsing_mode`. This must be called before [`process`](Self::process) or [`parse`](Self::parse).
         #[rust_name = "set_options_after_positional_arguments_mode"]
         fn setOptionsAfterPositionalArgumentsMode(
-            self: &mut QCommandLineParser,
+            &mut self,
             parsing_mode: QCommandLineParserOptionsAfterPositionalArgumentsMode,
         );
 
@@ -152,7 +152,7 @@ mod ffi {
         ///
         ///  This is automatically triggered by the `–version` option, but can also be used to display the version when not using [`process`](Self::process). The exit code is set to `EXIT_SUCCESS` (0).
         #[rust_name = "show_version"]
-        fn showVersion(self: &mut QCommandLineParser);
+        fn showVersion(&mut self);
 
         /// Returns a list of unknown option names.
         ///
@@ -160,7 +160,7 @@ mod ffi {
         ///
         /// The names in this list do not include the preceding dash characters. Names may appear more than once in this list if they were encountered more than once by the parser.
         #[rust_name = "unknown_option_names"]
-        fn unknownOptionNames(self: &QCommandLineParser) -> QStringList;
+        fn unknownOptionNames(&self) -> QStringList;
     }
     #[namespace = "rust::cxxqtlib1"]
     unsafe extern "C++" {

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.rs
@@ -36,16 +36,20 @@ mod ffi {
         ParseAsLongOptions,
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib-extras/core/qcommandlineparser.h");
-        type QCommandLineParser = super::QCommandLineParser;
-        include!("cxx-qt-lib-extras/core/qcommandlineoption.h");
-        type QCommandLineOption = crate::QCommandLineOption;
-
+    extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         type QString = cxx_qt_lib::QString;
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = cxx_qt_lib::QStringList;
+
+        include!("cxx-qt-lib-extras/core/qcommandlineoption.h");
+        type QCommandLineOption = crate::QCommandLineOption;
+
+        include!("cxx-qt-lib-extras/core/qcommandlineparser.h");
+    }
+
+    unsafe extern "C++" {
+        type QCommandLineParser = super::QCommandLineParser;
 
         /// Adds help options to the command-line parser.
         ///

--- a/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.rs
@@ -7,8 +7,11 @@ use cxx::{type_id, ExternType};
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib-extras/core/qelapsedtimer.h");
+    }
+
+    unsafe extern "C++" {
         type QElapsedTimer = crate::QElapsedTimer;
 
         /// Returns `false` if the timer has never been started or invalidated by a call to [`invalidate`](Self::invalidate).

--- a/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qelapsedtimer.rs
@@ -16,17 +16,17 @@ mod ffi {
 
         /// Returns `false` if the timer has never been started or invalidated by a call to [`invalidate`](Self::invalidate).
         #[rust_name = "is_valid"]
-        fn isValid(self: &QElapsedTimer) -> bool;
+        fn isValid(&self) -> bool;
 
         /// Marks this `QElapsedTimer` object as invalid.
         ///
         /// An invalid object can be checked with [`is_valid`](Self::is_valid). Calculations of timer elapsed since invalid data are undefined and will likely produce bizarre results.
-        fn invalidate(self: &mut QElapsedTimer);
+        fn invalidate(&mut self);
 
         /// Starts this timer. Once started, a timer value can be checked with [elapsed](https://doc.qt.io/qt/qelapsedtimer.html#elapsed)() or [msecsSinceReference](https://doc.qt.io/qt/qelapsedtimer.html#msecsSinceReference)().
         ///
         /// Also, starting a timer makes it valid again.
-        fn start(self: &mut QElapsedTimer);
+        fn start(&mut self);
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib-extras/src/core/qeventloop.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qeventloop.rs
@@ -35,10 +35,6 @@ mod ffi {
         type QEventLoopProcessEventsFlags = super::QEventLoopProcessEventsFlags;
     }
 
-    extern "Rust" {
-        type EventLoopClosure<'a>;
-    }
-
     unsafe extern "C++Qt" {
         /// The `QEventLoop` class provides a means of entering and leaving an event loop.
         ///
@@ -90,6 +86,10 @@ mod ffi {
         /// Wakes up the event loop.
         #[rust_name = "wake_up"]
         fn wakeUp(self: Pin<&mut QEventLoop>);
+    }
+
+    extern "Rust" {
+        type EventLoopClosure<'a>;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib-extras/src/core/qeventloop.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qeventloop.rs
@@ -149,7 +149,7 @@ impl QEventLoop {
     /// Enters an event loop, runs a `closure`, and exits the event loop when the closure completes.
     ///
     /// As with `QEventLoop`'s other methods, a [`QApplication`](crate::QApplication), [`QGuiApplication`](cxx_qt_lib::QGuiApplication), or [`QCoreApplication`](cxx_qt_lib::QCoreApplication) must be running.
-    pub fn exec_with<F>(self: Pin<&mut QEventLoop>, closure: F)
+    pub fn exec_with<F>(self: Pin<&mut Self>, closure: F)
     where
         F: FnOnce(),
     {
@@ -162,7 +162,7 @@ impl QEventLoop {
     /// Processes some pending events. Returns `true` if pending events were handled; otherwise returns `false`.
     ///
     /// This function is simply a wrapper for [QAbstractEventDispatcher::processEvents](https://doc.qt.io/qt/qabstracteventdispatcher.html#processEvents)(). See the documentation for that function for details.
-    pub fn process_all_events(self: Pin<&mut QEventLoop>) -> bool {
+    pub fn process_all_events(self: Pin<&mut Self>) -> bool {
         self.process_events(QEventLoopProcessEventsFlag::AllEvents.into())
     }
 
@@ -173,7 +173,7 @@ impl QEventLoop {
     /// * This function does not process events continuously; it returns after all available events are processed.
     /// * Specifying the [`QEventLoopProcessEventsFlag::WaitForMoreEvents`] flag makes no sense and will be ignored.
     pub fn process_events_until(
-        self: Pin<&mut QEventLoop>,
+        self: Pin<&mut Self>,
         flags: QEventLoopProcessEventsFlags,
         deadline: Duration,
     ) {
@@ -186,7 +186,7 @@ impl QEventLoop {
     /// Process pending events until `deadline` has expired, or until there are no more events to process, whichever happens first.
     ///
     /// **Note:** This function does not process events continuously; it returns after all available events are processed.
-    pub fn process_all_events_until<T>(self: Pin<&mut QEventLoop>, deadline: Duration) {
+    pub fn process_all_events_until<T>(self: Pin<&mut Self>, deadline: Duration) {
         self.process_events_until(QEventLoopProcessEventsFlag::AllEvents.into(), deadline);
     }
 }

--- a/crates/cxx-qt-lib-extras/src/gui/qapplication.rs
+++ b/crates/cxx-qt-lib-extras/src/gui/qapplication.rs
@@ -8,7 +8,7 @@ use cxx_qt_lib::{QByteArray, QFont, QString, QStringList, QVector};
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qbytearray.h");
         type QByteArray = cxx_qt_lib::QByteArray;
         include!("cxx-qt-lib/qstring.h");

--- a/crates/cxx-qt-lib/src/core/qanystringview.rs
+++ b/crates/cxx-qt-lib/src/core/qanystringview.rs
@@ -24,15 +24,15 @@ mod ffi {
 
         /// Returns `true` if the string has no characters; otherwise returns `false`.
         #[rust_name = "is_empty"]
-        fn isEmpty(self: &QAnyStringView) -> bool;
+        fn isEmpty(&self) -> bool;
 
         /// Returns `true` if this string is null; otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QAnyStringView) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns a deep copy of this string view's data as a QString.
         #[rust_name = "to_qstring"]
-        fn toString(self: &QAnyStringView) -> QString;
+        fn toString(&self) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qanystringview.rs
+++ b/crates/cxx-qt-lib/src/core/qanystringview.rs
@@ -10,15 +10,17 @@ use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qanystringview.h");
-        type QAnyStringView<'a> = super::QAnyStringView<'a>;
-
+    extern "C++" {
         include!("cxx-qt-lib/qbytearray.h");
         type QByteArray = crate::QByteArray;
-
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
+
+        include!("cxx-qt-lib/qanystringview.h");
+    }
+
+    unsafe extern "C++" {
+        type QAnyStringView<'a> = super::QAnyStringView<'a>;
 
         /// Returns `true` if the string has no characters; otherwise returns `false`.
         #[rust_name = "is_empty"]

--- a/crates/cxx-qt-lib/src/core/qcoreapplication.rs
+++ b/crates/cxx-qt-lib/src/core/qcoreapplication.rs
@@ -9,7 +9,7 @@ use core::pin::Pin;
 
 #[cxx_qt::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qbytearray.h");
         type QByteArray = crate::QByteArray;
         include!("cxx-qt-lib/qstring.h");
@@ -24,13 +24,6 @@ mod ffi {
         ///
         /// Qt Documentation: [QCoreApplication](https://doc.qt.io/qt/qcoreapplication.html#details)
         type QCoreApplication;
-    }
-
-    #[namespace = "rust::cxxqtlib1"]
-    unsafe extern "C++" {
-        #[doc(hidden)]
-        #[rust_name = "qcoreapplication_new"]
-        fn qcoreapplicationNew(args: &QVector_QByteArray) -> UniquePtr<QCoreApplication>;
     }
 
     unsafe extern "C++Qt" {
@@ -82,6 +75,13 @@ mod ffi {
         #[doc(hidden)]
         #[rust_name = "qcoreapplication_set_organization_name"]
         fn qapplicationSetOrganizationName(app: Pin<&mut QCoreApplication>, name: &QString);
+    }
+
+    #[namespace = "rust::cxxqtlib1"]
+    unsafe extern "C++" {
+        #[doc(hidden)]
+        #[rust_name = "qcoreapplication_new"]
+        fn qcoreapplicationNew(args: &QVector_QByteArray) -> UniquePtr<QCoreApplication>;
     }
 
     // QCoreApplication is not a trivial to CXX and is not relocatable in Qt

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -31,73 +31,73 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "add_days_qint64"]
-        fn addDays(self: &QDate, ndays: qint64) -> QDate;
+        fn addDays(&self, ndays: qint64) -> QDate;
 
         /// Returns a `QDate` object containing a date `nmonths` later than the date of this object (or earlier if `nmonths` is negative).
         #[rust_name = "add_months"]
-        fn addMonths(self: &QDate, nmonths: i32) -> QDate;
+        fn addMonths(&self, nmonths: i32) -> QDate;
 
         /// Returns a `QDate` object containing a date `nyears` later than the date of this object (or earlier if `nyears` is negative).
         ///
         /// **Note:** If the ending day/month combination does not exist in the resulting year (e.g., for the Gregorian calendar, if the date was Feb 29 and the final year is not a leap year), this function will return a date that is the latest valid date in the given month (in the example, Feb 28).
         #[rust_name = "add_years"]
-        fn addYears(self: &QDate, nyears: i32) -> QDate;
+        fn addYears(&self, nyears: i32) -> QDate;
 
         /// Returns the day of the month for this date.
         ///
         /// Uses the Gregorian calendar (for which the return ranges from 1 to 31). Returns 0 if the date is invalid.
-        fn day(self: &QDate) -> i32;
+        fn day(&self) -> i32;
 
         /// Returns the weekday (1 = Monday to 7 = Sunday) for this date.
         ///
         /// Uses the Gregorian calendar. Returns 0 if the date is invalid.
         #[rust_name = "day_of_week"]
-        fn dayOfWeek(self: &QDate) -> i32;
+        fn dayOfWeek(&self) -> i32;
 
         /// Returns the day of the year (1 for the first day) for this date.
         ///
         /// Uses the Gregorian calendar. Returns 0 if either the date or the first day of its year is invalid.
         #[rust_name = "day_of_year"]
-        fn dayOfYear(self: &QDate) -> i32;
+        fn dayOfYear(&self) -> i32;
 
         /// Returns the number of days in the month for this date.
         ///
         /// Uses the Gregorian calendar (for which the result ranges from 28 to 31). Returns 0 if the date is invalid.
         #[rust_name = "days_in_monyth"]
-        fn daysInMonth(self: &QDate) -> i32;
+        fn daysInMonth(&self) -> i32;
 
         /// Returns the number of days in the year for this date.
         ///
         /// Uses the Gregorian calendar (for which the result is 365 or 366). Returns 0 if the date is invalid.
         #[rust_name = "days_in_year"]
-        fn daysInYear(self: &QDate) -> i32;
+        fn daysInYear(&self) -> i32;
 
         /// Returns `true` if the date is null; otherwise returns `false`. A null date is invalid.
         #[rust_name = "is_null"]
-        fn isNull(self: &QDate) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns `true` if this date is valid; otherwise returns `false`.
         #[rust_name = "is_valid"]
-        fn isValid(self: &QDate) -> bool;
+        fn isValid(&self) -> bool;
 
         /// Returns the month-number for the date.
         ///
         /// Uses the Gregorian calendar (for which the result ranges from 1 to 12). Returns 0 if the date is invalid.
-        fn month(self: &QDate) -> i32;
+        fn month(&self) -> i32;
 
         /// Sets this date to represent the date, in the Gregorian calendar, with the given `year`, `month` and `day` numbers.
         /// Returns `true` if the resulting date is valid, otherwise it sets this date to represent an invalid date and returns `false`.
         #[rust_name = "set_date"]
-        fn setDate(self: &mut QDate, y: i32, m: i32, d: i32) -> bool;
+        fn setDate(&mut self, y: i32, m: i32, d: i32) -> bool;
 
         /// Returns the date as a string. The `format` parameter determines the format of the string.
         #[rust_name = "format_enum"]
-        fn toString(self: &QDate, format: DateFormat) -> QString;
+        fn toString(&self, format: DateFormat) -> QString;
 
         /// Returns the year of this date.
         ///
         /// Uses the Gregorian calendar. Returns 0 if the date is invalid.
-        fn year(self: &QDate) -> i32;
+        fn year(&self) -> i32;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -174,7 +174,7 @@ impl QDate {
     /// Returns a `QDate` object containing a date `ndays` later than the date of this object (or earlier if `ndays` is negative).
     ///
     /// Returns a null date if the current date is invalid or the new date is out of range.
-    pub fn add_days(self: &QDate, ndays: i64) -> QDate {
+    pub fn add_days(&self, ndays: i64) -> QDate {
         self.add_days_qint64(ndays.into())
     }
 

--- a/crates/cxx-qt-lib/src/core/qdate.rs
+++ b/crates/cxx-qt-lib/src/core/qdate.rs
@@ -12,21 +12,21 @@ use crate::QString;
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type DateFormat = crate::DateFormat;
     }
 
-    unsafe extern "C++" {
+    extern "C++" {
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
         include!("cxx-qt-lib/qtypes.h");
         type qint64 = crate::qint64;
+
+        include!("cxx-qt-lib/qdate.h");
     }
 
     unsafe extern "C++" {
-        include!("cxx-qt-lib/qstring.h");
-        type QString = crate::QString;
-
-        include!("cxx-qt-lib/qdate.h");
         type QDate = super::QDate;
 
         #[doc(hidden)]

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -39,103 +39,103 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "add_days_qint64"]
-        fn addDays(self: &QDateTime, ndays: qint64) -> QDateTime;
+        fn addDays(&self, ndays: qint64) -> QDateTime;
 
         /// Returns a QDateTime object containing a datetime `nmonths` months later than the datetime of this object (or earlier if `nmonths` is negative).
         ///
         /// If [`time_spec`](Self::time_spec) is [`TimeSpec::LocalTime`] or [`TimeSpec::TimeZone`] and the resulting date and time fall in the Standard Time to Daylight-Saving Time transition hour then the result will be just beyond this gap, in the direction of change. If the transition is at 2am and the clock goes forward to 3am, the result of aiming between 2am and 3am will be adjusted to fall before 2am (if `nmonths` is negative) or after 3am (otherwise).
         #[rust_name = "add_months"]
-        fn addMonths(self: &QDateTime, nmonths: i32) -> QDateTime;
+        fn addMonths(&self, nmonths: i32) -> QDateTime;
 
         #[doc(hidden)]
         #[rust_name = "add_msecs_qint64"]
-        fn addMSecs(self: &QDateTime, msecs: qint64) -> QDateTime;
+        fn addMSecs(&self, msecs: qint64) -> QDateTime;
 
         #[doc(hidden)]
         #[rust_name = "add_secs_qint64"]
-        fn addSecs(self: &QDateTime, secs: qint64) -> QDateTime;
+        fn addSecs(&self, secs: qint64) -> QDateTime;
 
         /// Returns a QDateTime object containing a datetime `nyears` years later than the datetime of this object (or earlier if `nyears` is negative).
         ///
         /// If [`time_spec`](Self::time_spec) is [`TimeSpec::LocalTime`] or [`TimeSpec::TimeZone`] and the resulting date and time fall in the Standard Time to Daylight-Saving Time transition hour then the result will be just beyond this gap, in the direction of change. If the transition is at 2am and the clock goes forward to 3am, the result of aiming between 2am and 3am will be adjusted to fall before 2am (if `nyears` is negative) or after 3am (otherwise).
         #[rust_name = "add_years"]
-        fn addYears(self: &QDateTime, nyears: i32) -> QDateTime;
+        fn addYears(&self, nyears: i32) -> QDateTime;
 
         /// Returns the date part of the datetime.
-        fn date(self: &QDateTime) -> QDate;
+        fn date(&self) -> QDate;
 
         #[doc(hidden)]
         #[rust_name = "days_to_qint64"]
-        fn daysTo(self: &QDateTime, other: &QDateTime) -> qint64;
+        fn daysTo(&self, other: &QDateTime) -> qint64;
 
         /// Returns `true` if this datetime falls in Daylight-Saving Time, otherwise `false`.
         ///
         /// If [`time_spec`](Self::time_spec) is not [`TimeSpec::LocalTime`] or [`TimeSpec::TimeZone`] then this will always return `false`.
         #[rust_name = "is_daylight_time"]
-        fn isDaylightTime(self: &QDateTime) -> bool;
+        fn isDaylightTime(&self) -> bool;
 
         /// Returns `true` if both the date and the time are null; otherwise returns `false`. A null datetime is invalid.
         #[rust_name = "is_null"]
-        fn isNull(self: &QDateTime) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns `true` if both the `date` and the `time` are valid and they are valid in the current [`TimeSpec`](TimeSpec), otherwise returns `false`.
         #[rust_name = "is_valid"]
-        fn isValid(self: &QDateTime) -> bool;
+        fn isValid(&self) -> bool;
 
         /// Returns this date-time's offset from UTC in seconds.
         #[rust_name = "offset_from_utc"]
-        fn offsetFromUtc(self: &QDateTime) -> i32;
+        fn offsetFromUtc(&self) -> i32;
 
         #[doc(hidden)]
         #[rust_name = "msecs_to_qint64"]
-        fn msecsTo(self: &QDateTime, other: &QDateTime) -> qint64;
+        fn msecsTo(&self, other: &QDateTime) -> qint64;
 
         #[doc(hidden)]
         #[rust_name = "secs_to_qint64"]
-        fn secsTo(self: &QDateTime, other: &QDateTime) -> qint64;
+        fn secsTo(&self, other: &QDateTime) -> qint64;
 
         #[doc(hidden)]
         #[rust_name = "set_msecs_since_epoch_qint64"]
-        fn setMSecsSinceEpoch(self: &mut QDateTime, msecs: qint64);
+        fn setMSecsSinceEpoch(&mut self, msecs: qint64);
 
         /// Sets the [`time_spec`](Self::time_spec) to [`TimeSpec::OffsetFromUTC`] and the offset to `offset_seconds`.
         ///
         /// **Note:** This method is only available with Qt < 6.8.
         #[cfg(not(cxxqt_qt_version_at_least_6_8))]
         #[rust_name = "set_offset_from_utc"]
-        fn setOffsetFromUtc(self: &mut QDateTime, offset_seconds: i32);
+        fn setOffsetFromUtc(&mut self, offset_seconds: i32);
 
         #[doc(hidden)]
         #[rust_name = "set_secs_since_epoch_qint64"]
-        fn setSecsSinceEpoch(self: &mut QDateTime, secs: qint64);
+        fn setSecsSinceEpoch(&mut self, secs: qint64);
 
         /// Sets the time specification used in this datetime to `spec`. The datetime will refer to a different point in time.
         ///
         /// **Note:** This method is only available with Qt < 6.8.
         #[cfg(not(cxxqt_qt_version_at_least_6_8))]
         #[rust_name = "set_time_spec"]
-        fn setTimeSpec(self: &mut QDateTime, spec: TimeSpec);
+        fn setTimeSpec(&mut self, spec: TimeSpec);
 
         /// Returns the time part of the datetime.
-        fn time(self: &QDateTime) -> QTime;
+        fn time(&self) -> QTime;
 
         /// Returns the time specification of the datetime.
         #[rust_name = "time_spec"]
-        fn timeSpec(self: &QDateTime) -> TimeSpec;
+        fn timeSpec(&self) -> TimeSpec;
 
         /// Returns the Time Zone Abbreviation for this datetime.
         #[rust_name = "time_zone_abbreviation"]
-        fn timeZoneAbbreviation(self: &QDateTime) -> QString;
+        fn timeZoneAbbreviation(&self) -> QString;
 
         /// Returns a copy of this datetime converted to local time.
         ///
         /// The result represents the same moment in time as, and is equal to, this datetime.
         #[rust_name = "to_local_time"]
-        fn toLocalTime(self: &QDateTime) -> QDateTime;
+        fn toLocalTime(&self) -> QDateTime;
 
         #[doc(hidden)]
         #[rust_name = "to_msecs_since_epoch_qint64"]
-        fn toMSecsSinceEpoch(self: &QDateTime) -> qint64;
+        fn toMSecsSinceEpoch(&self) -> qint64;
 
         /// Returns a copy of this datetime converted to a spec of [`TimeSpec::OffsetFromUTC`] with the given `offset_seconds`.
         ///
@@ -143,22 +143,22 @@ mod ffi {
         ///
         /// The result represents the same moment in time as, and is equal to, this datetime.
         #[rust_name = "to_offset_from_utc"]
-        fn toOffsetFromUtc(self: &QDateTime, offset_seconds: i32) -> QDateTime;
+        fn toOffsetFromUtc(&self, offset_seconds: i32) -> QDateTime;
 
         #[doc(hidden)]
         #[rust_name = "to_secs_since_epoch_qint64"]
-        fn toSecsSinceEpoch(self: &QDateTime) -> qint64;
+        fn toSecsSinceEpoch(&self) -> qint64;
 
         /// Returns the time as a string in the `format` given.
         #[rust_name = "format_enum"]
-        fn toString(self: &QDateTime, format: DateFormat) -> QString;
+        fn toString(&self, format: DateFormat) -> QString;
 
         /// Returns a copy of this datetime converted to the given time `spec`.
         ///
         /// Note this method is only available with Qt < 6.8
         #[cfg(not(cxxqt_qt_version_at_least_6_8))]
         #[rust_name = "to_time_spec"]
-        fn toTimeSpec(self: &QDateTime, spec: TimeSpec) -> QDateTime;
+        fn toTimeSpec(&self, spec: TimeSpec) -> QDateTime;
 
         /// Returns a copy of this datetime converted to the given `time_zone`.
         ///
@@ -166,13 +166,13 @@ mod ffi {
         ///
         /// If `time_zone` is invalid then the datetime will be invalid.
         #[rust_name = "to_time_zone"]
-        fn toTimeZone(self: &QDateTime, time_zone: &QTimeZone) -> QDateTime;
+        fn toTimeZone(&self, time_zone: &QTimeZone) -> QDateTime;
 
         /// Returns a copy of this datetime converted to UTC.
         ///
         /// The result represents the same moment in time as, and is equal to, this datetime.
         #[rust_name = "to_utc"]
-        fn toUTC(self: &QDateTime) -> QDateTime;
+        fn toUTC(&self) -> QDateTime;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -273,21 +273,21 @@ impl QDateTime {
     /// Returns a `QDateTime` object containing a datetime `ndays` days later than the datetime of this object (or earlier if `ndays` is negative).
     ///
     /// If [`time_spec`](Self::time_spec) is [`TimeSpec::LocalTime`] or [`TimeSpec::TimeZone`] and the resulting date and time fall in the Standard Time to Daylight-Saving Time transition hour then the result will be just beyond this gap, in the direction of change. If the transition is at 2am and the clock goes forward to 3am, the result of aiming between 2am and 3am will be adjusted to fall before 2am (if `ndays` is negative) or after 3am (otherwise).
-    pub fn add_days(self: &QDateTime, ndays: i64) -> QDateTime {
+    pub fn add_days(&self, ndays: i64) -> QDateTime {
         self.add_days_qint64(ndays.into())
     }
 
     /// Returns a `QDateTime` object containing a datetime `msecs` milliseconds later than the datetime of this object (or earlier if `msecs` is negative).
     ///
     /// If this datetime is invalid, an invalid datetime will be returned.
-    pub fn add_msecs(self: &QDateTime, msecs: i64) -> QDateTime {
+    pub fn add_msecs(&self, msecs: i64) -> QDateTime {
         self.add_msecs_qint64(msecs.into())
     }
 
     /// Returns a `QDateTime` object containing a datetime `secs` seconds later than the datetime of this object (or earlier if `secs` is negative).
     ///
     /// If this datetime is invalid, an invalid datetime will be returned.
-    pub fn add_secs(self: &QDateTime, secs: i64) -> QDateTime {
+    pub fn add_secs(&self, secs: i64) -> QDateTime {
         self.add_secs_qint64(secs.into())
     }
 
@@ -382,7 +382,7 @@ impl QDateTime {
     /// If the `other` datetime is earlier than this datetime, the value returned is negative.
     ///
     /// Returns 0 if either datetime is invalid.
-    pub fn msecs_to(self: &QDateTime, other: &QDateTime) -> i64 {
+    pub fn msecs_to(&self, other: &QDateTime) -> i64 {
         self.msecs_to_qint64(other).into()
     }
 
@@ -390,7 +390,7 @@ impl QDateTime {
     /// If the `other` datetime is earlier than this datetime, the value returned is negative.
     ///
     /// Returns 0 if either datetime is invalid.
-    pub fn secs_to(self: &QDateTime, other: &QDateTime) -> i64 {
+    pub fn secs_to(&self, other: &QDateTime) -> i64 {
         self.secs_to_qint64(other).into()
     }
 
@@ -405,14 +405,14 @@ impl QDateTime {
     /// On systems that do not support time zones, this function will behave as if local time were UTC.
     ///
     /// Note that passing `i64::MIN` to `msecs` will result in undefined behavior.
-    pub fn set_msecs_since_epoch(self: &mut QDateTime, msecs: i64) {
+    pub fn set_msecs_since_epoch(&mut self, msecs: i64) {
         self.set_msecs_since_epoch_qint64(msecs.into());
     }
 
     /// Sets the datetime to represent a moment a given number, `secs`, of seconds after the start, in UTC, of the year 1970.
     ///
     /// On systems that do not support time zones, this function will behave as if local time were UTC.
-    pub fn set_secs_since_epoch(self: &mut QDateTime, secs: i64) {
+    pub fn set_secs_since_epoch(&mut self, secs: i64) {
         self.set_secs_since_epoch_qint64(secs.into());
     }
 
@@ -432,7 +432,7 @@ impl QDateTime {
     /// On systems that do not support time zones, this function will behave as if local time were UTC.
     ///
     /// The behavior for this function is undefined if the datetime stored in this object is not valid. However, for all valid dates, this function returns a unique value.
-    pub fn to_msecs_since_epoch(self: &QDateTime) -> i64 {
+    pub fn to_msecs_since_epoch(&self) -> i64 {
         self.to_msecs_since_epoch_qint64().into()
     }
 
@@ -441,7 +441,7 @@ impl QDateTime {
     /// On systems that do not support time zones, this function will behave as if local time were UTC.
     ///
     /// The behavior for this function is undefined if the datetime stored in this object is not valid. However, for all valid dates, this function returns a unique value.
-    pub fn to_secs_since_epoch(self: &QDateTime) -> i64 {
+    pub fn to_secs_since_epoch(&self) -> i64 {
         self.to_secs_since_epoch_qint64().into()
     }
 }

--- a/crates/cxx-qt-lib/src/core/qdatetime.rs
+++ b/crates/cxx-qt-lib/src/core/qdatetime.rs
@@ -13,28 +13,29 @@ use crate::{DateFormat, QDate, QString, QTime, QTimeZone};
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type TimeSpec = crate::TimeSpec;
         type DateFormat = crate::DateFormat;
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qtypes.h");
-        type qint64 = crate::qint64;
-    }
-
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qdate.h");
         type QDate = crate::QDate;
-        include!("cxx-qt-lib/qdatetime.h");
-        type QDateTime = super::QDateTime;
         include!("cxx-qt-lib/qtime.h");
         type QTime = crate::QTime;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
         include!("cxx-qt-lib/qtimezone.h");
         type QTimeZone = crate::QTimeZone;
+        include!("cxx-qt-lib/qtypes.h");
+        type qint64 = crate::qint64;
+
+        include!("cxx-qt-lib/qdatetime.h");
+    }
+
+    unsafe extern "C++" {
+        type QDateTime = super::QDateTime;
 
         #[doc(hidden)]
         #[rust_name = "add_days_qint64"]

--- a/crates/cxx-qt-lib/src/core/qline.rs
+++ b/crates/cxx-qt-lib/src/core/qline.rs
@@ -25,64 +25,64 @@ mod ffi {
         type QLine = super::QLine;
 
         /// Returns the line's start point.
-        fn p1(self: &QLine) -> QPoint;
+        fn p1(&self) -> QPoint;
 
         /// Returns the line's end point.
-        fn p2(self: &QLine) -> QPoint;
+        fn p2(&self) -> QPoint;
 
         /// Returns the x-coordinate of the line's start point.
-        fn x1(self: &QLine) -> i32;
+        fn x1(&self) -> i32;
 
         /// Returns the x-coordinate of the line's end point.
-        fn x2(self: &QLine) -> i32;
+        fn x2(&self) -> i32;
 
         /// Returns the y-coordinate of the line's start point.
-        fn y1(self: &QLine) -> i32;
+        fn y1(&self) -> i32;
 
         /// Returns the y-coordinate of the line's end point.
-        fn y2(self: &QLine) -> i32;
+        fn y2(&self) -> i32;
 
         /// Returns the center point of this line. This is equivalent to `(self.p1() + self.p2()) / 2`, except it will never overflow.
-        fn center(self: &QLine) -> QPoint;
+        fn center(&self) -> QPoint;
 
         /// Returns the horizontal component of the line's vector.
-        fn dx(self: &QLine) -> i32;
+        fn dx(&self) -> i32;
 
         /// Returns the vertical component of the line's vector.
-        fn dy(self: &QLine) -> i32;
+        fn dy(&self) -> i32;
 
         /// Returns `true` if the line does not have distinct start and end points; otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QLine) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Sets the starting point of this line to `p1`.
         #[rust_name = "set_p1"]
-        fn setP1(self: &mut QLine, p1: &QPoint);
+        fn setP1(&mut self, p1: &QPoint);
 
         /// Sets the end point of this line to `p2`.
         #[rust_name = "set_p2"]
-        fn setP2(self: &mut QLine, p1: &QPoint);
+        fn setP2(&mut self, p1: &QPoint);
 
         /// Sets this line to the start in `x1`, `y1` and end in `x2`, `y2`.
         #[rust_name = "set_line"]
-        fn setLine(self: &mut QLine, x1: i32, y1: i32, x2: i32, y2: i32);
+        fn setLine(&mut self, x1: i32, y1: i32, x2: i32, y2: i32);
 
         /// Sets the start point of this line to `p1` and the end point of this line to `p2`.
         #[rust_name = "set_points"]
-        fn setPoints(self: &mut QLine, p1: &QPoint, p2: &QPoint);
+        fn setPoints(&mut self, p1: &QPoint, p2: &QPoint);
 
         /// Returns this line as a line with floating point accuracy.
         ///
         /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_linef"]
-        fn toLineF(self: &QLine) -> QLineF;
+        fn toLineF(&self) -> QLineF;
 
         /// Translates this line by the given `offset`.
-        fn translate(self: &mut QLine, offset: &QPoint);
+        fn translate(&mut self, offset: &QPoint);
 
         /// Returns this line translated by the given `offset`.
-        fn translated(self: &QLine, offset: &QPoint) -> QLine;
+        fn translated(&self, offset: &QPoint) -> QLine;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qline.rs
+++ b/crates/cxx-qt-lib/src/core/qline.rs
@@ -9,16 +9,20 @@ use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qline.h");
-        type QLine = super::QLine;
+    extern "C++" {
+        include!("cxx-qt-lib/qlinef.h");
+        #[allow(dead_code)]
+        type QLineF = crate::QLineF;
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = crate::QPoint;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
-        include!("cxx-qt-lib/qlinef.h");
-        #[allow(dead_code)]
-        type QLineF = crate::QLineF;
+
+        include!("cxx-qt-lib/qline.h");
+    }
+
+    unsafe extern "C++" {
+        type QLine = super::QLine;
 
         /// Returns the line's start point.
         fn p1(self: &QLine) -> QPoint;

--- a/crates/cxx-qt-lib/src/core/qlinef.rs
+++ b/crates/cxx-qt-lib/src/core/qlinef.rs
@@ -25,99 +25,99 @@ mod ffi {
         type QLineF = super::QLineF;
 
         /// Returns the angle of the line in degrees.
-        fn angle(self: &QLineF) -> f64;
+        fn angle(&self) -> f64;
 
         /// Returns the angle (in degrees) from this line to the given `line`, taking the direction of the lines into account.
         /// If the lines do not intersect within their range, it is the intersection point of the extended lines that serves as origin.
         ///
         /// The returned value represents the number of degrees you need to add to this line to make it have the same angle as the given `line`, going counter-clockwise.
         #[rust_name = "angle_to"]
-        fn angleTo(self: &QLineF, line: &QLineF) -> f64;
+        fn angleTo(&self, line: &QLineF) -> f64;
 
         /// Returns the line's start point.
-        fn p1(self: &QLineF) -> QPointF;
+        fn p1(&self) -> QPointF;
 
         /// Returns the line's end point.
-        fn p2(self: &QLineF) -> QPointF;
+        fn p2(&self) -> QPointF;
 
         /// Returns the x-coordinate of the line's start point.
-        fn x1(self: &QLineF) -> f64;
+        fn x1(&self) -> f64;
 
         /// Returns the x-coordinate of the line's end point.
-        fn x2(self: &QLineF) -> f64;
+        fn x2(&self) -> f64;
 
         /// Returns the y-coordinate of the line's start point.
-        fn y1(self: &QLineF) -> f64;
+        fn y1(&self) -> f64;
 
         /// Returns the y-coordinate of the line's end point.
-        fn y2(self: &QLineF) -> f64;
+        fn y2(&self) -> f64;
 
         /// Returns the center point of this line. This is equivalent to `(self.p1() + self.p2()) / 2`, except it will never overflow.
-        fn center(self: &QLineF) -> QPointF;
+        fn center(&self) -> QPointF;
 
         /// Returns the horizontal component of the line's vector.
-        fn dx(self: &QLineF) -> f64;
+        fn dx(&self) -> f64;
 
         /// Returns the vertical component of the line's vector.
-        fn dy(self: &QLineF) -> f64;
+        fn dy(&self) -> f64;
 
         /// Returns `true` if the line does not have distinct start and end points; otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QLineF) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns the length of the line.
-        fn length(self: &QLineF) -> f64;
+        fn length(&self) -> f64;
 
         /// Returns a line that is perpendicular to this line with the same starting point and length.
         #[rust_name = "normal_vector"]
-        fn normalVector(self: &QLineF) -> QLineF;
+        fn normalVector(&self) -> QLineF;
 
         /// Returns the point at the parameterized position specified by `t`. The function returns the line's start point if `t` = 0, and its end point if `t` = 1.
         #[rust_name = "point_at"]
-        fn pointAt(self: &QLineF, t: f64) -> QPointF;
+        fn pointAt(&self, t: f64) -> QPointF;
 
         /// Sets the angle of the line to the given `angle` (in degrees). This will change the position of the second point of the line such that the line has the given angle.
         ///
         /// Positive values for the angles mean counter-clockwise while negative values mean the clockwise direction. Zero degrees is at the 3 o'clock position.
         #[rust_name = "set_angle"]
-        fn setAngle(self: &mut QLineF, angle: f64);
+        fn setAngle(&mut self, angle: f64);
 
         /// Sets the length of the line to the given length. `QLineF` will move the end point ([`p2`](QLineF::p2)) of the line to give the line its new length, unless [`length`](Self::length) was previously zero,
         /// in which case no scaling is attempted. For lines with very short lengths (represented by denormal floating-point values), results may be imprecise.
         #[rust_name = "set_length"]
-        fn setLength(self: &mut QLineF, length: f64);
+        fn setLength(&mut self, length: f64);
 
         /// Sets the starting point of this line to `p1`.
         #[rust_name = "set_p1"]
-        fn setP1(self: &mut QLineF, p1: &QPointF);
+        fn setP1(&mut self, p1: &QPointF);
 
         /// Sets the end point of this line to `p2`.
         #[rust_name = "set_p2"]
-        fn setP2(self: &mut QLineF, p1: &QPointF);
+        fn setP2(&mut self, p1: &QPointF);
 
         /// Sets this line to the start in `x1`, `y1` and end in `x2`, `y2`.
         #[rust_name = "set_line"]
-        fn setLine(self: &mut QLineF, x1: f64, y1: f64, x2: f64, y2: f64);
+        fn setLine(&mut self, x1: f64, y1: f64, x2: f64, y2: f64);
 
         /// Sets the start point of this line to `p1` and the end point of this line to `p2`.
         #[rust_name = "set_points"]
-        fn setPoints(self: &mut QLineF, p1: &QPointF, p2: &QPointF);
+        fn setPoints(&mut self, p1: &QPointF, p2: &QPointF);
 
         /// Returns an integer based copy of this line.
         ///
         /// Note that the returned line's start and end points are rounded to the nearest integer.
         #[rust_name = "to_line"]
-        fn toLine(self: &QLineF) -> QLine;
+        fn toLine(&self) -> QLine;
 
         /// Translates this line by the given `offset`.
-        fn translate(self: &mut QLineF, offset: &QPointF);
+        fn translate(&mut self, offset: &QPointF);
 
         /// Returns this line translated by the given `offset`.
-        fn translated(self: &QLineF, offset: &QPointF) -> QLineF;
+        fn translated(&self, offset: &QPointF) -> QLineF;
 
         /// Returns the unit vector for this line, i.e a line starting at the same point as this line with a length of 1.0, provided the line is non-null.
         #[rust_name = "unit_vector"]
-        fn unitVector(self: &QLineF) -> QLineF;
+        fn unitVector(&self) -> QLineF;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qlinef.rs
+++ b/crates/cxx-qt-lib/src/core/qlinef.rs
@@ -10,15 +10,19 @@ use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qlinef.h");
-        type QLineF = super::QLineF;
+    extern "C++" {
         include!("cxx-qt-lib/qline.h");
         type QLine = crate::QLine;
         include!("cxx-qt-lib/qpointf.h");
         type QPointF = crate::QPointF;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
+
+        include!("cxx-qt-lib/qlinef.h");
+    }
+
+    unsafe extern "C++" {
+        type QLineF = super::QLineF;
 
         /// Returns the angle of the line in degrees.
         fn angle(self: &QLineF) -> f64;

--- a/crates/cxx-qt-lib/src/core/qmargins.rs
+++ b/crates/cxx-qt-lib/src/core/qmargins.rs
@@ -8,14 +8,18 @@ use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qmargins.h");
-        type QMargins = super::QMargins;
-        include!("cxx-qt-lib/qstring.h");
-        type QString = crate::QString;
+    extern "C++" {
         include!("cxx-qt-lib/qmarginsf.h");
         #[allow(dead_code)]
         type QMarginsF = crate::QMarginsF;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
+
+        include!("cxx-qt-lib/qmargins.h");
+    }
+
+    unsafe extern "C++" {
+        type QMargins = super::QMargins;
 
         /// Returns the bottom margin.
         fn bottom(self: &QMargins) -> i32;

--- a/crates/cxx-qt-lib/src/core/qmargins.rs
+++ b/crates/cxx-qt-lib/src/core/qmargins.rs
@@ -22,43 +22,43 @@ mod ffi {
         type QMargins = super::QMargins;
 
         /// Returns the bottom margin.
-        fn bottom(self: &QMargins) -> i32;
+        fn bottom(&self) -> i32;
 
         /// Returns `true` if all margins are is 0; otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QMargins) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns the left margin.
-        fn left(self: &QMargins) -> i32;
+        fn left(&self) -> i32;
 
         /// Returns the right margin.
-        fn right(self: &QMargins) -> i32;
+        fn right(&self) -> i32;
 
         /// Sets the bottom margin to `bottom`.
         #[rust_name = "set_bottom"]
-        fn setBottom(self: &mut QMargins, bottom: i32);
+        fn setBottom(&mut self, bottom: i32);
 
         /// Sets the left margin to `left`.
         #[rust_name = "set_left"]
-        fn setLeft(self: &mut QMargins, left: i32);
+        fn setLeft(&mut self, left: i32);
 
         /// Sets the right margin to `right`.
         #[rust_name = "set_right"]
-        fn setRight(self: &mut QMargins, right: i32);
+        fn setRight(&mut self, right: i32);
 
         /// Sets the top margin to `top`.
         #[rust_name = "set_top"]
-        fn setTop(self: &mut QMargins, top: i32);
+        fn setTop(&mut self, top: i32);
 
         /// Returns these margins as margins with floating point accuracy.
         ///
         /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_marginsf"]
-        fn toMarginsF(self: &QMargins) -> QMarginsF;
+        fn toMarginsF(&self) -> QMarginsF;
 
         /// Returns the top margin.
-        fn top(self: &QMargins) -> i32;
+        fn top(&self) -> i32;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qmarginsf.rs
+++ b/crates/cxx-qt-lib/src/core/qmarginsf.rs
@@ -23,42 +23,42 @@ mod ffi {
         type QMarginsF = super::QMarginsF;
 
         /// Returns the bottom margin.
-        fn bottom(self: &QMarginsF) -> f64;
+        fn bottom(&self) -> f64;
 
         /// Returns `true` if all margins are very close to 0; otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QMarginsF) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns the left margin.
-        fn left(self: &QMarginsF) -> f64;
+        fn left(&self) -> f64;
 
         /// Returns the right margin.
-        fn right(self: &QMarginsF) -> f64;
+        fn right(&self) -> f64;
 
         /// Sets the bottom margin to `abottom` (which must be finite).
         #[rust_name = "set_bottom"]
-        fn setBottom(self: &mut QMarginsF, abottom: f64);
+        fn setBottom(&mut self, abottom: f64);
 
         /// Sets the left margin to `aleft` (which must be finite).
         #[rust_name = "set_left"]
-        fn setLeft(self: &mut QMarginsF, aleft: f64);
+        fn setLeft(&mut self, aleft: f64);
 
         /// Sets the right margin to `aright` (which must be finite).
         #[rust_name = "set_right"]
-        fn setRight(self: &mut QMarginsF, aright: f64);
+        fn setRight(&mut self, aright: f64);
 
         /// Sets the top margin to `atop` (which must be finite).
         #[rust_name = "set_top"]
-        fn setTop(self: &mut QMarginsF, atop: f64);
+        fn setTop(&mut self, atop: f64);
 
         /// Returns an integer-based copy of this margins object.
         ///
         /// Note that the components in the returned margins will be rounded to the nearest integer.
         #[rust_name = "to_margins"]
-        fn toMargins(self: &QMarginsF) -> QMargins;
+        fn toMargins(&self) -> QMargins;
 
         /// Returns the top margin.
-        fn top(self: &QMarginsF) -> f64;
+        fn top(&self) -> f64;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qmarginsf.rs
+++ b/crates/cxx-qt-lib/src/core/qmarginsf.rs
@@ -10,13 +10,17 @@ use crate::QMargins;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qmargins.h");
         type QMargins = crate::QMargins;
-        include!("cxx-qt-lib/qmarginsf.h");
-        type QMarginsF = super::QMarginsF;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
+
+        include!("cxx-qt-lib/qmarginsf.h");
+    }
+
+    unsafe extern "C++" {
+        type QMarginsF = super::QMarginsF;
 
         /// Returns the bottom margin.
         fn bottom(self: &QMarginsF) -> f64;

--- a/crates/cxx-qt-lib/src/core/qmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.rs
@@ -21,31 +21,31 @@ mod ffi {
         type QModelIndex = super::QModelIndex;
 
         /// Returns the column this model index refers to.
-        fn column(self: &QModelIndex) -> i32;
+        fn column(&self) -> i32;
         /// Returns `true` if this model index is valid; otherwise returns `false`.
         ///
         /// A valid index belongs to a model, and has non-negative row and column numbers.
         #[rust_name = "is_valid"]
-        fn isValid(self: &QModelIndex) -> bool;
+        fn isValid(&self) -> bool;
         /// Returns the parent of the model index, or an invalid `QModelIndex` if it has no parent.
-        fn parent(self: &QModelIndex) -> QModelIndex;
+        fn parent(&self) -> QModelIndex;
         /// Returns the row this model index refers to.
-        fn row(self: &QModelIndex) -> i32;
+        fn row(&self) -> i32;
         /// Returns the sibling at `row` and `column`. If there is no sibling at this position, an invalid `QModelIndex` is returned.
-        fn sibling(self: &QModelIndex, row: i32, column: i32) -> QModelIndex;
+        fn sibling(&self, row: i32, column: i32) -> QModelIndex;
         /// Returns the sibling at `column` for the current row. If there is no sibling at this position, an invalid `QModelIndex` is returned.
         #[rust_name = "sibling_at_column"]
-        fn siblingAtColumn(self: &QModelIndex, column: i32) -> QModelIndex;
+        fn siblingAtColumn(&self, column: i32) -> QModelIndex;
         /// Returns the sibling at `row` for the current column. If there is no sibling at this position, an invalid `QModelIndex` is returned.
         #[rust_name = "sibling_at_row"]
-        fn siblingAtRow(self: &QModelIndex, row: i32) -> QModelIndex;
+        fn siblingAtRow(&self, row: i32) -> QModelIndex;
 
         #[doc(hidden)]
         #[rust_name = "internal_id_quintptr"]
-        fn internalId(self: &QModelIndex) -> quintptr;
+        fn internalId(&self) -> quintptr;
         /// Returns a `*mut c_void` pointer used by the model to associate the index with the internal data structure.
         #[rust_name = "internal_pointer_mut"]
-        fn internalPointer(self: &QModelIndex) -> *mut c_void;
+        fn internalPointer(&self) -> *mut c_void;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -106,7 +106,7 @@ impl fmt::Debug for QModelIndex {
 
 impl QModelIndex {
     /// Returns a `usize` used by the model to associate the index with the internal data structure.
-    pub fn internal_id(self: &QModelIndex) -> usize {
+    pub fn internal_id(&self) -> usize {
         self.internal_id_quintptr().into()
     }
 }

--- a/crates/cxx-qt-lib/src/core/qmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qmodelindex.rs
@@ -8,13 +8,17 @@ use std::mem::MaybeUninit;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qmodelindex.h");
+    extern "C++" {
         include!("cxx-qt-lib/qstring.h");
-
-        type QModelIndex = super::QModelIndex;
         type QString = crate::QString;
+        include!("cxx-qt-lib/qtypes.h");
         type quintptr = crate::quintptr;
+
+        include!("cxx-qt-lib/qmodelindex.h");
+    }
+
+    unsafe extern "C++" {
+        type QModelIndex = super::QModelIndex;
 
         /// Returns the column this model index refers to.
         fn column(self: &QModelIndex) -> i32;

--- a/crates/cxx-qt-lib/src/core/qobject.rs
+++ b/crates/cxx-qt-lib/src/core/qobject.rs
@@ -10,13 +10,14 @@ use std::ptr;
 
 #[cxx::bridge]
 pub mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
+
+        include!("cxx-qt-lib/qobject.h");
     }
 
     unsafe extern "C++" {
-        include!("cxx-qt-lib/qobject.h");
         #[rust_name = "QObjectExternal"]
         type QObject;
         #[rust_name = "block_signals"]

--- a/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
@@ -21,21 +21,21 @@ mod ffi {
         type QPersistentModelIndex = super::QPersistentModelIndex;
 
         /// Returns the column this persistent model index refers to.
-        fn column(self: &QPersistentModelIndex) -> i32;
+        fn column(&self) -> i32;
         /// Returns `true` if this persistent model index is valid; otherwise returns `false`.
         ///
         /// A valid index belongs to a model, and has non-negative row and column numbers.
         #[rust_name = "is_valid"]
-        fn isValid(self: &QPersistentModelIndex) -> bool;
+        fn isValid(&self) -> bool;
         /// Returns the parent `QModelIndex` for this persistent index, or an invalid `QModelIndex` if it has no parent.
-        fn parent(self: &QPersistentModelIndex) -> QModelIndex;
+        fn parent(&self) -> QModelIndex;
         /// Returns the row this persistent model index refers to.
-        fn row(self: &QPersistentModelIndex) -> i32;
+        fn row(&self) -> i32;
         /// Returns the sibling at `row` and `column` or an invalid `QModelIndex` if there is no sibling at this position.
-        fn sibling(self: &QPersistentModelIndex, row: i32, column: i32) -> QModelIndex;
+        fn sibling(&self, row: i32, column: i32) -> QModelIndex;
 
         /// Swaps this persistent modelindex with `other`. This function is very fast and never fails.
-        fn swap(self: &mut QPersistentModelIndex, other: &mut QPersistentModelIndex);
+        fn swap(&mut self, other: &mut QPersistentModelIndex);
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
+++ b/crates/cxx-qt-lib/src/core/qpersistentmodelindex.rs
@@ -8,15 +8,17 @@ use std::mem::MaybeUninit;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qpersistentmodelindex.h");
-        include!("cxx-qt-lib/qstring.h");
-
-        type QPersistentModelIndex = super::QPersistentModelIndex;
-        type QString = crate::QString;
-
+    extern "C++" {
         include!("cxx-qt-lib/qmodelindex.h");
         type QModelIndex = crate::QModelIndex;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
+
+        include!("cxx-qt-lib/qpersistentmodelindex.h");
+    }
+
+    unsafe extern "C++" {
+        type QPersistentModelIndex = super::QPersistentModelIndex;
 
         /// Returns the column this persistent model index refers to.
         fn column(self: &QPersistentModelIndex) -> i32;

--- a/crates/cxx-qt-lib/src/core/qpoint.rs
+++ b/crates/cxx-qt-lib/src/core/qpoint.rs
@@ -8,16 +8,18 @@ use std::fmt;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qpoint.h");
-        include!("cxx-qt-lib/qstring.h");
-
-        type QPoint = super::QPoint;
-        type QString = crate::QString;
-
+    extern "C++" {
         include!("cxx-qt-lib/qpointf.h");
         #[allow(dead_code)]
         type QPointF = crate::QPointF;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
+
+        include!("cxx-qt-lib/qpoint.h");
+    }
+
+    unsafe extern "C++" {
+        type QPoint = super::QPoint;
 
         /// Returns `true` if both the x and y coordinates are set to 0, otherwise returns `false`.
         #[rust_name = "is_null"]

--- a/crates/cxx-qt-lib/src/core/qpoint.rs
+++ b/crates/cxx-qt-lib/src/core/qpoint.rs
@@ -23,36 +23,36 @@ mod ffi {
 
         /// Returns `true` if both the x and y coordinates are set to 0, otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QPoint) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns the sum of the absolute values of [`x`](Self::x) and [`y`](Self::y),
         /// traditionally known as the "Manhattan length" of the vector from the origin to the point.
         #[rust_name = "manhattan_length"]
-        fn manhattanLength(self: &QPoint) -> i32;
+        fn manhattanLength(&self) -> i32;
 
         /// Sets the x coordinate of this point to the given `x` coordinate.
         #[rust_name = "set_x"]
-        fn setX(self: &mut QPoint, x: i32);
+        fn setX(&mut self, x: i32);
 
         /// Sets the y coordinate of this point to the given `y` coordinate.
         #[rust_name = "set_y"]
-        fn setY(self: &mut QPoint, y: i32);
+        fn setY(&mut self, y: i32);
 
         /// Returns this point as a point with floating point accuracy.
         ///
         /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_pointf"]
-        fn toPointF(self: &QPoint) -> QPointF;
+        fn toPointF(&self) -> QPointF;
 
         /// Returns a point with x and y coordinates exchanged.
-        fn transposed(self: &QPoint) -> QPoint;
+        fn transposed(&self) -> QPoint;
 
         /// Returns the x coordinate of this point.
-        fn x(self: &QPoint) -> i32;
+        fn x(&self) -> i32;
 
         /// Returns the y coordinate of this point.
-        fn y(self: &QPoint) -> i32;
+        fn y(&self) -> i32;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qpointf.rs
+++ b/crates/cxx-qt-lib/src/core/qpointf.rs
@@ -11,13 +11,17 @@ use crate::QPoint;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = crate::QPoint;
-        include!("cxx-qt-lib/qpointf.h");
-        type QPointF = super::QPointF;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
+
+        include!("cxx-qt-lib/qpointf.h");
+    }
+
+    unsafe extern "C++" {
+        type QPointF = super::QPointF;
 
         /// Returns `true` if both the x and y coordinates are set to 0.0 (ignoring the sign); otherwise returns `false`.
         #[rust_name = "is_null"]

--- a/crates/cxx-qt-lib/src/core/qpointf.rs
+++ b/crates/cxx-qt-lib/src/core/qpointf.rs
@@ -25,34 +25,34 @@ mod ffi {
 
         /// Returns `true` if both the x and y coordinates are set to 0.0 (ignoring the sign); otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QPointF) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns the sum of the absolute values of `self.x()` and `self.y()`,
         /// traditionally known as the "Manhattan length" of the vector from the origin to the point.
         #[rust_name = "manhattan_length"]
-        fn manhattanLength(self: &QPointF) -> f64;
+        fn manhattanLength(&self) -> f64;
 
         /// Sets the x coordinate of this point to the given finite `x` coordinate.
         #[rust_name = "set_x"]
-        fn setX(self: &mut QPointF, x: f64);
+        fn setX(&mut self, x: f64);
 
         /// Sets the y coordinate of this point to the given finite `y` coordinate.
         #[rust_name = "set_y"]
-        fn setY(self: &mut QPointF, y: f64);
+        fn setY(&mut self, y: f64);
 
         /// Rounds the coordinates of this point to the nearest integer,
         /// and returns a `QPoint` object with the rounded coordinates.
         #[rust_name = "to_point"]
-        fn toPoint(self: &QPointF) -> QPoint;
+        fn toPoint(&self) -> QPoint;
 
         /// Returns a point with x and y coordinates exchanged.
-        fn transposed(self: &QPointF) -> QPointF;
+        fn transposed(&self) -> QPointF;
 
         /// Returns the x coordinate of this point.
-        fn x(self: &QPointF) -> f64;
+        fn x(&self) -> f64;
 
         /// Returns the y coordinate of this point.
-        fn y(self: &QPointF) -> f64;
+        fn y(&self) -> f64;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qrect.rs
+++ b/crates/cxx-qt-lib/src/core/qrect.rs
@@ -10,20 +10,24 @@ use crate::QMargins;
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qmargins.h");
         type QMargins = crate::QMargins;
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = crate::QPoint;
-        include!("cxx-qt-lib/qrect.h");
-        type QRect = super::QRect;
+        include!("cxx-qt-lib/qrectf.h");
+        #[allow(dead_code)]
+        type QRectF = crate::QRectF;
         include!("cxx-qt-lib/qsize.h");
         type QSize = crate::QSize;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
-        include!("cxx-qt-lib/qrectf.h");
-        #[allow(dead_code)]
-        type QRectF = crate::QRectF;
+
+        include!("cxx-qt-lib/qrect.h");
+    }
+
+    unsafe extern "C++" {
+        type QRect = super::QRect;
 
         /// Adds `dx1`, `dy1`, `dx2` and `dy2` respectively to the existing coordinates of the rectangle.
         fn adjust(self: &mut QRect, dx1: i32, dy1: i32, dx2: i32, dy2: i32);

--- a/crates/cxx-qt-lib/src/core/qrect.rs
+++ b/crates/cxx-qt-lib/src/core/qrect.rs
@@ -30,227 +30,227 @@ mod ffi {
         type QRect = super::QRect;
 
         /// Adds `dx1`, `dy1`, `dx2` and `dy2` respectively to the existing coordinates of the rectangle.
-        fn adjust(self: &mut QRect, dx1: i32, dy1: i32, dx2: i32, dy2: i32);
+        fn adjust(&mut self, dx1: i32, dy1: i32, dx2: i32, dy2: i32);
 
         /// Returns a new rectangle with `dx1`, `dy1`, `dx2` and `dy2` added respectively to the existing coordinates of this rectangle.
-        fn adjusted(self: &QRect, dx1: i32, dy1: i32, dx2: i32, dy2: i32) -> QRect;
+        fn adjusted(&self, dx1: i32, dy1: i32, dx2: i32, dy2: i32) -> QRect;
 
         /// Returns the y-coordinate of the rectangle's bottom edge.
         ///
         /// Note that for historical reasons this function returns `self.top() + self.height() - 1`; use `self.y() + self.height()` to retrieve the true y-coordinate.
-        fn bottom(self: &QRect) -> i32;
+        fn bottom(&self) -> i32;
 
         /// Returns the position of the rectangle's bottom-left corner.
         ///
         /// Note that for historical reasons this function returns `QPoint::new(self.left(), self.top() + self.height() - 1)`.
         #[rust_name = "bottom_left"]
-        fn bottomLeft(self: &QRect) -> QPoint;
+        fn bottomLeft(&self) -> QPoint;
 
         /// Returns the position of the rectangle's bottom-right corner.
         ///
         /// Note that for historical reasons this function returns `QPoint::new(self.left() + width() - 1, self.top() + self.height() - 1)`.
         #[rust_name = "bottom_right"]
-        fn bottomRight(self: &QRect) -> QPoint;
+        fn bottomRight(&self) -> QPoint;
 
         /// Returns the center point of the rectangle.
-        fn center(self: &QRect) -> QPoint;
+        fn center(&self) -> QPoint;
 
         /// Returns `true` if the given point is inside or on the edge of the rectangle, otherwise returns `false`.
         /// If `proper` is `true`, this function only returns `true` if the given point is inside the rectangle (i.e., not on the edge).
-        fn contains(self: &QRect, point: &QPoint, proper: bool) -> bool;
+        fn contains(&self, point: &QPoint, proper: bool) -> bool;
 
         /// Returns the `height` of the rectangle.
-        fn height(self: &QRect) -> i32;
+        fn height(&self) -> i32;
 
         /// Returns the intersection of this rectangle and the given rectangle. Note that `r.intersected(s)` is equivalent to `r & s`.
-        fn intersected(self: &QRect, rectangle: &QRect) -> QRect;
+        fn intersected(&self, rectangle: &QRect) -> QRect;
 
         /// Returns `true` if this rectangle intersects with the given rectangle (i.e., there is at least one pixel that is within both rectangles), otherwise returns `false`.
-        fn intersects(self: &QRect, rectangle: &QRect) -> bool;
+        fn intersects(&self, rectangle: &QRect) -> bool;
 
         /// Returns `true` if the rectangle is empty, otherwise returns `false`.
         ///
         /// An empty rectangle has `self.left() > self.right()` or `self.top() > self.bottom()`. An empty rectangle is not valid (i.e., `self.is_empty() == !self.is_valid()`).
         #[rust_name = "is_empty"]
-        fn isEmpty(self: &QRect) -> bool;
+        fn isEmpty(&self) -> bool;
 
         /// Returns `true` if the rectangle is a null rectangle, otherwise returns `false`.
         ///
         /// A null rectangle has both the width and the height set to 0 (i.e., `self.right() == self.left() - 1` and `self.bottom() == self.top() - 1)`. A null rectangle is also empty, and hence is not valid.
         #[rust_name = "is_null"]
-        fn isNull(self: &QRect) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns `true` if the rectangle is valid, otherwise returns `false`.
         ///
         /// A valid rectangle has `self.left() <= self.right()` and `self.top() <= self.bottom()`. Note that non-trivial operations like intersections are not defined for invalid rectangles. A valid rectangle is not empty (i.e., `self.is_valid() == !self.is_empty()`).
         #[rust_name = "is_valid"]
-        fn isValid(self: &QRect) -> bool;
+        fn isValid(&self) -> bool;
 
         /// Returns the x-coordinate of the rectangle's left edge. Equivalent to `self.x()`.
-        fn left(self: &QRect) -> i32;
+        fn left(&self) -> i32;
 
         /// Returns a rectangle grown by the `margins`.
         #[rust_name = "margins_added"]
-        fn marginsAdded(self: &QRect, margins: &QMargins) -> QRect;
+        fn marginsAdded(&self, margins: &QMargins) -> QRect;
 
         /// Removes the `margins` from the rectangle, shrinking it.
         #[rust_name = "margins_removed"]
-        fn marginsRemoved(self: &QRect, margins: &QMargins) -> QRect;
+        fn marginsRemoved(&self, margins: &QMargins) -> QRect;
 
         /// Moves the rectangle vertically, leaving the rectangle's bottom edge at the given `y` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_bottom"]
-        fn moveBottom(self: &mut QRect, y: i32);
+        fn moveBottom(&mut self, y: i32);
 
         /// Moves the rectangle, leaving the bottom-left corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_bottom_left"]
-        fn moveBottomLeft(self: &mut QRect, position: &QPoint);
+        fn moveBottomLeft(&mut self, position: &QPoint);
 
         /// Moves the rectangle, leaving the bottom-right corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_bottom_right"]
-        fn moveBottomRight(self: &mut QRect, position: &QPoint);
+        fn moveBottomRight(&mut self, position: &QPoint);
 
         /// Moves the rectangle, leaving the center point at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_center"]
-        fn moveCenter(self: &mut QRect, position: &QPoint);
+        fn moveCenter(&mut self, position: &QPoint);
 
         /// Moves the rectangle horizontally, leaving the rectangle's left edge at the given `x` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_left"]
-        fn moveLeft(self: &mut QRect, x: i32);
+        fn moveLeft(&mut self, x: i32);
 
         /// Moves the rectangle horizontally, leaving the rectangle's right edge at the given `x` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_right"]
-        fn moveRight(self: &mut QRect, x: i32);
+        fn moveRight(&mut self, x: i32);
 
         /// Moves the rectangle, leaving the top-left corner at the given `position`.
         #[rust_name = "move_to"]
-        fn moveTo(self: &mut QRect, position: &QPoint);
+        fn moveTo(&mut self, position: &QPoint);
 
         /// Moves the rectangle vertically, leaving the rectangle's top edge at the given `y` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_top"]
-        fn moveTop(self: &mut QRect, y: i32);
+        fn moveTop(&mut self, y: i32);
 
         /// Moves the rectangle, leaving the top-left corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_top_left"]
-        fn moveTopLeft(self: &mut QRect, position: &QPoint);
+        fn moveTopLeft(&mut self, position: &QPoint);
 
         /// Moves the rectangle, leaving the top-right corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_top_right"]
-        fn moveTopRight(self: &mut QRect, position: &QPoint);
+        fn moveTopRight(&mut self, position: &QPoint);
 
         /// Returns a normalized rectangle; i.e., a rectangle that has a non-negative width and height.
-        fn normalized(self: &QRect) -> QRect;
+        fn normalized(&self) -> QRect;
 
         /// Returns the x-coordinate of the rectangle's right edge.
         ///
         /// Note that for historical reasons this function returns `self.left() + width() - 1`; use `self.x() + width()` to retrieve the true x-coordinate.
-        fn right(self: &QRect) -> i32;
+        fn right(&self) -> i32;
 
         /// Sets the bottom edge of the rectangle to the given `y` coordinate.
         /// May change the height, but will never change the top edge of the rectangle.
         #[rust_name = "set_bottom"]
-        fn setBottom(self: &mut QRect, y: i32);
+        fn setBottom(&mut self, y: i32);
 
         /// Set the bottom-left corner of the rectangle to the given `position`.
         /// May change the size, but will never change the top-right corner of the rectangle.
         #[rust_name = "set_bottom_left"]
-        fn setBottomLeft(self: &mut QRect, position: &QPoint);
+        fn setBottomLeft(&mut self, position: &QPoint);
 
         /// Set the bottom-right corner of the rectangle to the given `position`.
         /// May change the size, but will never change the top-left corner of the rectangle.
         #[rust_name = "set_bottom_right"]
-        fn setBottomRight(self: &mut QRect, position: &QPoint);
+        fn setBottomRight(&mut self, position: &QPoint);
 
         /// Sets the coordinates of the rectangle's top-left corner to (`x1`, `y1`), and the coordinates of its bottom-right corner to (`x2`, `y2`).
         #[rust_name = "set_coords"]
-        fn setCoords(self: &mut QRect, x1: i32, y1: i32, x2: i32, y2: i32);
+        fn setCoords(&mut self, x1: i32, y1: i32, x2: i32, y2: i32);
 
         /// Sets the height of the rectangle to the given `height`. The bottom edge is changed, but not the top one.
         #[rust_name = "set_height"]
-        fn setHeight(self: &mut QRect, h: i32);
+        fn setHeight(&mut self, h: i32);
 
         /// Sets the left edge of the rectangle to the given `x` coordinate. May change the width, but will never change the right edge of the rectangle.
         #[rust_name = "set_left"]
-        fn setLeft(self: &mut QRect, x: i32);
+        fn setLeft(&mut self, x: i32);
 
         /// Sets the coordinates of the rectangle's top-left corner to (`x`, `y`), and its size to the given `width` and `height`.
         #[rust_name = "set_rect"]
-        fn setRect(self: &mut QRect, x: i32, y: i32, width: i32, height: i32);
+        fn setRect(&mut self, x: i32, y: i32, width: i32, height: i32);
 
         /// Sets the right edge of the rectangle to the given `x` coordinate. May change the width, but will never change the left edge of the rectangle.
         #[rust_name = "set_right"]
-        fn setRight(self: &mut QRect, x: i32);
+        fn setRight(&mut self, x: i32);
 
         /// Sets the size of the rectangle to the given `size`. The top-left corner is not moved.
         #[rust_name = "set_size"]
-        fn setSize(self: &mut QRect, size: &QSize);
+        fn setSize(&mut self, size: &QSize);
 
         /// Sets the top edge of the rectangle to the given `y` coordinate. May change the height, but will never change the bottom edge of the rectangle.
         #[rust_name = "set_top"]
-        fn setTop(self: &mut QRect, y: i32);
+        fn setTop(&mut self, y: i32);
 
         /// Set the top-left corner of the rectangle to the given `position`. May change the size, but will never change the bottom-right corner of the rectangle.
         #[rust_name = "set_top_left"]
-        fn setTopLeft(self: &mut QRect, position: &QPoint);
+        fn setTopLeft(&mut self, position: &QPoint);
 
         /// Set the top-right corner of the rectangle to the given `position`. May change the size, but will never change the bottom-left corner of the rectangle.
         #[rust_name = "set_top_right"]
-        fn setTopRight(self: &mut QRect, position: &QPoint);
+        fn setTopRight(&mut self, position: &QPoint);
 
         /// Sets the width of the rectangle to the given `width`. The right edge is changed, but not the left one.
         #[rust_name = "set_width"]
-        fn setWidth(self: &mut QRect, w: i32);
+        fn setWidth(&mut self, w: i32);
 
         /// Sets the left edge of the rectangle to the given `x` coordinate. May change the width, but will never change the right edge of the rectangle.
         #[rust_name = "set_x"]
-        fn setX(self: &mut QRect, x: i32);
+        fn setX(&mut self, x: i32);
 
         /// Sets the top edge of the rectangle to the given `y` coordinate. May change the height, but will never change the bottom edge of the rectangle.
         #[rust_name = "set_y"]
-        fn setY(self: &mut QRect, y: i32);
+        fn setY(&mut self, y: i32);
 
         /// Returns the size of the rectangle.
-        fn size(self: &QRect) -> QSize;
+        fn size(&self) -> QSize;
 
         /// Returns this rectangle as a rectangle with floating point accuracy.
         ///
         /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_rectf"]
-        fn toRectF(self: &QRect) -> QRectF;
+        fn toRectF(&self) -> QRectF;
 
         /// Returns the y-coordinate of the rectangle's top edge. Equivalent to `self.y()`.
-        fn top(self: &QRect) -> i32;
+        fn top(&self) -> i32;
 
         /// Returns the position of the rectangle's top-left corner.
         #[rust_name = "top_left"]
-        fn topLeft(self: &QRect) -> QPoint;
+        fn topLeft(&self) -> QPoint;
 
         /// Returns the position of the rectangle's top-right corner.
         ///
         /// Note that for historical reasons this function returns `QPoint::new(self.left() + width() -1, self.top())`.
         #[rust_name = "top_right"]
-        fn topRight(self: &QRect) -> QPoint;
+        fn topRight(&self) -> QPoint;
 
         /// Moves the rectangle `offset.x()` along the x axis and `offset.y()` along the y axis, relative to the current position.
-        fn translate(self: &mut QRect, offset: &QPoint);
+        fn translate(&mut self, offset: &QPoint);
 
         /// Returns a copy of the rectangle that is translated `offset.x()` along the x axis and `offset.y()` along the y axis, relative to the current position.
-        fn translated(self: &QRect, offset: &QPoint) -> QRect;
+        fn translated(&self, offset: &QPoint) -> QRect;
 
         /// Returns a copy of the rectangle that has its width and height exchanged.
-        fn transposed(self: &QRect) -> QRect;
+        fn transposed(&self) -> QRect;
 
         /// Returns the bounding rectangle of this rectangle and the given `rectangle`.
-        fn united(self: &QRect, rectangle: &QRect) -> QRect;
+        fn united(&self, rectangle: &QRect) -> QRect;
 
         /// Returns the width of the rectangle.
-        fn width(self: &QRect) -> i32;
+        fn width(&self) -> i32;
 
         /// Returns the x-coordinate of the rectangle's left edge.
-        fn x(self: &QRect) -> i32;
+        fn x(&self) -> i32;
 
         /// Returns the y-coordinate of the rectangle's top edge.
-        fn y(self: &QRect) -> i32;
+        fn y(&self) -> i32;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qrectf.rs
+++ b/crates/cxx-qt-lib/src/core/qrectf.rs
@@ -29,226 +29,226 @@ mod ffi {
         type QRectF = super::QRectF;
 
         /// Adds `dx1`, `dy1`, `dx2` and `dy2` respectively to the existing coordinates of the rectangle. All parameters must be finite.
-        fn adjust(self: &mut QRectF, dx1: f64, dy1: f64, dx2: f64, dy2: f64);
+        fn adjust(&mut self, dx1: f64, dy1: f64, dx2: f64, dy2: f64);
 
         /// Returns a new rectangle with `dx1`, `dy1`, `dx2` and `dy2` added respectively to the existing coordinates of this rectangle. All parameters must be finite.
-        fn adjusted(self: &QRectF, dx1: f64, dy1: f64, dx2: f64, dy2: f64) -> QRectF;
+        fn adjusted(&self, dx1: f64, dy1: f64, dx2: f64, dy2: f64) -> QRectF;
 
         /// Returns the y-coordinate of the rectangle's bottom edge.
-        fn bottom(self: &QRectF) -> f64;
+        fn bottom(&self) -> f64;
 
         /// Returns the position of the rectangle's bottom-left corner.
         #[rust_name = "bottom_left"]
-        fn bottomLeft(self: &QRectF) -> QPointF;
+        fn bottomLeft(&self) -> QPointF;
 
         /// Returns the position of the rectangle's bottom-right corner.
         #[rust_name = "bottom_right"]
-        fn bottomRight(self: &QRectF) -> QPointF;
+        fn bottomRight(&self) -> QPointF;
 
         /// Returns the center point of the rectangle.
-        fn center(self: &QRectF) -> QPointF;
+        fn center(&self) -> QPointF;
 
         /// Returns `true` if the given point is inside or on the edge of the rectangle; otherwise returns `false`.
-        fn contains(self: &QRectF, point: &QPointF) -> bool;
+        fn contains(&self, point: &QPointF) -> bool;
 
         /// Returns the height of the rectangle.
-        fn height(self: &QRectF) -> f64;
+        fn height(&self) -> f64;
 
         /// Returns the intersection of this rectangle and the given rectangle. Note that `r.intersected(s)` is equivalent to `r & s`.
-        fn intersected(self: &QRectF, rectangle: &QRectF) -> QRectF;
+        fn intersected(&self, rectangle: &QRectF) -> QRectF;
 
         /// Returns `true` if this rectangle intersects with the given rectangle (i.e. there is a non-empty area of overlap between them), otherwise returns `false`.
-        fn intersects(self: &QRectF, rectangle: &QRectF) -> bool;
+        fn intersects(&self, rectangle: &QRectF) -> bool;
 
         /// Returns `true` if the rectangle is empty, otherwise returns `false`.
         ///
         /// An empty rectangle has `self.width() <= 0` or `self.height() <= 0`. An empty rectangle is not valid (i.e., `self.is_empty() == !self.is_valid()`).
         #[rust_name = "is_empty"]
-        fn isEmpty(self: &QRectF) -> bool;
+        fn isEmpty(&self) -> bool;
 
         /// Returns `true` if the rectangle is a null rectangle, otherwise returns `false`.
         ///
         /// A null rectangle has both the width and the height set to 0. A null rectangle is also empty, and hence not valid.
         #[rust_name = "is_null"]
-        fn isNull(self: &QRectF) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns `true` if the rectangle is valid, otherwise returns `false`.
         ///
         /// A valid rectangle has a `self.width() > 0` and `self.height() > 0`. Note that non-trivial operations like intersections are not defined for invalid rectangles. A valid rectangle is not empty (i.e., `self.is_valid() == !self.is_empty()`).
         #[rust_name = "is_valid"]
-        fn isValid(self: &QRectF) -> bool;
+        fn isValid(&self) -> bool;
 
         /// Returns the x-coordinate of the rectangle's left edge. Equivalent to `self.x()`.
-        fn left(self: &QRectF) -> f64;
+        fn left(&self) -> f64;
 
         /// Returns a rectangle grown by the `margins`.
         #[rust_name = "margins_added"]
-        fn marginsAdded(self: &QRectF, margins: &QMarginsF) -> QRectF;
+        fn marginsAdded(&self, margins: &QMarginsF) -> QRectF;
 
         /// Removes the `margins` from the rectangle, shrinking it.
         #[rust_name = "margins_removed"]
-        fn marginsRemoved(self: &QRectF, margins: &QMarginsF) -> QRectF;
+        fn marginsRemoved(&self, margins: &QMarginsF) -> QRectF;
 
         /// Moves the rectangle vertically, leaving the rectangle's bottom edge at the given finite `y` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_bottom"]
-        fn moveBottom(self: &mut QRectF, y: f64);
+        fn moveBottom(&mut self, y: f64);
 
         /// Moves the rectangle, leaving the bottom-left corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_bottom_left"]
-        fn moveBottomLeft(self: &mut QRectF, position: &QPointF);
+        fn moveBottomLeft(&mut self, position: &QPointF);
 
         /// Moves the rectangle, leaving the bottom-right corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_bottom_right"]
-        fn moveBottomRight(self: &mut QRectF, position: &QPointF);
+        fn moveBottomRight(&mut self, position: &QPointF);
 
         /// Moves the rectangle, leaving the center point at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_center"]
-        fn moveCenter(self: &mut QRectF, position: &QPointF);
+        fn moveCenter(&mut self, position: &QPointF);
 
         /// Moves the rectangle horizontally, leaving the rectangle's left edge at the given finite `x` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_left"]
-        fn moveLeft(self: &mut QRectF, x: f64);
+        fn moveLeft(&mut self, x: f64);
 
         /// Moves the rectangle horizontally, leaving the rectangle's right edge at the given finite `x` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_right"]
-        fn moveRight(self: &mut QRectF, x: f64);
+        fn moveRight(&mut self, x: f64);
 
         /// Moves the rectangle, leaving the top-left corner at the given `position`.
         #[rust_name = "move_to"]
-        fn moveTo(self: &mut QRectF, position: &QPointF);
+        fn moveTo(&mut self, position: &QPointF);
 
         /// Moves the rectangle vertically, leaving the rectangle's top line at the given finite `y` coordinate. The rectangle's size is unchanged.
         #[rust_name = "move_top"]
-        fn moveTop(self: &mut QRectF, y: f64);
+        fn moveTop(&mut self, y: f64);
 
         /// Moves the rectangle, leaving the top-left corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_top_left"]
-        fn moveTopLeft(self: &mut QRectF, position: &QPointF);
+        fn moveTopLeft(&mut self, position: &QPointF);
 
         /// Moves the rectangle, leaving the top-right corner at the given `position`. The rectangle's size is unchanged.
         #[rust_name = "move_top_right"]
-        fn moveTopRight(self: &mut QRectF, position: &QPointF);
+        fn moveTopRight(&mut self, position: &QPointF);
 
         /// Returns a normalized rectangle; i.e., a rectangle that has a non-negative width and height.
-        fn normalized(self: &QRectF) -> QRectF;
+        fn normalized(&self) -> QRectF;
 
         /// Returns the x-coordinate of the rectangle's right edge.
-        fn right(self: &QRectF) -> f64;
+        fn right(&self) -> f64;
 
         /// Sets the bottom edge of the rectangle to the given finite `y` coordinate.
         /// May change the height, but will never change the top edge of the rectangle.
         #[rust_name = "set_bottom"]
-        fn setBottom(self: &mut QRectF, y: f64);
+        fn setBottom(&mut self, y: f64);
 
         /// Set the bottom-left corner of the rectangle to the given `position`.
         /// May change the size, but will never change the top-right corner of the rectangle.
         #[rust_name = "set_bottom_left"]
-        fn setBottomLeft(self: &mut QRectF, position: &QPointF);
+        fn setBottomLeft(&mut self, position: &QPointF);
 
         /// Set the bottom-right corner of the rectangle to the given `position`.
         /// May change the size, but will never change the top-left corner of the rectangle.
         #[rust_name = "set_bottom_right"]
-        fn setBottomRight(self: &mut QRectF, position: &QPointF);
+        fn setBottomRight(&mut self, position: &QPointF);
 
         /// Sets the coordinates of the rectangle's top-left corner to (`x1`, `y1`),
         /// and the coordinates of its bottom-right corner to (`x2`, `y2`). All parameters must be finite.
         #[rust_name = "set_coords"]
-        fn setCoords(self: &mut QRectF, x1: f64, y1: f64, x2: f64, y2: f64);
+        fn setCoords(&mut self, x1: f64, y1: f64, x2: f64, y2: f64);
 
         /// Sets the height of the rectangle to the given finite `height`. The bottom edge is changed, but not the top one.
         #[rust_name = "set_height"]
-        fn setHeight(self: &mut QRectF, h: f64);
+        fn setHeight(&mut self, h: f64);
 
         /// Sets the left edge of the rectangle to the given finite `x` coordinate.
         /// May change the width, but will never change the right edge of the rectangle.
         #[rust_name = "set_left"]
-        fn setLeft(self: &mut QRectF, x: f64);
+        fn setLeft(&mut self, x: f64);
 
         /// Sets the coordinates of the rectangle's top-left corner to (`x`, `y`), and its size to the given `width` and `height`. All parameters must be finite.
         #[rust_name = "set_rect"]
-        fn setRect(self: &mut QRectF, x: f64, y: f64, width: f64, height: f64);
+        fn setRect(&mut self, x: f64, y: f64, width: f64, height: f64);
 
         /// Sets the right edge of the rectangle to the given finite `x` coordinate.
         /// May change the width, but will never change the left edge of the rectangle.
         #[rust_name = "set_right"]
-        fn setRight(self: &mut QRectF, x: f64);
+        fn setRight(&mut self, x: f64);
 
         /// Sets the size of the rectangle to the given finite `size`. The top-left corner is not moved.
         #[rust_name = "set_size"]
-        fn setSize(self: &mut QRectF, size: &QSizeF);
+        fn setSize(&mut self, size: &QSizeF);
 
         /// Sets the top edge of the rectangle to the given finite `y` coordinate.
         /// May change the height, but will never change the bottom edge of the rectangle.
         #[rust_name = "set_top"]
-        fn setTop(self: &mut QRectF, y: f64);
+        fn setTop(&mut self, y: f64);
 
         /// Set the top-left corner of the rectangle to the given `position`.
         /// May change the size, but will never change the bottom-right corner of the rectangle.
         #[rust_name = "set_top_left"]
-        fn setTopLeft(self: &mut QRectF, position: &QPointF);
+        fn setTopLeft(&mut self, position: &QPointF);
 
         /// Set the top-right corner of the rectangle to the given `position`.
         /// May change the size, but will never change the bottom-left corner of the rectangle.
         #[rust_name = "set_top_right"]
-        fn setTopRight(self: &mut QRectF, position: &QPointF);
+        fn setTopRight(&mut self, position: &QPointF);
 
         /// Sets the width of the rectangle to the given finite `width`. The right edge is changed, but not the left one.
         #[rust_name = "set_width"]
-        fn setWidth(self: &mut QRectF, w: f64);
+        fn setWidth(&mut self, w: f64);
 
         /// Sets the left edge of the rectangle to the given finite `x` coordinate.
         /// May change the width, but will never change the right edge of the rectangle.
         #[rust_name = "set_x"]
-        fn setX(self: &mut QRectF, x: f64);
+        fn setX(&mut self, x: f64);
 
         /// Sets the top edge of the rectangle to the given finite `y` coordinate.
         /// May change the height, but will never change the bottom edge of the rectangle.
         #[rust_name = "set_y"]
-        fn setY(self: &mut QRectF, y: f64);
+        fn setY(&mut self, y: f64);
 
         /// Returns the size of the rectangle.
-        fn size(self: &QRectF) -> QSizeF;
+        fn size(&self) -> QSizeF;
 
         /// Returns a `QRect` based on the values of this rectangle that is the smallest possible integer rectangle that completely contains this rectangle.
         #[rust_name = "to_aligned_rect"]
-        fn toAlignedRect(self: &QRectF) -> QRect;
+        fn toAlignedRect(&self) -> QRect;
 
         /// Returns a `QRect` based on the values of this rectangle.
         /// Note that the coordinates in the returned rectangle are rounded to the nearest integer.
         #[rust_name = "to_rect"]
-        fn toRect(self: &QRectF) -> QRect;
+        fn toRect(&self) -> QRect;
 
         /// Returns the y-coordinate of the rectangle's top edge. Equivalent to `self.y()`.
-        fn top(self: &QRectF) -> f64;
+        fn top(&self) -> f64;
 
         /// Returns the position of the rectangle's top-left corner.
         #[rust_name = "top_left"]
-        fn topLeft(self: &QRectF) -> QPointF;
+        fn topLeft(&self) -> QPointF;
 
         /// Returns the position of the rectangle's top-right corner.
         #[rust_name = "top_right"]
-        fn topRight(self: &QRectF) -> QPointF;
+        fn topRight(&self) -> QPointF;
 
         /// Moves the rectangle `offset.x()` along the x axis and `offset.y()` along the y axis, relative to the current position.
-        fn translate(self: &mut QRectF, offset: &QPointF);
+        fn translate(&mut self, offset: &QPointF);
 
         /// Returns a copy of the rectangle that is translated `offset.x()` along the x axis and `offset.y()` along the y axis, relative to the current position.
-        fn translated(self: &QRectF, offset: &QPointF) -> QRectF;
+        fn translated(&self, offset: &QPointF) -> QRectF;
 
         /// Returns a copy of the rectangle that has its width and height exchanged.
-        fn transposed(self: &QRectF) -> QRectF;
+        fn transposed(&self) -> QRectF;
 
         /// Returns the bounding rectangle of this rectangle and the given `rectangle`.
-        fn united(self: &QRectF, rectangle: &QRectF) -> QRectF;
+        fn united(&self, rectangle: &QRectF) -> QRectF;
 
         /// Returns the width of the rectangle.
-        fn width(self: &QRectF) -> f64;
+        fn width(&self) -> f64;
 
         /// Returns the x-coordinate of the rectangle's left edge.
-        fn x(self: &QRectF) -> f64;
+        fn x(&self) -> f64;
 
         /// Returns the y-coordinate of the rectangle's top edge.
-        fn y(self: &QRectF) -> f64;
+        fn y(&self) -> f64;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qrectf.rs
+++ b/crates/cxx-qt-lib/src/core/qrectf.rs
@@ -10,19 +10,23 @@ use crate::{QMarginsF, QRect};
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qmarginsf.h");
         type QMarginsF = crate::QMarginsF;
         include!("cxx-qt-lib/qpointf.h");
         type QPointF = crate::QPointF;
         include!("cxx-qt-lib/qrect.h");
         type QRect = crate::QRect;
-        include!("cxx-qt-lib/qrectf.h");
-        type QRectF = super::QRectF;
         include!("cxx-qt-lib/qsizef.h");
         type QSizeF = crate::QSizeF;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
+
+        include!("cxx-qt-lib/qrectf.h");
+    }
+
+    unsafe extern "C++" {
+        type QRectF = super::QRectF;
 
         /// Adds `dx1`, `dy1`, `dx2` and `dy2` respectively to the existing coordinates of the rectangle. All parameters must be finite.
         fn adjust(self: &mut QRectF, dx1: f64, dy1: f64, dx2: f64, dy2: f64);

--- a/crates/cxx-qt-lib/src/core/qsize.rs
+++ b/crates/cxx-qt-lib/src/core/qsize.rs
@@ -31,64 +31,64 @@ mod ffi {
 
         /// Returns a size holding the minimum width and height of this size and the given `other_size`.
         #[rust_name = "bounded_to"]
-        fn boundedTo(self: &QSize, other_size: &QSize) -> QSize;
+        fn boundedTo(&self, other_size: &QSize) -> QSize;
 
         /// Returns a size holding the maximum width and height of this size and the given `other_size`.
         #[rust_name = "expanded_to"]
-        fn expandedTo(self: &QSize, other_size: &QSize) -> QSize;
+        fn expandedTo(&self, other_size: &QSize) -> QSize;
 
         /// Returns the height.
-        fn height(self: &QSize) -> i32;
+        fn height(&self) -> i32;
 
         /// Returns `true` if either of the width and height is less than or equal to 0; otherwise returns `false`.
         #[rust_name = "is_empty"]
-        fn isEmpty(self: &QSize) -> bool;
+        fn isEmpty(&self) -> bool;
 
         /// Returns `true` if both the width and height is 0; otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QSize) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns `true` if both the width and height is equal to or greater than 0; otherwise returns `false`.
         #[rust_name = "is_valid"]
-        fn isValid(self: &QSize) -> bool;
+        fn isValid(&self) -> bool;
 
         /// Returns the size that results from growing this size by `margins`.
         #[rust_name = "grown_by"]
-        fn grownBy(self: &QSize, margins: QMargins) -> QSize;
+        fn grownBy(&self, margins: QMargins) -> QSize;
 
         /// Scales the size to a rectangle with the given `size`, according to the specified `mode`.
-        fn scale(self: &mut QSize, size: &QSize, mode: AspectRatioMode);
+        fn scale(&mut self, size: &QSize, mode: AspectRatioMode);
 
         /// Return a size scaled to a rectangle with the given size `s`, according to the specified `mode`.
-        fn scaled(self: &QSize, s: &QSize, mode: AspectRatioMode) -> QSize;
+        fn scaled(&self, s: &QSize, mode: AspectRatioMode) -> QSize;
 
         /// Sets the height to the given `height`.
         #[rust_name = "set_height"]
-        fn setHeight(self: &mut QSize, height: i32);
+        fn setHeight(&mut self, height: i32);
 
         /// Sets the width to the given `width`.
         #[rust_name = "set_width"]
-        fn setWidth(self: &mut QSize, width: i32);
+        fn setWidth(&mut self, width: i32);
 
         /// Returns the size that results from shrinking this size by `margins`.
         #[rust_name = "shrunk_by"]
-        fn shrunkBy(self: &QSize, margins: QMargins) -> QSize;
+        fn shrunkBy(&self, margins: QMargins) -> QSize;
 
         /// Returns this size as a size with floating point accuracy.
         ///
         /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_sizef"]
-        fn toSizeF(self: &QSize) -> QSizeF;
+        fn toSizeF(&self) -> QSizeF;
 
         /// Swaps the width and height values.
-        fn transpose(self: &mut QSize);
+        fn transpose(&mut self);
 
         /// Returns a `QSize` with width and height swapped.
-        fn transposed(self: &QSize) -> QSize;
+        fn transposed(&self) -> QSize;
 
         /// Returns the width.
-        fn width(self: &QSize) -> i32;
+        fn width(&self) -> i32;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qsize.rs
+++ b/crates/cxx-qt-lib/src/core/qsize.rs
@@ -9,21 +9,25 @@ use std::fmt;
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type AspectRatioMode = crate::AspectRatioMode;
     }
 
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qmargins.h");
         type QMargins = crate::QMargins;
-        include!("cxx-qt-lib/qsize.h");
-        type QSize = super::QSize;
-        include!("cxx-qt-lib/qstring.h");
-        type QString = crate::QString;
         include!("cxx-qt-lib/qsizef.h");
         #[allow(dead_code)]
         type QSizeF = crate::QSizeF;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
+
+        include!("cxx-qt-lib/qsize.h");
+    }
+
+    unsafe extern "C++" {
+        type QSize = super::QSize;
 
         /// Returns a size holding the minimum width and height of this size and the given `other_size`.
         #[rust_name = "bounded_to"]

--- a/crates/cxx-qt-lib/src/core/qsizef.rs
+++ b/crates/cxx-qt-lib/src/core/qsizef.rs
@@ -33,63 +33,63 @@ mod ffi {
 
         /// Returns a size holding the minimum width and height of this size and the given `other_size`.
         #[rust_name = "bounded_to"]
-        fn boundedTo(self: &QSizeF, other_size: &QSizeF) -> QSizeF;
+        fn boundedTo(&self, other_size: &QSizeF) -> QSizeF;
 
         /// Returns a size holding the maximum width and height of this size and the given `other_size`.
         #[rust_name = "expanded_to"]
-        fn expandedTo(self: &QSizeF, other_size: &QSizeF) -> QSizeF;
+        fn expandedTo(&self, other_size: &QSizeF) -> QSizeF;
 
         /// Returns the height.
-        fn height(self: &QSizeF) -> f64;
+        fn height(&self) -> f64;
 
         /// Returns `true` if either of the width and height is less than or equal to 0; otherwise returns `false`.
         #[rust_name = "is_empty"]
-        fn isEmpty(self: &QSizeF) -> bool;
+        fn isEmpty(&self) -> bool;
 
         /// Returns `true` if both the width and height are 0.0 (ignoring the sign); otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QSizeF) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns `true` if both the width and height are equal to or greater than 0; otherwise returns `false`.
         #[rust_name = "is_valid"]
-        fn isValid(self: &QSizeF) -> bool;
+        fn isValid(&self) -> bool;
 
         /// Returns the size that results from growing this size by `margins`.
         #[rust_name = "grown_by"]
-        fn grownBy(self: &QSizeF, margins: QMarginsF) -> QSizeF;
+        fn grownBy(&self, margins: QMarginsF) -> QSizeF;
 
         /// Scales the size to a rectangle with the given `size`, according to the specified `mode`.
-        fn scale(self: &mut QSizeF, size: &QSizeF, mode: AspectRatioMode);
+        fn scale(&mut self, size: &QSizeF, mode: AspectRatioMode);
 
         /// Returns a size scaled to a rectangle with the given size `s`, according to the specified `mode`.
-        fn scaled(self: &QSizeF, s: &QSizeF, mode: AspectRatioMode) -> QSizeF;
+        fn scaled(&self, s: &QSizeF, mode: AspectRatioMode) -> QSizeF;
 
         /// Sets the height to the given finite `height`.
         #[rust_name = "set_height"]
-        fn setHeight(self: &mut QSizeF, height: f64);
+        fn setHeight(&mut self, height: f64);
 
         /// Sets the width to the given finite `width`.
         #[rust_name = "set_width"]
-        fn setWidth(self: &mut QSizeF, width: f64);
+        fn setWidth(&mut self, width: f64);
 
         /// Returns the size that results from shrinking this size by `margins`.
         #[rust_name = "shrunk_by"]
-        fn shrunkBy(self: &QSizeF, margins: QMarginsF) -> QSizeF;
+        fn shrunkBy(&self, margins: QMarginsF) -> QSizeF;
 
         /// Returns an integer based copy of this size.
         ///
         /// Note that the coordinates in the returned size will be rounded to the nearest integer.
         #[rust_name = "to_size"]
-        fn toSize(self: &QSizeF) -> QSize;
+        fn toSize(&self) -> QSize;
 
         /// Swaps the width and height values.
-        fn transpose(self: &mut QSizeF);
+        fn transpose(&mut self);
 
         /// Returns the size with width and height values swapped.
-        fn transposed(self: &QSizeF) -> QSizeF;
+        fn transposed(&self) -> QSizeF;
 
         /// Returns the width.
-        fn width(self: &QSizeF) -> f64;
+        fn width(&self) -> f64;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qsizef.rs
+++ b/crates/cxx-qt-lib/src/core/qsizef.rs
@@ -12,20 +12,24 @@ use crate::QSize;
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type AspectRatioMode = crate::AspectRatioMode;
     }
 
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qmarginsf.h");
         type QMarginsF = crate::QMarginsF;
         include!("cxx-qt-lib/qsize.h");
         type QSize = crate::QSize;
-        include!("cxx-qt-lib/qsizef.h");
-        type QSizeF = super::QSizeF;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
+
+        include!("cxx-qt-lib/qsizef.h");
+    }
+
+    unsafe extern "C++" {
+        type QSizeF = super::QSizeF;
 
         /// Returns a size holding the minimum width and height of this size and the given `other_size`.
         #[rust_name = "bounded_to"]

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -32,79 +32,78 @@ mod ffi {
         type QString = super::QString;
 
         /// Appends the string `str` onto the end of this string.
-        fn append<'a>(self: &'a mut QString, str: &QString) -> &'a mut QString;
+        fn append<'a>(&'a mut self, str: &QString) -> &'a mut QString;
 
         /// Clears the contents of the string and makes it null.
-        fn clear(self: &mut QString);
+        fn clear(&mut self);
 
         // We wrap this method to provide an enum so hide it from docs
         #[doc(hidden)]
         #[rust_name = "compare_i32"]
-        fn compare(self: &QString, other: &QString, cs: CaseSensitivity) -> i32;
+        fn compare(&self, other: &QString, cs: CaseSensitivity) -> i32;
 
         /// Returns `true` if this string contains an occurrence of the string `str`; otherwise returns `false`.
         ///
         /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the search is case-insensitive.
-        fn contains(self: &QString, str: &QString, cs: CaseSensitivity) -> bool;
+        fn contains(&self, str: &QString, cs: CaseSensitivity) -> bool;
 
         /// Returns `true` if the string ends with `s`; otherwise returns `false`.
         ///
         /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the search is case-insensitive.
         #[rust_name = "ends_with"]
-        fn endsWith(self: &QString, s: &QString, cs: CaseSensitivity) -> bool;
+        fn endsWith(&self, s: &QString, cs: CaseSensitivity) -> bool;
 
         /// Returns `true` if the string has no characters; otherwise returns `false`.
         #[rust_name = "is_empty"]
-        fn isEmpty(self: &QString) -> bool;
+        fn isEmpty(&self) -> bool;
 
         /// Returns `true` if the string is lowercase, that is, it's identical to its [`to_lower`](Self::to_lower) folding.
         #[rust_name = "is_lower"]
-        fn isLower(self: &QString) -> bool;
+        fn isLower(&self) -> bool;
 
         /// Returns `true` if this string is null; otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QString) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns `true` if the string is read right to left.
         #[rust_name = "is_right_to_left"]
-        fn isRightToLeft(self: &QString) -> bool;
+        fn isRightToLeft(&self) -> bool;
 
         /// Returns `true` if the string is uppercase, that is, it's identical to its [`to_upper`](Self::to_upper) folding.
         #[rust_name = "is_upper"]
-        fn isUpper(self: &QString) -> bool;
+        fn isUpper(&self) -> bool;
 
         /// Returns `true` if the string contains valid UTF-16 encoded data, or `false` otherwise.
         #[rust_name = "is_valid_utf16"]
-        fn isValidUtf16(self: &QString) -> bool;
+        fn isValidUtf16(&self) -> bool;
 
         /// Prepends the string `str` to the beginning of this string and returns a mutable reference to this string.
-        fn prepend<'a>(self: &'a mut QString, str: &QString) -> &'a mut QString;
+        fn prepend<'a>(&'a mut self, str: &QString) -> &'a mut QString;
 
         /// Removes every occurrence of the given `str` string in this string, and returns a mutable reference to this string.
         ///
         /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the search is case-insensitive.
-        fn remove<'a>(self: &'a mut QString, str: &QString, cs: CaseSensitivity)
-            -> &'a mut QString;
+        fn remove<'a>(&'a mut self, str: &QString, cs: CaseSensitivity) -> &'a mut QString;
 
         /// Removes the first character in this string. If the string is empty, this function does nothing.
         ///
         /// This function was introduced in Qt 6.5.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_5))]
         #[rust_name = "remove_first"]
-        fn removeFirst(self: &mut QString) -> &mut QString;
+        fn removeFirst(&mut self) -> &mut QString;
 
         /// Removes the last character in this string. If the string is empty, this function does nothing.
         ///
         /// This function was introduced in Qt 6.5.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_5))]
         #[rust_name = "remove_last"]
-        fn removeLast(self: &mut QString) -> &mut QString;
+        fn removeLast(&mut self) -> &mut QString;
 
         /// Replaces every occurrence of the string `before` with the string `after` and returns a mutable reference to this string.
         ///
         /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the search is case-insensitive.
         fn replace<'a>(
-            self: &'a mut QString,
+            &'a mut self,
             before: &QString,
             after: &QString,
             cs: CaseSensitivity,
@@ -112,11 +111,11 @@ mod ffi {
 
         /// Returns `true` if the string starts with `s`; otherwise returns `false`.
         #[rust_name = "starts_with"]
-        fn startsWith(self: &QString, s: &QString, cs: CaseSensitivity) -> bool;
+        fn startsWith(&self, s: &QString, cs: CaseSensitivity) -> bool;
 
         /// Converts a plain text string to an HTML string with HTML metacharacters `<`, `>`, `&`, and `"` replaced by HTML entities.
         #[rust_name = "to_html_escaped"]
-        fn toHtmlEscaped(self: &QString) -> QString;
+        fn toHtmlEscaped(&self) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -386,7 +385,7 @@ impl QString {
     }
 
     /// Returns the number of characters in this string.
-    pub fn len(self: &QString) -> isize {
+    pub fn len(&self) -> isize {
         ffi::qstring_len(self)
     }
 

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -13,19 +13,23 @@ use crate::{CaseSensitivity, QByteArray, QStringList, SplitBehaviorFlags};
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type CaseSensitivity = crate::CaseSensitivity;
         type SplitBehaviorFlags = crate::SplitBehaviorFlags;
     }
 
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qbytearray.h");
         type QByteArray = crate::QByteArray;
-        include!("cxx-qt-lib/qstring.h");
-        type QString = super::QString;
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = crate::QStringList;
+
+        include!("cxx-qt-lib/qstring.h");
+    }
+
+    unsafe extern "C++" {
+        type QString = super::QString;
 
         /// Appends the string `str` onto the end of this string.
         fn append<'a>(self: &'a mut QString, str: &QString) -> &'a mut QString;

--- a/crates/cxx-qt-lib/src/core/qstringlist.rs
+++ b/crates/cxx-qt-lib/src/core/qstringlist.rs
@@ -33,21 +33,21 @@ mod ffi {
         /// Returns `true` if the list contains the string `str`; otherwise returns `false`.
         ///
         /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the comparison is case-insensitive.
-        fn contains(self: &QStringList, str: &QString, cs: CaseSensitivity) -> bool;
+        fn contains(&self, str: &QString, cs: CaseSensitivity) -> bool;
 
         /// Returns a list of all the strings containing the substring `str`.
         ///
         /// If `cs` is [`CaseSensitivity::CaseSensitive`], the search is case-sensitive; otherwise the comparison is case-insensitive.
-        fn filter(self: &QStringList, str: &QString, cs: CaseSensitivity) -> QStringList;
+        fn filter(&self, str: &QString, cs: CaseSensitivity) -> QStringList;
 
         /// Joins all the string list's strings into a single string with each element
         /// separated by the given `separator` (which can be an empty string).
-        fn join(self: &QStringList, separator: &QString) -> QString;
+        fn join(&self, separator: &QString) -> QString;
 
         /// Sorts the list of strings in ascending order.
         ///
         /// If `cs` is [`CaseSensitivity::CaseSensitive`], the string comparison is case-sensitive; otherwise the comparison is case-insensitive.
-        fn sort(self: &mut QStringList, cs: CaseSensitivity);
+        fn sort(&mut self, cs: CaseSensitivity);
 
         /// Returns a string list where every string has had the `before` text replaced with the `after` text wherever the `before` text is found.
         ///
@@ -56,7 +56,7 @@ mod ffi {
         /// If `cs` is [`CaseSensitivity::CaseSensitive`], the string comparison is case-sensitive; otherwise the comparison is case-insensitive.
         #[rust_name = "replace_in_strings"]
         fn replaceInStrings(
-            self: &mut QStringList,
+            &mut self,
             before: &QString,
             after: &QString,
             cs: CaseSensitivity,

--- a/crates/cxx-qt-lib/src/core/qstringlist.rs
+++ b/crates/cxx-qt-lib/src/core/qstringlist.rs
@@ -12,12 +12,12 @@ use std::ops::{Deref, DerefMut};
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type CaseSensitivity = crate::CaseSensitivity;
     }
 
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
 
@@ -25,6 +25,9 @@ mod ffi {
         type QList_QString = crate::QList<QString>;
 
         include!("cxx-qt-lib/qstringlist.h");
+    }
+
+    unsafe extern "C++" {
         type QStringList = super::QStringList;
 
         /// Returns `true` if the list contains the string `str`; otherwise returns `false`.

--- a/crates/cxx-qt-lib/src/core/qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qtime.rs
@@ -31,7 +31,7 @@ mod ffi {
         ///
         /// Returns a null time if this time is invalid.
         #[rust_name = "add_msecs"]
-        fn addMSecs(self: &QTime, ms: i32) -> QTime;
+        fn addMSecs(&self, ms: i32) -> QTime;
 
         /// Returns a `QTime` object containing a time `s` seconds later than the
         /// time of this object (or earlier if `s` is negative).
@@ -40,53 +40,53 @@ mod ffi {
         ///
         /// Returns a null time if this time is invalid.
         #[rust_name = "add_secs"]
-        fn addSecs(self: &QTime, s: i32) -> QTime;
+        fn addSecs(&self, s: i32) -> QTime;
 
         /// Returns the hour part (0 to 23) of the time.
         ///
         /// Returns -1 if the time is invalid.
-        fn hour(self: &QTime) -> i32;
+        fn hour(&self) -> i32;
 
         /// Returns `true` if the time is null (i.e., the `QTime` object was
         /// constructed using the default constructor); otherwise returns `false`.
         /// A null time is also an invalid time.
         #[rust_name = "is_null"]
-        fn isNull(self: &QTime) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns `true` if the time is valid; otherwise returns `false`. For example, the time 23:30:55.746 is valid, but 24:12:30 is invalid.
         #[rust_name = "is_valid"]
-        fn isValid(self: &QTime) -> bool;
+        fn isValid(&self) -> bool;
 
         /// Returns the minute part (0 to 59) of the time.
         ///
         /// Returns -1 if the time is invalid.
-        fn minute(self: &QTime) -> i32;
+        fn minute(&self) -> i32;
 
         /// Returns the millisecond part (0 to 999) of the time.
         ///
         /// Returns -1 if the time is invalid.
-        fn msec(self: &QTime) -> i32;
+        fn msec(&self) -> i32;
 
         /// Returns the number of msecs since the start of the day, i.e. since 00:00:00.
         #[rust_name = "msecs_since_start_of_day"]
-        fn msecsSinceStartOfDay(self: &QTime) -> i32;
+        fn msecsSinceStartOfDay(&self) -> i32;
 
         /// Returns the second part (0 to 59) of the time.
         ///
         /// Returns -1 if the time is invalid.
-        fn second(self: &QTime) -> i32;
+        fn second(&self) -> i32;
 
         /// Sets the time to hour `h`, minute `m`, seconds `s` and milliseconds `ms`.
         #[rust_name = "set_hms"]
-        fn setHMS(self: &mut QTime, h: i32, m: i32, s: i32, ms: i32) -> bool;
+        fn setHMS(&mut self, h: i32, m: i32, s: i32, ms: i32) -> bool;
 
         /// Returns the time as a string. The `format` parameter determines the format of the string.
         #[rust_name = "format"]
-        fn toString(self: &QTime, format: &QString) -> QString;
+        fn toString(&self, format: &QString) -> QString;
 
         /// Returns the time as a string. The `format` parameter determines the format of the string.
         #[rust_name = "format_enum"]
-        fn toString(self: &QTime, format: DateFormat) -> QString;
+        fn toString(&self, format: DateFormat) -> QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qtime.rs
+++ b/crates/cxx-qt-lib/src/core/qtime.rs
@@ -9,17 +9,20 @@ use std::fmt;
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type DateFormat = crate::DateFormat;
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qtime.h");
+    extern "C++" {
         include!("cxx-qt-lib/qstring.h");
-
-        type QTime = super::QTime;
         type QString = crate::QString;
+
+        include!("cxx-qt-lib/qtime.h");
+    }
+
+    unsafe extern "C++" {
+        type QTime = super::QTime;
 
         /// Returns a `QTime` object containing a time `ms` milliseconds later
         /// than the time of this object (or earlier if `ms` is negative).

--- a/crates/cxx-qt-lib/src/core/qtimezone.rs
+++ b/crates/cxx-qt-lib/src/core/qtimezone.rs
@@ -75,52 +75,52 @@ mod ffi {
         /// Returns the time zone abbreviation at the given `at_date_time`. The abbreviation may change depending on DST or even historical events.
         ///
         /// **Note:** The abbreviation is not guaranteed to be unique to this time zone and should not be used in place of the ID or display name.
-        fn abbreviation(self: &QTimeZone, at_date_time: &QDateTime) -> QString;
+        fn abbreviation(&self, at_date_time: &QDateTime) -> QString;
 
         /// Returns any comment for the time zone.
         ///
         /// A comment may be provided by the host platform to assist users in choosing the correct time zone. Depending on the platform this may not be localized.
-        fn comment(self: &QTimeZone) -> QString;
+        fn comment(&self) -> QString;
 
         /// Returns the daylight-saving time offset at the given `at_date_time`,
         /// i.e. the number of seconds to add to the standard time offset to obtain the local daylight-saving time.
         ///
         /// For example, for the time zone "Europe/Berlin" the DST offset is +3600 seconds. During standard time this function will return 0, and when daylight-saving is in effect it will return 3600.
         #[rust_name = "daylight_time_offset"]
-        fn daylightTimeOffset(self: &QTimeZone, at_date_time: &QDateTime) -> i32;
+        fn daylightTimeOffset(&self, at_date_time: &QDateTime) -> i32;
 
         /// Returns `true` if the time zone has practiced daylight-saving at any time.
         #[rust_name = "has_daylight_time"]
-        fn hasDaylightTime(self: &QTimeZone) -> bool;
+        fn hasDaylightTime(&self) -> bool;
 
         /// Returns `true` if the system backend supports obtaining transitions.
         #[rust_name = "has_transitions"]
-        fn hasTransitions(self: &QTimeZone) -> bool;
+        fn hasTransitions(&self) -> bool;
 
         /// Returns the IANA ID for the time zone.
-        fn id(self: &QTimeZone) -> QByteArray;
+        fn id(&self) -> QByteArray;
 
         /// Returns `true` if daylight-saving was in effect at the given `at_date_time`.
         #[rust_name = "is_daylight_time"]
-        fn isDaylightTime(self: &QTimeZone, at_date_time: &QDateTime) -> bool;
+        fn isDaylightTime(&self, at_date_time: &QDateTime) -> bool;
 
         /// Returns `true` if this time zone is valid.
         #[rust_name = "is_valid"]
-        fn isValid(self: &QTimeZone) -> bool;
+        fn isValid(&self) -> bool;
 
         /// Returns the total effective offset at the given `at_date_time`, i.e. the number of seconds to add to UTC to obtain the local time.
         /// This includes any DST offset that may be in effect, i.e. it is the sum of [`standard_time_offset`](QTimeZone::standard_time_offset) and [`daylight_time_offset`](QTimeZone::daylight_time_offset) for the given datetime.
         ///
         /// For example, for the time zone "Europe/Berlin" the standard time offset is +3600 seconds and the DST offset is +3600 seconds. During standard time this function will return 3600 (UTC+01:00), and during DST it will return 7200 (UTC+02:00).
         #[rust_name = "offset_from_utc"]
-        fn offsetFromUtc(self: &QTimeZone, at_date_time: &QDateTime) -> i32;
+        fn offsetFromUtc(&self, at_date_time: &QDateTime) -> i32;
 
         /// Returns the standard time offset at the given `at_date_time`, i.e. the number of seconds to add to UTC to obtain the local Standard Time.
         /// This excludes any DST offset that may be in effect.
         ///
         /// For example, for the time zone "Europe/Berlin" the standard time offset is +3600 seconds. During both standard and DST this function will return 3600 (UTC+01:00).
         #[rust_name = "standard_time_offset"]
-        fn standardTimeOffset(self: &QTimeZone, at_date_time: &QDateTime) -> i32;
+        fn standardTimeOffset(&self, at_date_time: &QDateTime) -> i32;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/core/qtlogging.rs
+++ b/crates/cxx-qt-lib/src/core/qtlogging.rs
@@ -25,12 +25,14 @@ mod ffi {
         QtCriticalMsg = 2,
     }
 
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
+    }
 
+    unsafe extern "C++" {
         include!("cxx-qt-lib/qtlogging.h");
-        type QMessageLogContext<'a> = crate::QMessageLogContext<'a>;
+        type QMessageLogContext<'a> = super::QMessageLogContext<'a>;
         type QtMsgType;
 
         /// Outputs a message in the Qt message handler.

--- a/crates/cxx-qt-lib/src/core/qtypes.rs
+++ b/crates/cxx-qt-lib/src/core/qtypes.rs
@@ -7,7 +7,7 @@ use cxx::{type_id, ExternType};
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qtypes.h");
     }
 }

--- a/crates/cxx-qt-lib/src/core/qurl.rs
+++ b/crates/cxx-qt-lib/src/core/qurl.rs
@@ -10,14 +10,18 @@ use crate::{QByteArray, QString, QStringList};
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qbytearray.h");
         type QByteArray = crate::QByteArray;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = crate::QStringList;
+
         include!("cxx-qt-lib/qurl.h");
+    }
+
+    unsafe extern "C++" {
         type QUrl = super::QUrl;
 
         /// Resets the content of the `QUrl`. After calling this function,

--- a/crates/cxx-qt-lib/src/core/qurl.rs
+++ b/crates/cxx-qt-lib/src/core/qurl.rs
@@ -26,59 +26,59 @@ mod ffi {
 
         /// Resets the content of the `QUrl`. After calling this function,
         /// the `QUrl` is equal to one that has been constructed with the default empty constructor.
-        fn clear(self: &mut QUrl);
+        fn clear(&mut self);
 
         /// Returns an error message if the last operation that modified this `QUrl` object ran into a parsing error.
         /// If no error was detected, this function returns an empty string and [`is_valid`](Self::is_valid) returns `true`.
         #[rust_name = "error_string"]
-        fn errorString(self: &QUrl) -> QString;
+        fn errorString(&self) -> QString;
 
         /// Returns `true` if this URL contains a fragment (i.e., if # was seen on it).
         #[rust_name = "has_fragment"]
-        fn hasFragment(self: &QUrl) -> bool;
+        fn hasFragment(&self) -> bool;
 
         /// Returns `true` if this URL contains a Query (i.e., if ? was seen on it).
         #[rust_name = "has_query"]
-        fn hasQuery(self: &QUrl) -> bool;
+        fn hasQuery(&self) -> bool;
 
         /// Returns `true` if the URL has no data; otherwise returns `false`.
         #[rust_name = "is_empty"]
-        fn isEmpty(self: &QUrl) -> bool;
+        fn isEmpty(&self) -> bool;
 
         /// Returns `true` if this URL is pointing to a local file path. A URL is a local file path if the scheme is "file".
         ///
         /// Note that this function considers URLs with hostnames to be local file paths.
         #[rust_name = "is_local_file"]
-        fn isLocalFile(self: &QUrl) -> bool;
+        fn isLocalFile(&self) -> bool;
 
         /// Returns `true` if this URL is a parent of `child_url`.
         /// `child_url` is a child of this URL if the two URLs share the same scheme and authority,
         /// and this URL's path is a parent of the path of `child_url`.
         #[rust_name = "is_parent_of"]
-        fn isParentOf(self: &QUrl, child_url: &QUrl) -> bool;
+        fn isParentOf(&self, child_url: &QUrl) -> bool;
 
         /// Returns `true` if the URL is relative; otherwise returns `false`.
         /// A URL is relative reference if its scheme is undefined;
         /// this function is therefore equivalent to calling `self.scheme().is_empty()`.
         #[rust_name = "is_relative"]
-        fn isRelative(self: &QUrl) -> bool;
+        fn isRelative(&self) -> bool;
 
         /// Returns `true` if the URL is non-empty and valid; otherwise returns `false`.
         ///
         /// The URL is run through a conformance test. Every part of the URL must conform to the standard encoding rules of the URI standard for the URL to be reported as valid.
         #[rust_name = "is_valid"]
-        fn isValid(self: &QUrl) -> bool;
+        fn isValid(&self) -> bool;
 
         /// Returns the port of the URL, or `default_port` if the port is unspecified.
         #[rust_name = "port_or"]
-        fn port(self: &QUrl, default_port: i32) -> i32;
+        fn port(&self, default_port: i32) -> i32;
 
         /// Returns the result of the merge of this URL with `relative`. This URL is used as a base to convert `relative` to an absolute URL.
         ///
         /// If `relative` is not a relative URL, this function will return `relative` directly. Otherwise, the paths of the two URLs are merged, and the new URL returned has the scheme and authority of the base URL, but with the merged path.
         ///
         /// Calling this function with `".."` returns a `QUrl` whose directory is one level higher than the original. Similarly, calling this function with `"../.."` removes two levels from the path. If `relative` is `"/"`, the path becomes `"/"`.
-        fn resolved(self: &QUrl, relative: &QUrl) -> QUrl;
+        fn resolved(&self, relative: &QUrl) -> QUrl;
 
         /// Returns the scheme of the URL. If an empty string is returned,
         /// this means the scheme is undefined and the URL is then relative.
@@ -87,21 +87,21 @@ mod ffi {
         /// which means it cannot contain any character that would otherwise require encoding.
         /// Additionally, schemes are always returned in lowercase form.
         #[rust_name = "scheme_or_default"]
-        fn scheme(self: &QUrl) -> QString;
+        fn scheme(&self) -> QString;
 
         /// Sets the port of the URL to `port`.
         /// The port is part of the authority of the URL, as described in [`set_authority`](Self::set_authority).
         ///
         /// `port` must be between 0 and 65535 inclusive. Setting the port to -1 indicates that the port is unspecified.
         #[rust_name = "set_port"]
-        fn setPort(self: &mut QUrl, port: i32);
+        fn setPort(&mut self, port: i32);
 
         /// Returns the path of this URL formatted as a local file path.
         /// The path returned will use forward slashes, even if it was originally created from one with backslashes.
         ///
         /// If this URL contains a non-empty hostname, it will be encoded in the returned value in the form found on SMB networks (for example, `"//servername/path/to/file.txt"`).
         #[rust_name = "to_local_file_or_default"]
-        fn toLocalFile(self: &QUrl) -> QString;
+        fn toLocalFile(&self) -> QString;
     }
 
     // Bitwise enums don't work well with Rust and CXX, so lets just use the defaults for now

--- a/crates/cxx-qt-lib/src/core/quuid.rs
+++ b/crates/cxx-qt-lib/src/core/quuid.rs
@@ -66,7 +66,7 @@ mod ffi {
         /// Returns the binary representation of this UUID. The byte array is in big endian format,
         /// and formatted according to RFC 4122, section 4.1.2 - "Layout and byte order".
         #[rust_name = "to_rfc_4122"]
-        fn toRfc4122(self: &QUuid) -> QByteArray;
+        fn toRfc4122(&self) -> QByteArray;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/gui/qcolor.rs
+++ b/crates/cxx-qt-lib/src/gui/qcolor.rs
@@ -39,13 +39,17 @@ mod ffi {
         type GlobalColor = crate::GlobalColor;
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qcolor.h");
-        type QColor = super::QColor;
+    extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = crate::QStringList;
+
+        include!("cxx-qt-lib/qcolor.h");
+    }
+
+    unsafe extern "C++" {
+        type QColor = super::QColor;
 
         /// Returns the alpha color component of this color.
         fn alpha(self: &QColor) -> i32;

--- a/crates/cxx-qt-lib/src/gui/qcolor.rs
+++ b/crates/cxx-qt-lib/src/gui/qcolor.rs
@@ -52,114 +52,114 @@ mod ffi {
         type QColor = super::QColor;
 
         /// Returns the alpha color component of this color.
-        fn alpha(self: &QColor) -> i32;
+        fn alpha(&self) -> i32;
         /// Returns the black color component of this color.
-        fn black(self: &QColor) -> i32;
+        fn black(&self) -> i32;
         /// Returns the blue color component of this color.
-        fn blue(self: &QColor) -> i32;
+        fn blue(&self) -> i32;
         /// Creates a copy of this color in the format specified by `color_spec`.
         #[rust_name = "convert_to"]
-        fn convertTo(self: &QColor, color_spec: QColorSpec) -> QColor;
+        fn convertTo(&self, color_spec: QColorSpec) -> QColor;
         /// Returns the cyan color component of this color.
-        fn cyan(self: &QColor) -> i32;
+        fn cyan(&self) -> i32;
         /// Returns a darker (or lighter) color, but does not change this object.
         ///
         /// If the `factor` is greater than 100, this functions returns a darker color. Setting `factor` to 300 returns a color that has one-third the brightness. If the `factor` is less than 100, the return color is lighter, but we recommend using [`lighter`](Self::lighter) for this purpose. If the `factor` is 0 or negative, the return value is unspecified.
         ///
         /// The function converts the current color to HSV, divides the value (V) component by factor and converts the color back to it's original color spec.
-        fn darker(self: &QColor, factor: i32) -> QColor;
+        fn darker(&self, factor: i32) -> QColor;
         /// Returns the green color component of this color.
-        fn green(self: &QColor) -> i32;
+        fn green(&self) -> i32;
         /// Returns the HSL hue color component of this color.
         #[rust_name = "hsl_hue"]
-        fn hslHue(self: &QColor) -> i32;
+        fn hslHue(&self) -> i32;
         /// Returns the HSL saturation color component of this color.
         #[rust_name = "hsl_saturation"]
-        fn hslSaturation(self: &QColor) -> i32;
+        fn hslSaturation(&self) -> i32;
         /// Returns the HSV hue color component of this color.
         #[rust_name = "hsv_hue"]
-        fn hsvHue(self: &QColor) -> i32;
+        fn hsvHue(&self) -> i32;
         /// Returns the HSV saturation color component of this color.
         #[rust_name = "hsv_saturation"]
-        fn hsvSaturation(self: &QColor) -> i32;
+        fn hsvSaturation(&self) -> i32;
         /// Returns the HSV hue color component of this color.
         ///
         /// The color is implicitly converted to HSV.
-        fn hue(self: &QColor) -> i32;
+        fn hue(&self) -> i32;
         /// Returns `true` if the color is valid; otherwise returns `false`.
         #[rust_name = "is_valid"]
-        fn isValid(self: &QColor) -> bool;
+        fn isValid(&self) -> bool;
         /// Returns a lighter (or darker) color, but does not change this object.
         ///
         /// If the `factor` is greater than 100, this functions returns a lighter color. Setting `factor` to 150 returns a color that is 50% brighter. If the `factor` is less than 100, the return color is darker, but we recommend using [`darker`](Self::darker) for this purpose. If the `factor` is 0 or negative, the return value is unspecified.
         ///
         /// The function converts the current color to HSV, multiplies the value (V) component by factor and converts the color back to it's original color spec.
-        fn lighter(self: &QColor, factor: i32) -> QColor;
+        fn lighter(&self, factor: i32) -> QColor;
         /// Returns the lightness color component of this color.
-        fn lightness(self: &QColor) -> i32;
+        fn lightness(&self) -> i32;
         /// Returns the magenta color component of this color.
-        fn magenta(self: &QColor) -> i32;
+        fn magenta(&self) -> i32;
         /// Returns the name of the color in the specified `format`.
-        fn name(self: &QColor, format: QColorNameFormat) -> QString;
+        fn name(&self, format: QColorNameFormat) -> QString;
         /// Returns the red color component of this color.
-        fn red(self: &QColor) -> i32;
+        fn red(&self) -> i32;
         /// Returns the HSV saturation color component of this color.
         ///
         /// The color is implicitly converted to HSV.
-        fn saturation(self: &QColor) -> i32;
+        fn saturation(&self) -> i32;
         /// Sets the alpha of this color to `alpha`. Integer alpha is specified in the range 0-255.
         #[rust_name = "set_alpha"]
-        fn setAlpha(self: &mut QColor, alpha: i32);
+        fn setAlpha(&mut self, alpha: i32);
         /// Sets the blue color component of this color to 1. Integer components are specified in the range 0-255.
         #[rust_name = "set_blue"]
-        fn setBlue(self: &mut QColor, blue: i32);
+        fn setBlue(&mut self, blue: i32);
         /// Sets the color to CMYK values, `c` (cyan), `m` (magenta), `y` (yellow), `k` (black), and `a` (alpha-channel, i.e. transparency).
         ///
         /// All the values must be in the range 0-255.
         #[rust_name = "set_cmyk"]
-        fn setCmyk(self: &mut QColor, c: i32, m: i32, y: i32, k: i32, a: i32);
+        fn setCmyk(&mut self, c: i32, m: i32, y: i32, k: i32, a: i32);
         /// Sets the green color component of this color to `green`. Integer components are specified in the range 0-255.
         #[rust_name = "set_green"]
-        fn setGreen(self: &mut QColor, green: i32);
+        fn setGreen(&mut self, green: i32);
         /// Sets a HSL color value; `h` is the hue, `s` is the saturation, `l` is the lightness and `a` is the alpha component of the HSL color.
         ///
         /// The saturation, value and alpha-channel values must be in the range 0-255, and the hue value must be greater than -1.
         #[rust_name = "set_hsl"]
-        fn setHsl(self: &mut QColor, h: i32, s: i32, l: i32, a: i32);
+        fn setHsl(&mut self, h: i32, s: i32, l: i32, a: i32);
         /// Sets a HSV color value; `h` is the hue, `s` is the saturation, `v` is the value and `a` is the alpha component of the HSV color.
         ///
         /// The saturation, value and alpha-channel values must be in the range 0-255, and the hue value must be greater than -1.
         #[rust_name = "set_hsv"]
-        fn setHsv(self: &mut QColor, h: i32, s: i32, v: i32, a: i32);
+        fn setHsv(&mut self, h: i32, s: i32, v: i32, a: i32);
         /// Sets the red color component of this color to `red`. Integer components are specified in the range 0-255.
         #[rust_name = "set_red"]
-        fn setRed(self: &mut QColor, red: i32);
+        fn setRed(&mut self, red: i32);
         /// Sets the RGB value to `r`, `g`, `b` and the alpha value to `a`.
         ///
         /// All the values must be in the range 0-255.
         #[rust_name = "set_rgb"]
-        fn setRgb(self: &mut QColor, r: i32, g: i32, b: i32, a: i32);
+        fn setRgb(&mut self, r: i32, g: i32, b: i32, a: i32);
         /// Returns how the color was specified.
-        fn spec(self: &QColor) -> QColorSpec;
+        fn spec(&self) -> QColorSpec;
         /// Creates and returns a CMYK `QColor` based on this color.
         #[rust_name = "to_cmyk"]
-        fn toCmyk(self: &QColor) -> QColor;
+        fn toCmyk(&self) -> QColor;
         /// Create and returns an extended RGB `QColor` based on this color.
         #[rust_name = "to_extended_rgb"]
-        fn toExtendedRgb(self: &QColor) -> QColor;
+        fn toExtendedRgb(&self) -> QColor;
         /// Creates and returns an HSL `QColor` based on this color.
         #[rust_name = "to_hsl"]
-        fn toHsl(self: &QColor) -> QColor;
+        fn toHsl(&self) -> QColor;
         /// Creates and returns an HSV `QColor` based on this color.
         #[rust_name = "to_hsv"]
-        fn toHsv(self: &QColor) -> QColor;
+        fn toHsv(&self) -> QColor;
         /// Create and returns an RGB `QColor` based on this color.
         #[rust_name = "to_rgb"]
-        fn toRgb(self: &QColor) -> QColor;
+        fn toRgb(&self) -> QColor;
         /// Returns the value color component of this color.
-        fn value(self: &QColor) -> i32;
+        fn value(&self) -> i32;
         /// Returns the yellow color component of this color.
-        fn yellow(self: &QColor) -> i32;
+        fn yellow(&self) -> i32;
     }
 
     #[namespace = "rust::cxxqtlib1"]
@@ -438,7 +438,7 @@ impl QColor {
     /// Returns the HSV hue color component of this color.
     ///
     /// The color is implicitly converted to HSV.
-    pub fn hue_f(self: &QColor) -> f32 {
+    pub fn hue_f(&self) -> f32 {
         ffi::qcolor_hue_f(self)
     }
 
@@ -519,12 +519,12 @@ impl QColor {
     }
 
     /// Returns the value color component of this color.
-    pub fn value_f(self: &QColor) -> f32 {
+    pub fn value_f(&self) -> f32 {
         ffi::qcolor_value_f(self)
     }
 
     /// Returns the yellow color component of this color.
-    pub fn yellow_f(self: &QColor) -> f32 {
+    pub fn yellow_f(&self) -> f32 {
         ffi::qcolor_yellow_f(self)
     }
 }

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -156,201 +156,201 @@ mod ffi {
         type QFont = super::QFont;
 
         /// Returns `true` if [weight](https://doc.qt.io/qt/qfont.html#weight)() is a value greater than 400; otherwise returns `false`.
-        fn bold(self: &QFont) -> bool;
+        fn bold(&self) -> bool;
 
         /// Returns the current capitalization type of the font.
-        fn capitalization(self: &QFont) -> QFontCapitalization;
+        fn capitalization(&self) -> QFontCapitalization;
 
         /// Returns the family name that corresponds to the current style hint.
         #[rust_name = "default_family"]
-        fn defaultFamily(self: &QFont) -> QString;
+        fn defaultFamily(&self) -> QString;
 
         /// Returns `true` if a window system font exactly matching
         /// the settings of this font is available.
         #[rust_name = "exact_match"]
-        fn exactMatch(self: &QFont) -> bool;
+        fn exactMatch(&self) -> bool;
 
         /// Returns the requested font family name. This will always be the same as the first entry in [`families`](Self::families).
         #[rust_name = "family_or_default"]
-        fn family(self: &QFont) -> QString;
+        fn family(&self) -> QString;
 
         /// Returns the requested font family names, i.e. the names set in the last [`set_families`](Self::set_families)
         /// call or via the constructor. Otherwise it returns an empty list.
-        fn families(self: &QFont) -> QStringList;
+        fn families(&self) -> QStringList;
 
         /// Returns `true` if fixed pitch has been set; otherwise returns `false`.
         #[rust_name = "fixed_pitch"]
-        fn fixedPitch(self: &QFont) -> bool;
+        fn fixedPitch(&self) -> bool;
 
         /// Sets this font to match the description `descrip`. The description is a comma-separated
         /// list of the font attributes, as returned by [`to_qstring`](Self::to_qstring).
         #[rust_name = "from_string"]
-        fn fromString(self: &mut QFont, descrip: &QString) -> bool;
+        fn fromString(&mut self, descrip: &QString) -> bool;
 
         /// Returns the currently preferred hinting level for glyphs rendered with this font.
         #[rust_name = "hinting_preference"]
-        fn hintingPreference(self: &QFont) -> QFontHintingPreference;
+        fn hintingPreference(&self) -> QFontHintingPreference;
 
         /// Returns `true` if this font and `f` are copies of each other, i.e. one of them was created
         /// as a copy of the other and neither has been modified since. This is much stricter than equality.
         #[rust_name = "is_copy_of"]
-        fn isCopyOf(self: &QFont, font: &QFont) -> bool;
+        fn isCopyOf(&self, font: &QFont) -> bool;
 
         /// Returns `true` if the [style](https://doc.qt.io/qt/qfont.html#style)() of the font is not [`QFontStyle::StyleNormal`].
-        fn italic(self: &QFont) -> bool;
+        fn italic(&self) -> bool;
 
         /// Returns `true` if kerning should be used when drawing text with this font.
-        fn kerning(self: &QFont) -> bool;
+        fn kerning(&self) -> bool;
 
         /// Returns the font's key, a textual representation of a font.
         /// It is typically used as the key for a cache or dictionary of fonts.
-        fn key(self: &QFont) -> QString;
+        fn key(&self) -> QString;
 
         /// Returns the letter spacing for the font.
         #[rust_name = "letter_spacing"]
-        fn letterSpacing(self: &QFont) -> f64;
+        fn letterSpacing(&self) -> f64;
 
         /// Returns the spacing type used for letter spacing.
         #[rust_name = "letter_spacing_type"]
-        fn letterSpacingType(self: &QFont) -> QFontSpacingType;
+        fn letterSpacingType(&self) -> QFontSpacingType;
 
         /// Returns `true` if overline has been set; otherwise returns `false`.
-        fn overline(self: &QFont) -> bool;
+        fn overline(&self) -> bool;
 
         /// Returns the pixel size of the font if it was set with [`set_pixel_size`](Self::set_pixel_size). Returns -1 if the size was not specified in pixels.
         #[rust_name = "pixel_size"]
-        fn pixelSize(self: &QFont) -> i32;
+        fn pixelSize(&self) -> i32;
 
         /// Returns the point size of the font. Returns -1 if the font size was specified in pixels.
         #[rust_name = "point_size"]
-        fn pointSize(self: &QFont) -> i32;
+        fn pointSize(&self) -> i32;
 
         /// Returns a new `QFont` that has attributes copied from other that have not been previously set on this font.
-        fn resolve(self: &QFont, other: &QFont) -> QFont;
+        fn resolve(&self, other: &QFont) -> QFont;
 
         /// If `enable` is `true` sets the font's weight to 700; otherwise sets the weight to 400.
         ///
         /// For finer boldness control use [setWeight](https://doc.qt.io/qt/qfont.html#setWeight)().
         #[rust_name = "set_bold"]
-        fn setBold(self: &mut QFont, enable: bool);
+        fn setBold(&mut self, enable: bool);
 
         /// Sets the capitalization of the text in this font to `caps`.
         ///
         /// A font's capitalization makes the text appear in the selected capitalization mode.
         #[rust_name = "set_capitalization"]
-        fn setCapitalization(self: &mut QFont, caps: QFontCapitalization);
+        fn setCapitalization(&mut self, caps: QFontCapitalization);
 
         /// Sets the family name of the font. The name is case insensitive and may include a foundry name.
         ///
         /// The family name may optionally also include a foundry name, e.g. "Helvetica [Cronyx]". If the family is available from more than one foundry and the foundry isn't specified, an arbitrary foundry is chosen. If the family isn't available a family will be set using the [font matching](https://doc.qt.io/qt/qfont.html#fontmatching) algorithm.
         #[rust_name = "set_family"]
-        fn setFamily(self: &mut QFont, family: &QString);
+        fn setFamily(&mut self, family: &QString);
 
         /// Sets the list of family names for the font. The names are case insensitive and may include
         /// a foundry name. The first family in `families` will be set as the main family for the font.
         ///
         /// Each family name entry in families may optionally also include a foundry name, e.g. "Helvetica [Cronyx]". If the family is available from more than one foundry and the foundry isn't specified, an arbitrary foundry is chosen. If the family isn't available a family will be set using the [font matching](https://doc.qt.io/qt/qfont.html#fontmatching) algorithm.
         #[rust_name = "set_families"]
-        fn setFamilies(self: &mut QFont, families: &QStringList);
+        fn setFamilies(&mut self, families: &QStringList);
 
         /// If `enable` is `true`, sets fixed pitch on; otherwise sets fixed pitch off.
         #[rust_name = "set_fixed_pitch"]
-        fn setFixedPitch(self: &mut QFont, enable: bool);
+        fn setFixedPitch(&mut self, enable: bool);
 
         /// Sets the style strategy for the font to `strategy`.
         #[rust_name = "set_style_strategy"]
-        fn setStyleStrategy(self: &mut QFont, strategy: QFontStyleStrategy);
+        fn setStyleStrategy(&mut self, strategy: QFontStyleStrategy);
 
         /// Set the preference for the hinting level of the glyphs to `hinting_preference`.
         ///  This is a hint to the underlying font rendering system to use a certain level of hinting, and has varying support across platforms.
         #[rust_name = "set_hinting_preference"]
-        fn setHintingPreference(self: &mut QFont, hinting_preference: QFontHintingPreference);
+        fn setHintingPreference(&mut self, hinting_preference: QFontHintingPreference);
 
         /// Sets the [style](https://doc.qt.io/qt/qfont.html#style)() of the font to [`QFontStyle::StyleItalic`] if `enable` is `true`; otherwise the style is set to [`QFontStyle::StyleNormal`].
         ///
         /// Note: If [`style_name`](Self::style_name) is set, this value may be ignored, or if supported on the platform, the font may be rendered tilted instead of picking a designed italic font-variant.
         #[rust_name = "set_italic"]
-        fn setItalic(self: &mut QFont, enable: bool);
+        fn setItalic(&mut self, enable: bool);
 
         /// Enables kerning for this font if `enable` is `true`; otherwise disables it. By default, kerning is enabled.
         ///
         /// When kerning is enabled, glyph metrics do not add up anymore, even for Latin text. In other words, the assumption that `width("a") + width("b") = width("ab")` is not necessarily true.
         #[rust_name = "set_kerning"]
-        fn setKerning(self: &mut QFont, enable: bool);
+        fn setKerning(&mut self, enable: bool);
 
         /// Sets the letter spacing for the font to `spacing` and the type of spacing to `spacing_type`.
         ///
         /// Letter spacing changes the default spacing between individual letters in the font. The spacing between the letters can be made smaller as well as larger either in percentage of the character width or in pixels, depending on the selected spacing type.
         #[rust_name = "set_letter_spacing"]
-        fn setLetterSpacing(self: &mut QFont, spacing_type: QFontSpacingType, spacing: f64);
+        fn setLetterSpacing(&mut self, spacing_type: QFontSpacingType, spacing: f64);
 
         /// If `enable` is `true`, sets overline on; otherwise sets overline off.
         #[rust_name = "set_overline"]
-        fn setOverline(self: &mut QFont, enable: bool);
+        fn setOverline(&mut self, enable: bool);
 
         /// Sets the font size to `pixel_size` pixels.
         #[rust_name = "set_pixel_size"]
-        fn setPixelSize(self: &mut QFont, pixel_size: i32);
+        fn setPixelSize(&mut self, pixel_size: i32);
 
         /// Sets the stretch `factor` for the font.
         #[rust_name = "set_stretch"]
-        fn setStretch(self: &mut QFont, factor: i32);
+        fn setStretch(&mut self, factor: i32);
 
         /// If `enable` is `true`, sets strikeout on; otherwise sets strikeout off.
         #[rust_name = "set_strikeout"]
-        fn setStrikeOut(self: &mut QFont, enable: bool);
+        fn setStrikeOut(&mut self, enable: bool);
 
         /// Sets the style of the font to `style`.
         #[rust_name = "set_style"]
-        fn setStyle(self: &mut QFont, style: QFontStyle);
+        fn setStyle(&mut self, style: QFontStyle);
 
         /// Sets the style hint and strategy to `hint` and `strategy`, respectively.
         /// Qt does not support style hints on X11 since this information is not provided by the window system.
         #[rust_name = "set_style_hint"]
-        fn setStyleHint(self: &mut QFont, hint: QFontStyleHint, strategy: QFontStyleStrategy);
+        fn setStyleHint(&mut self, hint: QFontStyleHint, strategy: QFontStyleStrategy);
 
         /// Sets the style name of the font to `style_name`.
         #[rust_name = "set_style_name"]
-        fn setStyleName(self: &mut QFont, style_name: &QString);
+        fn setStyleName(&mut self, style_name: &QString);
 
         /// If `enable` is `true`, sets underline on; otherwise sets underline off.
         #[rust_name = "set_underline"]
-        fn setUnderline(self: &mut QFont, enable: bool);
+        fn setUnderline(&mut self, enable: bool);
 
         /// Sets the word spacing for the font to `spacing`.
         #[rust_name = "set_word_spacing"]
-        fn setWordSpacing(self: &mut QFont, spacing: f64);
+        fn setWordSpacing(&mut self, spacing: f64);
 
         /// Returns the stretch factor for the font.
-        fn stretch(self: &QFont) -> i32;
+        fn stretch(&self) -> i32;
 
         /// Returns `true` if strikeout has been set; otherwise returns `false`.
         #[rust_name = "strike_out"]
-        fn strikeOut(self: &QFont) -> bool;
+        fn strikeOut(&self) -> bool;
 
         /// Returns the style hint.
         #[rust_name = "style_hint"]
-        fn styleHint(self: &QFont) -> QFontStyleHint;
+        fn styleHint(&self) -> QFontStyleHint;
 
         /// Returns the requested font style name. This can be used to match the font
         /// with irregular styles (that can't be normalized in other style properties).
         #[rust_name = "style_name"]
-        fn styleName(self: &QFont) -> QString;
+        fn styleName(&self) -> QString;
 
         /// Returns the style strategy.
         #[rust_name = "style_strategy"]
-        fn styleStrategy(self: &QFont) -> QFontStyleStrategy;
+        fn styleStrategy(&self) -> QFontStyleStrategy;
 
         /// Returns the font as a string.
         #[rust_name = "to_qstring"]
-        fn toString(self: &QFont) -> QString;
+        fn toString(&self) -> QString;
 
         /// Returns `true` if underline has been set; otherwise returns `false`.
-        fn underline(self: &QFont) -> bool;
+        fn underline(&self) -> bool;
 
         /// Returns the word spacing for the font.
         #[rust_name = "word_spacing"]
-        fn wordSpacing(self: &QFont) -> f64;
+        fn wordSpacing(&self) -> f64;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -143,13 +143,17 @@ mod ffi {
         Fantasy,
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qfont.h");
-        type QFont = super::QFont;
+    extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = crate::QStringList;
+
+        include!("cxx-qt-lib/qfont.h");
+    }
+
+    unsafe extern "C++" {
+        type QFont = super::QFont;
 
         /// Returns `true` if [weight](https://doc.qt.io/qt/qfont.html#weight)() is a value greater than 400; otherwise returns `false`.
         fn bold(self: &QFont) -> bool;

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.rs
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.rs
@@ -9,29 +9,29 @@ use core::pin::Pin;
 
 #[cxx_qt::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    #[namespace = "Qt"]
+    extern "C++" {
+        include!("cxx-qt-lib/qt.h");
+        type KeyboardModifiers = crate::KeyboardModifiers;
+        type MouseButtons = crate::MouseButtons;
+    }
+
+    extern "C++" {
         include!("cxx-qt-lib/qbytearray.h");
         type QByteArray = crate::QByteArray;
+        include!("cxx-qt-lib/qcoreapplication.h");
+        type QCoreApplication = crate::QCoreApplication;
+        include!("cxx-qt-lib/qfont.h");
+        type QFont = crate::QFont;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = crate::QStringList;
         include!("cxx-qt-lib/core/qvector/qvector_QByteArray.h");
         type QVector_QByteArray = crate::QVector<QByteArray>;
-        include!("cxx-qt-lib/qfont.h");
-        type QFont = crate::QFont;
-
-        include!("cxx-qt-lib/qcoreapplication.h");
-        type QCoreApplication = crate::QCoreApplication;
     }
 
-    #[namespace = "Qt"]
-    unsafe extern "C++" {
-        type KeyboardModifiers = crate::KeyboardModifiers;
-        type MouseButtons = crate::MouseButtons;
-    }
-
-    unsafe extern "C++Qt" {
+    extern "C++Qt" {
         include!("cxx-qt-lib/qguiapplication.h");
 
         /// The `QGuiApplication` class manages the GUI application's control flow and main settings.

--- a/crates/cxx-qt-lib/src/gui/qimage.rs
+++ b/crates/cxx-qt-lib/src/gui/qimage.rs
@@ -10,7 +10,7 @@ use std::mem::MaybeUninit;
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type TransformationMode = crate::TransformationMode;
         type AspectRatioMode = crate::AspectRatioMode;
@@ -104,23 +104,27 @@ mod ffi {
         */
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qimage.h");
-        type QImage = super::QImage;
-        include!("cxx-qt-lib/qsize.h");
-        type QSize = crate::QSize;
-        include!("cxx-qt-lib/qstring.h");
-        type QString = crate::QString;
-        include!("cxx-qt-lib/qrect.h");
-        type QRect = crate::QRect;
+    extern "C++" {
         include!("cxx-qt-lib/qcolor.h");
         type QColor = crate::QColor;
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = crate::QPoint;
+        include!("cxx-qt-lib/qrect.h");
+        type QRect = crate::QRect;
+        include!("cxx-qt-lib/qsize.h");
+        type QSize = crate::QSize;
         include!("cxx-qt-lib/qsizef.h");
         #[allow(dead_code)]
         type QSizeF = crate::QSizeF;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
+
+        include!("cxx-qt-lib/qimage.h");
         type QImageCleanupFunction = super::QImageCleanupFunction;
+    }
+
+    unsafe extern "C++" {
+        type QImage = super::QImage;
 
         /// Returns `true` if all the colors in the image are shades of gray (i.e. their red, green and blue components are equal); otherwise `false`.
         ///

--- a/crates/cxx-qt-lib/src/gui/qimage.rs
+++ b/crates/cxx-qt-lib/src/gui/qimage.rs
@@ -130,13 +130,13 @@ mod ffi {
         ///
         /// Note that this function is slow for images without color table.
         #[rust_name = "all_gray"]
-        fn allGray(self: &QImage) -> bool;
+        fn allGray(&self) -> bool;
 
         /// Returns the number of bit planes in the image.
         ///
         /// The number of bit planes is the number of bits of color and transparency information for each pixel. This is different from (i.e. smaller than) the depth when the image format contains unused bits.
         #[rust_name = "bit_plane_count"]
-        fn bitPlaneCount(self: &QImage) -> i32;
+        fn bitPlaneCount(&self) -> i32;
 
         /// Returns a sub-area of the image as a new image.
         ///
@@ -145,7 +145,7 @@ mod ffi {
         /// In areas beyond this image, pixels are set to 0. For 32-bit RGB images, this means black; for 32-bit ARGB images, this means transparent black; for 8-bit images, this means the color with index 0 in the color table which can be anything; for 1-bit images, this means Qt::color0.
         ///
         /// If the given `rectangle` is a null rectangle the entire image is copied.
-        fn copy(self: &QImage, rectangle: &QRect) -> QImage;
+        fn copy(&self, rectangle: &QRect) -> QImage;
 
         /// Creates and returns a 1-bpp heuristic mask for this image.
         ///
@@ -157,20 +157,20 @@ mod ffi {
         ///
         /// Note that this function disregards the alpha buffer.
         #[rust_name = "create_heuristic_mask"]
-        fn createHeuristicMask(self: &QImage, clip_tight: bool) -> QImage;
+        fn createHeuristicMask(&self, clip_tight: bool) -> QImage;
 
         /// Returns the size of the color table for the image.
         ///
         /// Notice that this function returns 0 for 32-bpp images because these images do not use color tables, but instead encode pixel values as ARGB quadruplets.
         #[rust_name = "color_count"]
-        fn colorCount(self: &QImage) -> i32;
+        fn colorCount(&self) -> i32;
 
         /// Returns the depth of the image.
         ///
         /// The image depth is the number of bits used to store a single pixel, also called bits per pixel (bpp).
         ///
         /// The supported depths are 1, 8, 16, 24, 32 and 64.
-        fn depth(self: &QImage) -> i32;
+        fn depth(&self) -> i32;
 
         /// Returns the size of the image in device independent pixels.
         /// This value should be used when using the image size in user interface size calculations.
@@ -179,31 +179,31 @@ mod ffi {
         /// This function was introduced in Qt 6.2.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_2))]
         #[rust_name = "device_independent_size"]
-        fn deviceIndependentSize(self: &QImage) -> QSizeF;
+        fn deviceIndependentSize(&self) -> QSizeF;
 
         /// Returns the number of pixels that fit horizontally in a physical meter. Together with [`dots_per_meter_y`](Self::dots_per_meter_y), this number defines the intended scale and aspect ratio of the image.
         #[rust_name = "dots_per_meter_x"]
-        fn dotsPerMeterX(self: &QImage) -> i32;
+        fn dotsPerMeterX(&self) -> i32;
 
         /// Returns the number of pixels that fit vertically in a physical meter. Together with [`dots_per_meter_x`](Self::dots_per_meter_x), this number defines the intended scale and aspect ratio of the image.
         #[rust_name = "dots_per_meter_y"]
-        fn dotsPerMeterY(self: &QImage) -> i32;
+        fn dotsPerMeterY(&self) -> i32;
 
         /// Fills the entire image with the given `color`.
         ///
         /// If the depth of this image is 1, only the lowest bit is used. If you say fill(0), fill(2), etc., the image is filled with 0s. If you say fill(1), fill(3), etc., the image is filled with 1s. If the depth is 8, the lowest 8 bits are used and if the depth is 16 the lowest 16 bits are used.
         ///
         /// If the image depth is higher than 32bit the result is undefined.
-        fn fill(self: &mut QImage, color: &QColor);
+        fn fill(&mut self, color: &QColor);
 
         /// Flips or mirrors the image in the horizontal and/or the vertical direction depending on orient.
         ///
         /// This function was introduced in Qt 6.9.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_9))]
-        fn flip(self: &mut QImage, orient: Orientations);
+        fn flip(&mut self, orient: Orientations);
 
         /// Returns the format of the image.
-        fn format(self: &QImage) -> QImageFormat;
+        fn format(&self) -> QImageFormat;
 
         /// Inverts all pixel values in the image.
         ///
@@ -213,26 +213,26 @@ mod ffi {
         ///
         /// If the image has a premultiplied alpha channel, the image is first converted to an unpremultiplied image format to be inverted and then converted back.
         #[rust_name = "invert_pixels"]
-        fn invertPixels(self: &mut QImage, mode: QImageInvertMode);
+        fn invertPixels(&mut self, mode: QImageInvertMode);
 
         /// Returns `true` if it is a null image, otherwise returns `false`.
         ///
         /// A null image has all parameters set to zero and no allocated data.
         #[rust_name = "is_null"]
-        fn isNull(self: &QImage) -> bool;
+        fn isNull(&self) -> bool;
 
         /// For 32-bit images, this function is equivalent to [`all_gray`](Self::all_gray).
         /// For color indexed images, this function returns `true` if color(i) is QRgb(i, i, i)
         /// for all indexes of the color table; otherwise returns `false`.
         #[rust_name = "is_gray_scale"]
-        fn isGrayscale(self: &QImage) -> bool;
+        fn isGrayscale(&self) -> bool;
 
         /// Returns `true` if the image has a format that respects the alpha channel, otherwise returns `false`.
         #[rust_name = "has_alpha_channel"]
-        fn hasAlphaChannel(self: &QImage) -> bool;
+        fn hasAlphaChannel(&self) -> bool;
 
         /// Returns the height of the image.
-        fn height(self: &QImage) -> i32;
+        fn height(&self) -> i32;
 
         /// Mirrors of the image in the horizontal and/or the vertical direction depending on whether `horizontal` and `vertical` are set to `true` or `false`.
         ///
@@ -243,21 +243,21 @@ mod ffi {
             not(cxxqt_qt_version_at_least_6_13),
             not(cxxqt_qt_version_at_least_7)
         ))]
-        fn mirror(self: &mut QImage, horizontal: bool, vertical: bool);
+        fn mirror(&mut self, horizontal: bool, vertical: bool);
 
         /// Swaps the values of the red and blue components of all pixels, effectively converting an RGB image to an BGR image.
         ///
         /// This function was introduced in Qt 6.0.
         #[cfg(cxxqt_qt_version_at_least_6)]
         #[rust_name = "rgb_swap"]
-        fn rgbSwap(self: &mut QImage);
+        fn rgbSwap(&mut self);
 
         /// Returns the enclosing rectangle (`0`, `0`, `width()`, `height()`) of the image.
-        fn rect(self: &QImage) -> QRect;
+        fn rect(&self) -> QRect;
 
         /// Returns a copy of the image scaled to a rectangle with the given `width` and `height` according to the given `aspect_ratio_mode` and `transform_mode`.
         fn scaled(
-            self: &QImage,
+            &self,
             width: i32,
             height: i32,
             aspect_ratio_mode: AspectRatioMode,
@@ -270,7 +270,7 @@ mod ffi {
         ///
         /// If the given `height` is 0 or negative, a null image is returned.
         #[rust_name = "scaled_to_height"]
-        fn scaledToHeight(self: &QImage, height: i32, mode: TransformationMode) -> QImage;
+        fn scaledToHeight(&self, height: i32, mode: TransformationMode) -> QImage;
 
         /// Returns a scaled copy of the image. The returned image is scaled to the given `width` using the specified transformation `mode`.
         ///
@@ -278,7 +278,7 @@ mod ffi {
         ///
         /// If the given `width` is 0 or negative, a null image is returned.
         #[rust_name = "scaled_to_width"]
-        fn scaledToWidth(self: &QImage, width: i32, mode: TransformationMode) -> QImage;
+        fn scaledToWidth(&self, width: i32, mode: TransformationMode) -> QImage;
 
         /// Resizes the color table to contain `color_count` entries.
         ///
@@ -286,7 +286,7 @@ mod ffi {
         ///
         /// When the image is used, the color table must be large enough to have entries for all the pixel/index values present in the image, otherwise the results are undefined.
         #[rust_name = "set_color_count"]
-        fn setColorCount(self: &mut QImage, color_count: i32);
+        fn setColorCount(&mut self, color_count: i32);
 
         /// Sets the alpha channel of this image to the given `alpha_channel`.
         ///
@@ -294,31 +294,31 @@ mod ffi {
         ///
         /// If the image already has an alpha channel, the existing alpha channel is multiplied with the new one. If the image doesn't have an alpha channel it will be converted to a format that does.
         #[rust_name = "set_alpha_channel"]
-        fn setAlphaChannel(self: &mut QImage, alpha_channel: &QImage);
+        fn setAlphaChannel(&mut self, alpha_channel: &QImage);
 
         /// Sets the number of pixels that fit horizontally in a physical meter, to `x`.
         #[rust_name = "set_dots_per_meter_x"]
-        fn setDotsPerMeterX(self: &mut QImage, x: i32);
+        fn setDotsPerMeterX(&mut self, x: i32);
 
         /// Sets the number of pixels that fit vertically in a physical meter, to `y`.
         #[rust_name = "set_dots_per_meter_y"]
-        fn setDotsPerMeterY(self: &mut QImage, y: i32);
+        fn setDotsPerMeterY(&mut self, y: i32);
 
         /// Sets the number of pixels by which the image is intended to be offset by when positioning relative to other images, to `offset`.
         #[rust_name = "set_offset"]
-        fn setOffset(self: &mut QImage, offset: &QPoint);
+        fn setOffset(&mut self, offset: &QPoint);
 
         /// Sets the pixel color at (`x`, `y`) to `color`.
         ///
         /// If (`x`, `y`) is not a valid coordinate pair in the image, or the image's format is either monochrome or paletted, the result is undefined.
         #[rust_name = "set_pixel_color"]
-        fn setPixelColor(self: &mut QImage, x: i32, y: i32, color: &QColor);
+        fn setPixelColor(&mut self, x: i32, y: i32, color: &QColor);
 
         /// Returns the size of the image.
-        fn size(self: &QImage) -> QSize;
+        fn size(&self) -> QSize;
 
         /// Swaps image `other` with this image. This operation is very fast and never fails.
-        fn swap(self: &mut QImage, other: &mut QImage);
+        fn swap(&mut self, other: &mut QImage);
 
         /// Changes the format of the image to `format` without changing the data. Only works between formats of the same depth.
         ///
@@ -330,28 +330,28 @@ mod ffi {
         ///
         /// **Warning:** If the image is not detached, this will cause the data to be copied.
         #[rust_name = "reinterpret_as_format"]
-        fn reinterpretAsFormat(self: &mut QImage, format: QImageFormat) -> bool;
+        fn reinterpretAsFormat(&mut self, format: QImageFormat) -> bool;
 
         /// Returns the number of pixels by which the image is intended to be offset by when positioning relative to other images.
-        fn offset(self: &QImage) -> QPoint;
+        fn offset(&self) -> QPoint;
 
         /// Returns the color of the pixel at coordinates (`x`, `y`) as a `QColor`.
         ///
         /// If the position (`x`, `y`) is not valid, an invalid `QColor` is returned.
         #[rust_name = "pixel_color"]
-        fn pixelColor(self: &QImage, x: i32, y: i32) -> QColor;
+        fn pixelColor(&self, x: i32, y: i32) -> QColor;
 
         /// Returns the pixel index at (`x`, `y`).
         ///
         /// If the position (`x`, `y`) is not valid, or if the image is not a paletted image ([`depth`](Self::depth) > 8), the results are undefined.
         #[rust_name = "pixel_index"]
-        fn pixelIndex(self: &QImage, x: i32, y: i32) -> i32;
+        fn pixelIndex(&self, x: i32, y: i32) -> i32;
 
         /// Returns `true` if (`x`, `y`) is a valid coordinate pair within the image; otherwise returns `false`.
-        fn valid(self: &QImage, x: i32, y: i32) -> bool;
+        fn valid(&self, x: i32, y: i32) -> bool;
 
         /// Returns the width of the image.
-        fn width(self: &QImage) -> i32;
+        fn width(&self) -> i32;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/gui/qpainter.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainter.rs
@@ -150,42 +150,46 @@ mod ffi {
         LosslessImageRendering = 0x40,
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qpainter.h");
-        /// The `QPainter` class performs low-level painting on widgets and other paint devices.
-        ///
-        /// Qt Documentation: [QPainter](https://doc.qt.io/qt/qpainter.html#details)
-        type QPainter;
-        include!("cxx-qt-lib/qrect.h");
-        type QRect = crate::QRect;
-        include!("cxx-qt-lib/qrectf.h");
-        type QRectF = crate::QRectF;
-        include!("cxx-qt-lib/qpoint.h");
-        type QPoint = crate::QPoint;
+    extern "C++" {
+        include!("cxx-qt-lib/qcolor.h");
+        type QColor = crate::QColor;
+        include!("cxx-qt-lib/qfont.h");
+        type QFont = crate::QFont;
+        include!("cxx-qt-lib/qimage.h");
+        type QImage = crate::QImage;
         include!("cxx-qt-lib/qline.h");
         type QLine = crate::QLine;
         include!("cxx-qt-lib/qlinef.h");
         type QLineF = crate::QLineF;
-        include!("cxx-qt-lib/qcolor.h");
-        type QColor = crate::QColor;
-        include!("cxx-qt-lib/qimage.h");
-        type QImage = crate::QImage;
-        include!("cxx-qt-lib/qstring.h");
-        type QString = crate::QString;
         include!("cxx-qt-lib/qpainterpath.h");
         type QPainterPath = crate::QPainterPath;
-        include!("cxx-qt-lib/qfont.h");
-        type QFont = crate::QFont;
         include!("cxx-qt-lib/qpen.h");
         type QPen = crate::QPen;
+        include!("cxx-qt-lib/qpoint.h");
+        type QPoint = crate::QPoint;
         include!("cxx-qt-lib/qpolygon.h");
         type QPolygon = crate::QPolygon;
+        include!("cxx-qt-lib/qrect.h");
+        type QRect = crate::QRect;
+        include!("cxx-qt-lib/qrectf.h");
+        type QRectF = crate::QRectF;
         include!("cxx-qt-lib/qregion.h");
         type QRegion = crate::QRegion;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
         include!("cxx-qt-lib/core/qvector/qvector_QLine.h");
-        include!("cxx-qt-lib/core/qvector/qvector_QLineF.h");
         type QVector_QLine = crate::QVector<QLine>;
+        include!("cxx-qt-lib/core/qvector/qvector_QLineF.h");
         type QVector_QLineF = crate::QVector<QLineF>;
+
+        include!("cxx-qt-lib/qpainter.h");
+    }
+
+    unsafe extern "C++" {
+        /// The `QPainter` class performs low-level painting on widgets and other paint devices.
+        ///
+        /// Qt Documentation: [QPainter](https://doc.qt.io/qt/qpainter.html#details)
+        type QPainter;
 
         /// Returns the current background mode.
         #[rust_name = "background_mode"]

--- a/crates/cxx-qt-lib/src/gui/qpainter.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainter.rs
@@ -193,34 +193,34 @@ mod ffi {
 
         /// Returns the current background mode.
         #[rust_name = "background_mode"]
-        fn backgroundMode(self: &QPainter) -> BGMode;
+        fn backgroundMode(&self) -> BGMode;
 
         /// Returns the currently set brush origin.
         #[rust_name = "brush_origin"]
-        fn brushOrigin(self: &QPainter) -> QPoint;
+        fn brushOrigin(&self) -> QPoint;
 
         /// Returns the bounding rectangle of the current clip if there is a clip;
         /// otherwise returns an empty rectangle. Note that the clip region is given in logical coordinates.
         ///
         /// The bounding rectangle is not guaranteed to be tight.
         #[rust_name = "clip_bounding_rect_or_empty"]
-        fn clipBoundingRect(self: &QPainter) -> QRectF;
+        fn clipBoundingRect(&self) -> QRectF;
 
         /// Returns the current clip path in logical coordinates.
         ///
         /// **Warning:** `QPainter` does not store the combined clip explicitly as this is handled by the underlying [QPaintEngine](https://doc.qt.io/qt/qpaintengine.html), so the path is recreated on demand and transformed to the current logical coordinate system. This is potentially an expensive operation.
         #[rust_name = "clip_path"]
-        fn clipPath(self: &QPainter) -> QPainterPath;
+        fn clipPath(&self) -> QPainterPath;
 
         /// Returns the currently set clip region. Note that the clip region is given in logical coordinates.
         ///
         /// **Warning:** `QPainter` does not store the combined clip explicitly as this is handled by the underlying [QPaintEngine](https://doc.qt.io/qt/qpaintengine.html), so the path is recreated on demand and transformed to the current logical coordinate system. This is potentially an expensive operation.
         #[rust_name = "clip_region"]
-        fn clipRegion(self: &QPainter) -> QRegion;
+        fn clipRegion(&self) -> QRegion;
 
         /// Returns the current composition mode.
         #[rust_name = "composition_mode"]
-        fn compositionMode(self: &QPainter) -> QPainterCompositionMode;
+        fn compositionMode(&self) -> QPainterCompositionMode;
 
         /// Draws the arc defined by the rectangle beginning at (`x`, `y`) with the specified `width` and `height`,
         /// and the given `start_angle` and `span_angle`.
@@ -228,7 +228,7 @@ mod ffi {
         /// The `start_angle` and `span_angle` must be specified in 1/16th of a degree, i.e. a full circle equals 5760 (16 * 360). Positive values for the angles mean counter-clockwise while negative values mean the clockwise direction. Zero degrees is at the 3 o'clock position.
         #[rust_name = "draw_arc"]
         fn drawArc(
-            self: Pin<&mut QPainter>,
+            self: Pin<&mut Self>,
             x: i32,
             y: i32,
             width: i32,
@@ -242,7 +242,7 @@ mod ffi {
         /// The `start_angle` and `span_angle` must be specified in 1/16th of a degree, i.e. a full circle equals 5760 (16 * 360). Positive values for the angles mean counter-clockwise while negative values mean the clockwise direction. Zero degrees is at the 3 o'clock position.
         #[rust_name = "draw_chord"]
         fn drawChord(
-            self: Pin<Pin<&mut QPainter>>,
+            self: Pin<Pin<&mut Self>>,
             rectangle: &QRect,
             start_angle: i32,
             span_angle: i32,
@@ -252,11 +252,11 @@ mod ffi {
         ///
         /// If the supplied polygon is not convex, i.e. it contains at least one angle larger than 180 degrees, the results are undefined.
         #[rust_name = "draw_convex_polygon"]
-        fn drawConvexPolygon(self: Pin<&mut QPainter>, polygon: &QPolygon);
+        fn drawConvexPolygon(self: Pin<&mut Self>, polygon: &QPolygon);
 
         /// Draws the ellipse defined by the given `rectangle`.
         #[rust_name = "draw_ellipse"]
-        fn drawEllipse(self: Pin<&mut QPainter>, rectangle: &QRect);
+        fn drawEllipse(self: Pin<&mut Self>, rectangle: &QRect);
 
         /// Draws the given `image` into the given `rectangle`.
         ///
@@ -264,53 +264,53 @@ mod ffi {
         ///
         /// **Note:** See [Drawing High Resolution Versions of Pixmaps and Images](https://doc.qt.io/qt/qpainter.html#drawing-high-resolution-versions-of-pixmaps-and-images) on how this is affected by [QImage::devicePixelRatio](https://doc.qt.io/qt/qimage.html#devicePixelRatio)().
         #[rust_name = "draw_image"]
-        fn drawImage(self: Pin<&mut QPainter>, rectangle: &QRect, image: &QImage);
+        fn drawImage(self: Pin<&mut Self>, rectangle: &QRect, image: &QImage);
 
         /// Draws a line defined by `line`.
         #[rust_name = "draw_line"]
-        fn drawLine(self: Pin<&mut QPainter>, line: &QLine);
+        fn drawLine(self: Pin<&mut Self>, line: &QLine);
 
         /// Draws a line defined by `line`.
         #[rust_name = "draw_linef"]
-        fn drawLine(self: Pin<&mut QPainter>, line: &QLineF);
+        fn drawLine(self: Pin<&mut Self>, line: &QLineF);
 
         /// Draws the set of lines defined by the list `lines` using the current pen and brush.
         #[rust_name = "draw_lines"]
-        fn drawLines(self: Pin<&mut QPainter>, lines: &QVector_QLine);
+        fn drawLines(self: Pin<&mut Self>, lines: &QVector_QLine);
 
         /// Draws the set of lines defined by the list `lines` using the current pen and brush.
         #[rust_name = "draw_linefs"]
-        fn drawLines(self: Pin<&mut QPainter>, lines: &QVector_QLineF);
+        fn drawLines(self: Pin<&mut Self>, lines: &QVector_QLineF);
 
         /// Draws the given painter `path` using the current pen for outline and the current brush for filling.
         #[rust_name = "draw_path"]
-        fn drawPath(self: Pin<&mut QPainter>, path: &QPainterPath);
+        fn drawPath(self: Pin<&mut Self>, path: &QPainterPath);
 
         /// Draws a pie defined by the given `rectangle`, `start_angle` and `span_angle`.
         ///
         /// The `start_angle` and `span_angle` must be specified in 1/16th of a degree, i.e. a full circle equals 5760 (16 * 360). Positive values for the angles mean counter-clockwise while negative values mean the clockwise direction. Zero degrees is at the 3 o'clock position.
         #[rust_name = "draw_pie"]
-        fn drawPie(self: Pin<&mut QPainter>, rectangle: &QRectF, start_angle: i32, span_angle: i32);
+        fn drawPie(self: Pin<&mut Self>, rectangle: &QRectF, start_angle: i32, span_angle: i32);
 
         /// Draws a single point at the given `position` using the current pen's color.
         #[rust_name = "draw_point"]
-        fn drawPoint(self: Pin<&mut QPainter>, point: &QPoint);
+        fn drawPoint(self: Pin<&mut Self>, point: &QPoint);
 
         /// Draws the points in the vector `points`.
         #[rust_name = "draw_points"]
-        fn drawPoints(self: Pin<&mut QPainter>, points: &QPolygon);
+        fn drawPoints(self: Pin<&mut Self>, points: &QPolygon);
 
         /// Draws the polygon defined by the given `points` using the fill rule `fill_rule`.
         #[rust_name = "draw_polygon"]
-        fn drawPolygon(self: Pin<&mut QPainter>, points: &QPolygon, fill_rule: FillRule);
+        fn drawPolygon(self: Pin<&mut Self>, points: &QPolygon, fill_rule: FillRule);
 
         /// Draws the polyline defined by the given `points` using the current pen.
         #[rust_name = "draw_polyline"]
-        fn drawPolyline(self: Pin<&mut QPainter>, points: &QPolygon);
+        fn drawPolyline(self: Pin<&mut Self>, points: &QPolygon);
 
         /// Draws the current `rectangle` with the current pen and brush.
         #[rust_name = "draw_rect_f"]
-        fn drawRect(self: Pin<&mut QPainter>, rectangle: &QRectF);
+        fn drawRect(self: Pin<&mut Self>, rectangle: &QRectF);
 
         /// Draws the given rectangle `rect` with rounded corners.
         ///
@@ -319,7 +319,7 @@ mod ffi {
         /// A filled rectangle has a size of `rect.size()`. A stroked rectangle has a size of `rect.size()` plus the pen width.
         #[rust_name = "draw_rounded_rect"]
         fn drawRoundedRect(
-            self: Pin<&mut QPainter>,
+            self: Pin<&mut Self>,
             rect: &QRectF,
             x_radiu: f64,
             y_radius: f64,
@@ -334,40 +334,40 @@ mod ffi {
         ///
         /// Note: The y-position is used as the baseline of the font.
         #[rust_name = "draw_text"]
-        fn drawText(self: Pin<&mut QPainter>, position: &QPoint, text: &QString);
+        fn drawText(self: Pin<&mut Self>, position: &QPoint, text: &QString);
 
         /// Erases the area inside the given `rectangle`.
         #[rust_name = "erase_rect"]
-        fn eraseRect(self: Pin<&mut QPainter>, rectangle: &QRectF);
+        fn eraseRect(self: Pin<&mut Self>, rectangle: &QRectF);
 
         /// Fills the given `rectangle` with the `color` specified.
         #[rust_name = "fill_rect"]
-        fn fillRect(self: Pin<&mut QPainter>, rectangle: &QRectF, color: &QColor);
+        fn fillRect(self: Pin<&mut Self>, rectangle: &QRectF, color: &QColor);
 
         /// Returns the currently set font used for drawing text.
-        fn font(self: &QPainter) -> &QFont;
+        fn font(&self) -> &QFont;
 
         /// Returns `true` if clipping has been set; otherwise returns `false`.
         #[rust_name = "has_clipping"]
-        fn hasClipping(self: &QPainter) -> bool;
+        fn hasClipping(&self) -> bool;
 
         /// Returns `true` if [begin](https://doc.qt.io/qt/qpainter.html#begin)() has been called and [end](https://doc.qt.io/qt/qpainter.html#end)() has not yet been called; otherwise returns `false`.
         #[rust_name = "is_active"]
-        fn isActive(self: &QPainter) -> bool;
+        fn isActive(&self) -> bool;
 
         /// Returns the layout direction used by the painter when drawing text.
         #[rust_name = "layout_direction"]
-        fn layoutDirection(self: &QPainter) -> LayoutDirection;
+        fn layoutDirection(&self) -> LayoutDirection;
 
         /// Returns the opacity of the painter. The default value is 1.
-        fn opacity(self: &QPainter) -> f64;
+        fn opacity(&self) -> f64;
 
         /// Returns the painter's current pen.
-        fn pen(self: &QPainter) -> &QPen;
+        fn pen(&self) -> &QPen;
 
         /// Saves the current painter state (pushes the state onto a stack).
         /// A save() must be followed by a corresponding [restore](Self::restore)(); the [end](https://doc.qt.io/qt/qpainter.html#end)() function unwinds the stack.
-        fn save(self: Pin<&mut QPainter>);
+        fn save(self: Pin<&mut Self>);
 
         /// Sets the background mode of the painter to the given `mode`.
         ///
@@ -375,63 +375,63 @@ mod ffi {
         ///
         /// Note that in order to draw a bitmap or pixmap transparently, you must use [QPixmap::setMask](https://doc.qt.io/qt/qpixmap.html#setMask)().
         #[rust_name = "set_background_mode"]
-        fn setBackgroundMode(self: Pin<&mut QPainter>, mode: BGMode);
+        fn setBackgroundMode(self: Pin<&mut Self>, mode: BGMode);
 
         /// Enables clipping if `enable` is `true`, or disables clipping if `enable` is `false`.
         #[rust_name = "set_clipping"]
-        fn setClipping(self: Pin<&mut QPainter>, enable: bool);
+        fn setClipping(self: Pin<&mut Self>, enable: bool);
 
         /// Enables clipping, and sets the clip path for the painter to the given `path`, with the clip `operation`.
         ///
         /// Note that the clip path is specified in logical (painter) coordinates.
         #[rust_name = "set_clip_path"]
-        fn setClipPath(self: Pin<&mut QPainter>, path: &QPainterPath, operation: ClipOperation);
+        fn setClipPath(self: Pin<&mut Self>, path: &QPainterPath, operation: ClipOperation);
 
         /// Enables clipping, and sets the clip region to the given `rectangle` using the given clip `operation`.
         ///
         /// Note that the clip rectangle is specified in logical (painter) coordinates.
         #[rust_name = "set_clip_rect"]
-        fn setClipRect(self: Pin<&mut QPainter>, rectangle: &QRect, operation: ClipOperation);
+        fn setClipRect(self: Pin<&mut Self>, rectangle: &QRect, operation: ClipOperation);
 
         /// Sets the clip region to the given `region` using the specified clip `operation`.
         ///
         /// Note that the clip region is given in logical coordinates.
         #[rust_name = "set_clip_region"]
-        fn setClipRegion(self: Pin<&mut QPainter>, region: &QRegion, operation: ClipOperation);
+        fn setClipRegion(self: Pin<&mut Self>, region: &QRegion, operation: ClipOperation);
 
         /// Sets the composition mode to the given `mode`.
         ///
         /// Warning: Only a `QPainter` operating on a [`QImage`](crate::QImage) fully supports all composition modes. The RasterOp modes are supported for X11 as described in [`composition_mode`](Self::composition_mode).
         #[rust_name = "set_composition_mode"]
-        fn setCompositionMode(self: Pin<&mut QPainter>, mode: QPainterCompositionMode);
+        fn setCompositionMode(self: Pin<&mut Self>, mode: QPainterCompositionMode);
 
         /// Sets the painter's font to the given font.
         /// This font is used by subsequent [`draw_text`](Self::draw_text) functions. The text color is the same as the pen color.
         ///
         /// If you set a font that isn't available, Qt finds a close match. [`font`](Self::font) will return what you set using this function and [fontInfo](https://doc.qt.io/qt/qpainter.html#fontInfo)() returns the font actually being used (which may be the same).
         #[rust_name = "set_font"]
-        fn setFont(self: Pin<&mut QPainter>, font: &QFont);
+        fn setFont(self: Pin<&mut Self>, font: &QFont);
 
         /// Sets the layout direction used by the painter when drawing text, to the specified `direction`.
         #[rust_name = "set_layout_direction"]
-        fn setLayoutDirection(self: Pin<&mut QPainter>, direction: LayoutDirection);
+        fn setLayoutDirection(self: Pin<&mut Self>, direction: LayoutDirection);
 
         /// Sets the opacity of the painter to `opacity`. The value should be in the range 0.0 to 1.0,
         /// where 0.0 is fully transparent and 1.0 is fully opaque.
         ///
         /// Opacity set on the painter will apply to all drawing operations individually.
         #[rust_name = "set_opacity"]
-        fn setOpacity(self: Pin<&mut QPainter>, opacity: f64);
+        fn setOpacity(self: Pin<&mut Self>, opacity: f64);
 
         /// Sets the painter's pen to be the given `pen`.
         ///
         /// The `pen` defines how to draw lines and outlines, and it also defines the text color.
         #[rust_name = "set_pen"]
-        fn setPen(self: Pin<&mut QPainter>, pen: &QPen);
+        fn setPen(self: Pin<&mut Self>, pen: &QPen);
 
         /// Sets the given render `hint` on the painter if `on` is `true`; otherwise clears the render hint.
         #[rust_name = "set_render_hint"]
-        fn setRenderHint(self: Pin<&mut QPainter>, hint: QPainterRenderHint, on: bool);
+        fn setRenderHint(self: Pin<&mut Self>, hint: QPainterRenderHint, on: bool);
 
         /// Sets the painter's viewport rectangle to the given `rectangle`, and enables view transformations.
         ///
@@ -439,7 +439,7 @@ mod ffi {
         ///
         /// The default viewport rectangle is the same as the device's rectangle.
         #[rust_name = "set_viewport"]
-        fn setViewport(self: Pin<&mut QPainter>, rectangle: &QRect);
+        fn setViewport(self: Pin<&mut Self>, rectangle: &QRect);
 
         /// Sets the painter's window to the given `rectangle`, and enables view transformations.
         ///
@@ -447,34 +447,34 @@ mod ffi {
         ///
         /// The default window rectangle is the same as the device's rectangle.
         #[rust_name = "set_window"]
-        fn setWindow(self: Pin<&mut QPainter>, rectangle: &QRect);
+        fn setWindow(self: Pin<&mut Self>, rectangle: &QRect);
 
         /// Draws the outline (strokes) the path `path` with the pen specified by `pen`.
         #[rust_name = "stroke_path"]
-        fn strokePath(self: Pin<&mut QPainter>, path: &QPainterPath, pen: &QPen);
+        fn strokePath(self: Pin<&mut Self>, path: &QPainterPath, pen: &QPen);
 
         /// Returns `true` if `hint` is set; otherwise returns `false`.
         #[rust_name = "test_render_hint"]
-        fn testRenderHint(self: &QPainter, hint: QPainterRenderHint) -> bool;
+        fn testRenderHint(&self, hint: QPainterRenderHint) -> bool;
 
         /// Restores the current painter state (pops a saved state off the stack).
-        fn restore(self: Pin<&mut QPainter>);
+        fn restore(self: Pin<&mut Self>);
 
         /// Rotates the coordinate system clockwise. The given `angle` parameter is in degrees.
-        fn rotate(self: Pin<&mut QPainter>, angle: f64);
+        fn rotate(self: Pin<&mut Self>, angle: f64);
 
         /// Translates the coordinate system by the given `offset`; i.e. the given `offset` is added to points.
-        fn translate(self: Pin<&mut QPainter>, offset: &QPoint);
+        fn translate(self: Pin<&mut Self>, offset: &QPoint);
 
         /// Returns `true` if view transformation is enabled; otherwise returns `false`.
         #[rust_name = "view_transform_enabled"]
-        fn viewTransformEnabled(self: &QPainter) -> bool;
+        fn viewTransformEnabled(&self) -> bool;
 
         /// Returns the viewport rectangle.
-        fn viewport(self: &QPainter) -> QRect;
+        fn viewport(&self) -> QRect;
 
         /// Returns the window rectangle.
-        fn window(self: &QPainter) -> QRect;
+        fn window(&self) -> QRect;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/gui/qpainterpath.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainterpath.rs
@@ -41,52 +41,46 @@ mod ffi {
         ///
         /// The ellipse is composed of a clockwise curve, starting and finishing at zero degrees (the 3 o'clock position).
         #[rust_name = "add_ellipse"]
-        fn addEllipse(self: &mut QPainterPath, bounding_rectangle: &QRectF);
+        fn addEllipse(&mut self, bounding_rectangle: &QRectF);
 
         /// Adds the given `path` to this path as a closed subpath.
         #[rust_name = "add_path"]
-        fn addPath(self: &mut QPainterPath, path: &QPainterPath);
+        fn addPath(&mut self, path: &QPainterPath);
 
         /// Adds the given `polygon` to the path as an (unclosed) subpath.
         ///
         /// Note that the current position after the polygon has been added, is the last point in `polygon`. To draw a line back to the first point, use [`close_subpath`](Self::close_subpath).
         #[rust_name = "add_polygon"]
-        fn addPolygon(self: &mut QPainterPath, polygon: &QPolygonF);
+        fn addPolygon(&mut self, polygon: &QPolygonF);
 
         /// Adds the given `rectangle` to this path as a closed subpath.
         ///
         /// The `rectangle` is added as a clockwise set of lines. The painter path's current position after the `rectangle` has been added is at the top-left corner of the rectangle.
         #[rust_name = "add_rect"]
-        fn addRect(self: &mut QPainterPath, rectangle: &QRectF);
+        fn addRect(&mut self, rectangle: &QRectF);
 
         /// Adds the given `region` to the path by adding each rectangle in the region as a separate closed subpath.
         #[rust_name = "add_region"]
-        fn addRegion(self: &mut QPainterPath, region: &QRegion);
+        fn addRegion(&mut self, region: &QRegion);
 
         /// Adds the given rectangle `rect` with rounded corners to the path.
         ///
         /// The `x_radius` and `y_radius` arguments specify the radii of the ellipses defining the corners of the rounded rectangle. When `mode` is [`SizeMode::RelativeSize`], `x_radius` and `y_radius` are specified in percentage of half the rectangle's width and height respectively, and should be in the range 0.0 to 100.0.
         #[rust_name = "add_rounded_rect"]
-        fn addRoundedRect(
-            self: &mut QPainterPath,
-            rect: &QRectF,
-            x_radius: f64,
-            y_radius: f64,
-            mode: SizeMode,
-        );
+        fn addRoundedRect(&mut self, rect: &QRectF, x_radius: f64, y_radius: f64, mode: SizeMode);
 
         /// Creates a move to that lies on the arc that occupies the given `rectangle` at `angle`.
         ///
         /// Angles are specified in degrees. Clockwise arcs can be specified using negative angles.
         #[rust_name = "arc_move_to"]
-        fn arcMoveTo(self: &mut QPainterPath, rectangle: &QRectF, angle: f64);
+        fn arcMoveTo(&mut self, rectangle: &QRectF, angle: f64);
 
         /// Adds the given `text` to this path as a set of closed subpaths created from the `font` supplied.
         /// The subpaths are positioned so that the left end of the text's baseline lies at the specified `point`.
         ///
         /// Some fonts may yield overlapping subpaths and will require the [`FillRule::WindingFill`] fill rule for correct rendering.
         #[rust_name = "add_text"]
-        fn addText(self: &mut QPainterPath, point: &QPointF, font: &QFont, text: &QString);
+        fn addText(&mut self, point: &QPointF, font: &QFont, text: &QString);
 
         /// Creates an arc that occupies the given `rectangle`, beginning at the specified
         /// `start_angle` and extending `sweep_length` degrees counter-clockwise.
@@ -95,118 +89,118 @@ mod ffi {
         ///
         /// Note that this function connects the starting point of the arc to the current position if they are not already connected. After the arc has been added, the current position is the last point in arc. To draw a line back to the first point, use [`close_subpath`](Self::close_subpath).
         #[rust_name = "arc_to"]
-        fn arcTo(self: &mut QPainterPath, rectangle: &QRectF, start_angle: f64, sweep_length: f64);
+        fn arcTo(&mut self, rectangle: &QRectF, start_angle: f64, sweep_length: f64);
 
         /// Returns the bounding rectangle of this painter path as a rectangle with floating point precision.
         #[rust_name = "bounding_rect"]
-        fn boundingRect(self: &QPainterPath) -> QRectF;
+        fn boundingRect(&self) -> QRectF;
 
         /// Returns the number of elements allocated by the `QPainterPath`.
-        fn capacity(self: &QPainterPath) -> i32;
+        fn capacity(&self) -> i32;
 
         /// Clears the path elements stored.
         ///
         /// This allows the path to reuse previous memory allocations.
-        fn clear(self: &mut QPainterPath);
+        fn clear(&mut self);
 
         /// Closes the current subpath by drawing a line to the beginning of the subpath,
         /// automatically starting a new path. The current point of the new path is (0, 0).
         ///
         /// If the subpath does not contain any elements, this function does nothing.
         #[rust_name = "close_subpath"]
-        fn closeSubpath(self: &mut QPainterPath);
+        fn closeSubpath(&mut self);
 
         /// Connects the given `path` to this path by adding a line from the last element of
         /// this path to the first element of the given path.
         #[rust_name = "connect_path"]
-        fn connectPath(self: &mut QPainterPath, path: &QPainterPath);
+        fn connectPath(&mut self, path: &QPainterPath);
 
         /// Returns `true` if the given `point` is inside the path, otherwise returns `false`.
-        fn contains(self: &QPainterPath, point: &QPointF) -> bool;
+        fn contains(&self, point: &QPointF) -> bool;
 
         /// Returns the rectangle containing all the points and control points in this path.
         ///
         /// This function is significantly faster to compute than the exact [`bounding_rect`](Self::bounding_rect), and the returned rectangle is always a superset of the rectangle returned by [`bounding_rect`](Self::bounding_rect).
         #[rust_name = "control_point_rect"]
-        fn controlPointRect(self: &QPainterPath) -> QRectF;
+        fn controlPointRect(&self) -> QRectF;
 
         /// Adds a cubic Bezier curve between the current position and the given `end_point` using the control
         /// points specified by `c1`, and `c2`.
         /// After the curve is added, the current position is updated to be at the end point of the curve.
         #[rust_name = "cubic_to"]
-        fn cubicTo(self: &mut QPainterPath, c1: &QPointF, c2: &QPointF, end_point: &QPointF);
+        fn cubicTo(&mut self, c1: &QPointF, c2: &QPointF, end_point: &QPointF);
 
         /// Returns the current position of the path.
         #[rust_name = "current_position"]
-        fn currentPosition(self: &QPainterPath) -> QPointF;
+        fn currentPosition(&self) -> QPointF;
 
         /// Returns the number of path elements in the painter path.
         #[rust_name = "element_count"]
-        fn elementCount(self: &QPainterPath) -> i32;
+        fn elementCount(&self) -> i32;
 
         /// Returns the painter path's currently set fill rule.
         #[rust_name = "fill_rule"]
-        fn fillRule(self: &QPainterPath) -> FillRule;
+        fn fillRule(&self) -> FillRule;
 
         /// Returns a path which is the intersection of this path's fill area and `p`'s fill area.
         /// Bezier curves may be flattened to line segments due to numerical instability of doing bezier curve intersections.
-        fn intersected(self: &QPainterPath, p: &QPainterPath) -> QPainterPath;
+        fn intersected(&self, p: &QPainterPath) -> QPainterPath;
 
         /// Returns `true` if the current path intersects at any point the given path `p`.
         /// Also returns `true` if the current path contains or is contained by any part of `p`.
-        fn intersects(self: &QPainterPath, p: &QPainterPath) -> bool;
+        fn intersects(&self, p: &QPainterPath) -> bool;
 
         /// Returns `true` if either there are no elements in this path,
         /// or if the only element is a [MoveToElement](https://doc.qt.io/qt/qpainterpath.html#ElementType-enum); otherwise returns `false`.
         #[rust_name = "is_empty"]
-        fn isEmpty(self: &QPainterPath) -> bool;
+        fn isEmpty(&self) -> bool;
 
         /// Returns the length of the current path.
-        fn length(self: &QPainterPath) -> f64;
+        fn length(&self) -> f64;
 
         /// Adds a straight line from the current position to the given `end_point`.
         /// After the line is drawn, the current position is updated to be at the end point of the line.
         #[rust_name = "line_to"]
-        fn lineTo(self: &mut QPainterPath, end_point: &QPointF);
+        fn lineTo(&mut self, end_point: &QPointF);
 
         /// Adds a quadratic Bezier curve between the current position and the given `end_point`
         /// with the control point specified by `c`.
         /// After the curve is added, the current point is updated to be at the end point of the curve.
         #[rust_name = "quad_to"]
-        fn quadTo(self: &mut QPainterPath, c: &QPointF, endPoint: &QPointF);
+        fn quadTo(&mut self, c: &QPointF, endPoint: &QPointF);
 
         /// Reserves a given amount of elements in `QPainterPath`'s internal memory.
         ///
         /// Attempts to allocate memory for at least `size` elements.
-        fn reserve(self: &mut QPainterPath, size: i32);
+        fn reserve(&mut self, size: i32);
 
         /// Sets the fill rule of the painter path to the given `fill_rule`.
         #[rust_name = "set_fill_rule"]
-        fn setFillRule(self: &mut QPainterPath, fill_rule: FillRule);
+        fn setFillRule(&mut self, fill_rule: FillRule);
 
         /// Returns a simplified version of this path.
         /// This implies merging all subpaths that intersect, and returning a path containing no intersecting edges. Consecutive parallel lines will also be merged. The simplified path will always use the default fill rule, [`FillRule::OddEvenFill`]. Bezier curves may be flattened to line segments due to numerical instability of doing bezier curve intersections.
-        fn simplified(self: &QPainterPath) -> QPainterPath;
+        fn simplified(&self) -> QPainterPath;
 
         /// Returns a path which is `p`'s fill area subtracted from this path's fill area.
         ///
         /// Set operations on paths will treat the paths as areas. Non-closed paths will be treated as implicitly closed. Bezier curves may be flattened to line segments due to numerical instability of doing bezier curve intersections.
-        fn subtracted(self: &QPainterPath, painterpath: &QPainterPath) -> QPainterPath;
+        fn subtracted(&self, painterpath: &QPainterPath) -> QPainterPath;
 
         /// Translates all elements in the path by (`dx`, `dy`).
-        fn translate(self: &mut QPainterPath, dx: f64, dy: f64);
+        fn translate(&mut self, dx: f64, dy: f64);
 
         /// Returns a copy of the path that is translated by the given `offset`.
-        fn translated(self: &QPainterPath, offset: &QPointF) -> QPainterPath;
+        fn translated(&self, offset: &QPointF) -> QPainterPath;
 
         /// Creates and returns a reversed copy of the path.
         ///
         /// It is the order of the elements that is reversed: If a `QPainterPath` is composed by calling the moveTo(), lineTo() and cubicTo() functions in the specified order, the reversed copy is composed by calling cubicTo(), lineTo() and moveTo().
         #[rust_name = "to_reversed"]
-        fn toReversed(self: &QPainterPath) -> QPainterPath;
+        fn toReversed(&self) -> QPainterPath;
 
         /// Returns a path which is the union of this path's fill area and `p`'s fill area.
-        fn united(self: &QPainterPath, p: &QPainterPath) -> QPainterPath;
+        fn united(&self, p: &QPainterPath) -> QPainterPath;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/gui/qpainterpath.rs
+++ b/crates/cxx-qt-lib/src/gui/qpainterpath.rs
@@ -10,27 +10,31 @@ use std::mem::MaybeUninit;
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type FillRule = crate::FillRule;
         type SizeMode = crate::SizeMode;
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qpainterpath.h");
-        type QPainterPath = super::QPainterPath;
-        include!("cxx-qt-lib/qrectf.h");
-        type QRectF = crate::QRectF;
-        include!("cxx-qt-lib/qpointf.h");
-        type QPointF = crate::QPointF;
+    extern "C++" {
         include!("cxx-qt-lib/qfont.h");
         type QFont = crate::QFont;
-        include!("cxx-qt-lib/qstring.h");
-        type QString = crate::QString;
+        include!("cxx-qt-lib/qpointf.h");
+        type QPointF = crate::QPointF;
         include!("cxx-qt-lib/qpolygonf.h");
         type QPolygonF = crate::QPolygonF;
+        include!("cxx-qt-lib/qrectf.h");
+        type QRectF = crate::QRectF;
         include!("cxx-qt-lib/qregion.h");
         type QRegion = crate::QRegion;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
+
+        include!("cxx-qt-lib/qpainterpath.h");
+    }
+
+    unsafe extern "C++" {
+        type QPainterPath = super::QPainterPath;
 
         /// Creates an ellipse within the specified `bounding_rectangle` and adds it to the painter
         /// path as a closed subpath.

--- a/crates/cxx-qt-lib/src/gui/qpen.rs
+++ b/crates/cxx-qt-lib/src/gui/qpen.rs
@@ -11,20 +11,24 @@ use crate::{PenStyle, QColor};
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type PenStyle = crate::PenStyle;
         type PenCapStyle = crate::PenCapStyle;
         type PenJoinStyle = crate::PenJoinStyle;
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qpen.h");
-        type QPen = super::QPen;
+    extern "C++" {
         include!("cxx-qt-lib/qcolor.h");
         type QColor = crate::QColor;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
+
+        include!("cxx-qt-lib/qpen.h");
+    }
+
+    unsafe extern "C++" {
+        type QPen = super::QPen;
 
         /// Returns the pen's cap style.
         #[rust_name = "cap_style"]

--- a/crates/cxx-qt-lib/src/gui/qpen.rs
+++ b/crates/cxx-qt-lib/src/gui/qpen.rs
@@ -32,14 +32,14 @@ mod ffi {
 
         /// Returns the pen's cap style.
         #[rust_name = "cap_style"]
-        fn capStyle(self: &QPen) -> PenCapStyle;
+        fn capStyle(&self) -> PenCapStyle;
 
         /// Returns the color of this pen's brush.
-        fn color(self: &QPen) -> QColor;
+        fn color(&self) -> QColor;
 
         /// Returns the dash offset for the pen.
         #[rust_name = "dash_offset"]
-        fn dashOffset(self: &QPen) -> f64;
+        fn dashOffset(&self) -> f64;
 
         /// Returns `true` if the pen is cosmetic; otherwise returns `false`.
         ///
@@ -47,46 +47,46 @@ mod ffi {
         ///
         /// A zero width pen is cosmetic by default.
         #[rust_name = "is_comestic"]
-        fn isCosmetic(self: &QPen) -> bool;
+        fn isCosmetic(&self) -> bool;
 
         /// Returns `true` if the pen has a solid fill, otherwise `false`.
         #[rust_name = "is_solid"]
-        fn isSolid(self: &QPen) -> bool;
+        fn isSolid(&self) -> bool;
 
         /// Returns the pen's join style.
         #[rust_name = "join_style"]
-        fn joinStyle(self: &QPen) -> PenJoinStyle;
+        fn joinStyle(&self) -> PenJoinStyle;
 
         /// Returns the miter limit of the pen. The miter limit is only
         /// relevant when the join style is set to [`PenJoinStyle::MiterJoin`].
         #[rust_name = "miter_limit"]
-        fn miterLimit(self: &QPen) -> f64;
+        fn miterLimit(&self) -> f64;
 
         /// Sets the pen's cap style to the given `style`. The default value is [`PenCapStyle::SquareCap`].
         #[rust_name = "set_cap_style"]
-        fn setCapStyle(self: &mut QPen, style: PenCapStyle);
+        fn setCapStyle(&mut self, style: PenCapStyle);
 
         /// Sets the color of this pen's brush to the given `color`.
         #[rust_name = "set_color"]
-        fn setColor(self: &mut QPen, color: &QColor);
+        fn setColor(&mut self, color: &QColor);
 
         /// Sets this pen to cosmetic or non-cosmetic, depending on the value of `cosmetic`.
         #[rust_name = "set_cosmetic"]
-        fn setCosmetic(self: &mut QPen, cosmetic: bool);
+        fn setCosmetic(&mut self, cosmetic: bool);
 
         /// Sets the dash offset (the starting point on the dash pattern) for this pen to
         /// the `offset` specified. The offset is measured in terms of the units used to
         /// specify the dash pattern.
         #[rust_name = "set_dash_offset"]
-        fn setDashOffset(self: &mut QPen, offset: f64);
+        fn setDashOffset(&mut self, offset: f64);
 
         /// Sets the pen's join style to the given style. The default value is [`PenJoinStyle::BevelJoin`].
         #[rust_name = "set_join_style"]
-        fn setJoinStyle(self: &mut QPen, style: PenJoinStyle);
+        fn setJoinStyle(&mut self, style: PenJoinStyle);
 
         /// Sets the pen style to the given `style`.
         #[rust_name = "set_style"]
-        fn setStyle(self: &mut QPen, style: PenStyle);
+        fn setStyle(&mut self, style: PenStyle);
 
         /// Sets the miter limit of this pen to the given `limit`.
         ///
@@ -94,7 +94,7 @@ mod ffi {
         ///
         /// This value does only have effect when the pen style is set to [`PenJoinStyle::MiterJoin`]. The value is specified in units of the pen's width, e.g. a miter limit of 5 in width 10 is 50 pixels long. The default miter limit is 2, i.e. twice the pen width in pixels.
         #[rust_name = "set_miter_limit"]
-        fn setMiterLimit(self: &mut QPen, limit: f64);
+        fn setMiterLimit(&mut self, limit: f64);
 
         /// Sets the pen width to the given `width` in pixels with integer precision.
         ///
@@ -102,13 +102,13 @@ mod ffi {
         ///
         /// Setting a pen width with a negative value is not supported.
         #[rust_name = "set_width"]
-        fn setWidth(self: &mut QPen, width: i32);
+        fn setWidth(&mut self, width: i32);
 
         /// Returns the pen style.
-        fn style(self: &QPen) -> PenStyle;
+        fn style(&self) -> PenStyle;
 
         /// Returns the pen width with integer precision.
-        fn width(self: &QPen) -> i32;
+        fn width(&self) -> i32;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/gui/qpolygon.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.rs
@@ -12,26 +12,28 @@ use std::ops::{Deref, DerefMut};
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type FillRule = crate::FillRule;
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/core/qvector/qvector_QPoint.h");
-        type QVector_QPoint = crate::QVector<QPoint>;
-
+    extern "C++" {
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = crate::QPoint;
+        include!("cxx-qt-lib/qpolygonf.h");
+        #[allow(dead_code)]
+        type QPolygonF = crate::QPolygonF;
         include!("cxx-qt-lib/qrect.h");
         type QRect = crate::QRect;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
-        include!("cxx-qt-lib/qpolygonf.h");
-        #[allow(dead_code)]
-        type QPolygonF = crate::QPolygonF;
+        include!("cxx-qt-lib/core/qvector/qvector_QPoint.h");
+        type QVector_QPoint = crate::QVector<QPoint>;
 
         include!("cxx-qt-lib/qpolygon.h");
+    }
+
+    unsafe extern "C++" {
         type QPolygon = super::QPolygon;
 
         /// Returns the bounding rectangle of the polygon, or `QRect::new(0, 0, 0, 0)` if the polygon is empty.

--- a/crates/cxx-qt-lib/src/gui/qpolygon.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygon.rs
@@ -38,52 +38,52 @@ mod ffi {
 
         /// Returns the bounding rectangle of the polygon, or `QRect::new(0, 0, 0, 0)` if the polygon is empty.
         #[rust_name = "bounding_rect"]
-        fn boundingRect(self: &QPolygon) -> QRect;
+        fn boundingRect(&self) -> QRect;
 
         /// Returns `true` if the given `point` is inside the polygon according to the specified `fill_rule`; otherwise returns `false`.
         #[rust_name = "contains_point"]
-        fn containsPoint(self: &QPolygon, point: &QPoint, fill_rule: FillRule) -> bool;
+        fn containsPoint(&self, point: &QPoint, fill_rule: FillRule) -> bool;
 
         /// Returns a polygon which is the intersection of this polygon and `r`.
         ///
         /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
-        fn intersected(self: &QPolygon, r: &QPolygon) -> QPolygon;
+        fn intersected(&self, r: &QPolygon) -> QPolygon;
 
         /// Returns `true` if the current polygon intersects at any point the given polygon `p`.
         /// Also returns `true` if the current polygon contains or is contained by any part of `p`.
         ///
         /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
-        fn intersects(self: &QPolygon, p: &QPolygon) -> bool;
+        fn intersects(&self, p: &QPolygon) -> bool;
 
         /// Returns the point at the given `index`.
-        fn point(self: &QPolygon, index: i32) -> QPoint;
+        fn point(&self, index: i32) -> QPoint;
 
         /// Sets the point at the given `index` to the given `point`.
         #[rust_name = "set_point"]
-        fn setPoint(self: &mut QPolygon, index: i32, point: &QPoint);
+        fn setPoint(&mut self, index: i32, point: &QPoint);
 
         /// Returns a polygon which is `r` subtracted from this polygon.
         ///
         /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
-        fn subtracted(self: &QPolygon, r: &QPolygon) -> QPolygon;
+        fn subtracted(&self, r: &QPolygon) -> QPolygon;
 
         /// Returns this polygon as a polygon with floating point accuracy.
         ///
         /// This function was introduced in Qt 6.4.
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         #[rust_name = "to_polygonf"]
-        fn toPolygonF(self: &QPolygon) -> QPolygonF;
+        fn toPolygonF(&self) -> QPolygonF;
 
         /// Translates all points in the polygon by (`dx`, `dy`).
-        fn translate(self: &mut QPolygon, dx: i32, dy: i32);
+        fn translate(&mut self, dx: i32, dy: i32);
 
         /// Returns a copy of the polygon that is translated by (`dx`, `dy`).
-        fn translated(self: &QPolygon, dx: i32, dy: i32) -> QPolygon;
+        fn translated(&self, dx: i32, dy: i32) -> QPolygon;
 
         /// Returns a polygon which is the union of this polygon and `r`.
         ///
         /// Set operations on polygons, will treat the polygons as areas, and implicitly close the polygon.
-        fn united(self: &QPolygon, r: &QPolygon) -> QPolygon;
+        fn united(&self, r: &QPolygon) -> QPolygon;
     }
 
     #[namespace = "rust::cxxqt1"]

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.rs
@@ -38,48 +38,48 @@ mod ffi {
 
         /// Returns the bounding rectangle of the polygon, or QRectF(0, 0, 0, 0) if the polygon is empty.
         #[rust_name = "bounding_rect"]
-        fn boundingRect(self: &QPolygonF) -> QRectF;
+        fn boundingRect(&self) -> QRectF;
 
         /// Returns `true` if the given point is inside the polygon according to the specified `fill_rule`; otherwise returns `false`.
         #[rust_name = "contains_point"]
-        fn containsPoint(self: &QPolygonF, point: &QPointF, fill_rule: FillRule) -> bool;
+        fn containsPoint(&self, point: &QPointF, fill_rule: FillRule) -> bool;
 
         /// Returns a polygon which is the intersection of this polygon and `r`.
         ///
         /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
-        fn intersected(self: &QPolygonF, r: &QPolygonF) -> QPolygonF;
+        fn intersected(&self, r: &QPolygonF) -> QPolygonF;
 
         /// Returns `true` if the current polygon intersects at any point the given polygon `p`.
         /// Also returns `true` if the current polygon contains or is contained by any part of `p`.
         ///
         /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
-        fn intersects(self: &QPolygonF, p: &QPolygonF) -> bool;
+        fn intersects(&self, p: &QPolygonF) -> bool;
 
         /// Returns `true` if the polygon is closed; otherwise returns `false`.
         ///
         /// A polygon is said to be closed if its start point and end point are equal.
         #[rust_name = "is_closed"]
-        fn isClosed(self: &QPolygonF) -> bool;
+        fn isClosed(&self) -> bool;
 
         /// Returns a polygon which is `r` subtracted from this polygon.
         ///
         /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
-        fn subtracted(self: &QPolygonF, r: &QPolygonF) -> QPolygonF;
+        fn subtracted(&self, r: &QPolygonF) -> QPolygonF;
 
         /// Creates and returns a `QPolygon` by converting each [`QPointF`](crate::QPointF) to a [`QPoint`](crate::QPoint).
         #[rust_name = "to_polygon"]
-        fn toPolygon(self: &QPolygonF) -> QPolygon;
+        fn toPolygon(&self) -> QPolygon;
 
         /// Translates all points in the polygon by (`dx`, `dy`).
-        fn translate(self: &mut QPolygonF, dx: f64, dy: f64);
+        fn translate(&mut self, dx: f64, dy: f64);
 
         /// Returns a copy of the polygon that is translated by (`dx`, `dy`).
-        fn translated(self: &QPolygonF, dx: f64, dy: f64) -> QPolygonF;
+        fn translated(&self, dx: f64, dy: f64) -> QPolygonF;
 
         /// Returns a polygon which is the union of this polygon and `r`.
         ///
         /// Set operations on polygons will treat the polygons as areas. Non-closed polygons will be treated as implicitly closed.
-        fn united(self: &QPolygonF, r: &QPolygonF) -> QPolygonF;
+        fn united(&self, r: &QPolygonF) -> QPolygonF;
     }
 
     #[namespace = "rust::cxxqt1"]

--- a/crates/cxx-qt-lib/src/gui/qpolygonf.rs
+++ b/crates/cxx-qt-lib/src/gui/qpolygonf.rs
@@ -13,25 +13,27 @@ use crate::{QPointF, QPolygon, QRectF, QVector};
 #[cxx::bridge]
 mod ffi {
     #[namespace = "Qt"]
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qt.h");
         type FillRule = crate::FillRule;
     }
 
-    unsafe extern "C++" {
+    extern "C++" {
+        include!("cxx-qt-lib/qpointf.h");
+        type QPointF = crate::QPointF;
+        include!("cxx-qt-lib/qpolygon.h");
+        type QPolygon = crate::QPolygon;
+        include!("cxx-qt-lib/qrectf.h");
+        type QRectF = crate::QRectF;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
         include!("cxx-qt-lib/core/qvector/qvector_QPointF.h");
         type QVector_QPointF = crate::QVector<QPointF>;
 
-        include!("cxx-qt-lib/qpointf.h");
-        type QPointF = crate::QPointF;
-        include!("cxx-qt-lib/qrectf.h");
-        type QRectF = crate::QRectF;
-        include!("cxx-qt-lib/qpolygon.h");
-        type QPolygon = crate::QPolygon;
-        include!("cxx-qt-lib/qstring.h");
-        type QString = crate::QString;
-
         include!("cxx-qt-lib/qpolygonf.h");
+    }
+
+    unsafe extern "C++" {
         type QPolygonF = super::QPolygonF;
 
         /// Returns the bounding rectangle of the polygon, or QRectF(0, 0, 0, 0) if the polygon is empty.

--- a/crates/cxx-qt-lib/src/gui/qquaternion.rs
+++ b/crates/cxx-qt-lib/src/gui/qquaternion.rs
@@ -13,19 +13,19 @@ use crate::{QMatrix3x3, QVector3D, QVector4D};
 #[cxx::bridge]
 mod ffi {
     extern "C++" {
-        include!("cxx-qt-lib/qstring.h");
-        type QString = crate::QString;
-
         include!("cxx-qt-lib/qgenericmatrix.h");
         type QMatrix3x3 = crate::QMatrix3x3;
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
         include!("cxx-qt-lib/qvector3d.h");
         type QVector3D = crate::QVector3D;
         include!("cxx-qt-lib/qvector4d.h");
         type QVector4D = crate::QVector4D;
+
+        include!("cxx-qt-lib/qquaternion.h");
     }
 
     unsafe extern "C++" {
-        include!("cxx-qt-lib/qquaternion.h");
         type QQuaternion = super::QQuaternion;
 
         /// Returns the conjugate of this quaternion, which is (-x, -y, -z, scalar).

--- a/crates/cxx-qt-lib/src/gui/qregion.rs
+++ b/crates/cxx-qt-lib/src/gui/qregion.rs
@@ -43,45 +43,45 @@ mod ffi {
 
         /// Returns the bounding rectangle of this region. An empty region gives a rectangle that is [`QRect::is_null`].
         #[rust_name = "bounding_rect"]
-        fn boundingRect(self: &QRegion) -> QRect;
+        fn boundingRect(&self) -> QRect;
 
         /// Returns `true` if the region overlaps the rectangle `r`; otherwise returns `false`.
-        fn contains(self: &QRegion, r: &QRect) -> bool;
+        fn contains(&self, r: &QRect) -> bool;
 
         /// Returns a region which is the intersection of this region and `r`.
-        fn intersected(self: &QRegion, r: &QRegion) -> QRegion;
+        fn intersected(&self, r: &QRegion) -> QRegion;
 
         /// Returns `true` if the region is empty; otherwise returns `false`. An empty region is a region that contains no points.
         #[rust_name = "is_empty"]
-        fn isEmpty(self: &QRegion) -> bool;
+        fn isEmpty(&self) -> bool;
 
         /// Returns `true` if the region is empty; otherwise returns `false`. An empty region is a region that contains no points.
         /// This function is the same as [`is_empty`](Self::is_empty).
         #[rust_name = "is_null"]
-        fn isNull(self: &QRegion) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns the number of rectangles that this region is composed of.
         #[rust_name = "rect_count"]
-        fn rectCount(self: &QRegion) -> i32;
+        fn rectCount(&self) -> i32;
 
         /// Returns a region which is `r` subtracted from this region.
-        fn subtracted(self: &QRegion, r: &QRegion) -> QRegion;
+        fn subtracted(&self, r: &QRegion) -> QRegion;
 
         /// Translates the region `point.x()` along the x axis and `point.y()` along the y axis, relative to the current position.
         /// Positive values move the region to the right and down.
         ///
         /// Translates to the given `point`.
-        fn translate(self: &mut QRegion, point: &QPoint);
+        fn translate(&mut self, point: &QPoint);
 
         /// Returns a copy of the region that is translated `p.x()` along the x axis and `p.y()` along the y axis,
         /// relative to the current position. Positive values move the rectangle to the right and down.
-        fn translated(self: &QRegion, p: &QPoint) -> QRegion;
+        fn translated(&self, p: &QPoint) -> QRegion;
 
         /// Returns a region which is the union of this region and `r`.
-        fn united(self: &QRegion, r: &QRegion) -> QRegion;
+        fn united(&self, r: &QRegion) -> QRegion;
 
         /// Returns a region which is the exclusive or (XOR) of this region and `r`.
-        fn xored(self: &QRegion, r: &QRegion) -> QRegion;
+        fn xored(&self, r: &QRegion) -> QRegion;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/gui/qregion.rs
+++ b/crates/cxx-qt-lib/src/gui/qregion.rs
@@ -23,6 +23,15 @@ mod ffi {
         type FillRule = crate::FillRule;
     }
 
+    extern "C++" {
+        include!("cxx-qt-lib/qpoint.h");
+        type QPoint = crate::QPoint;
+        include!("cxx-qt-lib/qpolygon.h");
+        type QPolygon = crate::QPolygon;
+        include!("cxx-qt-lib/qrect.h");
+        type QRect = crate::QRect;
+    }
+
     #[namespace = "rust::cxxqtlib1"]
     extern "C++" {
         include!("cxx-qt-lib/qregion.h");
@@ -31,15 +40,6 @@ mod ffi {
 
     unsafe extern "C++" {
         type QRegion = super::QRegion;
-
-        include!("cxx-qt-lib/qrect.h");
-        type QRect = crate::QRect;
-
-        include!("cxx-qt-lib/qpoint.h");
-        type QPoint = crate::QPoint;
-
-        include!("cxx-qt-lib/qpolygon.h");
-        type QPolygon = crate::QPolygon;
 
         /// Returns the bounding rectangle of this region. An empty region gives a rectangle that is [`QRect::is_null`].
         #[rust_name = "bounding_rect"]

--- a/crates/cxx-qt-lib/src/gui/qvector2d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.rs
@@ -31,46 +31,46 @@ mod ffi {
 
         /// Returns `true` if the x and y coordinates are set to 0.0, otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QVector2D) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns the length of the vector from the origin.
-        fn length(self: &QVector2D) -> f32;
+        fn length(&self) -> f32;
 
         /// Returns the squared length of the vector from the origin.
         /// This is equivalent to the dot product of the vector with itself.
         #[rust_name = "length_squared"]
-        fn lengthSquared(self: &QVector2D) -> f32;
+        fn lengthSquared(&self) -> f32;
 
         /// Normalizes the current vector in place. Nothing happens
         /// if this vector is a null vector or the length of the vector is very close to 1.
-        fn normalize(self: &mut QVector2D);
+        fn normalize(&mut self);
 
         /// Returns the normalized unit vector form of this vector.
         ///
         /// If this vector is null, then a null vector is returned.
         /// If the length of the vector is very close to 1, then the vector will be returned as-is.
         /// Otherwise the normalized form of the vector of length 1 will be returned.
-        fn normalized(self: &QVector2D) -> QVector2D;
+        fn normalized(&self) -> QVector2D;
 
         /// Sets the x coordinate of this point to the given finite `x` coordinate.
         #[rust_name = "set_x"]
-        fn setX(self: &mut QVector2D, x: f32);
+        fn setX(&mut self, x: f32);
         /// Sets the y coordinate of this point to the given finite `y` coordinate.
         #[rust_name = "set_y"]
-        fn setY(self: &mut QVector2D, y: f32);
+        fn setY(&mut self, y: f32);
 
         // From trait is more idiomatic to Rust and implemented in QPoint and QPointF
         #[doc(hidden)]
         #[rust_name = "to_point"]
-        fn toPoint(self: &QVector2D) -> QPoint;
+        fn toPoint(&self) -> QPoint;
         #[doc(hidden)]
         #[rust_name = "to_pointf"]
-        fn toPointF(self: &QVector2D) -> QPointF;
+        fn toPointF(&self) -> QPointF;
 
         /// Returns the x coordinate of this point.
-        fn x(self: &QVector2D) -> f32;
+        fn x(&self) -> f32;
         /// Returns the y coordinate of this point.
-        fn y(self: &QVector2D) -> f32;
+        fn y(&self) -> f32;
 
     }
 

--- a/crates/cxx-qt-lib/src/gui/qvector2d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector2d.rs
@@ -11,20 +11,23 @@ use crate::{QPoint, QPointF, QVector3D, QVector4D};
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = crate::QPoint;
         include!("cxx-qt-lib/qpointf.h");
         type QPointF = crate::QPointF;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
-
-        include!("cxx-qt-lib/qvector2d.h");
-        type QVector2D = super::QVector2D;
         include!("cxx-qt-lib/qvector3d.h");
         type QVector3D = crate::QVector3D;
         include!("cxx-qt-lib/qvector4d.h");
         type QVector4D = crate::QVector4D;
+
+        include!("cxx-qt-lib/qvector2d.h");
+    }
+
+    unsafe extern "C++" {
+        type QVector2D = super::QVector2D;
 
         /// Returns `true` if the x and y coordinates are set to 0.0, otherwise returns `false`.
         #[rust_name = "is_null"]

--- a/crates/cxx-qt-lib/src/gui/qvector3d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.rs
@@ -31,59 +31,59 @@ mod ffi {
 
         /// Returns `true` if the x, y, and z coordinates are set to 0.0, otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QVector3D) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns the length of the vector from the origin.
-        fn length(self: &QVector3D) -> f32;
+        fn length(&self) -> f32;
 
         /// Returns the squared length of the vector from the origin.
         /// This is equivalent to the dot product of the vector with itself.
         #[rust_name = "length_squared"]
-        fn lengthSquared(self: &QVector3D) -> f32;
+        fn lengthSquared(&self) -> f32;
 
         /// Normalizes the currect vector in place. Nothing happens if this vector is a null vector
         /// or the length of the vector is very close to 1.
-        fn normalize(self: &mut QVector3D);
+        fn normalize(&mut self);
 
         /// Returns the normalized unit vector form of this vector.
         ///
         /// If this vector is null, then a null vector is returned.
         /// If the length of the vector is very close to 1, then the vector will be returned as-is.
         /// Otherwise the normalized form of the vector of length 1 will be returned.
-        fn normalized(self: &QVector3D) -> QVector3D;
+        fn normalized(&self) -> QVector3D;
 
         /// Sets the x coordinate of this point to the given finite `x` coordinate.
         #[rust_name = "set_x"]
-        fn setX(self: &mut QVector3D, x: f32);
+        fn setX(&mut self, x: f32);
         /// Sets the y coordinate of this point to the given finite `y` coordinate.
         #[rust_name = "set_y"]
-        fn setY(self: &mut QVector3D, y: f32);
+        fn setY(&mut self, y: f32);
         /// Sets the z coordinate of this point to the given finite `z` coordinate.
         #[rust_name = "set_z"]
-        fn setZ(self: &mut QVector3D, z: f32);
+        fn setZ(&mut self, z: f32);
 
         // From trait is more idiomatic to Rust and implemented in QPoint and QPointF
         #[doc(hidden)]
         #[rust_name = "to_point"]
-        fn toPoint(self: &QVector3D) -> QPoint;
+        fn toPoint(&self) -> QPoint;
         #[doc(hidden)]
         #[rust_name = "to_pointf"]
-        fn toPointF(self: &QVector3D) -> QPointF;
+        fn toPointF(&self) -> QPointF;
 
         /// Returns the 2D vector form of this 3D vector, dropping the z coordinate.
         #[rust_name = "to_vector2d"]
-        fn toVector2D(self: &QVector3D) -> QVector2D;
+        fn toVector2D(&self) -> QVector2D;
 
         /// Returns the 4D form of this 3D vector, with the w coordinate set to zero.
         #[rust_name = "to_vector4d"]
-        fn toVector4D(self: &QVector3D) -> QVector4D;
+        fn toVector4D(&self) -> QVector4D;
 
         /// Returns the x coordinate of this point.
-        fn x(self: &QVector3D) -> f32;
+        fn x(&self) -> f32;
         /// Returns the y coordinate of this point.
-        fn y(self: &QVector3D) -> f32;
+        fn y(&self) -> f32;
         /// Returns the z coordinate of this point.
-        fn z(self: &QVector3D) -> f32;
+        fn z(&self) -> f32;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/gui/qvector3d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector3d.rs
@@ -11,20 +11,23 @@ use crate::{QPoint, QPointF, QVector2D, QVector4D};
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = crate::QPoint;
         include!("cxx-qt-lib/qpointf.h");
         type QPointF = crate::QPointF;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
-
         include!("cxx-qt-lib/qvector2d.h");
         type QVector2D = crate::QVector2D;
-        include!("cxx-qt-lib/qvector3d.h");
-        type QVector3D = super::QVector3D;
         include!("cxx-qt-lib/qvector4d.h");
         type QVector4D = crate::QVector4D;
+
+        include!("cxx-qt-lib/qvector3d.h");
+    }
+
+    unsafe extern "C++" {
+        type QVector3D = super::QVector3D;
 
         /// Returns `true` if the x, y, and z coordinates are set to 0.0, otherwise returns `false`.
         #[rust_name = "is_null"]

--- a/crates/cxx-qt-lib/src/gui/qvector4d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.rs
@@ -11,19 +11,22 @@ use crate::{QPoint, QPointF, QVector2D, QVector3D};
 
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
         include!("cxx-qt-lib/qpoint.h");
         type QPoint = crate::QPoint;
         include!("cxx-qt-lib/qpointf.h");
         type QPointF = crate::QPointF;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
-
         include!("cxx-qt-lib/qvector2d.h");
         type QVector2D = crate::QVector2D;
         include!("cxx-qt-lib/qvector3d.h");
         type QVector3D = crate::QVector3D;
+
         include!("cxx-qt-lib/qvector4d.h");
+    }
+
+    unsafe extern "C++" {
         type QVector4D = super::QVector4D;
 
         /// Returns `true` if the x, y, z, and w coordinates are set to 0.0, otherwise returns `false`.

--- a/crates/cxx-qt-lib/src/gui/qvector4d.rs
+++ b/crates/cxx-qt-lib/src/gui/qvector4d.rs
@@ -31,67 +31,67 @@ mod ffi {
 
         /// Returns `true` if the x, y, z, and w coordinates are set to 0.0, otherwise returns `false`.
         #[rust_name = "is_null"]
-        fn isNull(self: &QVector4D) -> bool;
+        fn isNull(&self) -> bool;
 
         /// Returns the length of the vector from the origin.
-        fn length(self: &QVector4D) -> f32;
+        fn length(&self) -> f32;
 
         /// Returns the squared length of the vector from the origin.
         /// This is equivalent to the dot product of the vector with itself.
         #[rust_name = "length_squared"]
-        fn lengthSquared(self: &QVector4D) -> f32;
+        fn lengthSquared(&self) -> f32;
 
         /// Normalizes the current vector in place. Nothing happens
         /// if this vector is a null vector or the length of the vector is very close to 1.
-        fn normalize(self: &mut QVector4D);
+        fn normalize(&mut self);
 
         /// Returns the normalized unit vector form of this vector.
         ///
         /// If this vector is null, then a null vector is returned.
         /// If the length of the vector is very close to 1, then the vector will be returned as-is.
         /// Otherwise the normalized form of the vector of length 1 will be returned.
-        fn normalized(self: &QVector4D) -> QVector4D;
+        fn normalized(&self) -> QVector4D;
 
         /// Sets the w coordinate of this point to the given finite `w` coordinate.
         #[rust_name = "set_w"]
-        fn setW(self: &mut QVector4D, w: f32);
+        fn setW(&mut self, w: f32);
         /// Sets the x coordinate of this point to the given finite `x` coordinate.
         #[rust_name = "set_x"]
-        fn setX(self: &mut QVector4D, x: f32);
+        fn setX(&mut self, x: f32);
         /// Sets the y coordinate of this point to the given finite `y` coordinate.
         #[rust_name = "set_y"]
-        fn setY(self: &mut QVector4D, y: f32);
+        fn setY(&mut self, y: f32);
         /// Sets the z coordinate of this point to the given finite `z` coordinate.
         #[rust_name = "set_z"]
-        fn setZ(self: &mut QVector4D, z: f32);
+        fn setZ(&mut self, z: f32);
 
         // From trait is more idiomatic to Rust and implemented in QPoint and QPointF
         #[doc(hidden)]
         #[rust_name = "to_point"]
-        fn toPoint(self: &QVector4D) -> QPoint;
+        fn toPoint(&self) -> QPoint;
         #[doc(hidden)]
         #[rust_name = "to_pointf"]
-        fn toPointF(self: &QVector4D) -> QPointF;
+        fn toPointF(&self) -> QPointF;
 
         /// Returns the 2D vector form of this 4D vector,
         /// dividing the x and y coordinates by the w coordinate and dropping the z coordinate.
         /// Returns a null vector if w is zero.
         #[rust_name = "to_vector_2d_affine"]
-        fn toVector2DAffine(self: &QVector4D) -> QVector2D;
+        fn toVector2DAffine(&self) -> QVector2D;
         /// Returns the 3D vector form of this 4D vector,
         /// dividing the x, y, and z coordinates by the w coordinate.
         /// Returns a null vector if w is zero.
         #[rust_name = "to_vector_3d_affine"]
-        fn toVector3DAffine(self: &QVector4D) -> QVector3D;
+        fn toVector3DAffine(&self) -> QVector3D;
 
         /// Returns the w coordinate of this point.
-        fn w(self: &QVector4D) -> f32;
+        fn w(&self) -> f32;
         /// Returns the x coordinate of this point.
-        fn x(self: &QVector4D) -> f32;
+        fn x(&self) -> f32;
         /// Returns the y coordinate of this point.
-        fn y(self: &QVector4D) -> f32;
+        fn y(&self) -> f32;
         /// Returns the z coordinate of this point.
-        fn z(self: &QVector4D) -> f32;
+        fn z(&self) -> f32;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.rs
+++ b/crates/cxx-qt-lib/src/qml/qqmlapplicationengine.rs
@@ -10,12 +10,25 @@ mod ffi {
         type QByteArray = crate::QByteArray;
         include!("cxx-qt-lib/qmap.h");
         type QMap_QString_QVariant = crate::QMap<crate::QMapPair_QString_QVariant>;
+        include!("cxx-qt-lib/qqmlengine.h");
+        type QQmlEngine = crate::QQmlEngine;
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = crate::QStringList;
         include!("cxx-qt-lib/qurl.h");
         type QUrl = crate::QUrl;
+
+        include!("cxx-qt-lib/qqmlapplicationengine.h");
+    }
+
+    unsafe extern "C++Qt" {
+        /// `QQmlApplicationEngine` provides a convenient way to load an application from a single QML file.
+        ///
+        /// Qt Documentation: [QQmlApplicationEngine](https://doc.qt.io/qt/qqmlapplicationengine.html#details)
+        #[qobject]
+        #[base = QQmlEngine]
+        type QQmlApplicationEngine;
 
         /// Adds `path` as a directory where the engine searches for installed modules in a URL-based directory structure.
         #[rust_name = "add_import_path"]
@@ -71,19 +84,7 @@ mod ffi {
         /// Sets `path` as string for storing offline user data.
         #[rust_name = "set_offline_storage_path"]
         fn setOfflineStoragePath(self: Pin<&mut QQmlApplicationEngine>, dir: &QString);
-    }
 
-    unsafe extern "C++Qt" {
-        include!("cxx-qt-lib/qqmlapplicationengine.h");
-        /// `QQmlApplicationEngine` provides a convenient way to load an application from a single QML file.
-        ///
-        /// Qt Documentation: [QQmlApplicationEngine](https://doc.qt.io/qt/qqmlapplicationengine.html#details)
-        #[qobject]
-        #[base = QQmlEngine]
-        type QQmlApplicationEngine;
-    }
-
-    unsafe extern "C++Qt" {
         /// This signal is emitted when an object finishes loading. If loading was successful, `object` contains a pointer to the loaded object, otherwise the pointer is null.
         ///
         /// The `url` to the component the `object` came from is also provided.
@@ -108,11 +109,6 @@ mod ffi {
         #[rust_name = "object_creation_failed"]
         #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_4))]
         fn objectCreationFailed(self: Pin<&mut QQmlApplicationEngine>, url: &QUrl);
-    }
-
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qqmlengine.h");
-        type QQmlEngine = crate::QQmlEngine;
     }
 
     #[namespace = "rust::cxxqtlib1"]

--- a/crates/cxx-qt-lib/src/quickcontrols/qquickstyle.rs
+++ b/crates/cxx-qt-lib/src/quickcontrols/qquickstyle.rs
@@ -5,15 +5,15 @@
 
 #[cxx_qt::bridge]
 mod ffi {
-    unsafe extern "C++" {
+    extern "C++" {
+        include!("cxx-qt-lib/qstring.h");
+        type QString = crate::QString;
+
         include!("cxx-qt-lib/qquickstyle.h");
         /// The `QQuickStyle` class allows configuring the application style.
         ///
         /// Qt Documentation: [QQuickStyle](https://doc.qt.io/qt/qquickstyle.html#details)
         type QQuickStyle;
-
-        include!("cxx-qt-lib/qstring.h");
-        type QString = crate::QString;
     }
 
     #[namespace = "rust::cxxqtlib1"]


### PR DESCRIPTION
This is a purely syntactic change for the sake of readability.