### PR TITLE
Fix memory leaks caused by `std::move` on types with no move constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
@@ -500,11 +500,12 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.176"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e9fd2958ba90283c0398c7cef1972aa23db8ab6e4323759a4fa8affb0299c4"
+checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
 dependencies = [
  "cc",
+ "cxx-build",
  "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
@@ -513,12 +514,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx-gen"
-version = "0.7.176"
+name = "cxx-build"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d360688b0291d6714aef4ea75ff06485da64790a098ec49be0aa5014b69f66c9"
+checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
 dependencies = [
- "codespan-reporting 0.12.0",
+ "cc",
+ "codespan-reporting 0.13.1",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxx-gen"
+version = "0.7.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "035b6c61a944483e8a4b2ad4fb8b13830d63491bd004943716ad16d85dcc64bc"
+dependencies = [
+ "codespan-reporting 0.13.1",
  "indexmap",
  "proc-macro2",
  "quote",
@@ -645,12 +661,12 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.176"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50e90729633aea1cc7847bd9a52b8e35ca6e0fe7e07c4359026562f71b81108"
+checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
 dependencies = [
  "clap",
- "codespan-reporting 0.12.0",
+ "codespan-reporting 0.13.1",
  "indexmap",
  "proc-macro2",
  "quote",
@@ -659,20 +675,19 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.176"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74e4c542a20cc6fb0ad077f84c019a76cb689fc3406f49b304183994a92e513"
+checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.176"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3dfe4bd1e09446577a0629578b9087c1d610a2dd3fef7a6bb51dc096d88cf7e"
+checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
 dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -2106,6 +2121,12 @@ checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,9 @@ cc = { version = "1.0.100", features = ["parallel"] }
 # ./book/src/getting-started/4-cargo-executable.md
 # ./book/src/getting-started/5-cmake-integration.md
 # TODO: Can we re-export cxx from cxx-qt, so people don't need to manually add this anymore?
-cxx = "1.0.176"
-cxx-build = { version = "1.0.176", features = [ "parallel" ] }
-cxx-gen = "0.7.176"
+cxx = "1.0.177"
+cxx-build = { version = "1.0.177", features = [ "parallel" ] }
+cxx-gen = "0.7.177"
 proc-macro2 = "1.0"
 syn = { version = "2.0", features = ["extra-traits", "full"] }
 quote = "1.0"

--- a/crates/cxx-qt-lib-extras/include/core/qcommandlineoption.h
+++ b/crates/cxx-qt-lib-extras/include/core/qcommandlineoption.h
@@ -7,15 +7,3 @@
 #pragma once
 
 #include <QtCore/QCommandLineOption>
-
-#include "rust/cxx.h"
-
-// Define namespace otherwise we hit a GCC bug
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
-namespace rust {
-
-template<>
-struct IsRelocatable<QCommandLineOption> : ::std::true_type
-{};
-
-} // namespace rust

--- a/crates/cxx-qt-lib-extras/include/core/qcommandlineparser.h
+++ b/crates/cxx-qt-lib-extras/include/core/qcommandlineparser.h
@@ -8,24 +8,20 @@
 
 #include <QtCore/QCommandLineParser>
 
-#include "rust/cxx.h"
-
-// Define namespace otherwise we hit a GCC bug
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
-namespace rust {
-
-template<>
-struct IsRelocatable<QCommandLineParser> : ::std::true_type
-{};
-
-} // namespace rust
-
 namespace rust {
 namespace cxxqtlib1 {
 using QCommandLineParserOptionsAfterPositionalArgumentsMode =
   QCommandLineParser::OptionsAfterPositionalArgumentsMode;
 using QCommandLineParserSingleDashWordOptionMode =
   QCommandLineParser::SingleDashWordOptionMode;
+
+void
+qcommandlineparserAddHelpOption(QCommandLineParser& parser,
+                                QCommandLineOption* uninit);
+
+void
+qcommandlineparserAddVersionOption(QCommandLineParser& parser,
+                                   QCommandLineOption* uninit);
 
 QString
 qcommandlineparserValue(const QCommandLineParser& parser,

--- a/crates/cxx-qt-lib-extras/include/gui/qapplication.h
+++ b/crates/cxx-qt-lib-extras/include/gui/qapplication.h
@@ -22,8 +22,8 @@ qapplicationNew(const QVector<QByteArray>& args);
 void
 qapplicationSetFont(QApplication& app, const QFont& font);
 
-QFont
-qapplicationFont(const QApplication& app);
+void
+qapplicationFont(const QApplication& app, QFont* uninit);
 
 }
 }

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineoption.rs
@@ -7,6 +7,8 @@ use cxx::{type_id, ExternType};
 use cxx_qt_lib::{QString, QStringList};
 use std::mem::MaybeUninit;
 
+use crate::util::new_in_place;
+
 #[cxx::bridge]
 mod ffi {
     unsafe extern "C++" {
@@ -73,15 +75,18 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "qcommandlineoption_init_from_qcommandlineoption"]
-        fn construct(commandLineOption: &QCommandLineOption) -> QCommandLineOption;
+        unsafe fn constructInPlace(
+            uninit: *mut QCommandLineOption,
+            commandLineOption: &QCommandLineOption,
+        );
 
         #[doc(hidden)]
         #[rust_name = "qcommandlineoption_init_from_qstring"]
-        fn construct(string: &QString) -> QCommandLineOption;
+        unsafe fn constructInPlace(uninit: *mut QCommandLineOption, string: &QString);
 
         #[doc(hidden)]
         #[rust_name = "qcommandlineoption_init_from_qstringlist"]
-        fn construct(names: &QStringList) -> QCommandLineOption;
+        unsafe fn constructInPlace(uninit: *mut QCommandLineOption, names: &QStringList);
     }
 }
 
@@ -96,7 +101,11 @@ pub struct QCommandLineOption {
 impl Clone for QCommandLineOption {
     /// Constructs a copy of this `QCommandLineOption`.
     fn clone(&self) -> Self {
-        ffi::qcommandlineoption_init_from_qcommandlineoption(self)
+        unsafe {
+            new_in_place(|uninit| {
+                ffi::qcommandlineoption_init_from_qcommandlineoption(uninit, self)
+            })
+        }
     }
 }
 
@@ -110,14 +119,16 @@ impl Drop for QCommandLineOption {
 impl From<&QString> for QCommandLineOption {
     /// Constructs a command line option object with the name name.
     fn from(name: &QString) -> Self {
-        ffi::qcommandlineoption_init_from_qstring(name)
+        unsafe { new_in_place(|uninit| ffi::qcommandlineoption_init_from_qstring(uninit, name)) }
     }
 }
 
 impl From<&QStringList> for QCommandLineOption {
     /// Constructs a command line option object with the name name.
     fn from(names: &QStringList) -> Self {
-        ffi::qcommandlineoption_init_from_qstringlist(names)
+        unsafe {
+            new_in_place(|uninit| ffi::qcommandlineoption_init_from_qstringlist(uninit, names))
+        }
     }
 }
 

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.cpp
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.cpp
@@ -18,6 +18,20 @@ static_assert(!::std::is_trivially_copy_assignable<QCommandLineParser>::value);
 
 namespace rust {
 namespace cxxqtlib1 {
+void
+qcommandlineparserAddHelpOption(QCommandLineParser& parser,
+                                QCommandLineOption* uninit)
+{
+  new (uninit) QCommandLineOption(parser.addHelpOption());
+}
+
+void
+qcommandlineparserAddVersionOption(QCommandLineParser& parser,
+                                   QCommandLineOption* uninit)
+{
+  new (uninit) QCommandLineOption(parser.addVersionOption());
+}
+
 QString
 qcommandlineparserValue(const QCommandLineParser& parser,
                         const QString& optionName)

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.rs
@@ -6,6 +6,9 @@ use cxx::{type_id, ExternType};
 use cxx_qt_lib::{QString, QStringList};
 use std::mem::MaybeUninit;
 
+use crate::QCommandLineOption;
+use crate::util::new_in_place;
+
 #[cxx::bridge]
 mod ffi {
     /// This enum describes the way the parser interprets options that occur after positional arguments.
@@ -47,14 +50,6 @@ mod ffi {
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = cxx_qt_lib::QStringList;
 
-        /// Adds help options to the command-line parser.
-        ///
-        /// The options specified for this command-line are described by `-h` or `--help`. On Windows, the alternative `-?` is also supported. The option `--help-all` extends that to include generic Qt options, not defined by this command, in the output.
-        ///
-        /// These options are handled automatically by `QCommandLineParser`.
-        #[rust_name = "add_help_option"]
-        fn addHelpOption(self: &mut QCommandLineParser) -> QCommandLineOption;
-
         /// Adds the option `option` to look for while parsing.
         /// Returns `true` if adding the option was successful; otherwise returns `false`.
         ///
@@ -62,12 +57,6 @@ mod ffi {
         /// or the option has a name that clashes with an option name added before.
         #[rust_name = "add_option"]
         fn addOption(self: &mut QCommandLineParser, option: &QCommandLineOption) -> bool;
-
-        /// Adds the `-v` / `--version` option, which displays the version string of the application.
-        ///
-        /// This option is handled automatically by `QCommandLineParser`.
-        #[rust_name = "add_version_option"]
-        fn addVersionOption(self: &mut QCommandLineParser) -> QCommandLineOption;
 
         /// Returns the application description.
         #[rust_name = "application_description"]
@@ -160,6 +149,18 @@ mod ffi {
     }
     #[namespace = "rust::cxxqtlib1"]
     unsafe extern "C++" {
+        #[rust_name = "qcommandlineparser_add_help_option"]
+        unsafe fn qcommandlineparserAddHelpOption(
+            parser: &mut QCommandLineParser,
+            uninit: *mut QCommandLineOption,
+        );
+
+        #[rust_name = "qcommandlineparser_add_version_option"]
+        unsafe fn qcommandlineparserAddVersionOption(
+            parser: &mut QCommandLineParser,
+            uninit: *mut QCommandLineOption,
+        );
+
         #[rust_name = "qcommandlineparser_value"]
         fn qcommandlineparserValue(parser: &QCommandLineParser, optionName: &QString) -> QString;
 
@@ -185,7 +186,7 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "qcommandlineparser_init_default"]
-        fn construct() -> QCommandLineParser;
+        unsafe fn constructInPlace(uninit: *mut QCommandLineParser);
     }
 }
 
@@ -199,6 +200,22 @@ pub struct QCommandLineParser {
 }
 
 impl QCommandLineParser {
+    /// Adds help options to the command-line parser.
+    ///
+    /// The options specified for this command-line are described by `-h` or `--help`. On Windows, the alternative `-?` is also supported. The option `--help-all` extends that to include generic Qt options, not defined by this command, in the output.
+    ///
+    /// These options are handled automatically by `QCommandLineParser`.
+    pub fn add_help_option(&mut self) -> QCommandLineOption {
+        unsafe { new_in_place(|uninit| ffi::qcommandlineparser_add_help_option(self, uninit)) }
+    }
+
+    /// Adds the `-v` / `--version` option, which displays the version string of the application.
+    ///
+    /// This option is handled automatically by `QCommandLineParser`.
+    pub fn add_version_option(&mut self) -> QCommandLineOption {
+        unsafe { new_in_place(|uninit| ffi::qcommandlineparser_add_version_option(self, uninit)) }
+    }
+
     /// Returns the option value found for the given option name `option_name`, or an empty string if not found.
     ///
     /// The name provided can be any long or short name of any option that was added with [`add_option`](Self::add_option). All the option names are treated as being equivalent. If the name is not recognized or that option was not present, an empty string is returned.
@@ -234,7 +251,7 @@ impl QCommandLineParser {
 impl Default for QCommandLineParser {
     /// Constructs a command line parser object.
     fn default() -> Self {
-        ffi::qcommandlineparser_init_default()
+        unsafe { new_in_place(|uninit| ffi::qcommandlineparser_init_default(uninit)) }
     }
 }
 
@@ -258,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_default_value() {
-        let commandlineparser = ffi::qcommandlineparser_init_default();
+        let commandlineparser = QCommandLineParser::default();
         assert!(commandlineparser.error_text().is_empty());
         assert!(commandlineparser.application_description().is_empty());
     }

--- a/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.rs
+++ b/crates/cxx-qt-lib-extras/src/core/qcommandlineparser.rs
@@ -6,8 +6,8 @@ use cxx::{type_id, ExternType};
 use cxx_qt_lib::{QString, QStringList};
 use std::mem::MaybeUninit;
 
-use crate::QCommandLineOption;
 use crate::util::new_in_place;
+use crate::QCommandLineOption;
 
 #[cxx::bridge]
 mod ffi {

--- a/crates/cxx-qt-lib-extras/src/gui/qapplication.cpp
+++ b/crates/cxx-qt-lib-extras/src/gui/qapplication.cpp
@@ -34,10 +34,10 @@ qapplicationSetFont(QApplication& app, const QFont& font)
   app.setFont(font);
 }
 
-QFont
-qapplicationFont(const QApplication& app)
+void
+qapplicationFont(const QApplication& app, QFont *uninit)
 {
-  return app.font();
+  new (uninit) QFont(app.font());
 }
 
 }

--- a/crates/cxx-qt-lib-extras/src/gui/qapplication.cpp
+++ b/crates/cxx-qt-lib-extras/src/gui/qapplication.cpp
@@ -35,7 +35,7 @@ qapplicationSetFont(QApplication& app, const QFont& font)
 }
 
 void
-qapplicationFont(const QApplication& app, QFont *uninit)
+qapplicationFont(const QApplication& app, QFont* uninit)
 {
   new (uninit) QFont(app.font());
 }

--- a/crates/cxx-qt-lib-extras/src/gui/qapplication.rs
+++ b/crates/cxx-qt-lib-extras/src/gui/qapplication.rs
@@ -3,9 +3,9 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::util::new_in_place;
 use core::pin::Pin;
 use cxx_qt_lib::{QByteArray, QFont, QString, QStringList, QVector};
-use crate::util::new_in_place;
 
 #[cxx::bridge]
 mod ffi {

--- a/crates/cxx-qt-lib-extras/src/gui/qapplication.rs
+++ b/crates/cxx-qt-lib-extras/src/gui/qapplication.rs
@@ -5,6 +5,7 @@
 
 use core::pin::Pin;
 use cxx_qt_lib::{QByteArray, QFont, QString, QStringList, QVector};
+use crate::util::new_in_place;
 
 #[cxx::bridge]
 mod ffi {
@@ -82,7 +83,7 @@ mod ffi {
         fn qapplicationSetFont(app: Pin<&mut QApplication>, font: &QFont);
         #[doc(hidden)]
         #[rust_name = "qapplication_font"]
-        fn qapplicationFont(app: &QApplication) -> QFont;
+        unsafe fn qapplicationFont(app: &QApplication, uninit: *mut QFont);
         #[doc(hidden)]
         #[rust_name = "qapplication_set_library_paths"]
         fn qapplicationSetLibraryPaths(app: Pin<&mut QApplication>, paths: &QStringList);
@@ -137,7 +138,7 @@ impl QApplication {
 
     /// Returns the default application font.
     pub fn font(&self) -> QFont {
-        ffi::qapplication_font(self)
+        unsafe { new_in_place(|uninit| ffi::qapplication_font(self, uninit)) }
     }
 
     /// Returns a list of paths that the application will search when dynamically loading libraries.

--- a/crates/cxx-qt-lib-extras/src/lib.rs
+++ b/crates/cxx-qt-lib-extras/src/lib.rs
@@ -11,3 +11,5 @@ pub use crate::core::*;
 
 mod gui;
 pub use crate::gui::*;
+
+mod util;

--- a/crates/cxx-qt-lib-extras/src/util.rs
+++ b/crates/cxx-qt-lib-extras/src/util.rs
@@ -1,0 +1,43 @@
+use std::mem::MaybeUninit;
+
+/// # Safety
+///
+/// `constructor` must initialize the passed pointer in-place (using `new (uninit) T(...)` in C++).
+///
+/// # Examples
+///
+/// ```ignore
+/// using crate::util::new_in_place;
+///
+/// #[cxx::bridge]
+/// mod ffi {
+///     extern "C++" {
+///         include!("cxx-qt-lib/qfont.h");
+///         type QFont = super::QFont;
+///     }
+///
+///     #[namespace = "rust::cxxqtlib1"]
+///     unsafe extern "C++" {
+///         include!("cxx-qt-lib/common.h");
+///
+///         #[rust_name = "qfont_clone"]
+///         unsafe fn constructInPlace(uninit: *mut QFont, clone_from: &QFont);
+///     }
+/// }
+///
+/// impl Clone for ffi::QFont {
+///     fn clone(&self) -> Self {
+///         unsafe { new_in_place(|uninit| ffi::qfont_clone(uninit, self)) }
+///     }
+/// }
+/// ```
+#[allow(unused)]
+pub(crate) unsafe fn new_in_place<T, F>(constructor: F) -> T
+where
+    F: FnOnce(*mut T),
+{
+    let mut uninit = MaybeUninit::uninit();
+    constructor(uninit.as_mut_ptr());
+    // SAFETY: `constructor` initializes the passed pointer in-place.
+    unsafe { uninit.assume_init() }
+}

--- a/crates/cxx-qt-lib-extras/src/util.rs
+++ b/crates/cxx-qt-lib-extras/src/util.rs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Joshua Booth <joshua.n.booth@gmail.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::mem::MaybeUninit;
 
 /// # Safety

--- a/crates/cxx-qt-lib/include/common.h
+++ b/crates/cxx-qt-lib/include/common.h
@@ -20,7 +20,14 @@ template<typename T, typename... Args>
 T
 construct(Args... args)
 {
-  return T(args...);
+  return T(std::forward<Args>(args)...);
+}
+
+template<typename T, typename... Args>
+void
+constructInPlace(T* uninit, Args... args)
+{
+  new (uninit) T(std::forward<Args>(args)...);
 }
 
 template<typename T>

--- a/crates/cxx-qt-lib/include/core/qanystringview.h
+++ b/crates/cxx-qt-lib/include/core/qanystringview.h
@@ -12,16 +12,6 @@
 
 #include "rust/cxx.h"
 
-// Define namespace otherwise we hit a GCC bug
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
-namespace rust {
-
-template<>
-struct IsRelocatable<QAnyStringView> : ::std::true_type
-{};
-
-} // namespace rust
-
 namespace rust {
 namespace cxxqtlib1 {
 

--- a/crates/cxx-qt-lib/include/core/qtlogging.h
+++ b/crates/cxx-qt-lib/include/core/qtlogging.h
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #pragma once
 
-#include "rust/cxx.h"
 #include <QDebug>
 #include <QtCore/qlogging.h>
 
@@ -27,13 +26,3 @@ qmessagelogcontext_function(const QMessageLogContext& context);
 
 const char*
 qmessagelogcontext_category(const QMessageLogContext& context);
-
-// Define namespace otherwise we hit a GCC bug
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
-namespace rust {
-
-template<>
-struct IsRelocatable<QMessageLogContext> : ::std::true_type
-{};
-
-} // namespace rust

--- a/crates/cxx-qt-lib/include/core/qvariant.h
+++ b/crates/cxx-qt-lib/include/core/qvariant.h
@@ -72,6 +72,13 @@ qvariantConstruct(const T& value) noexcept
 }
 
 template<typename T>
+void
+qvariantInitValueOrDefault(const QVariant& variant, T* uninit)
+{
+  new (uninit) T(variant.value<T>());
+}
+
+template<typename T>
 T
 qvariantValueOrDefault(const QVariant& variant) noexcept
 {

--- a/crates/cxx-qt-lib/include/gui/qfont.h
+++ b/crates/cxx-qt-lib/include/gui/qfont.h
@@ -8,16 +8,9 @@
 
 #include <QtGui/QFont>
 
-#include "rust/cxx.h"
-
 // Define namespace otherwise we hit a GCC bug
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
 namespace rust {
-
-template<>
-struct IsRelocatable<QFont> : ::std::true_type
-{};
-
 namespace cxxqtlib1 {
 using QFontStyle = QFont::Style;
 using QFontHintingPreference = QFont::HintingPreference;
@@ -26,6 +19,9 @@ using QFontSpacingType = QFont::SpacingType;
 using QFontStyleStrategy = QFont::StyleStrategy;
 using QFontStyleHint = QFont::StyleHint;
 using QFontWeight = QFont::Weight;
+
+void
+qfontResolve(const QFont& font, const QFont& other, QFont* uninit);
 
 } // namespace cxxqtlib1
 } // namespace rust

--- a/crates/cxx-qt-lib/include/gui/qguiapplication.h
+++ b/crates/cxx-qt-lib/include/gui/qguiapplication.h
@@ -19,9 +19,10 @@ namespace cxxqtlib1 {
 ::std::unique_ptr<QGuiApplication>
 qguiapplicationNew(const QVector<QByteArray>& args);
 
-inline void (*qguiapplicationSetFont)(const QFont&) = QGuiApplication::setFont;
+void
+qguiapplicationFont(QFont* uninit);
 
-inline QFont (*qguiapplicationFont)() = QGuiApplication::font;
+inline void (*qguiapplicationSetFont)(const QFont&) = QGuiApplication::setFont;
 
 inline void (*qguiapplicationSetDesktopFileName)(const QString&) =
   QGuiApplication::setDesktopFileName;

--- a/crates/cxx-qt-lib/src/core/qtlogging.rs
+++ b/crates/cxx-qt-lib/src/core/qtlogging.rs
@@ -84,8 +84,8 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "construct_qmessagelogcontext"]
-        unsafe fn constructInPlace<'a>(
-            uninit: *mut QMessageLogContext<'a>,
+        unsafe fn constructInPlace(
+            uninit: *mut QMessageLogContext<'_>,
             file_name: *const c_char,
             line_number: i32,
             function_name: *const c_char,

--- a/crates/cxx-qt-lib/src/core/qtlogging.rs
+++ b/crates/cxx-qt-lib/src/core/qtlogging.rs
@@ -8,6 +8,8 @@ use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::mem::size_of;
 
+use crate::util::new_in_place;
+
 #[cxx::bridge]
 mod ffi {
     /// The level the message is sent to the message handler at.
@@ -82,12 +84,13 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "construct_qmessagelogcontext"]
-        unsafe fn construct<'a>(
+        unsafe fn constructInPlace<'a>(
+            uninit: *mut QMessageLogContext<'a>,
             file_name: *const c_char,
             line_number: i32,
             function_name: *const c_char,
             category_name: *const c_char,
-        ) -> QMessageLogContext<'a>;
+        );
     }
 }
 
@@ -117,12 +120,15 @@ impl<'a> QMessageLogContext<'a> {
         category: &'a CStr,
     ) -> QMessageLogContext<'a> {
         unsafe {
-            ffi::construct_qmessagelogcontext(
-                file.as_ptr(),
-                line,
-                function.as_ptr(),
-                category.as_ptr(),
-            )
+            new_in_place(|uninit| {
+                ffi::construct_qmessagelogcontext(
+                    uninit,
+                    file.as_ptr(),
+                    line,
+                    function.as_ptr(),
+                    category.as_ptr(),
+                )
+            })
         }
     }
 

--- a/crates/cxx-qt-lib/src/core/qvariant/generate.sh
+++ b/crates/cxx-qt-lib/src/core/qvariant/generate.sh
@@ -93,6 +93,49 @@ EOF
     rustfmt "$SCRIPTPATH/qvariant_$2.rs"
 }
 
+function generate_bridge_qt_in_place() {
+    tee "$SCRIPTPATH/qvariant_$2.rs" <<EOF
+// SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Andrew Hayzen <andrew.hayzen@kdab.com>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cxx::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/$2.h");
+        type $1 = crate::$1;
+
+        include!("cxx-qt-lib/qvariant.h");
+        type QVariant = crate::QVariant;
+    }
+
+    #[namespace = "rust::cxxqtlib1::qvariant"]
+    unsafe extern "C++" {
+        #[rust_name = "can_convert_$1"]
+        fn qvariantCanConvert$1(variant: &QVariant) -> bool;
+        #[rust_name = "construct_$1"]
+        fn qvariantConstruct(value: &$1) -> QVariant;
+        #[rust_name = "qvariant_init_value_or_default_$1"]
+        unsafe fn qvariantInitValueOrDefault(variant: &QVariant, uninit: *mut $1);
+    }
+}
+
+pub(crate) fn can_convert(variant: &ffi::QVariant) -> bool {
+    ffi::can_convert_$1(variant)
+}
+
+pub(crate) fn construct(value: &ffi::$1) -> ffi::QVariant {
+    ffi::construct_$1(value)
+}
+
+pub(crate) fn value_or_default(variant: &ffi::QVariant) -> ffi::$1 {
+    unsafe { crate::util::new_in_place(|p| ffi::qvariant_init_value_or_default_$1(variant, p)) }
+}
+EOF
+    rustfmt "$SCRIPTPATH/qvariant_$2.rs"
+}
+
 generate_bridge_primitive "bool" "Bool"
 generate_bridge_primitive "f32" "F32"
 generate_bridge_primitive "f64" "F64"
@@ -124,7 +167,7 @@ generate_bridge_primitive "u32" "U32"
 generate_bridge_primitive "u64" "U64"
 
 generate_bridge_qt "QColor" "qcolor"
-generate_bridge_qt "QFont" "qfont"
+generate_bridge_qt_in_place "QFont" "qfont"
 generate_bridge_qt "QImage" "qimage"
 generate_bridge_qt "QPen" "qpen"
 generate_bridge_qt "QPolygon" "qpolygon"

--- a/crates/cxx-qt-lib/src/core/qvariant/qvariant_qfont.rs
+++ b/crates/cxx-qt-lib/src/core/qvariant/qvariant_qfont.rs
@@ -19,8 +19,8 @@ pub mod ffi {
         fn qvariantCanConvertQFont(variant: &QVariant) -> bool;
         #[rust_name = "construct_QFont"]
         fn qvariantConstruct(value: &QFont) -> QVariant;
-        #[rust_name = "value_or_default_QFont"]
-        fn qvariantValueOrDefault(variant: &QVariant) -> QFont;
+        #[rust_name = "qvariant_init_value_or_default_QFont"]
+        unsafe fn qvariantInitValueOrDefault(variant: &QVariant, uninit: *mut QFont);
     }
 }
 
@@ -33,5 +33,5 @@ pub(crate) fn construct(value: &ffi::QFont) -> ffi::QVariant {
 }
 
 pub(crate) fn value_or_default(variant: &ffi::QVariant) -> ffi::QFont {
-    ffi::value_or_default_QFont(variant)
+    unsafe { crate::util::new_in_place(|p| ffi::qvariant_init_value_or_default_QFont(variant, p)) }
 }

--- a/crates/cxx-qt-lib/src/gui/qfont.cpp
+++ b/crates/cxx-qt-lib/src/gui/qfont.cpp
@@ -21,3 +21,13 @@ static_assert(!::std::is_trivially_copy_constructible<QFont>::value);
 
 static_assert(!::std::is_trivially_destructible<QFont>::value);
 static_assert(QTypeInfo<QFont>::isRelocatable);
+
+namespace rust {
+namespace cxxqtlib1 {
+void
+qfontResolve(const QFont& font, const QFont& other, QFont* uninit)
+{
+  new (uninit) QFont(font.resolve(other));
+}
+}
+}

--- a/crates/cxx-qt-lib/src/gui/qfont.rs
+++ b/crates/cxx-qt-lib/src/gui/qfont.rs
@@ -6,6 +6,7 @@ use cxx::{type_id, ExternType};
 use std::fmt;
 use std::mem::MaybeUninit;
 
+use crate::util::new_in_place;
 use crate::QString;
 
 #[cxx::bridge]
@@ -143,14 +144,17 @@ mod ffi {
         Fantasy,
     }
 
-    unsafe extern "C++" {
-        include!("cxx-qt-lib/qfont.h");
-        type QFont = super::QFont;
+    extern "C++" {
         include!("cxx-qt-lib/qstring.h");
         type QString = crate::QString;
         include!("cxx-qt-lib/qstringlist.h");
         type QStringList = crate::QStringList;
 
+        include!("cxx-qt-lib/qfont.h");
+    }
+
+    unsafe extern "C++" {
+        type QFont = super::QFont;
         /// Returns `true` if [weight](https://doc.qt.io/qt/qfont.html#weight)() is a value greater than 400; otherwise returns `false`.
         fn bold(self: &QFont) -> bool;
 
@@ -220,9 +224,6 @@ mod ffi {
         /// Returns the point size of the font. Returns -1 if the font size was specified in pixels.
         #[rust_name = "point_size"]
         fn pointSize(self: &QFont) -> i32;
-
-        /// Returns a new `QFont` that has attributes copied from other that have not been previously set on this font.
-        fn resolve(self: &QFont, other: &QFont) -> QFont;
 
         /// If `enable` is `true` sets the font's weight to 700; otherwise sets the weight to 400.
         ///
@@ -351,6 +352,12 @@ mod ffi {
 
     #[namespace = "rust::cxxqtlib1"]
     unsafe extern "C++" {
+        #[rust_name = "qfont_resolve"]
+        unsafe fn qfontResolve(font: &QFont, other: &QFont, uninit: *mut QFont);
+    }
+
+    #[namespace = "rust::cxxqtlib1"]
+    unsafe extern "C++" {
         include!("cxx-qt-lib/common.h");
         type QFontStyle;
         type QFontHintingPreference;
@@ -361,7 +368,7 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "qfont_init_default"]
-        fn construct() -> QFont;
+        unsafe fn constructInPlace(uninit: *mut QFont);
 
         #[doc(hidden)]
         #[rust_name = "qfont_drop"]
@@ -369,7 +376,7 @@ mod ffi {
 
         #[doc(hidden)]
         #[rust_name = "qfont_clone"]
-        fn construct(font: &QFont) -> QFont;
+        unsafe fn constructInPlace(uninit: *mut QFont, font: &QFont);
 
         #[doc(hidden)]
         #[rust_name = "qfont_eq"]
@@ -393,7 +400,7 @@ pub struct QFont {
 
 impl Default for QFont {
     fn default() -> Self {
-        ffi::qfont_init_default()
+        unsafe { new_in_place(|uninit| ffi::qfont_init_default(uninit)) }
     }
 }
 
@@ -405,7 +412,7 @@ impl Drop for QFont {
 
 impl Clone for QFont {
     fn clone(&self) -> Self {
-        ffi::qfont_clone(self)
+        unsafe { new_in_place(|uninit| ffi::qfont_clone(uninit, self)) }
     }
 }
 
@@ -439,6 +446,11 @@ impl QFont {
         } else {
             Some(result)
         }
+    }
+
+    /// Returns a new `QFont` that has attributes copied from other that have not been previously set on this font.
+    pub fn resolve(self: &QFont, other: &QFont) -> QFont {
+        unsafe { new_in_place(|uninit| ffi::qfont_resolve(self, other, uninit)) }
     }
 }
 

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.cpp
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.cpp
@@ -29,5 +29,11 @@ qguiapplicationNew(const QVector<QByteArray>& args)
   return ptr;
 }
 
+void
+qguiapplicationFont(QFont* uninit)
+{
+  new (uninit) QFont(QGuiApplication::font());
+}
+
 }
 }

--- a/crates/cxx-qt-lib/src/gui/qguiapplication.rs
+++ b/crates/cxx-qt-lib/src/gui/qguiapplication.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::util::new_in_place;
 use crate::{KeyboardModifiers, MouseButtons, QByteArray, QFont, QString, QStringList, QVector};
 use core::pin::Pin;
 
@@ -96,7 +97,7 @@ mod ffi {
         fn qguiapplicationSetFont(font: &QFont);
         #[doc(hidden)]
         #[rust_name = "qguiapplication_font"]
-        fn qguiapplicationFont() -> QFont;
+        unsafe fn qguiapplicationFont(uninit: *mut QFont);
         #[doc(hidden)]
         #[rust_name = "qguiapplication_set_library_paths"]
         fn qapplicationSetLibraryPaths(app: Pin<&mut QGuiApplication>, paths: &QStringList);
@@ -166,7 +167,7 @@ impl QGuiApplication {
 
     /// Returns the default application font.
     pub fn font(&self) -> QFont {
-        ffi::qguiapplication_font()
+        unsafe { new_in_place(|uninit| ffi::qguiapplication_font(uninit)) }
     }
 
     /// Returns a list of paths that the application will search when dynamically loading libraries.

--- a/crates/cxx-qt-lib/src/util.rs
+++ b/crates/cxx-qt-lib/src/util.rs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::mem::MaybeUninit;
+
 /// Asserts that a boolean expression is true at compile time.
 ///
 /// See [`core::assert!`] for more information.
@@ -16,4 +18,46 @@ macro_rules! const_assert {
     ($x:expr $(,)?) => {
         const _: () = ::core::assert!($x);
     };
+}
+
+/// # Safety
+///
+/// `constructor` must initialize the passed pointer in-place (using `new (uninit) T(...)` in C++).
+///
+/// # Examples
+///
+/// ```ignore
+/// using crate::util::new_in_place;
+///
+/// #[cxx::bridge]
+/// mod ffi {
+///     extern "C++" {
+///         include!("cxx-qt-lib/qfont.h");
+///         type QFont = super::QFont;
+///     }
+///
+///     #[namespace = "rust::cxxqtlib1"]
+///     unsafe extern "C++" {
+///         include!("cxx-qt-lib/common.h");
+///
+///         #[rust_name = "qfont_clone"]
+///         unsafe fn constructInPlace(uninit: *mut QFont, clone_from: &QFont);
+///     }
+/// }
+///
+/// impl Clone for ffi::QFont {
+///     fn clone(&self) -> Self {
+///         unsafe { new_in_place(|uninit| ffi::qfont_clone(uninit, self)) }
+///     }
+/// }
+/// ```
+#[allow(unused)]
+pub(crate) unsafe fn new_in_place<T, F>(constructor: F) -> T
+where
+    F: FnOnce(*mut T),
+{
+    let mut uninit = MaybeUninit::uninit();
+    constructor(uninit.as_mut_ptr());
+    // SAFETY: `constructor` initializes the passed pointer in-place.
+    unsafe { uninit.assume_init() }
 }


### PR DESCRIPTION
`cxx` uses the `IsRelocatable` struct to detect whether a C++ type is safe to move by `memcpy`. It permits only types that have trivial move constructors and no destructor. `cxx-qt-lib` and `cxx-qt-lib-extras` sometimes override that check, like so:

```cpp
namespace rust {
template<>
struct IsRelocatable<MyType> : ::std::true_type
{};
}
```

This is a violation of `cxx`'s assumptions, but it's valid if two conditions are met:

1. `QTypeInfo<MyType>::isRelocatable` must be true. This ensures `memcpy` is safe to use.
2. `MyType` must have a move constructor (i.e. `MyType(MyType&& other)`). This ensures that if the type is passed from Rust into C++ by value, C++ will take ownership of it, and vice versa.

The first condition can be checked at compile time with `static_assert(QTypeInfo<MyType>::isRelocatable)`, which is exactly what `cxx-qt-lib` and `cxx-qt-lib-extras` do. However, as far as I know, there is no way to check the second condition at compile time. Due to this, `cxx-qt-lib` and `cxx-qt-lib-extras` declare `IsRelocatable` for several types that do not have move constructors: `QFont`, `QMessageLogContext`, `QCommandLineOption`, and `QCommandLineParser`. If any of these types are passed by value into C++, their reference counter will not decrement, which means they will never deallocate.

However, when those invalid `IsRelocatable` declarations are removed, another problem arises: it is no longer possible for Rust to bind to C++ functions that return those types, since those are *also* passing by value. That includes the FFI bindings we use for `MyType::default()`, `MyType::clone()`, and so on. The solution is to construct the types in-place using `new (p) MyType(...)`, which is the C++ syntax for applying a constructor to the existing place in memory at pointer address `p`, rather than constructing a new value on the stack and returning it. (`cxx` makes heavy use of that syntax in generated code, which is how I learned about it.) So now `common.h` has a new constructor function:

```cpp
// (CURRENT) Constructs a value on the stack and returns it.
template<typename T, typename... Args>
T
construct(Args... args)
{
  return T(std::forward<Args>(args)...);
}

// (ADDED) Constructs a value in-place at the specified pointer address.
template<typename T, typename... Args>
void
constructInPlace(T* uninit, Args... args)
{
  new (uninit) T(std::forward<Args>(args)...);
}
```

On the Rust side, those types now use the `crate::util::new_in_place` helper function to construct their values, which uses `MaybeUninit` under the hood.

```rs
pub(crate) unsafe fn new_in_place<T, F: FnOnce(*mut T)>(constructor: F) -> T
{
    let mut uninit = MaybeUninit::uninit();
    constructor(uninit.as_mut_ptr());
    unsafe { uninit.assume_init() }
}
```

So instead of this:

```rust
impl Clone for MyType {
    fn clone(&self) -> Self {
        ffi::mytype_clone(self)
    }
}
```

Corresponding implementations now do this:

```rust
impl Clone for MyType {
    fn clone(&self) -> Self {
        unsafe { new_in_place(|uninit| ffi::mytype_clone(uninit, self)) }
    }
}
```

It's a bit unwieldy, but I think it's the cleanest approach. The only other way to prevent memory leaks that I can think of is to wrap those types in `UniquePtr`s, but that would be a significant breaking change for those types and wouldn't really be an improvement anyway (in my opinion). This way, it's all kept internal behind the API.

EDIT: Also to note, this is how `cxx` handles it. When an initializer is defined in a bridge, this is the Rust side:

```rs
extern "C" {
void rust$cxxqtlib1$cxxbridge1$192$qfont_init_default(::QFont *return$) noexcept {
  ::QFont (*qfont_init_default$)() = ::rust::cxxqtlib1::construct;
  new (return$) ::QFont(qfont_init_default$());
}
```

And this is the C++ side:

```cpp
    pub fn qfont_init_default() -> QFont {
        unsafe extern "C" {
            #[link_name = "rust$cxxqtlib1$cxxbridge1$192$qfont_init_default"]
            fn __qfont_init_default(__return: *mut QFont);

        }
        unsafe {
            let mut __return = ::cxx::core::mem::MaybeUninit::<QFont>::uninit();
            __qfont_init_default(__return.as_mut_ptr());
            __return.assume_init()
        }
    }
```