### PR TITLE
book: remove deprecated 'multilingual' key in book.toml

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -6,7 +6,6 @@
 [book]
 authors = ["Andrew Hayzen <andrew.hayzen@kdab.com>"]
 language = "en"
-multilingual = false
 src = "src"
 title = "CXX-Qt Documentation"
 


### PR DESCRIPTION
In version 0.5 of mdBook, support for the `book.multilingual` key in book.toml was removed. Trying to build the CXX-Qt book with a current version of mdBook will fail because of this, so the field should be removed.

(see: https://github.com/rust-lang/mdBook/pull/2775)