### PR TITLE
cxx-qt-lib: harden conversion of QObjectMutPtr from / to raw pointer.

### DIFF
--- a/crates/cxx-qt-lib/include/core/qobjectmutptr.h
+++ b/crates/cxx-qt-lib/include/core/qobjectmutptr.h
@@ -9,6 +9,6 @@
 #include <QtCore/QObject>
 
 // Mirrors the Rust
-// `#[repr(transparent)] struct QObjectMutPtr(pub *mut QObject)`
+// `#[repr(transparent)] struct QObjectMutPtr(*mut QObject)`
 // so it can be used as a shared type across the bridge.
 using QObjectMutPtr = ::QObject*;

--- a/crates/cxx-qt-lib/src/core/qobjectmutptr.rs
+++ b/crates/cxx-qt-lib/src/core/qobjectmutptr.rs
@@ -7,20 +7,37 @@ use cxx_qt::QObject;
 
 /// A thin wrapper around `*mut QObject`.
 /// Using the 'newtype' idiom lets us implement `ExternType`
-/// for it, which wouldn't possible for pure `*mut QObject` itself.
+/// for it, which wouldn't be possible for pure `*mut QObject` itself.
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct QObjectMutPtr(pub *mut QObject);
+pub struct QObjectMutPtr(*mut QObject);
 
-impl From<*mut QObject> for QObjectMutPtr {
-    fn from(value: *mut QObject) -> Self {
-        QObjectMutPtr(value)
+impl QObjectMutPtr {
+    /// Create a new instance from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// The pointer is passed to C++ as a `QObject*` and may be dereferenced
+    /// there. This wrapper tracks neither ownership nor lifetime,
+    /// so the object must outlive every use of the underlying QObject pointer
+    /// (including any copy stored in a `QVariant` or `QList`).
+    pub unsafe fn from_raw(raw: *mut QObject) -> Self {
+        Self(raw)
     }
-}
 
-impl From<QObjectMutPtr> for *mut QObject {
-    fn from(value: QObjectMutPtr) -> Self {
-        value.0
+    /// Return a wrapped raw const pointer.
+    pub fn as_ptr(&self) -> *const QObject {
+        self.0
+    }
+
+    /// Return a wrapped raw mut pointer.
+    pub fn as_mut_ptr(&self) -> *mut QObject {
+        self.0
+    }
+
+    /// Consume an object a return a wrapped raw mut pointer.
+    pub fn into_raw(self) -> *mut QObject {
+        self.0
     }
 }
 


### PR DESCRIPTION
Replace `From` trait implementations with dedicated conversion methods to make raw pointer conversions a bit more explicit.