### PR TITLE
qt-build-utils: drop redundant qmldir alias from generated qrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/KDAB/cxx-qt/compare/v0.8.1...HEAD)
 
+### Fixed
+
+- `qt-build-utils`: drop redundant explicit `qmldir` alias from the generated
+  QML module `.qrc` so `rcc` no longer emits
+  `Warning: potential duplicate alias detected: 'qmldir'` on every build.
+
 ## [0.8.1](https://github.com/KDAB/cxx-qt/compare/v0.8.0...v0.8.1) - 2026-02-16
 
 ### Fixed

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -346,15 +346,24 @@ impl QtBuild {
             let qml_module_dir_str = qml_module_dir.to_str().unwrap();
             let qml_uri_dirs_prefix = format!("/qt/qml/{qml_uri_dirs}");
             let mut qrc = File::create(&qrc_path).expect("Could not create qrc file");
+            // The first <qresource> registers the QML module's generated
+            // directory (which contains the generated `qmldir` and
+            // `plugin.qmltypes`); rcc walks it and registers every file
+            // inside under the module's resource prefix. The second
+            // <qresource> then adds the source-tree `.qml` files (which
+            // live outside that directory) with explicit aliases.
+            //
+            // We deliberately do NOT add an explicit `qmldir` alias to
+            // the second block — the directory walk above already covers
+            // it, and adding it again makes rcc emit
+            //   Warning: potential duplicate alias detected: 'qmldir'
+            // on every build.
             QResources::new()
                 .resource(QResource::new().prefix("/".to_string()).file(
                     QResourceFile::new(qml_module_dir_str).alias(qml_uri_dirs_prefix.clone()),
                 ))
                 .resource({
-                    let mut resource = QResource::new().prefix(qml_uri_dirs_prefix.clone()).file(
-                        QResourceFile::new(format!("{qml_module_dir_str}/qmldir"))
-                            .alias("qmldir".to_string()),
-                    );
+                    let mut resource = QResource::new().prefix(qml_uri_dirs_prefix.clone());
 
                     fn resource_add_path(resource: QResource, path: &Path) -> QResource {
                         let resolved = std::fs::canonicalize(path)


### PR DESCRIPTION
## Summary

`QtBuild::register_qml_module` writes two `<qresource>` blocks into the generated `qml_module_resources_*.qrc`:

1. A directory-level alias under `prefix=\"/\"`, registering the whole `qml_modules/<uri>/` directory (which contains the freshly-generated `qmldir` and `plugin.qmltypes`). `rcc` walks it and registers every file inside under the module's resource prefix.
2. An explicit per-file block under `prefix=\"/qt/qml/<uri>\"`, which **also** explicitly listed `qmldir` before iterating the source-tree `.qml` files.

Both ended up registering `qmldir` at the same final resource path. `rcc` warned on every build:

```
Warning: potential duplicate alias detected: 'qmldir'
```

The binary still worked at runtime — one registration shadowed the other and `qmldir` was still findable through whichever won — but the warning fired on every `cargo build` for every downstream Qt6 app using a `QmlModule`.

## Fix

The directory walk in block (1) already covers `qmldir`, so this PR removes the redundant explicit `qmldir` alias from block (2). Net effect on `rcc`'s output: identical resource layout, one fewer warning per build.

Before:
```xml
<RCC>
  <qresource prefix=\"/\">
    <file alias=\"/qt/qml/com/kdab/cxx_qt/demo\">.../qml_modules/com/kdab/cxx_qt/demo</file>
  </qresource>
  <qresource prefix=\"/qt/qml/com/kdab/cxx_qt/demo\">
    <file alias=\"qmldir\">.../qml_modules/com/kdab/cxx_qt/demo/qmldir</file>   <!-- redundant -->
    <file alias=\"../qml/main.qml\">.../examples/qml_minimal/qml/main.qml</file>
  </qresource>
</RCC>
```

After:
```xml
<RCC>
  <qresource prefix=\"/\">
    <file alias=\"/qt/qml/com/kdab/cxx_qt/demo\">.../qml_modules/com/kdab/cxx_qt/demo</file>
  </qresource>
  <qresource prefix=\"/qt/qml/com/kdab/cxx_qt/demo\">
    <file alias=\"../qml/main.qml\">.../examples/qml_minimal/qml/main.qml</file>
  </qresource>
</RCC>
```

## Verification

- `cargo test -p qt-build-utils` — green (9/9 tests pass, same as `main`)
- `cargo test -p cxx-qt-gen` — green (no impact)
- `cargo build` of `examples/qml_minimal/rust` — succeeds; generated `.qrc` no longer contains the duplicate `qmldir` alias
- Built a downstream Qt6 / Kirigami app (~20 QML files in a single module) against this branch via `[patch.crates-io]`:
  - Cargo build log: 0 occurrences of `potential duplicate alias` (was 1 per build before)
  - App launches normally; QML module loads; all QML files still resolved via the resource system (no `qrc:///` 404s in the logs)

## Test plan

- [x] `qt-build-utils` unit tests pass
- [x] `qml_minimal` example builds with patched crate
- [x] Generated `qrc` inspected and confirmed to no longer list `qmldir` explicitly
- [x] Downstream Qt6 app builds without the `rcc` warning
- [x] Downstream Qt6 app loads its QML module at runtime (no resource-not-found errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)