### PR TITLE
cxx-qt-lib: implement QVariantValue for QList of QObject pointers

### DIFF
--- a/crates/cxx-qt-lib/build.rs
+++ b/crates/cxx-qt-lib/build.rs
@@ -155,6 +155,7 @@ fn main() {
         "core/qvariant/qvariant_qlist_i32",
         "core/qvariant/qvariant_qlist_i64",
         "core/qvariant/qvariant_qlist_i8",
+        "core/qvariant/qvariant_qlist_qobjectmutptr",
         "core/qvariant/qvariant_qlist_u16",
         "core/qvariant/qvariant_qlist_u32",
         "core/qvariant/qvariant_qlist_u64",

--- a/crates/cxx-qt-lib/include/core/qvariant.h
+++ b/crates/cxx-qt-lib/include/core/qvariant.h
@@ -34,6 +34,8 @@
 #include <QtCore/QUrl>
 #include <QtCore/QUuid>
 
+#include <cxx-qt-lib/qobjectmutptr.h>
+
 #ifdef CXX_QT_GUI_FEATURE
 #include <QtGui/QColor>
 #include <QtGui/QFont>
@@ -128,6 +130,7 @@ CXX_QT_QVARIANT_CAN_CONVERT(QList_u8)
 CXX_QT_QVARIANT_CAN_CONVERT(QList_u16)
 CXX_QT_QVARIANT_CAN_CONVERT(QList_u32)
 CXX_QT_QVARIANT_CAN_CONVERT(QList_u64)
+CXX_QT_QVARIANT_CAN_CONVERT(QList_QObjectMutPtr)
 
 #ifdef CXX_QT_GUI_FEATURE
 CXX_QT_QVARIANT_CAN_CONVERT(QColor)

--- a/crates/cxx-qt-lib/src/core/qvariant/mod.rs
+++ b/crates/cxx-qt-lib/src/core/qvariant/mod.rs
@@ -7,7 +7,7 @@ use cxx::{type_id, ExternType};
 use std::fmt;
 use std::mem::MaybeUninit;
 
-use crate::QMetaTypeType;
+use crate::{QMetaTypeType, QObjectMutPtr};
 
 #[cxx::bridge]
 mod ffi {
@@ -232,6 +232,7 @@ impl_qvariant_value!(crate::QList<u8>, qvariant_qlist_u8);
 impl_qvariant_value!(crate::QList<u16>, qvariant_qlist_u16);
 impl_qvariant_value!(crate::QList<u32>, qvariant_qlist_u32);
 impl_qvariant_value!(crate::QList<u64>, qvariant_qlist_u64);
+impl_qvariant_value!(crate::QList<QObjectMutPtr>, qvariant_qlist_qobjectmutptr);
 impl_qvariant_value!(crate::QList<QVariant>, qvariant_qvariantlist);
 impl_qvariant_value!(
     crate::QMap<crate::QMapPair_QString_QVariant>,

--- a/crates/cxx-qt-lib/src/core/qvariant/qvariant.cpp
+++ b/crates/cxx-qt-lib/src/core/qvariant/qvariant.cpp
@@ -100,6 +100,7 @@ CXX_QT_QVARIANT_CAN_CONVERT_IMPL(::QList<::std::uint8_t>, QList_u8)
 CXX_QT_QVARIANT_CAN_CONVERT_IMPL(::QList<::std::uint16_t>, QList_u16)
 CXX_QT_QVARIANT_CAN_CONVERT_IMPL(::QList<::std::uint32_t>, QList_u32)
 CXX_QT_QVARIANT_CAN_CONVERT_IMPL(::QList<::std::uint64_t>, QList_u64)
+CXX_QT_QVARIANT_CAN_CONVERT_IMPL(::QList<::QObjectMutPtr>, QList_QObjectMutPtr)
 
 #ifdef CXX_QT_GUI_FEATURE
 CXX_QT_QVARIANT_CAN_CONVERT_IMPL(::QColor, QColor)

--- a/crates/cxx-qt-lib/src/core/qvariant/qvariant_qlist_qobjectmutptr.rs
+++ b/crates/cxx-qt-lib/src/core/qvariant/qvariant_qlist_qobjectmutptr.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileContributor: Yuri Knigavko <yuri.knigavko@qt.io>
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cxx::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("cxx-qt-lib/core/qlist/qlist_QObjectMutPtr.h");
+        type QList_QObjectMutPtr = crate::QList<crate::QObjectMutPtr>;
+
+        include!("cxx-qt-lib/qvariant.h");
+        type QVariant = crate::QVariant;
+    }
+
+    #[namespace = "rust::cxxqtlib1::qvariant"]
+    unsafe extern "C++" {
+        #[rust_name = "can_convert_QList_QObjectMutPtr"]
+        fn qvariantCanConvertQList_QObjectMutPtr(variant: &QVariant) -> bool;
+        #[rust_name = "construct_QList_QObjectMutPtr"]
+        fn qvariantConstruct(value: &QList_QObjectMutPtr) -> QVariant;
+        #[rust_name = "value_or_default_QList_QObjectMutPtr"]
+        fn qvariantValueOrDefault(variant: &QVariant) -> QList_QObjectMutPtr;
+    }
+}
+
+pub(crate) fn can_convert(variant: &ffi::QVariant) -> bool {
+    ffi::can_convert_QList_QObjectMutPtr(variant)
+}
+
+pub(crate) fn construct(value: &ffi::QList_QObjectMutPtr) -> ffi::QVariant {
+    ffi::construct_QList_QObjectMutPtr(value)
+}
+
+pub(crate) fn value_or_default(variant: &ffi::QVariant) -> ffi::QList_QObjectMutPtr {
+    ffi::value_or_default_QList_QObjectMutPtr(variant)
+}


### PR DESCRIPTION
Add implementation of `QVariantValue` trait for `QList<QObjectMutPtr>`.