### PR TITLE
qt-build-utils: qt minimal fallback if other versions are available

### DIFF
--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -177,11 +177,11 @@ impl QtBuild {
 
                     // Download from Qt artifacts
                     //
-                    // NOTE: we assume the last version is the newest
-                    if let Some(version_last) = versions.last() {
-                        if let Ok(qt_installation) =
-                            QtInstallationQtMinimal::try_from(version_last.clone())
-                        {
+                    // NOTE: we assume the last version is the newest and
+                    // try each version in case there is a mismatch between
+                    // qt_artifacts and qt_versions
+                    for version in versions.into_iter().rev() {
+                        if let Ok(qt_installation) = QtInstallationQtMinimal::try_from(version) {
                             return Ok(Box::new(qt_installation));
                         }
                     }

--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -157,16 +157,16 @@ impl QtBuild {
                         // Merge artifacts into combined bin/ and include/
                         let mut artifacts = QtInstallationQtMinimal::group_artifacts(artifacts);
 
-                        // Sort the artifacts by version, largest first
+                        // Sort the artifacts by version
                         artifacts.sort_by_key(|artifact| artifact.version.clone());
-                        artifacts.reverse();
 
-                        // Pick the first found version
-                        if let Some(artifact) = artifacts.first() {
+                        // Try all the local available Qt minimal installs
+                        // starting with the largest Qt version
+                        for artifact in artifacts.into_iter().rev() {
                             // Try building a Qt installation from the url
-                            if let Ok(qt_installation) = QtInstallationQtMinimal::try_from(
-                                PathBuf::from(artifact.url.clone()),
-                            ) {
+                            if let Ok(qt_installation) =
+                                QtInstallationQtMinimal::try_from(PathBuf::from(artifact.url))
+                            {
                                 return Ok(Box::new(qt_installation));
                             }
                         }


### PR DESCRIPTION
Do not try just the first matching version try others too