### PR TITLE
Implement `PartialEq<[u8]>` for QByteArray and `PartialEq<str>` for QString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.8.1...HEAD)
 
+### Added
+
+- `QByteArray` now implements `PartialEq` for `[u8]` and `Vec<u8>`.
+- `QString` now implements `PartialEq` for `str` and `String`.
+
 ## [0.8.1](https://github.com/KDAB/cxx-qt/compare/v0.8.0...v0.8.1) - 2026-02-16
 
 ### Fixed

--- a/crates/cxx-qt-lib/src/core/qbytearray.rs
+++ b/crates/cxx-qt-lib/src/core/qbytearray.rs
@@ -200,13 +200,66 @@ impl Default for QByteArray {
     }
 }
 
-impl std::cmp::PartialEq for QByteArray {
+impl PartialEq for QByteArray {
     fn eq(&self, other: &Self) -> bool {
         ffi::qbytearray_eq(self, other)
     }
 }
 
-impl std::cmp::Eq for QByteArray {}
+impl Eq for QByteArray {}
+
+impl PartialEq<[u8]> for QByteArray {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.as_slice() == other
+    }
+}
+impl PartialEq<QByteArray> for [u8] {
+    fn eq(&self, other: &QByteArray) -> bool {
+        other == self
+    }
+}
+impl PartialEq<&[u8]> for QByteArray {
+    fn eq(&self, other: &&[u8]) -> bool {
+        self == *other
+    }
+}
+impl PartialEq<QByteArray> for &[u8] {
+    fn eq(&self, other: &QByteArray) -> bool {
+        other == self
+    }
+}
+
+impl<const N: usize> PartialEq<[u8; N]> for QByteArray {
+    fn eq(&self, other: &[u8; N]) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+impl<const N: usize> PartialEq<QByteArray> for [u8; N] {
+    fn eq(&self, other: &QByteArray) -> bool {
+        other == self
+    }
+}
+impl<const N: usize> PartialEq<&[u8; N]> for QByteArray {
+    fn eq(&self, other: &&[u8; N]) -> bool {
+        self == *other
+    }
+}
+impl<const N: usize> PartialEq<QByteArray> for &[u8; N] {
+    fn eq(&self, other: &QByteArray) -> bool {
+        other == self
+    }
+}
+
+impl PartialEq<Vec<u8>> for QByteArray {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+impl PartialEq<QByteArray> for Vec<u8> {
+    fn eq(&self, other: &QByteArray) -> bool {
+        other == self
+    }
+}
 
 impl fmt::Display for QByteArray {
     /// Convert the `QByteArray` to a Rust string.
@@ -537,6 +590,16 @@ mod tests {
         let encoded = qbytearray.to_base64(options);
         let decoded = QByteArray::from_base64_encoding(&encoded, options);
         assert_eq!(decoded, Ok(qbytearray));
+    }
+
+    #[test]
+    fn qbytearray_eq_slice() {
+        assert_eq!(QByteArray::from("KDAB"), b"KDAB");
+    }
+
+    #[test]
+    fn qbytearray_eq_vec() {
+        assert_eq!(QByteArray::from("KDAB"), b"KDAB".to_owned());
     }
 
     #[cfg(feature = "bytes")]

--- a/crates/cxx-qt-lib/src/core/qstring.rs
+++ b/crates/cxx-qt-lib/src/core/qstring.rs
@@ -247,6 +247,39 @@ impl PartialEq for QString {
 
 impl Eq for QString {}
 
+impl PartialEq<str> for QString {
+    fn eq(&self, other: &str) -> bool {
+        self.as_slice().iter().copied().eq(other.encode_utf16())
+    }
+}
+impl PartialEq<QString> for str {
+    fn eq(&self, other: &QString) -> bool {
+        other == self
+    }
+}
+
+impl PartialEq<&str> for QString {
+    fn eq(&self, other: &&str) -> bool {
+        self == *other
+    }
+}
+impl PartialEq<QString> for &str {
+    fn eq(&self, other: &QString) -> bool {
+        other == self
+    }
+}
+
+impl PartialEq<String> for QString {
+    fn eq(&self, other: &String) -> bool {
+        self == other.as_str()
+    }
+}
+impl PartialEq<QString> for String {
+    fn eq(&self, other: &QString) -> bool {
+        other == self
+    }
+}
+
 impl PartialOrd for QString {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
@@ -505,6 +538,16 @@ impl<'de> serde::Deserialize<'de> for QString {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn qstring_eq_str() {
+        assert_eq!(QString::from("KDAB"), "KDAB");
+    }
+
+    #[test]
+    fn qstring_eq_string() {
+        assert_eq!(QString::from("KDAB"), "KDAB".to_owned());
+    }
 
     #[cfg(feature = "serde")]
     #[test]

--- a/tests/qt_types_standalone/rust/src/qcoreapplication.rs
+++ b/tests/qt_types_standalone/rust/src/qcoreapplication.rs
@@ -27,5 +27,5 @@ fn construct_qcoreapplication() -> cxx::UniquePtr<QCoreApplication> {
 }
 
 fn read_qcoreapplication(app: &QCoreApplication) -> bool {
-    String::from(&app.application_name()) == "kdab"
+    app.application_name() == "kdab"
 }

--- a/tests/qt_types_standalone/rust/src/qguiapplication.rs
+++ b/tests/qt_types_standalone/rust/src/qguiapplication.rs
@@ -27,5 +27,5 @@ fn construct_qguiapplication() -> cxx::UniquePtr<QGuiApplication> {
 }
 
 fn read_qguiapplication(app: &QGuiApplication) -> bool {
-    String::from(&app.application_name()) == "kdab"
+    app.application_name() == "kdab"
 }

--- a/tests/qt_types_standalone/rust/src/qhash.rs
+++ b/tests/qt_types_standalone/rust/src/qhash.rs
@@ -40,7 +40,7 @@ fn read_qhash_qstring_qvariant(h: &QHash<QHashPair_QString_QVariant>) -> bool {
         None => false,
     };
     let value_qt = match h.get_or_default(&QString::from("Qt")).value::<QString>() {
-        Some(value) => String::from(&value) == "Rust",
+        Some(value) => value == "Rust",
         _ => false,
     };
 

--- a/tests/qt_types_standalone/rust/src/qmap.rs
+++ b/tests/qt_types_standalone/rust/src/qmap.rs
@@ -42,7 +42,7 @@ fn read_qmap_qstring_qvariant(h: &QMap<QMapPair_QString_QVariant>) -> bool {
     let value_qt = h
         .get_or_default(&QString::from("Qt"))
         .value::<QString>()
-        .map_or_else(|| false, |value| String::from(&value) == "Rust");
+        .map_or_else(|| false, |value| value == "Rust");
 
     h.contains(&QString::from("kdab"))
         && value_kdab

--- a/tests/qt_types_standalone/rust/src/qstring.rs
+++ b/tests/qt_types_standalone/rust/src/qstring.rs
@@ -33,7 +33,7 @@ fn construct_qstring(slice: bool) -> QString {
 }
 
 fn read_qstring(s: &cxx_qt_lib::QString) -> bool {
-    String::from(s) == "String constructed by C++"
+    s == "String constructed by C++"
 }
 
 fn modify_qstring(mut s: core::pin::Pin<&mut cxx_qt_lib::QString>) {
@@ -46,11 +46,11 @@ fn can_handle_qstring_change() -> bool {
 
     let short_s = "Short string";
     let mut short_s_ptr = QString::from(short_s);
-    assert!(String::from(&short_s_ptr) == short_s);
+    assert_eq!(short_s_ptr, short_s);
 
     short_s_ptr = long_s_ptr;
 
-    String::from(&short_s_ptr) == long_s
+    short_s_ptr == long_s
 }
 
 fn clone_qstring(s: &QString) -> QString {

--- a/tests/qt_types_standalone/rust/src/qurl.rs
+++ b/tests/qt_types_standalone/rust/src/qurl.rs
@@ -28,7 +28,7 @@ fn construct_qurl(test: &QString) -> QUrl {
 }
 
 fn read_qurl(u: &QUrl, test: &QString) -> bool {
-    u.to_string() == String::from(test)
+    u.to_string() == *test
 }
 
 fn clone_qurl(u: &QUrl) -> QUrl {

--- a/tests/qt_types_standalone/rust/src/qvariant.rs
+++ b/tests/qt_types_standalone/rust/src/qvariant.rs
@@ -170,7 +170,7 @@ fn read_qvariant(v: &cxx_qt_lib::QVariant, test: VariantTest) -> bool {
             None => false,
         },
         VariantTest::QString => match v.value::<QString>() {
-            Some(s) => String::from(&s) == "C++ string",
+            Some(s) => s == "C++ string",
             None => false,
         },
         VariantTest::QTime => match v.value::<QTime>() {


### PR DESCRIPTION
In Qt, you can test equality for QByteArrays and QStrings against raw data without needing to allocate memory, e.g. `QStringLiteral("test") == "test"`. This PR makes it possible to do the same in Rust by implementing `PartialEq` for the corresponding types.