### PR TITLE
qt-build-utils: fix qmake finding from path

### DIFF
--- a/crates/qt-build-utils/src/installation/qmake.rs
+++ b/crates/qt-build-utils/src/installation/qmake.rs
@@ -86,7 +86,7 @@ impl QtInstallationQMake {
                         },
                     ))
                 } else {
-                    None
+                    acc
                 }
             })
             .unwrap_or_else(|| Err(QtBuildError::QtMissing.into()))


### PR DESCRIPTION
If there's only `qmake6` and no `qmake`, the method will shadow the existing findings. This PR fixes such case.