### PR TITLE
Fix deprecation message about QImage::mirror in every compilation

### DIFF
--- a/crates/cxx-qt-lib/src/gui/qimage.rs
+++ b/crates/cxx-qt-lib/src/gui/qimage.rs
@@ -234,7 +234,10 @@ mod ffi {
         ///
         /// This function was introduced in Qt 6.0.
         /// This function is scheduled for deprecation in version 6.13.
-        #[cfg(not(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_9)))]
+        #[cfg(all(
+            cxxqt_qt_version_at_least_6_0,
+            not(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_9))
+        ))]
         fn mirror(self: &mut QImage, horizontal: bool, vertical: bool);
 
         /// Swaps the values of the red and blue components of all pixels, effectively converting an RGB image to an BGR image.

--- a/crates/cxx-qt-lib/src/gui/qimage.rs
+++ b/crates/cxx-qt-lib/src/gui/qimage.rs
@@ -234,11 +234,7 @@ mod ffi {
         ///
         /// This function was introduced in Qt 6.0.
         /// This function is scheduled for deprecation in version 6.13.
-        #[cfg(all(
-            cxxqt_qt_version_at_least_6,
-            not(cxxqt_qt_version_at_least_6_13),
-            not(cxxqt_qt_version_at_least_7)
-        ))]
+        #[cfg(not(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_9)))]
         fn mirror(self: &mut QImage, horizontal: bool, vertical: bool);
 
         /// Swaps the values of the red and blue components of all pixels, effectively converting an RGB image to an BGR image.
@@ -579,6 +575,21 @@ impl QImage {
     /// Construct a `QImage` from a given `width`, `height`, and image `format`.
     pub fn from_width_height_and_format(width: i32, height: i32, format: QImageFormat) -> Self {
         ffi::qimage_init_from_width_and_height_and_image_format(width, height, format)
+    }
+
+    /// Mirrors of the image in the horizontal and/or the vertical direction depending on whether `horizontal` and `vertical` are set to `true` or `false`.
+    ///
+    /// This function was introduced in Qt 6.0.
+    /// This function is scheduled for deprecation in version 6.13.
+    #[cfg(any(cxxqt_qt_version_at_least_7, cxxqt_qt_version_at_least_6_9))]
+    #[deprecated = "use QImage::flip instead"]
+    pub fn mirror(self: &mut QImage, horizontal: bool, vertical: bool) {
+        use crate::{Orientation, Orientations};
+
+        let mut orientations = Orientations::new();
+        orientations.set_flag(Orientation::Horizontal, horizontal);
+        orientations.set_flag(Orientation::Vertical, vertical);
+        self.flip(orientations);
     }
 }
 


### PR DESCRIPTION
Every time that you compile a project with `cxx-qt-lib`, this happens:

```
warning: cxx-qt-lib@0.8.1: target/debug/build/cxx-qt-lib-20f19b85df8ca8bc/out/cxxqtgen/src/gui/qimage.cxx.cpp:696:54: warning: 'mirror' is deprecated: Use flip(Qt::Orientations) instead [-Wdeprecated-declarations]
warning: cxx-qt-lib@0.8.1:   696 |   void (::QImage::*mirror$)(bool, bool) = &::QImage::mirror;
warning: cxx-qt-lib@0.8.1:       |                                                      ^
warning: cxx-qt-lib@0.8.1: QtGui.framework/Headers/qimage.h:225:5: note: 'mirror' has been explicitly marked deprecated here
warning: cxx-qt-lib@0.8.1:   225 |     QT_DEPRECATED_VERSION_X_6_13("Use flip(Qt::Orientations) instead")
warning: cxx-qt-lib@0.8.1:       |     ^
warning: cxx-qt-lib@0.8.1: QtCore.framework/Headers/qtdeprecationmarkers.h:246:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_6_13'
warning: cxx-qt-lib@0.8.1:   246 | # define QT_DEPRECATED_VERSION_X_6_13(text) QT_DEPRECATED_X(text)
warning: cxx-qt-lib@0.8.1:       |                                             ^
warning: cxx-qt-lib@0.8.1: QtCore.framework/Headers/qtdeprecationmarkers.h:30:33: note: expanded from macro 'QT_DEPRECATED_X'
warning: cxx-qt-lib@0.8.1:    30 | #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
warning: cxx-qt-lib@0.8.1:       |                                 ^
warning: cxx-qt-lib@0.8.1: QtCore.framework/Headers/qcompilerdetection.h:1017:36: note: expanded from macro 'Q_DECL_DEPRECATED_X'
warning: cxx-qt-lib@0.8.1:  1017 | #  define Q_DECL_DEPRECATED_X(x) [[deprecated(x)]]
warning: cxx-qt-lib@0.8.1:       |                                    ^
warning: cxx-qt-lib@0.8.1: 1 warning generated.
```

This PR removes the message by reimplementing `QImage::mirror` in terms of `QImage::flip` if `QImage::flip` is available.